### PR TITLE
fix(server): neutralize cmd.exe injection in Windows browser launch (M4)

### DIFF
--- a/packages/server/src/cli-launch.test.ts
+++ b/packages/server/src/cli-launch.test.ts
@@ -47,6 +47,17 @@ describe('openCommand — per-platform OS open', () => {
   it('Linux uses `xdg-open`', () => {
     expect(openCommand('http://x', 'linux')).toEqual({ cmd: 'xdg-open', args: ['http://x'] });
   });
+  it('Windows percent-encodes cmd metacharacters so a URL cannot break out of `start`', () => {
+    const { args } = openCommand('http://x/?a=1&b=2^c|calc', 'win32');
+    const encoded = args[3] ?? '';
+    expect(encoded).toBe('http://x/?a=1%26b=2%5Ec%7Ccalc');
+    for (const dangerous of ['&', '^', '|', '<', '>']) {
+      expect(encoded.includes(dangerous)).toBe(false);
+    }
+  });
+  it('Windows leaves existing percent-encoding intact (no double-encoding)', () => {
+    expect(openCommand('http://x/?q=a%20b', 'win32').args[3]).toBe('http://x/?q=a%20b');
+  });
 });
 
 describe('openInBrowser', () => {

--- a/packages/server/src/cli-launch.ts
+++ b/packages/server/src/cli-launch.ts
@@ -109,13 +109,24 @@ export function decideOpen(sessions: { url: string }[], url: string | undefined)
   return match !== undefined ? { action: 'reuse', url: match.url } : { action: 'open', url };
 }
 
+/**
+ * Percent-encode the cmd.exe metacharacters that `start` re-parses so a URL can't break out into
+ * command execution on Windows (`?next=x&calc` → command chaining). `%` is left untouched so an
+ * already-encoded URL isn't double-encoded; the browser decodes the escapes back to the real URL.
+ */
+function encodeForWindowsStart(url: string): string {
+  return url.replace(/[&^|<>()"'!]/g, (ch) => `%${ch.charCodeAt(0).toString(16).toUpperCase()}`);
+}
+
 /** The OS command that opens a URL in the default browser, per platform. Pure — unit-tested. */
 export function openCommand(
   url: string,
   platform: NodeJS.Platform,
 ): { cmd: string; args: string[] } {
   if (platform === 'darwin') return { cmd: 'open', args: [url] };
-  if (platform === 'win32') return { cmd: 'cmd', args: ['/c', 'start', '', url] };
+  if (platform === 'win32') {
+    return { cmd: 'cmd', args: ['/c', 'start', '', encodeForWindowsStart(url)] };
+  }
   return { cmd: 'xdg-open', args: [url] };
 }
 


### PR DESCRIPTION
Fixes MEDIUM finding M4 from `plan/SECURITY-AUDIT.md`.

## Problem
`cli-launch.ts` opened URLs on Windows via `{ cmd: 'cmd', args: ['/c','start','',url] }`. `cmd.exe` re-parses `start`'s args, so `&`/`^`/`|` in a URL (which can originate from a connected tab's self-reported `location`) can break out into command execution.

## Fix
`encodeForWindowsStart()` percent-encodes the cmd metacharacters (`&^|<>()"'!`) before they reach `start`. `%` is intentionally left untouched so an already-encoded URL isn't double-encoded; the browser decodes the escapes back to the real URL. macOS/Linux paths unchanged.

## Tests
`cli-launch.test.ts`: metacharacters encoded and absent from the arg; existing `%20` encoding left intact.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)