### PR TITLE
fix(browser): redact credential-bearing query params in network observer (M3)

### DIFF
--- a/packages/browser/src/observers/network.test.ts
+++ b/packages/browser/src/observers/network.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EventType } from '@reticlehq/protocol';
-import { installNetwork } from './network.js';
+import { installNetwork, redactUrl } from './network.js';
 import type { Emit, Teardown } from './types.js';
 
 interface Emitted {
@@ -20,6 +20,24 @@ function collect(): { emit: Emit; events: Emitted[] } {
 function fakeResponse(status: number): Response {
   return { status, ok: status >= 200 && status < 300 } as Response;
 }
+
+describe('redactUrl', () => {
+  it('redacts credential-bearing query params, keeps the rest', () => {
+    expect(redactUrl('http://api/x?access_token=secret&page=2')).toBe(
+      'http://api/x?access_token=%5BREDACTED%5D&page=2',
+    );
+    expect(redactUrl('/magic?api_key=abc')).toBe('/magic?api_key=%5BREDACTED%5D');
+  });
+
+  it('leaves URLs with no sensitive params byte-for-byte unchanged', () => {
+    expect(redactUrl('http://api/x?page=2&sort=asc')).toBe('http://api/x?page=2&sort=asc');
+    expect(redactUrl('http://api/x')).toBe('http://api/x');
+  });
+
+  it('preserves a trailing #hash', () => {
+    expect(redactUrl('/p?token=t#section')).toBe('/p?token=%5BREDACTED%5D#section');
+  });
+});
 
 describe('installNetwork (fetch)', () => {
   let teardown: Teardown | undefined;

--- a/packages/browser/src/observers/network.ts
+++ b/packages/browser/src/observers/network.ts
@@ -1,5 +1,31 @@
-import { EventType } from '@reticlehq/protocol';
+import { EventType, REDACTED_VALUE } from '@reticlehq/protocol';
+import { isSensitiveKey } from '../security/serialization.js';
 import type { Emit, Teardown } from './types.js';
+
+/**
+ * Redact credential-bearing query params (`?access_token=…`, signed-URL keys, magic-link tokens) so
+ * they don't leak into the agent transcript / flow / run artifacts. Only the query string is rewritten
+ * — the path (relative or absolute) and any hash are preserved — and only when something actually
+ * matched, so non-sensitive URLs pass through byte-for-byte. Uses the shared `isSensitiveKey` regex.
+ */
+export function redactUrl(raw: string): string {
+  const queryStart = raw.indexOf('?');
+  if (queryStart === -1) return raw;
+  const base = raw.slice(0, queryStart);
+  const rest = raw.slice(queryStart + 1);
+  const hashStart = rest.indexOf('#');
+  const query = hashStart === -1 ? rest : rest.slice(0, hashStart);
+  const hash = hashStart === -1 ? '' : rest.slice(hashStart);
+  const params = new URLSearchParams(query);
+  let changed = false;
+  for (const key of [...params.keys()]) {
+    if (isSensitiveKey(key)) {
+      params.set(key, REDACTED_VALUE);
+      changed = true;
+    }
+  }
+  return changed ? `${base}?${params.toString()}${hash}` : raw;
+}
 
 interface XhrMeta {
   id: string;
@@ -38,7 +64,7 @@ export function installNetwork(emit: Emit): Teardown {
     const id = nextId();
     const start = performance.now();
     const method = methodOf(input, init);
-    const url = urlOf(input);
+    const url = redactUrl(urlOf(input));
     emit(EventType.NET_PENDING, { id, method, url, initiator: 'fetch' });
     try {
       const res = await callFetch(input, init);
@@ -81,7 +107,12 @@ export function installNetwork(emit: Emit): Teardown {
     url: string | URL,
     ...rest: unknown[]
   ): void {
-    meta.set(this, { id: nextId(), method: method.toUpperCase(), url: String(url), start: 0 });
+    meta.set(this, {
+      id: nextId(),
+      method: method.toUpperCase(),
+      url: redactUrl(String(url)),
+      start: 0,
+    });
     callOpen.call(this, method, url, ...rest);
   };
 


### PR DESCRIPTION
Fixes MEDIUM finding M3 from `plan/SECURITY-AUDIT.md`.

## Problem
The network observer captured request `url` verbatim. Tokens/keys in query strings (`?access_token=…`, signed S3 URLs, magic-link tokens) reached the agent transcript and flow/run artifacts.

## Fix
`redactUrl()` rewrites sensitive query params (shared `isSensitiveKey` regex) to `[REDACTED]`, applied at both the fetch and XHR capture points. Only the query is touched, only when a param matched — non-sensitive URLs pass through unchanged.

## Tests
`network.test.ts`: `redactUrl` unit cases (redacts, leaves clean URLs untouched, preserves `#hash`).

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)