### PR TITLE
fix(browser): redact typed secrets from recorded flow files (H1)

### DIFF
--- a/packages/browser/src/dom/a11y.ts
+++ b/packages/browser/src/dom/a11y.ts
@@ -178,28 +178,43 @@ export function getStates(el: Element): ElementState[] {
   return states;
 }
 
+/**
+ * True when a form field holds a secret the SDK must never capture verbatim — a password input, a
+ * sensitive `autocomplete` (cc-number, one-time-code, …), or a name/id/testid/aria-label that trips
+ * `isSensitiveKey`. The single source of truth for both live-snapshot redaction (`getValue`) and the
+ * flow recorder's fill-value redaction, so recorded flows never persist typed passwords/OTPs/keys.
+ */
+export function isSensitiveField(el: Element): boolean {
+  if (
+    !(el instanceof HTMLInputElement) &&
+    !(el instanceof HTMLTextAreaElement) &&
+    !(el instanceof HTMLSelectElement)
+  ) {
+    return false;
+  }
+  const autocomplete = el.getAttribute('autocomplete') ?? '';
+  const identifiers = [
+    el.getAttribute('name') ?? '',
+    el.id,
+    el.getAttribute('data-testid') ?? '',
+    el.getAttribute('aria-label') ?? '',
+  ];
+  const sensitiveAutocomplete =
+    /current-password|new-password|cc-number|cc-csc|one-time-code/i.test(autocomplete);
+  return (
+    (el instanceof HTMLInputElement && el.type.toLowerCase() === 'password') ||
+    sensitiveAutocomplete ||
+    identifiers.some(isSensitiveKey)
+  );
+}
+
 export function getValue(el: Element): string | undefined {
   if (
     el instanceof HTMLInputElement ||
     el instanceof HTMLTextAreaElement ||
     el instanceof HTMLSelectElement
   ) {
-    const autocomplete = el.getAttribute('autocomplete') ?? '';
-    const identifiers = [
-      el.getAttribute('name') ?? '',
-      el.id,
-      el.getAttribute('data-testid') ?? '',
-      el.getAttribute('aria-label') ?? '',
-    ];
-    const sensitiveAutocomplete =
-      /current-password|new-password|cc-number|cc-csc|one-time-code/i.test(autocomplete);
-    if (
-      (el instanceof HTMLInputElement && el.type.toLowerCase() === 'password') ||
-      sensitiveAutocomplete ||
-      identifiers.some(isSensitiveKey)
-    ) {
-      return REDACTED_VALUE;
-    }
+    if (isSensitiveField(el)) return REDACTED_VALUE;
     return el.value;
   }
   const valueNow = el.getAttribute('aria-valuenow');

--- a/packages/browser/src/recorder/recorder.test.ts
+++ b/packages/browser/src/recorder/recorder.test.ts
@@ -119,6 +119,32 @@ describe('recorder capture — semantic anchored steps', () => {
     expect(step.anchor).toEqual({ kind: AnchorKind.TESTID, value: 'hook' });
   });
 
+  it('redacts a typed password so the secret never lands in a git-checked flow file', () => {
+    document.body.innerHTML = `<input type="password" data-testid="pw" />`;
+    const { emit } = makeEmits();
+    mount(emit);
+    clickRecord();
+    const input = document.querySelector('input') as HTMLInputElement;
+    input.value = 'hunter2';
+    fire(input, 'change');
+
+    const step = handle?.steps()[0] as FlowStep;
+    expect(step.action).toBe(ActionType.FILL);
+    expect(step.args?.['value']).toBe('[REDACTED]');
+  });
+
+  it('redacts a sensitively-named field (autocomplete one-time-code)', () => {
+    document.body.innerHTML = `<input autocomplete="one-time-code" data-testid="otp" />`;
+    const { emit } = makeEmits();
+    mount(emit);
+    clickRecord();
+    const input = document.querySelector('input') as HTMLInputElement;
+    input.value = '123456';
+    fire(input, 'change');
+
+    expect((handle?.steps()[0] as FlowStep).args?.['value']).toBe('[REDACTED]');
+  });
+
   it('keystroke inputs debounce to one fill step (latest value)', () => {
     document.body.innerHTML = `<input data-testid="hook" />`;
     const { emit } = makeEmits();

--- a/packages/browser/src/recorder/recorder.ts
+++ b/packages/browser/src/recorder/recorder.ts
@@ -11,7 +11,8 @@ import {
   type FlowFile,
   type FlowStep,
 } from '@reticlehq/protocol';
-import { getAccessibleName, getRole } from '../dom/a11y.js';
+import { REDACTED_VALUE } from '@reticlehq/protocol';
+import { getAccessibleName, getRole, isSensitiveField } from '../dom/a11y.js';
 import { isReticleOverlay } from '../dom/dom-ignore.js';
 import { getCapabilities } from '../registry/capabilities.js';
 import { TOOLBAR_CSS, BTN_CSS, NAME_CSS, STATUS_CSS, MENU_CSS } from './recorder-styles.js';
@@ -311,7 +312,10 @@ class Recorder implements RecorderHandle {
     const pending = this.#pendingFill;
     if (pending === undefined) return;
     this.#pendingFill = undefined;
-    this.#steps.push(buildStep(pending.el, ActionType.FILL, { value: pending.value }));
+    // Never persist a typed secret into a git-checked flow file: password/OTP/cc/sensitive-keyed
+    // fields record REDACTED_VALUE, the same redaction live snapshots apply (dom/a11y.ts getValue).
+    const value = isSensitiveField(pending.el) ? REDACTED_VALUE : pending.value;
+    this.#steps.push(buildStep(pending.el, ActionType.FILL, { value }));
   }
 
   // ---- annotation ----


### PR DESCRIPTION
Fixes HIGH finding H1 from `plan/SECURITY-AUDIT.md`.

## Problem
The recorder captured raw input values (incl. `password` fields) and persisted them verbatim into `.reticle/flows/<name>.json` — files the tooling calls "git-checked". A demoed login committed the customer's password/OTP/key. Live DOM snapshots already redacted these; the recorder path skipped it.

## Fix
Extracted the sensitive-field detection out of `a11y.getValue` into a shared `isSensitiveField(el)` and applied it on the recorder's fill-flush path. Password, sensitive-`autocomplete` (cc-number/one-time-code/…), and sensitive-keyed fields now record `[REDACTED]`. Single source of truth for both redaction sites.

## Tests
`recorder.test.ts`: typed password → `[REDACTED]`, `autocomplete=one-time-code` → `[REDACTED]`; existing non-sensitive fill still records the value.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)