### PR TITLE
chore(github): security-finding issue template + PR security checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/security_finding.yml
+++ b/.github/ISSUE_TEMPLATE/security_finding.yml
@@ -1,0 +1,61 @@
+name: Security finding (maintainers / audit tracking)
+description: Track a security finding that is ALREADY mitigated or is safe to discuss in public (e.g. from an internal audit)
+labels: ['security']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ⚠️ **Do not use this template for an undisclosed, exploitable vulnerability.**
+        Report those **privately** to **hey@reticle.ai** — see [SECURITY.md](https://github.com/reticlehq/reticle/blob/main/SECURITY.md).
+
+        This template is for tracking findings that are already public-safe: an internal audit item,
+        a hardening task, or a finding whose fix has shipped. It mirrors the structure of
+        `plan/SECURITY-AUDIT.md` so a finding maps 1:1 to an issue.
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+  - type: input
+    id: files
+    attributes:
+      label: Affected files / area
+      description: The package(s) and file:line(s) the finding lives in.
+      placeholder: 'packages/server/src/http-server.ts:56-73, token-auth.ts:35-38'
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: The finding
+      description: What is wrong, and which security property (localhost-only, no-telemetry, no-arbitrary-JS, redaction, path-traversal, auth) it breaks.
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact / exploit
+      description: What can an attacker do? Concrete inputs/state → outcome. Note any preconditions.
+      placeholder: 'A visited webpage rebound to 127.0.0.1 authorizes against /mcp/* and can drive the agent browser…'
+    validations:
+      required: true
+  - type: textarea
+    id: fix
+    attributes:
+      label: Proposed fix
+      description: The intended remediation, ideally the smallest correct change.
+    validations:
+      required: true
+  - type: checkboxes
+    id: disclosure
+    attributes:
+      label: Disclosure check
+      options:
+        - label: This finding is already mitigated OR is not an undisclosed exploitable vulnerability (otherwise I will email hey@reticle.ai instead of filing here).
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,4 @@ Closes #
 - [ ] No `console.log` or internal tracking codes left in the diff
 - [ ] Each changed file is under the 500-line cap
 - [ ] Docs and `CHANGELOG.md` updated if this is user-facing (entry under `[Unreleased]`)
+- [ ] Security-affecting? Auth/redaction/trust-boundary changes keep the localhost-only, no-telemetry, no-arbitrary-JS posture and are covered by a test


### PR DESCRIPTION
## What & why
The repo already had PR, bug, and feature templates. This adds the one gap relative to how we've been working: a **security-finding** issue template.

- `.github/ISSUE_TEMPLATE/security_finding.yml` — a form mirroring `plan/SECURITY-AUDIT.md` (severity, affected files, the finding, impact/exploit, proposed fix), labeled `security`, so an audit finding maps 1:1 to an issue like C1–M4 did. Includes a **disclosure guard**: undisclosed exploitable vulns are routed to `SECURITY.md` (private email), not this public form.
- `PULL_REQUEST_TEMPLATE.md` — one added checklist line for security-affecting changes (keep the localhost-only / no-telemetry / no-arbitrary-JS posture, covered by a test).

Existing `bug_report.yml`, `feature_request.yml`, `config.yml`, and the PR template body are unchanged.

## How it was verified
`security_finding.yml` passes `yaml.safe_load`; all templates use full URLs consistent with `config.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)