### PR TITLE
fix(server): bake issuer public key, fail closed on enterprise gate (H2)

### DIFF
--- a/packages/server/src/license/license.test.ts
+++ b/packages/server/src/license/license.test.ts
@@ -122,4 +122,30 @@ describe('env-resolved activation (describeLicense / assertEnterpriseFromEnv)', 
       EnterpriseLicenseError,
     );
   });
+
+  it('a baked-in issuer key fails closed: enforcement cannot be disabled by unsetting env', () => {
+    // Simulates a release build (baked key present) with an operator who never sets the env var.
+    // Old behavior: eval mode, features free. New behavior: enforced, throws without a valid key.
+    expect(() => assertEnterpriseFromEnv('audit-log', NOW, {}, PUBKEY_PEM)).toThrow(
+      EnterpriseLicenseError,
+    );
+    expect(describeLicense(NOW, {}, PUBKEY_PEM).status).toBe('missing');
+    // A valid customer key still activates against the baked issuer key.
+    expect(describeLicense(NOW, { [LICENSE_KEY_ENV]: key() }, PUBKEY_PEM).status).toBe('active');
+  });
+
+  it('the baked issuer key wins over an env public key (operator cannot swap in their own)', () => {
+    const attacker = generateKeyPairSync('ed25519');
+    const attackerPem = attacker.publicKey.export({ type: 'spki', format: 'pem' }).toString();
+    // Operator bakes nothing but tries to point env at THEIR key + a self-signed license — with a real
+    // baked key, the env key is ignored, so their self-signed license fails signature verification.
+    const selfSigned = signLicenseKey(payload(), attacker.privateKey);
+    expect(
+      describeLicense(
+        NOW,
+        { [LICENSE_PUBLIC_KEY_ENV]: attackerPem, [LICENSE_KEY_ENV]: selfSigned },
+        PUBKEY_PEM,
+      ).status,
+    ).toBe('invalid');
+  });
 });

--- a/packages/server/src/license/license.ts
+++ b/packages/server/src/license/license.ts
@@ -147,6 +147,29 @@ export function assertEnterprise(feature: string, ctx: GateContext): void {
 export const LICENSE_KEY_ENV = 'RETICLE_LICENSE_KEY';
 export const LICENSE_PUBLIC_KEY_ENV = 'RETICLE_LICENSE_PUBLIC_KEY';
 
+/**
+ * Issuer public key COMPILED INTO the build. Empty in the source tree; the release pipeline replaces
+ * this literal with the real spki PEM. Baking it (rather than only reading env) is what makes the
+ * enterprise gate fail closed: a self-hosted operator can no longer disable enforcement by simply
+ * never setting RETICLE_LICENSE_PUBLIC_KEY, because the baked key takes precedence. The public key is
+ * safe to ship openly — it can only verify licenses, never mint them (that needs the private key).
+ */
+export const BAKED_ISSUER_PUBLIC_KEY_PEM = '';
+
+/**
+ * Resolve the issuer public-key PEM enforcement uses: the baked-in release key wins, so it can't be
+ * turned off from the environment. Only when nothing is baked (dev/repo) does the env var apply — that
+ * env path is the test/self-eval escape hatch, not the production switch.
+ */
+export function resolveIssuerPublicKeyPem(
+  env: NodeJS.ProcessEnv,
+  baked: string = BAKED_ISSUER_PUBLIC_KEY_PEM,
+): string | undefined {
+  if (baked.length > 0) return baked;
+  const envPem = env[LICENSE_PUBLIC_KEY_ENV];
+  return envPem !== undefined && envPem.length > 0 ? envPem : undefined;
+}
+
 /** The human-facing state of enterprise activation on this machine (what `reticle license status` shows). */
 interface LicenseReport {
   status: 'active' | 'missing' | 'invalid' | 'expired' | 'eval';
@@ -171,8 +194,12 @@ function loadPublicKey(pem: string | undefined): KeyObject | undefined {
  * issuer public key, the operator sets RETICLE_LICENSE_KEY. No public key configured ⇒ evaluation mode
  * (enterprise features run free, dev/test only). Offline, no phone-home.
  */
-export function describeLicense(now: number, env: NodeJS.ProcessEnv = process.env): LicenseReport {
-  const pem = env[LICENSE_PUBLIC_KEY_ENV];
+export function describeLicense(
+  now: number,
+  env: NodeJS.ProcessEnv = process.env,
+  baked: string = BAKED_ISSUER_PUBLIC_KEY_PEM,
+): LicenseReport {
+  const pem = resolveIssuerPublicKeyPem(env, baked);
   if (pem === undefined || pem.length === 0) {
     return {
       status: 'eval',
@@ -218,8 +245,9 @@ export function assertEnterpriseFromEnv(
   feature: string,
   now: number,
   env: NodeJS.ProcessEnv = process.env,
+  baked: string = BAKED_ISSUER_PUBLIC_KEY_PEM,
 ): void {
-  const publicKey = loadPublicKey(env[LICENSE_PUBLIC_KEY_ENV]);
+  const publicKey = loadPublicKey(resolveIssuerPublicKeyPem(env, baked));
   const key = env[LICENSE_KEY_ENV];
   assertEnterprise(feature, {
     requireLicense: publicKey !== undefined,


### PR DESCRIPTION
Fixes HIGH finding H2 from `plan/SECURITY-AUDIT.md`.

## Problem
Enterprise enforcement was on only if `RETICLE_LICENSE_PUBLIC_KEY` happened to be in the environment. Since the server is source-available and self-hosted, any operator got full enterprise features by simply never setting that env var (`describeLicense` → `eval`, features free).

## Fix
Added a compiled-in `BAKED_ISSUER_PUBLIC_KEY_PEM` (empty in-repo; the release pipeline replaces the literal with the real spki PEM). `resolveIssuerPublicKeyPem` prefers the baked key over env, so:
- Once a real key is baked, enforcement **cannot** be disabled by unsetting the env var (fail closed).
- An operator can't swap in their own issuer key via env to self-sign licenses.
- With nothing baked (dev/repo) the env path still works as the test/self-eval escape hatch.

The public key is safe to ship — it only verifies, never mints.

## Tests
`license.test.ts`: baked key + no env → enforced/`missing` (not `eval`); valid customer key still `active`; baked key wins over an attacker env public key (self-signed license → `invalid`).

## Follow-up
Depends on H3 (#6) rotation producing the real issuer keypair, whose public half gets baked here at release. The repo stays in eval mode until then.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)