### PR TITLE
fix(server): block DNS-rebinding on the MCP/HTTP control plane (C1)

### DIFF
--- a/packages/server/src/http-server.test.ts
+++ b/packages/server/src/http-server.test.ts
@@ -20,10 +20,14 @@ function listen(server: SharedServer): Promise<number> {
   });
 }
 
-function get(port: number, path: string): Promise<{ status: number; body: string }> {
+function get(
+  port: number,
+  path: string,
+  headers: http.OutgoingHttpHeaders = {},
+): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
     http
-      .get({ host: '127.0.0.1', port, path }, (res) => {
+      .get({ host: '127.0.0.1', port, path, headers }, (res) => {
         let body = '';
         res.setEncoding('utf8');
         res.on('data', (c: string) => (body += c));
@@ -62,6 +66,29 @@ describe('GET /status', () => {
     shared = createSharedServer({ token: 'a-secret-pairing-token' });
     const port = await listen(shared);
     const res = await get(port, STATUS_PATH);
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects a DNS-rebound request whose Host header is not loopback (no token configured)', async () => {
+    // Rebinding: the page resolves evil.com -> 127.0.0.1 so the peer is loopback, but the browser
+    // still sends the attacker Host. Loopback-peer trust must not short-circuit past that.
+    shared = createSharedServer();
+    const port = await listen(shared);
+    const res = await get(port, STATUS_PATH, { host: 'evil.com' });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a request carrying a non-loopback Origin even from a loopback peer', async () => {
+    shared = createSharedServer();
+    const port = await listen(shared);
+    const res = await get(port, STATUS_PATH, { origin: 'http://evil.com' });
+    expect(res.status).toBe(401);
+  });
+
+  it('serves a loopback peer that sends a loopback Origin (a legit same-daemon page)', async () => {
+    shared = createSharedServer();
+    const port = await listen(shared);
+    const res = await get(port, STATUS_PATH, { origin: `http://localhost:${String(port)}` });
     expect(res.status).toBe(200);
   });
 });

--- a/packages/server/src/http-server.ts
+++ b/packages/server/src/http-server.ts
@@ -2,7 +2,13 @@ import * as http from 'node:http';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { log } from './log.js';
-import { isLoopbackPeer, requestToken, tokensMatch } from './token-auth.js';
+import {
+  isLoopbackHost,
+  isLocalWebOrigin,
+  isLoopbackPeer,
+  requestToken,
+  tokensMatch,
+} from './token-auth.js';
 
 // These paths form the agent↔server wire contract. Keep in sync with skill/SKILL.md.
 export const MCP_SSE_PATH = '/mcp/sse';
@@ -53,8 +59,19 @@ export function createSharedServer(options: { token?: string } = {}): SharedServ
   // non-loopback peer must present the pairing token. Without this, binding the daemon beyond loopback
   // (RETICLE_HOST) would expose reticle_act/reticle_navigate and session enumeration to the whole network even
   // though the WS demanded a token. When no token is configured the bind is loopback-only anyway.
+  //
+  // Loopback-peer trust alone is not enough: a DNS-rebound webpage reaches us AS a loopback peer while
+  // its browser sends the attacker's original Host/Origin. So the loopback-trust tier additionally
+  // requires a loopback Host header and a loopback-or-absent Origin/Referer — the same rebinding
+  // defense the WS bridge has (#originAllowed). A rebound page fails those and falls through to the
+  // token check (which it cannot satisfy). Legitimate remote clients on a RETICLE_HOST bind present the
+  // token instead of relying on loopback trust, so this never breaks them.
   const authorized = (req: http.IncomingMessage, url: URL): boolean => {
-    if (isLoopbackPeer(req.socket.remoteAddress)) return true;
+    const localClient =
+      isLoopbackPeer(req.socket.remoteAddress) &&
+      isLoopbackHost(req.headers.host) &&
+      isLocalWebOrigin(req.headers.origin, req.headers.referer);
+    if (localClient) return true;
     if (token === undefined) return false;
     return tokensMatch(token, requestToken(req, url));
   };

--- a/packages/server/src/token-auth.test.ts
+++ b/packages/server/src/token-auth.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import type { IncomingMessage } from 'node:http';
-import { isLoopbackPeer, requestToken, tokensMatch } from './token-auth.js';
+import {
+  isLocalWebOrigin,
+  isLoopbackHost,
+  isLoopbackPeer,
+  requestToken,
+  tokensMatch,
+} from './token-auth.js';
 
 function reqWith(headers: Record<string, string>): IncomingMessage {
   return { headers } as unknown as IncomingMessage;
@@ -45,5 +51,37 @@ describe('isLoopbackPeer', () => {
     expect(isLoopbackPeer('10.0.0.5')).toBe(false);
     expect(isLoopbackPeer('203.0.113.7')).toBe(false);
     expect(isLoopbackPeer(undefined)).toBe(false);
+  });
+});
+
+describe('isLoopbackHost', () => {
+  it('accepts loopback Host headers with and without a port', () => {
+    expect(isLoopbackHost('127.0.0.1:9000')).toBe(true);
+    expect(isLoopbackHost('localhost:5173')).toBe(true);
+    expect(isLoopbackHost('[::1]:9000')).toBe(true);
+  });
+
+  it('rejects a non-loopback Host (DNS rebinding) and a missing Host', () => {
+    expect(isLoopbackHost('evil.com')).toBe(false);
+    expect(isLoopbackHost('evil.com:9000')).toBe(false);
+    expect(isLoopbackHost('127.0.0.1.evil.com')).toBe(false);
+    expect(isLoopbackHost(undefined)).toBe(false);
+  });
+});
+
+describe('isLocalWebOrigin', () => {
+  it('passes when Origin/Referer are absent (non-browser local clients)', () => {
+    expect(isLocalWebOrigin(undefined, undefined)).toBe(true);
+  });
+
+  it('passes for loopback Origin/Referer', () => {
+    expect(isLocalWebOrigin('http://localhost:5173', undefined)).toBe(true);
+    expect(isLocalWebOrigin(undefined, 'http://127.0.0.1:9000/page')).toBe(true);
+  });
+
+  it('fails for any non-loopback Origin or Referer (a rebound attacker page)', () => {
+    expect(isLocalWebOrigin('http://evil.com', undefined)).toBe(false);
+    expect(isLocalWebOrigin(undefined, 'http://evil.com/x')).toBe(false);
+    expect(isLocalWebOrigin('null', undefined)).toBe(false);
   });
 });

--- a/packages/server/src/token-auth.ts
+++ b/packages/server/src/token-auth.ts
@@ -36,3 +36,39 @@ export function isLoopbackPeer(remoteAddress: string | undefined): boolean {
   if (remoteAddress === undefined) return false;
   return isLoopbackHostname(remoteAddress.replace(IPV4_MAPPED_PREFIX, ''));
 }
+
+/** Extract the hostname from a `Host` value (`127.0.0.1:9000`) or a full origin/referer URL. */
+function hostnameOf(value: string): string | undefined {
+  const direct = value.includes('://') ? value : `http://${value}`;
+  try {
+    return new URL(direct).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * True when the `Host` header names a loopback host. This is the anti-DNS-rebinding guard: a rebound
+ * page reaches us as a loopback *peer* but its browser still sends the attacker's original `Host`
+ * (`evil.com`), so a non-loopback Host means "not actually a local client" even when the socket is.
+ * Missing Host is untrusted — every real HTTP/1.1 client (incl. `reticle status`, the stdio proxy) sends it.
+ */
+export function isLoopbackHost(hostHeader: string | undefined): boolean {
+  if (hostHeader === undefined) return false;
+  const hostname = hostnameOf(hostHeader);
+  return hostname !== undefined && isLoopbackHostname(hostname);
+}
+
+/**
+ * True when neither `Origin` nor `Referer` betrays a non-loopback web origin. Absent headers pass —
+ * non-browser local clients (the stdio MCP proxy, `reticle status`) send neither. Any present-but-
+ * non-loopback value fails, which is what kills a rebound `http://evil.com` page reading the plane.
+ */
+export function isLocalWebOrigin(origin: string | undefined, referer: string | undefined): boolean {
+  for (const value of [origin, referer]) {
+    if (value === undefined) continue;
+    const hostname = hostnameOf(value);
+    if (hostname === undefined || !isLoopbackHostname(hostname)) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Fixes the CRITICAL finding from `plan/SECURITY-AUDIT.md`.

## Problem
`/mcp/sse`, `/mcp/message`, and `/status` authorized a request solely by peer IP. A DNS-rebound page (`evil.com` → `127.0.0.1`) reaches the daemon as a loopback peer and was authorized — able to drive `reticle_navigate`/`reticle_act` and exfiltrate DOM/state/network. The WS bridge already defended against this; the HTTP plane did not.

## Fix
Loopback-peer trust now additionally requires a loopback `Host` header and a loopback-or-absent `Origin`/`Referer`. A rebound page sends the attacker's original Host/Origin, fails those, and falls through to the token check it cannot satisfy. Legitimate `RETICLE_HOST` clients present the token and are unaffected. Also closes L2 (`/status` session-URL leak, same root cause).

## Tests
- `token-auth.test.ts`: unit tests for `isLoopbackHost` / `isLocalWebOrigin`.
- `http-server.test.ts`: rebound Host → 401, non-loopback Origin → 401, loopback Origin → 200, existing local-trust paths still 200.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)