### PR TITLE
fix(browser): production runtime backstop for the SDK (L1)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -419,4 +419,4 @@ The errors Reticle returns to the agent now carry a `recovery` hint for this exa
 
 **Nothing should run in production**
 
-- Keep `reticle.connect()` behind a dev guard (`import.meta.env.DEV` / `NODE_ENV`). The package is side-effect free and tree-shakes out when unused.
+- Keep `reticle.connect()` behind a dev guard (`import.meta.env.DEV` / `NODE_ENV`). The package is side-effect free and tree-shakes out when unused. As a backstop, `connect()` also self-disables when the build reports `NODE_ENV=production` (so an SSR healthcheck or a prod bundle opened on localhost won't activate it) — pass `allowInProduction: true` only for a deliberate prod diagnostic.

--- a/packages/browser/src/reticle.session.test.ts
+++ b/packages/browser/src/reticle.session.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { SESSION_AUTO, TRANSPORT_LIMITS } from '@reticlehq/protocol';
-import { connectionPolicy, resolveSessionLabel } from './reticle.js';
+import { connectionPolicy, resolveSessionLabel, shouldBlockProduction } from './reticle.js';
 
 describe('resolveSessionLabel', () => {
   const gen = (): string => 'unique-123';
@@ -74,5 +74,21 @@ describe('connectionPolicy', () => {
 
   it('rejects non-WebSocket bridge URLs', () => {
     expect(connectionPolicy('localhost', 'javascript:alert(1)', true, 'token').allowed).toBe(false);
+  });
+});
+
+describe('shouldBlockProduction', () => {
+  it('blocks a production build by default', () => {
+    expect(shouldBlockProduction('production', false)).toBe(true);
+  });
+
+  it('allows dev/test/undefined NODE_ENV (the normal dev-only case)', () => {
+    expect(shouldBlockProduction('development', false)).toBe(false);
+    expect(shouldBlockProduction('test', false)).toBe(false);
+    expect(shouldBlockProduction(undefined, false)).toBe(false);
+  });
+
+  it('honors the explicit allowInProduction override', () => {
+    expect(shouldBlockProduction('production', true)).toBe(false);
   });
 });

--- a/packages/browser/src/reticle.ts
+++ b/packages/browser/src/reticle.ts
@@ -58,6 +58,13 @@ export interface ReticleConnectOptions {
   token?: string;
   /** Explicitly allow Reticle on a non-localhost page or bridge. Requires token. */
   allowNonLocalhost?: boolean;
+  /**
+   * Escape hatch for the production backstop. Reticle is dev-only and refuses to connect when the
+   * build reports NODE_ENV=production (an SSR healthcheck or a prod bundle opened locally would
+   * otherwise activate). The real fix is to gate the import behind `import.meta.env.DEV` so it's
+   * tree-shaken out; this flag only exists for the rare intentional prod diagnostic.
+   */
+  allowInProduction?: boolean;
   /** Show a small in-page status chip (connection + event count). */
   overlay?: boolean;
   /** Presenter mode: glow border, animated cursor, click/hover effects, narration HUD. */
@@ -88,6 +95,19 @@ export interface ReticleConnectOptions {
   endedFadeMs?: number;
   /** Session auto-end after this much agent idle (presenter). Default 5min; agent-tunable via reticle_session. */
   idleEndMs?: number;
+}
+
+/**
+ * Runtime backstop for the dev-only SDK: block connecting when the build reports production, unless
+ * explicitly overridden. Pure so it's testable; connect() reads NODE_ENV safely (process may be absent
+ * in a raw browser). This is defense-in-depth — the primary guard is the consumer gating the import
+ * behind `import.meta.env.DEV` so the SDK is dead-code-eliminated from prod bundles entirely.
+ */
+export function shouldBlockProduction(
+  nodeEnv: string | undefined,
+  allowInProduction: boolean,
+): boolean {
+  return nodeEnv === 'production' && !allowInProduction;
 }
 
 export function connectionPolicy(
@@ -204,6 +224,18 @@ export class Reticle {
   connect(options: ReticleConnectOptions = {}): void {
     if (this.#connected) return;
     if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+    // Dev-only backstop: refuse to activate in a production build (SSR healthcheck, prod bundle opened
+    // on localhost). `process` may not exist in a raw browser, so read NODE_ENV off globalThis.
+    const proc = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
+    const nodeEnv = proc?.env?.NODE_ENV;
+    if (shouldBlockProduction(nodeEnv, options.allowInProduction === true)) {
+      globalThis.console.warn(
+        '[Reticle] disabled in production (NODE_ENV=production). Gate the import behind ' +
+          'import.meta.env.DEV, or pass allowInProduction:true to override.',
+      );
+      return;
+    }
 
     const url = options.url ?? `ws://localhost:${String(RETICLE_DEFAULT_PORT)}${RETICLE_WS_PATH}`;
     const policy = connectionPolicy(


### PR DESCRIPTION
Fixes LOW finding L1 from `plan/SECURITY-AUDIT.md`.

## Problem
The "tree-shaken out of prod" guarantee depended solely on the consumer gating the import behind `import.meta.env.DEV`. A prod build accessed via localhost (SSR healthcheck, a dev opening the prod bundle locally) would activate the SDK.

## Fix
`connect()` now self-disables when the build reports `NODE_ENV=production` (read defensively off `globalThis.process`, safe in a raw browser). Pure, tested `shouldBlockProduction()` helper; `allowInProduction: true` overrides for a deliberate prod diagnostic. DCE via `import.meta.env.DEV` remains the primary guard.

## Tests
`reticle.session.test.ts`: `shouldBlockProduction` blocks `production`, allows dev/test/undefined, honors the override.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)