### PR TITLE
fix(server): treat missing WS Origin as untrusted unless a token is set (M1)

### DIFF
--- a/packages/server/src/agent-presence.e2e.test.ts
+++ b/packages/server/src/agent-presence.e2e.test.ts
@@ -62,7 +62,9 @@ class FakeBrowser {
     private readonly sessionId: string,
   ) {
     const host = '127.0.0.1';
-    this.#ws = new WebSocket(`ws://${host}:${String(port)}${RETICLE_WS_PATH}`);
+    this.#ws = new WebSocket(`ws://${host}:${String(port)}${RETICLE_WS_PATH}`, {
+      origin: 'http://localhost',
+    });
   }
   open(): Promise<void> {
     return new Promise((resolve) => {

--- a/packages/server/src/bridge.replay.test.ts
+++ b/packages/server/src/bridge.replay.test.ts
@@ -25,7 +25,9 @@ class PanelClient {
     private readonly sessionId: string,
   ) {
     const host = '127.0.0.1';
-    this.#ws = new WebSocket(`ws://${host}:${String(port)}${RETICLE_WS_PATH}`);
+    this.#ws = new WebSocket(`ws://${host}:${String(port)}${RETICLE_WS_PATH}`, {
+      origin: 'http://localhost',
+    });
   }
   open(): Promise<void> {
     return new Promise((resolve) => {

--- a/packages/server/src/bridge.security.test.ts
+++ b/packages/server/src/bridge.security.test.ts
@@ -30,10 +30,12 @@ async function makeBridge(options: Omit<ConstructorParameters<typeof Bridge>[0],
   return { bridge, port: await bridge.ready };
 }
 
-function openSocket(port: number, origin?: string): Promise<WebSocket> {
+// Default to a loopback Origin — a real browser SDK always sends one. Pass `null` to simulate a
+// non-browser local process that omits Origin entirely (the M1 case).
+function openSocket(port: number, origin: string | null = 'http://localhost'): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
     const socket = new WebSocket(`ws://127.0.0.1:${String(port)}${RETICLE_WS_PATH}`, {
-      ...(origin === undefined ? {} : { origin }),
+      ...(origin === null ? {} : { origin }),
     });
     sockets.push(socket);
     socket.once('open', () => resolve(socket));
@@ -94,6 +96,19 @@ describe('Bridge security boundary', () => {
     good.send(JSON.stringify(hello('good', 'shared-secret')));
     await waitUntil(() => bridge.sessions.count() === 1);
     expect(bridge.sessions.get('good')).toBeDefined();
+  });
+
+  it('rejects a handshake with no Origin when no token is configured (non-browser local process)', async () => {
+    const { port } = await makeBridge();
+    await expect(openSocket(port, null)).rejects.toThrow(/Unexpected server response: 403/);
+  });
+
+  it('allows a no-Origin handshake when a token is configured (HELLO token check is the gate)', async () => {
+    const { bridge, port } = await makeBridge({ token: 'shared-secret' });
+    const socket = await openSocket(port, null);
+    socket.send(JSON.stringify(hello('nobrowser', 'shared-secret')));
+    await waitUntil(() => bridge.sessions.count() === 1);
+    expect(bridge.sessions.get('nobrowser')).toBeDefined();
   });
 
   it('requires a token before binding beyond localhost', () => {

--- a/packages/server/src/bridge.test-harness.ts
+++ b/packages/server/src/bridge.test-harness.ts
@@ -43,7 +43,10 @@ export class FakeBrowser {
     private readonly sessionId: string,
     private readonly hasCapabilities = false,
   ) {
-    this.#ws = new WebSocket(`ws://${LOOPBACK_HOST}:${String(port)}${RETICLE_WS_PATH}`);
+    // Real browsers always send an Origin on the WS handshake; simulate a loopback app page.
+    this.#ws = new WebSocket(`ws://${LOOPBACK_HOST}:${String(port)}${RETICLE_WS_PATH}`, {
+      origin: 'http://localhost',
+    });
   }
 
   open(): Promise<void> {

--- a/packages/server/src/bridge.ts
+++ b/packages/server/src/bridge.ts
@@ -270,7 +270,10 @@ export class Bridge {
   }
 
   #originAllowed(origin: string | undefined): boolean {
-    if (origin === undefined) return true;
+    // A real browser SDK connection always carries an Origin. A missing Origin means a non-browser
+    // local process (another app, a malicious npm postinstall, an extension's native host) — untrusted
+    // unless a pairing token is required, in which case the HELLO token check is the real gate.
+    if (origin === undefined) return this.#token !== undefined;
     const normalized = normalizeOrigin(origin);
     if (normalized === null) return false;
     if (this.#allowedOrigins.has(normalized)) return true;

--- a/packages/server/src/multi-project.test.ts
+++ b/packages/server/src/multi-project.test.ts
@@ -414,7 +414,9 @@ describe('messy human scenarios', () => {
 
     function connectWithUrl(sessionId: string, url: string): Promise<void> {
       return new Promise((resolve) => {
-        const sock = new ws.WebSocket(`ws://${LOOPBACK_HOST}:${String(port)}${RETICLE_WS_PATH}`);
+        const sock = new ws.WebSocket(`ws://${LOOPBACK_HOST}:${String(port)}${RETICLE_WS_PATH}`, {
+          origin: 'http://localhost',
+        });
         sock.on('open', () => {
           sock.send(
             JSON.stringify({

--- a/packages/server/src/session/session-manager.scope.test.ts
+++ b/packages/server/src/session/session-manager.scope.test.ts
@@ -29,7 +29,9 @@ afterEach(async () => {
 /** Connect a raw session announcing a sessionId, url, and (optionally) a stable projectId. */
 function connect(opts: { sessionId: string; url: string; projectId?: string }): Promise<void> {
   return new Promise((resolve) => {
-    const sock = new WebSocket(`ws://${LOOPBACK_HOST}:${String(port)}${RETICLE_WS_PATH}`);
+    const sock = new WebSocket(`ws://${LOOPBACK_HOST}:${String(port)}${RETICLE_WS_PATH}`, {
+      origin: 'http://localhost',
+    });
     open.push(sock);
     sock.on('open', () => {
       sock.send(


### PR DESCRIPTION
Fixes MEDIUM finding M1 from `plan/SECURITY-AUDIT.md`.

## Problem
`Bridge.#originAllowed` returned `true` when `origin === undefined`. Browsers always send `Origin`, but a non-browser local process (another app, a malicious npm postinstall, a browser extension's native host) can open a WS with no `Origin` and, in tokenless mode, register/drive a session.

## Fix
A missing `Origin` is now trusted only when a pairing token is configured — in which case the HELLO token check is the real gate. A real browser SDK always sends `Origin`, so the zero-config dev flow is unaffected; only tokenless non-browser clients are blocked.

## Tests
- `bridge.security.test.ts`: no-Origin handshake → 403 tokenless; no-Origin allowed then gated by HELLO token when a token is set.
- Test WS helpers updated to send a loopback `Origin` (they stand in for a browser, which always sends one).

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)