### PR TITLE
feat(security): auto-provision a pairing token so loopback origins need a secret (M2)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -269,7 +269,10 @@ export function ReticleDev() {
     if (process.env.NODE_ENV !== 'development') return;
     void import('@reticlehq/core').then(({ reticle, install, registerCapabilities }) => {
       install();
-      reticle.connect();
+      // The bridge requires a pairing token. Vite users get it auto-injected; hand-wired Next passes it
+      // in: set RETICLE_TOKEN for the daemon and expose the same value as NEXT_PUBLIC_RETICLE_TOKEN.
+      const token = process.env.NEXT_PUBLIC_RETICLE_TOKEN;
+      reticle.connect(token ? { token } : {});
       registerCapabilities({
         testids: [], // your data-testid values
         signals: [], // your reticle.signal() names

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -149,6 +149,13 @@ On React 19 you then also need the source-mapping Babel plugin from Step 3. The 
 
 </details>
 
+### The pairing token (why some setups need one line more)
+
+The daemon auto-generates a **pairing token** on first run and stores it at `~/.reticle/pairing-token` (owner-only, `0600`). The bridge requires it, so another app running on `http://localhost:<some-other-port>` can't quietly register or drive your session — only code that can read that file (your dev server, not a web page) can present it.
+
+- **Vite plugin users:** nothing to do. The plugin reads the token server-side and injects it into `connect()` for you.
+- **Next.js / hand-wired `connect()`:** your `connect()` runs in the browser and can't read the file, so pass the token in yourself. The simplest path is a shared secret: set `RETICLE_TOKEN` for the daemon (it uses that instead of auto-generating) and expose the same value to the client as `NEXT_PUBLIC_RETICLE_TOKEN`, then pass it to `connect({ token })` (see below). On a single-user machine you can also just read `~/.reticle/pairing-token` in your dev tooling and forward it the same way.
+
 ### Next.js
 
 Create a tiny client component and mount it in your root layout, dev-only:
@@ -162,8 +169,10 @@ export function ReticleDev() {
   useEffect(() => {
     if (process.env.NODE_ENV === 'development') {
       // SESSION_AUTO = a unique id per tab, so several Next apps/tabs never collide on one session.
+      // NEXT_PUBLIC_RETICLE_TOKEN carries the pairing token to the browser (see "The pairing token").
+      const token = process.env.NEXT_PUBLIC_RETICLE_TOKEN;
       void import('@reticlehq/core').then(({ reticle, SESSION_AUTO }) =>
-        reticle.connect({ session: SESSION_AUTO }),
+        reticle.connect({ session: SESSION_AUTO, ...(token ? { token } : {}) }),
       );
     }
   }, []);
@@ -193,7 +202,9 @@ Anywhere your app boots in dev:
 
 ```ts
 import { reticle, SESSION_AUTO } from '@reticlehq/core';
-if (location.hostname === 'localhost') reticle.connect({ session: SESSION_AUTO });
+// Pass the pairing token (see "The pairing token" above); on a hand-wired setup you supply it yourself.
+if (location.hostname === 'localhost')
+  reticle.connect({ session: SESSION_AUTO, token: import.meta.env.VITE_RETICLE_TOKEN });
 ```
 
 Or, with no build step, a script tag pointed at the bridge:

--- a/packages/protocol/src/constants.ts
+++ b/packages/protocol/src/constants.ts
@@ -44,6 +44,8 @@ export const ReticleEnv = {
   /** Ms of continuous idleness (no agent, no browser session, no lease) before the daemon self-exits;
    * `0` disables. Keeps Reticle from lingering on a user's machine after the editor closes. */
   IDLE_SHUTDOWN: 'RETICLE_IDLE_SHUTDOWN_MS',
+  /** Directory holding the auto-provisioned pairing token. Defaults to ~/.reticle; relocatable for CI. */
+  PAIRING_TOKEN_DIR: 'RETICLE_PAIRING_TOKEN_DIR',
 } as const;
 
 /** Hard transport bounds shared by the browser and bridge. */
@@ -95,6 +97,12 @@ export const ReticleDir = {
   VISUAL_SUBDIR: 'visual',
   /** verification-run artifacts — .reticle/runs/<runId>.json (the OEM/CI-consumable verdict). */
   RUNS_SUBDIR: 'runs',
+  /**
+   * Auto-provisioned bridge pairing token, stored at ~/.reticle/pairing-token (mode 0600). Written by
+   * the daemon, read Node-side by the build plugins to inject into connect(). A browser sandbox cannot
+   * read it, so a rogue localhost app can't present it — that's what stops cross-app session hijack.
+   */
+  PAIRING_TOKEN_FILE: 'pairing-token',
 } as const;
 
 /**

--- a/packages/server/src/bridge-security.ts
+++ b/packages/server/src/bridge-security.ts
@@ -1,5 +1,11 @@
 import { ReticleEnv } from '@reticlehq/protocol';
 import type { StartOptions } from './index.js';
+import {
+  defaultPairingTokenDir,
+  nodePairingTokenDeps,
+  readOrCreatePairingToken,
+} from './pairing-token.js';
+import { log } from './log.js';
 
 /** The security contract the bridge/daemon enforce: bind host, pairing token, and WS origin allow-list. */
 interface BridgeSecurity {
@@ -30,4 +36,25 @@ export function resolveBridgeSecurity(options: StartOptions): BridgeSecurity {
     ...(token === undefined ? {} : { token }),
     ...(allowedOrigins === undefined ? {} : { allowedOrigins }),
   };
+}
+
+/**
+ * Same as `resolveBridgeSecurity`, but when no explicit/env token is set it auto-provisions one from
+ * ~/.reticle/pairing-token so the bridge always requires a secret by default — this is what closes the
+ * "any loopback origin is trusted" gap (a rogue localhost app can't read the file to present it). The
+ * build plugins read the same file and inject it, so plugin-served apps stay zero-config. Best-effort:
+ * if provisioning fails, the daemon degrades to the prior tokenless behavior rather than failing to start.
+ */
+export async function resolveBridgeSecurityWithAutoToken(
+  options: StartOptions,
+): Promise<BridgeSecurity> {
+  const security = resolveBridgeSecurity(options);
+  if (security.token !== undefined) return security;
+  const dir = options.pairingTokenDir ?? defaultPairingTokenDir();
+  const token = await readOrCreatePairingToken(dir, nodePairingTokenDeps());
+  if (token === undefined) {
+    log('pairing_token_provision_failed', { dir });
+    return security;
+  }
+  return { ...security, token };
 }

--- a/packages/server/src/index.daemon.test.ts
+++ b/packages/server/src/index.daemon.test.ts
@@ -71,7 +71,8 @@ describe('startDaemon port collision', () => {
     const dir = await mkdtemp(join(tmpdir(), 'reticle-daemon-collide-'));
     root = join(dir, '.reticle');
     await expect(
-      startDaemon({ port, reticleRoot: root, now: () => 1_700_000_000_000 }),
+      // pairingTokenDir → temp so auto-provisioning never writes to the real ~/.reticle in tests.
+      startDaemon({ port, reticleRoot: root, pairingTokenDir: root, now: () => 1_700_000_000_000 }),
     ).rejects.toThrow();
   });
 });

--- a/packages/server/src/index.drive.test.ts
+++ b/packages/server/src/index.drive.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { DriveErrorCode, InputMode, SessionState } from '@reticlehq/protocol';
 import type { CommandResult } from '@reticlehq/protocol';
 import { start, type RunningServer } from './index.js';
+import { PAIRING_TOKEN_DIR_ENV } from './pairing-token.js';
+
+// start() auto-provisions a pairing token; keep it out of the real ~/.reticle during tests.
+process.env[PAIRING_TOKEN_DIR_ENV] = join(tmpdir(), 'reticle-drive-token-test');
 import { TOOLS, type ToolDeps } from './tools/tools.js';
 import { ReticleTool } from './tools/tool-names.js';
 import { BaselineStore } from './project/baselines.js';

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -13,7 +13,7 @@ import {
 import type { FlowReplayResult } from '@reticlehq/protocol';
 import { replayNamedFlow } from './flows/flow-tools.js';
 import { createSharedServer } from './http-server.js';
-import { resolveBridgeSecurity } from './bridge-security.js';
+import { resolveBridgeSecurityWithAutoToken } from './bridge-security.js';
 import { Bridge } from './bridge.js';
 import { BaselineStore } from './project/baselines.js';
 import { RecordingStore } from './flows/recordings.js';
@@ -178,6 +178,8 @@ export interface StartOptions {
   storageState?: string;
   /** absolute .reticle root. Defaults to process.cwd()/.reticle. Injectable for tests. */
   reticleRoot?: string;
+  /** Directory holding the auto-provisioned pairing token. Defaults to ~/.reticle. Injectable for tests. */
+  pairingTokenDir?: string;
   /** injectable clock for contract.json's generatedAt stamp. Defaults to Date.now. */
   now?: () => number;
   /** 'core' exposes the lean tool surface. Defaults to env RETICLE_TOOL_PROFILE, else 'full'. */
@@ -202,6 +204,8 @@ export interface RunningServer {
   /** True when nothing is using the daemon: no agent connected, no browser session, no pool lease.
    * The daemon entry (cli.ts) polls this to self-shut-down when idle so Reticle never lingers. */
   isIdle?: () => boolean;
+  /** The pairing token the bridge is enforcing (explicit, env, or auto-provisioned); undefined if none. */
+  token?: string;
   close: () => Promise<void>;
 }
 
@@ -225,7 +229,8 @@ function createBrowserPool(headless: boolean): BrowserPool {
 /** Start the Reticle bridge (browser WS endpoint) and, by default, the MCP stdio server. */
 export async function start(options: StartOptions = {}): Promise<RunningServer> {
   const port = options.port ?? RETICLE_DEFAULT_PORT;
-  const bridge = new Bridge({ port, ...resolveBridgeSecurity(options) });
+  const security = await resolveBridgeSecurityWithAutoToken(options);
+  const bridge = new Bridge({ port, ...security });
   // Server-authoritative liveness: a Node-side reaper (immune to browser throttling) ends sessions
   // whose agent has gone idle, so a forgotten/crashed agent never leaves the HUD "running" forever.
   const reaper = new SessionReaper(bridge.sessions);
@@ -316,6 +321,7 @@ export async function start(options: StartOptions = {}): Promise<RunningServer> 
   return {
     bridge,
     ...(realInput !== undefined ? { realInput } : {}),
+    ...(security.token !== undefined ? { token: security.token } : {}),
     close: async () => {
       reaper.stop();
       leaseReaper?.stop();
@@ -335,7 +341,7 @@ export async function start(options: StartOptions = {}): Promise<RunningServer> 
 export async function startDaemon(options: StartOptions = {}): Promise<RunningServer> {
   const port = options.port ?? RETICLE_DEFAULT_PORT;
 
-  const security = resolveBridgeSecurity(options);
+  const security = await resolveBridgeSecurityWithAutoToken(options);
   const shared = createSharedServer(security.token === undefined ? {} : { token: security.token });
   const bridge = new Bridge({ port, server: shared.httpServer, ...security });
   // The daemon owns listen() (below), so the real bind error is reported there; absorb bridge.ready's
@@ -489,6 +495,7 @@ export async function startDaemon(options: StartOptions = {}): Promise<RunningSe
     bridge,
     ...(realInput !== undefined ? { realInput } : {}),
     ...(verifyHttp !== undefined ? { verifyPort: verifyHttp.port } : {}),
+    ...(security.token !== undefined ? { token: security.token } : {}),
     // Idle = nobody is using the daemon: no agent attached, no browser tab connected, no pool lease.
     // The daemon entry self-shuts-down after this holds for the grace window (see cli.ts / IdleShutdown).
     isIdle: () => !agentConnected && bridge.sessions.count() === 0 && pool.activeCount() === 0,

--- a/packages/server/src/pairing-token.test.ts
+++ b/packages/server/src/pairing-token.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  pairingTokenPath,
+  readOrCreatePairingToken,
+  type PairingTokenDeps,
+} from './pairing-token.js';
+
+/** In-memory IO adapter so the provisioner never touches the real ~/.reticle. */
+function memDeps(
+  seed: Record<string, string> = {},
+  randomToken = (): string => 'generated-token',
+): { deps: PairingTokenDeps; files: Map<string, string>; writes: () => number } {
+  const files = new Map(Object.entries(seed));
+  let writes = 0;
+  const deps: PairingTokenDeps = {
+    readFile: (path) => {
+      const v = files.get(path);
+      if (v === undefined) {
+        return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+      }
+      return Promise.resolve(v);
+    },
+    writeFile: (path, data) => {
+      writes += 1;
+      files.set(path, data);
+      return Promise.resolve();
+    },
+    mkdir: () => Promise.resolve(),
+    randomToken,
+  };
+  return { deps, files, writes: () => writes };
+}
+
+const DIR = '/home/u/.reticle';
+
+describe('readOrCreatePairingToken', () => {
+  it('creates and persists a token on first run', async () => {
+    const { deps, files } = memDeps();
+    const token = await readOrCreatePairingToken(DIR, deps);
+    expect(token).toBe('generated-token');
+    expect(files.get(pairingTokenPath(DIR))).toBe('generated-token');
+  });
+
+  it('returns the existing token on subsequent runs (stable, no rewrite)', async () => {
+    const ctx = memDeps({ [pairingTokenPath(DIR)]: 'existing-secret\n' });
+    const token = await readOrCreatePairingToken(DIR, ctx.deps);
+    expect(token).toBe('existing-secret');
+    expect(ctx.writes()).toBe(0);
+  });
+
+  it('regenerates when the stored token is blank', async () => {
+    const { deps } = memDeps({ [pairingTokenPath(DIR)]: '   ' });
+    expect(await readOrCreatePairingToken(DIR, deps)).toBe('generated-token');
+  });
+
+  it('degrades to undefined (not a throw) when writing fails', async () => {
+    const { deps } = memDeps();
+    deps.writeFile = () => Promise.reject(new Error('EACCES'));
+    expect(await readOrCreatePairingToken(DIR, deps)).toBeUndefined();
+  });
+
+  it('returns undefined rather than an empty token when randomness yields nothing', async () => {
+    const { deps } = memDeps({}, () => '');
+    expect(await readOrCreatePairingToken(DIR, deps)).toBeUndefined();
+  });
+});

--- a/packages/server/src/pairing-token.ts
+++ b/packages/server/src/pairing-token.ts
@@ -1,0 +1,81 @@
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { randomBytes } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { ReticleDir, ReticleEnv } from '@reticlehq/protocol';
+
+/**
+ * Auto-provisioned bridge pairing token. The daemon reads-or-creates a per-user secret at
+ * ~/.reticle/pairing-token; the bridge then requires it, so a rogue localhost app (which, running in a
+ * browser sandbox, cannot read the file) can no longer register/drive sessions just by being on a
+ * loopback origin. The build plugins read the same file Node-side and inject it into connect(), so a
+ * legitimately-served app stays zero-config.
+ */
+
+/** Injectable IO + randomness so the provisioner is unit-testable without touching the real home dir. */
+export interface PairingTokenDeps {
+  readFile: (path: string) => Promise<string>;
+  writeFile: (path: string, data: string) => Promise<void>;
+  mkdir: (path: string) => Promise<void>;
+  randomToken: () => string;
+}
+
+/** 24 random bytes → 48 hex chars: well under MAX_TOKEN_LENGTH, ample entropy for a local secret. */
+const TOKEN_BYTES = 24;
+
+/** Env override for the token directory (`RETICLE_PAIRING_TOKEN_DIR`) — relocate the secret off $HOME. */
+export const PAIRING_TOKEN_DIR_ENV = ReticleEnv.PAIRING_TOKEN_DIR;
+
+/** The default directory that holds the token — the per-user ~/.reticle so it's shared across projects. */
+export function defaultPairingTokenDir(): string {
+  const override = process.env[PAIRING_TOKEN_DIR_ENV];
+  if (override !== undefined && override.length > 0) return override;
+  return join(homedir(), ReticleDir.ROOT);
+}
+
+export function pairingTokenPath(dir: string): string {
+  return join(dir, ReticleDir.PAIRING_TOKEN_FILE);
+}
+
+/** Production IO adapter: 0600 file + 0700 dir so only the owner can read the secret. */
+export function nodePairingTokenDeps(): PairingTokenDeps {
+  return {
+    readFile: (path) => readFile(path, 'utf8'),
+    writeFile: async (path, data) => {
+      await writeFile(path, data, { encoding: 'utf8', mode: 0o600 });
+      // Enforce perms even if the file pre-existed with a looser mode (writeFile keeps old perms).
+      await chmod(path, 0o600);
+    },
+    mkdir: async (path) => {
+      await mkdir(path, { recursive: true, mode: 0o700 });
+    },
+    randomToken: () => randomBytes(TOKEN_BYTES).toString('hex'),
+  };
+}
+
+/**
+ * Read the stored token, or create + persist one on first run. Stable across restarts so a
+ * plugin-injected page keeps working after the daemon bounces. Best-effort: returns undefined if IO
+ * fails, so the caller degrades to the prior tokenless behavior rather than bricking the daemon.
+ */
+export async function readOrCreatePairingToken(
+  dir: string,
+  deps: PairingTokenDeps,
+): Promise<string | undefined> {
+  const path = pairingTokenPath(dir);
+  try {
+    const existing = (await deps.readFile(path)).trim();
+    if (existing.length > 0) return existing;
+  } catch {
+    // Missing/unreadable — fall through to create one.
+  }
+  try {
+    const token = deps.randomToken().trim();
+    if (token.length === 0) return undefined;
+    await deps.mkdir(dir);
+    await deps.writeFile(path, token);
+    return token;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/server/src/runs/verify-daemon.test.ts
+++ b/packages/server/src/runs/verify-daemon.test.ts
@@ -30,6 +30,7 @@ describe('reticle serve --http (daemon wiring)', () => {
       httpVerifyPort: 0,
       httpVerifyToken: 'sek',
       reticleRoot: root,
+      pairingTokenDir: root, // keep the auto-provisioned token out of the real ~/.reticle
       now: () => 1_700_000_000_000,
     });
 

--- a/packages/vite-plugin/src/index.test.ts
+++ b/packages/vite-plugin/src/index.test.ts
@@ -1,7 +1,19 @@
-import { describe, it, expect } from 'vitest';
+import { afterAll, describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { SOURCE_ATTR } from '@reticlehq/babel-plugin';
-import { RETICLE_DEFAULT_PORT } from '@reticlehq/protocol';
+import { RETICLE_DEFAULT_PORT, ReticleDir, ReticleEnv } from '@reticlehq/protocol';
 import { reticle, RETICLE_VITE_PLUGIN_NAME, RETICLE_CONNECT_MODULE } from './index.js';
+
+// Point the token lookup at an empty temp dir so tests never pick up a real ~/.reticle/pairing-token.
+const emptyTokenDir = mkdtempSync(join(tmpdir(), 'reticle-vite-token-'));
+const savedTokenDir = process.env[ReticleEnv.PAIRING_TOKEN_DIR];
+process.env[ReticleEnv.PAIRING_TOKEN_DIR] = emptyTokenDir;
+afterAll(() => {
+  if (savedTokenDir === undefined) delete process.env[ReticleEnv.PAIRING_TOKEN_DIR];
+  else process.env[ReticleEnv.PAIRING_TOKEN_DIR] = savedTokenDir;
+});
 
 describe('reticle vite plugin', () => {
   it('only applies during serve (never ships to production builds)', () => {
@@ -75,6 +87,26 @@ describe('reticle vite plugin', () => {
     const code = reticle({ session: 'my-app', token: 'secret' }).load?.(RETICLE_CONNECT_MODULE);
     expect(code).toContain('my-app');
     expect(code).toContain('secret');
+  });
+
+  it('auto-injects the daemon pairing token from the token dir when no explicit token is set', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'reticle-vite-hastoken-'));
+    writeFileSync(join(dir, ReticleDir.PAIRING_TOKEN_FILE), 'daemon-secret-123\n');
+    const prev = process.env[ReticleEnv.PAIRING_TOKEN_DIR];
+    process.env[ReticleEnv.PAIRING_TOKEN_DIR] = dir;
+    try {
+      const code = reticle().load?.(RETICLE_CONNECT_MODULE);
+      expect(code).toContain('daemon-secret-123');
+      expect(code).toContain('token');
+    } finally {
+      process.env[ReticleEnv.PAIRING_TOKEN_DIR] = prev;
+    }
+  });
+
+  it('omits the token when the daemon has not provisioned one yet (no file)', () => {
+    // Env points at the empty dir from the top of the file — no token file present.
+    const code = reticle().load?.(RETICLE_CONNECT_MODULE);
+    expect(code).not.toContain('"token"');
   });
 
   it('auto-stamps a derived projectId with zero config', () => {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,6 +1,9 @@
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { transformSync } from '@babel/core';
 import reticleSource from '@reticlehq/babel-plugin';
-import { RETICLE_DEFAULT_PORT, RETICLE_WS_PATH } from '@reticlehq/protocol';
+import { RETICLE_DEFAULT_PORT, RETICLE_WS_PATH, ReticleDir, ReticleEnv } from '@reticlehq/protocol';
 import { resolveProjectId } from './project-id.js';
 
 export const RETICLE_VITE_PLUGIN_NAME = 'reticle';
@@ -80,6 +83,24 @@ function stamp(code: string, id: string): { code: string; map: string | null } |
   };
 }
 
+/**
+ * Read the daemon's auto-provisioned pairing token (~/.reticle/pairing-token, or the
+ * RETICLE_PAIRING_TOKEN_DIR override) so the served app can present it. Node-side only — a browser
+ * sandbox can't read the file, which is exactly why a rogue localhost app can't forge it. Best-effort:
+ * undefined if the daemon hasn't started yet (the page reloads once it has). Exported for testing.
+ */
+export function readPairingToken(): string | undefined {
+  const override = process.env[ReticleEnv.PAIRING_TOKEN_DIR];
+  const dir =
+    override !== undefined && override.length > 0 ? override : join(homedir(), ReticleDir.ROOT);
+  try {
+    const token = readFileSync(join(dir, ReticleDir.PAIRING_TOKEN_FILE), 'utf8').trim();
+    return token.length > 0 ? token : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Build the `reticle.connect()` argument literal — only includes keys the user set. */
 function connectArgs(options: ReticleVitePluginOptions): string {
   const args: Record<string, string | number> = {};
@@ -130,7 +151,11 @@ export function reticle(options: ReticleVitePluginOptions = {}): ReticleVitePlug
       return inject && id === RETICLE_CONNECT_MODULE ? RETICLE_CONNECT_MODULE : null;
     },
     load(id) {
-      return inject && id === RETICLE_CONNECT_MODULE ? connectModuleSource(resolved) : null;
+      if (!inject || id !== RETICLE_CONNECT_MODULE) return null;
+      // Read the token lazily per request: by the time the browser loads the app the daemon is up and
+      // has written it. An explicit token option still wins. Undefined ⇒ omitted (page reloads once up).
+      const token = resolved.token ?? readPairingToken();
+      return connectModuleSource(token !== undefined ? { ...resolved, token } : resolved);
     },
     transformIndexHtml() {
       if (!inject) return [];


### PR DESCRIPTION
Fixes MEDIUM finding M2 from `plan/SECURITY-AUDIT.md`. Chosen approach: **auto-token by default** (the full fix).

## Problem
`Bridge.#originAllowed` returned `true` for any loopback-hostname origin, so any app on `http://localhost:<anything>` (a second dev server, an Electron devtools, localhost malware) could register/drive sessions with no token — cross-app access on a shared dev box.

## Fix
There's no way to tell the real app from a rogue localhost app by origin alone, so the fix requires a secret. The daemon now **auto-provisions** a per-user pairing token at `~/.reticle/pairing-token` (mode `0600`, read-or-create, stable across restarts) and the bridge requires it. A browser sandbox can't read that file, so a rogue page can't present it.

- **Vite plugin users:** zero-config — the plugin reads the token Node-side and injects it into `connect()`.
- **Next / hand-wired users:** supply it yourself (`RETICLE_TOKEN` for the daemon + `NEXT_PUBLIC_RETICLE_TOKEN` to the client), now documented. This is the accepted breaking part.

## Changes
- `protocol`: `ReticleDir.PAIRING_TOKEN_FILE`, `ReticleEnv.PAIRING_TOKEN_DIR`.
- `server`: `pairing-token.ts` (injectable IO + randomness, `0600`/`0700` perms, best-effort degrade), `resolveBridgeSecurityWithAutoToken`, `RunningServer.token`, `StartOptions.pairingTokenDir`.
- `vite-plugin`: `readPairingToken()` merged into the connect module at serve time.
- `docs/getting-started.md`, `SKILL.md`: the pairing-token section + Next/plain wiring.

## Tests
- `pairing-token.test.ts`: create/reuse/blank-regen/IO-failure-degrade/empty-random.
- `vite-plugin/index.test.ts`: injects the file token, omits when absent (hermetic via the env override).
- Existing bridge/daemon suites updated to stay hermetic (temp token dir); all 978 server + 26 vite-plugin tests pass.
- **End-to-end smoke:** started the real daemon → token file provisioned (48 chars), `running.token` matches, Vite `readPairingToken()` matches, **tokenless loopback HELLO → closed 1008**, **injected-token HELLO → accepted**.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)