### PR TITLE
v2.0.1 — bug-fix release (flow verifier honesty, prune, zero-config discovery, HUD)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
+## [2.0.1] — 2026-07-17
+
+A bug-fix release focused on the verifier's honesty (no more silent false negatives), flow ergonomics, and zero-config setup. No breaking changes — every schema addition stays back-compatible and on-disk flow files remain version 1.
+
+### Fixed
+
+- **The event buffer no longer answers a confident "no" after it dropped the evidence.** The ring buffer evicts events on an age/size cap; when it has, `reticle_observe` / `reticle_network` / `reticle_console` now carry a `buffer: { held, dropped, note }` block so a negative result is distinguishable from "the evidence expired" — the difference between an honest verifier and a silent false negative on a long rollout. Omitted entirely when nothing was dropped (an intact buffer stays token-flat). (#27) (`@reticlehq/server`, `@reticlehq/core`)
+- **`reticle_domain` no longer reports a fully-tested app as untested.** `FlowStore.load()` with no `projectId` (the CLI/CI/`reticle_domain` caller) now scans the per-project subdirs like `list()` already did, instead of resolving only the flat path — so a project-scoped flow is loaded, not listed-then-silently-dropped (which reported `flowCount: 0` and every declared signal/testid as a gap). (#26) (`@reticlehq/server`)
+- **A flow that starts on another page no longer drifts on step 1 with a mystifying "a step no longer matches."** The recorder now captures the journey's `startPath`; on replay, when the tab is on a different route, the decision's next action says "navigate there (`reticle_navigate`), then replay." (#23) (`@reticlehq/browser`, `@reticlehq/core`, `@reticlehq/server`)
+- **The "no browser session connected" error names the real cause.** In a multi-repo / multi-agent setup the usual culprit is a port mismatch between the app's SDK and the daemon's `RETICLE_PORT`; the error now says so instead of only pointing at the SDK flag. (`@reticlehq/server`, `@reticlehq/core`)
+- **Security hardening (dev-only, same-machine trust):** `VisualStore.baselinePath`/`diffPath` now reject a traversal name like their siblings, and a failed pairing-token auto-provision warns loudly that the bridge is running without auth instead of degrading silently. (`@reticlehq/server`)
+
+### Added
+
+- **Zero-config daemon discovery.** Each live daemon publishes a `~/.reticle/daemon-<port>.json` registry entry; the Vite plugin, absent an explicit port, connects to the daemon serving THIS project's id — no more hand-reconciling a port in the app config and the daemon's `RETICLE_PORT`. Falls back to the default when nothing matches; an explicit port still overrides. (#24) (`@reticlehq/core`, `@reticlehq/server`, `@reticlehq/vite-plugin`)
+- **Prune saved flows.** `reticle_flow_delete` removes a renamed/obsolete flow so it stops lingering in the replay list (project-scoped like `reticle_flow_load`; `not_found` on an absent flow, never a silent no-op). (#25) (`@reticlehq/server`)
+
+### Changed
+
+- **The HUD composer is polished.** The multi-line input's default OS scrollbar is replaced with the thin styled one used elsewhere in the panel, content-box sizing no longer causes a height jump on the first keystroke, and the textarea gains an accessible name. (`@reticlehq/browser`)
+- **One `bridgeWsUrl()` builder** in `@reticlehq/core` replaces the four hand-built `ws://…/reticle` strings across the SDK, the Vite/Next snippet generators, and the CLI — the wire string can no longer drift. (`@reticlehq/core`, `@reticlehq/browser`, `@reticlehq/server`, `@reticlehq/vite-plugin`)
+
 ## [2.0.0] — 2026-07-11
 
 The single-install `@reticlehq/core` umbrella is retired in favour of **audience-scoped packages**. Each package now depends only on what it needs — `@reticlehq/core` sits at the bottom of the graph as the wire contract (constants + zod schemas, `zod` its only dependency), so the dev-only browser SDK never reaches your server and the Node bridge never reaches your bundle. The split is the one breaking change; the migration is a rename with no behaviour change. This release also folds in the security-hardening work from 1.3.x and adds collision-safe multi-app flow storage.
@@ -12,20 +34,19 @@ The single-install `@reticlehq/core` umbrella is retired in favour of **audience
 
 - **The `@reticlehq/core` umbrella is split into scoped packages.** In v1 you installed one package and imported everything from it via `/server`, `/vite`, `/next`, … subpaths. In v2 you install the package for your role:
 
-  | v1 (umbrella subpath) | v2 (install this) |
-  | --- | --- |
-  | `@reticlehq/core` (the dev SDK + React adapter) | `@reticlehq/react` |
-  | `@reticlehq/core/vite` | `@reticlehq/vite-plugin` |
-  | `@reticlehq/core/next` | `@reticlehq/next` |
-  | `@reticlehq/core/babel` | `@reticlehq/babel-plugin` |
-  | `@reticlehq/core/test` | `@reticlehq/test` |
-  | `@reticlehq/core/eslint` | `@reticlehq/eslint-plugin` |
-  | `@reticlehq/core/server` (and the `reticle` CLI) | `@reticlehq/server` |
+  | v1 (umbrella subpath)                            | v2 (install this)          |
+  | ------------------------------------------------ | -------------------------- |
+  | `@reticlehq/core` (the dev SDK + React adapter)  | `@reticlehq/react`         |
+  | `@reticlehq/core/vite`                           | `@reticlehq/vite-plugin`   |
+  | `@reticlehq/core/next`                           | `@reticlehq/next`          |
+  | `@reticlehq/core/babel`                          | `@reticlehq/babel-plugin`  |
+  | `@reticlehq/core/test`                           | `@reticlehq/test`          |
+  | `@reticlehq/core/eslint`                         | `@reticlehq/eslint-plugin` |
+  | `@reticlehq/core/server` (and the `reticle` CLI) | `@reticlehq/server`        |
 
   `@reticlehq/core` still exists but is now **only the wire contract** shared across browser ↔ bridge ↔ agent. `@reticlehq/protocol` is a thin deprecated alias re-exporting `@reticlehq/core` (pulled in automatically; import from `@reticlehq/core` in new code — the alias is removed in v3).
 
   **Migrate:**
-
   1. Replace the single install with the packages for your app: `npm i -D @reticlehq/react @reticlehq/vite-plugin` (or `@reticlehq/next` for Next.js). Your agent runs `@reticlehq/server`.
   2. Update imports: `@reticlehq/core` → `@reticlehq/react` for the SDK; `@reticlehq/core/vite` → `@reticlehq/vite-plugin`; `@reticlehq/core/next` → `@reticlehq/next`; `@reticlehq/core/test` → `@reticlehq/test`.
   3. Update your MCP client config: the `reticle` CLI now ships in `@reticlehq/server`, so the command becomes `npx @reticlehq/server mcp`. Recorded flows, baselines, `.reticle.json`, tool names, and env vars are unchanged.

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ It reads the _program_ (network, store state, signals, the React commit stream),
 
 <div align="center">
 
-### **[⚡ Install](#install-in-30-seconds)**  ·  [All install options](#install-the-full-options)  ·  [Manual setup (docs)](docs/getting-started.md)
+### **[⚡ Install](#install-in-30-seconds)** · [All install options](#install-the-full-options) · [Manual setup (docs)](docs/getting-started.md)
 
-[How it works](#how-it-works)  ·  [How to use it](#how-to-use-it)  ·  [Benchmarks](#honest-benchmarks)  ·  [vs Playwright & DevTools](#when-to-use-reticle-vs-playwright-and-devtools)  ·  [What's inside](#whats-inside)
+[How it works](#how-it-works) · [How to use it](#how-to-use-it) · [Benchmarks](#honest-benchmarks) · [vs Playwright & DevTools](#when-to-use-reticle-vs-playwright-and-devtools) · [What's inside](#whats-inside)
 
 </div>
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -334,10 +334,12 @@ Fill in `framework` from Q1. **Leave `port` out** — it defaults to `4400` and 
 > **`port` here is the Reticle _bridge_ port — NOT your dev server port.** The bridge is the daemon ↔ SDK channel (default `4400`); your dev server (Q3, e.g. 5173) is a separate thing Reticle never touches. Do **not** set `.reticle.json` `port` to your dev-server port — that collides the daemon with your app.
 >
 > Only set `port` when running **multiple apps at once**, so each gets its own bridge. When you do, set the **same** value in two places or the SDK and daemon never meet:
+>
 > ```jsonc
 > // .reticle.json          →  reticle({ port: 4460 })  in vite.config.ts
 > { "framework": "vite-react", "port": 4460 }
 > ```
+>
 > Pick any free port that is **not** your dev-server port (4460, 4461, …).
 
 Tell the user: **"Run `npm run dev` (your normal dev server) and open the app in your browser."**
@@ -348,13 +350,10 @@ Once they confirm the app is open, call `reticle_run({ tool: "reticle_wait_ready
 
 Most no-connect cases are one of these. Fastest signal first:
 
-1. **Read the browser console.** The SDK announces its own failures. If you see
-   `[Reticle] could not reach the bridge at ws://localhost:<port> … Is the Reticle daemon running on that port?`
-   — that's a **port mismatch or a dead daemon** (items 2–3), and the message tells you which port the app is dialing. No `[Reticle]` line at all → the SDK never loaded (item 4).
+1. **Read the browser console.** The SDK announces its own failures. If you see `[Reticle] could not reach the bridge at ws://localhost:<port> … Is the Reticle daemon running on that port?` — that's a **port mismatch or a dead daemon** (items 2–3), and the message tells you which port the app is dialing. No `[Reticle]` line at all → the SDK never loaded (item 4).
 2. **Port match (the #1 manual-setup bug).** The app's bridge port MUST equal the daemon's. Check both:
    - App side: `reticle({ port: N })` in `vite.config.ts` (or `connect({ url: 'ws://localhost:N/reticle' })`) — omitted ⇒ `4400`.
-   - Daemon side: `.reticle.json` `"port"` / `RETICLE_PORT` — omitted ⇒ `4400`.
-   They must be the **same number**, and it must **not** be your dev-server port. Simplest fix: remove the port from both and let them default to `4400`.
+   - Daemon side: `.reticle.json` `"port"` / `RETICLE_PORT` — omitted ⇒ `4400`. They must be the **same number**, and it must **not** be your dev-server port. Simplest fix: remove the port from both and let them default to `4400`.
 3. **Is the daemon up on that port?** `npx @reticlehq/server status` lists running daemons + connected sessions. Nothing there ⇒ the agent hasn't launched it yet (restart the agent / `/mcp`), or it's on a different port than the app (item 2).
 4. **Is the SDK actually wired + loaded in dev?** `reticle()` present in `vite.config.ts`; for the manual entry, `if (import.meta.env.DEV) import('./reticle-dev')` in `src/main.tsx`. After editing `vite.config.ts` you **must restart `vite`** (config changes need a fresh dev server), then **hard-reload the browser tab**. A production build won't connect — the SDK is dev-only by design.
 5. **Still nothing?** See the full [Troubleshooting](#troubleshooting) section (stale `npx` cache, Stop-hook killing the daemon, `-32000`).

--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   // strictPort fails loudly instead of silently drifting to vite's default when the port is taken.
   server: { port: 4310, strictPort: true },
   // port must match the reticle daemon this repo's MCP drives (RETICLE_PORT in root .mcp.json).
-  // The default 4400 is taken by a separate Reticle-protocol daemon on this machine.
-  plugins: [react(), reticle({ port: 58432 })],
+  // Env-overridable so it isn't pinned to one machine's daemon; defaults to 58432 because 4400 is
+  // taken by a separate Reticle-protocol daemon on the maintainer's machine.
+  plugins: [react(), reticle({ port: Number(process.env['RETICLE_PORT'] ?? 58432) })],
 });

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/babel-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Babel plugin that stamps data-reticle-source=\"file:line:col\" on JSX host elements so @reticlehq/react can map a DOM node to its source (works on React 19, which dropped _debugSource).",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/browser",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Reticle browser SDK — installs observers, builds semantic snapshots, executes actions, talks to the bridge.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/browser/src/presenter/presenter-controls.ts
+++ b/packages/browser/src/presenter/presenter-controls.ts
@@ -22,6 +22,8 @@ const CONTROL_LABEL = {
   SEND: 'Send',
 } as const;
 const INPUT_PLACEHOLDER = 'Tell the agent something…';
+/** Accessible name for the composer (a placeholder is not an accessible name). */
+const INPUT_ARIA_LABEL = 'Message to the agent';
 const PAUSED_BADGE_TEXT = 'PAUSED';
 const ENDED_BANNER_TEXT = 'Session ended';
 const COPY_LABEL = 'Copy run';
@@ -32,6 +34,9 @@ const COPIED_TEXT = 'Copied ✓';
 const RUN_FILENAME = 'reticle-run.json';
 /** Border fade-out delay after a session ends (native timer; presenter-only tunable). */
 export const ENDED_FADE_MS = 4000;
+/** Max composer height (px) before it scrolls. One source for both the CSS cap and the JS auto-grow
+ *  clamp — they measure the same border-box, so the scrollbar appears exactly when growth stops. */
+const MSG_MAX_H = 96;
 
 /**
  * One replayable flow as pushed to the panel. `start` is the first step's testid anchor — a page hint
@@ -68,8 +73,11 @@ export const CONTROLS_CSS = `
   border:1px solid var(--reticle-line);border-radius:14px;padding:5px 6px 5px 14px;transition:border-color .15s,box-shadow .15s;}
 [data-reticle-hud] .reticle-composer:focus-within{border-color:var(--reticle-accent);box-shadow:0 0 0 3px var(--reticle-accent-soft);}
 [data-reticle-hud] .reticle-msg{flex:1;min-width:0;pointer-events:auto;background:transparent;border:none;outline:none;resize:none;
-  color:var(--reticle-fg);font-family:var(--reticle-font);font-size:13px;line-height:18px;height:18px;min-height:18px;max-height:96px;
-  padding:5px 0;overflow-y:auto;}
+  box-sizing:border-box;color:var(--reticle-fg);font-family:var(--reticle-font);font-size:13px;line-height:18px;
+  height:28px;min-height:28px;max-height:${MSG_MAX_H}px;padding:5px 0;overflow-y:auto;
+  scrollbar-width:thin;scrollbar-color:rgba(255,255,255,.14) transparent;}
+[data-reticle-hud] .reticle-msg::-webkit-scrollbar{width:9px;}
+[data-reticle-hud] .reticle-msg::-webkit-scrollbar-thumb{background:rgba(255,255,255,.14);border-radius:9px;border:2px solid transparent;background-clip:content-box;}
 [data-reticle-hud] .reticle-msg::placeholder{color:var(--reticle-faint);}
 [data-reticle-hud] .reticle-msg:disabled{opacity:.5;}
 [data-reticle-hud] .reticle-send{flex:none;width:30px;height:30px;padding:0;border-radius:10px;border:none;cursor:pointer;pointer-events:auto;
@@ -140,7 +148,7 @@ export const CONTROLS_FLOWS_HTML = `<div data-reticle-flows class="reticle-flows
 const SEND_ICON = `<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="22" y1="2" x2="11" y2="13"></line><polygon points="22 2 15 22 11 13 2 9 22 2"></polygon></svg>`;
 
 /** Footer markup: a rounded composer pill (input + icon Send), appended after the log div. */
-export const CONTROLS_FOOT_HTML = `<div data-reticle-foot><div class="reticle-composer"><textarea data-reticle-input class="reticle-msg" rows="1" placeholder="${INPUT_PLACEHOLDER}"></textarea><button type="button" data-reticle-send class="reticle-send" aria-label="${CONTROL_LABEL.SEND}">${SEND_ICON}</button></div><div class="reticle-export"><button type="button" data-reticle-copy class="reticle-ctl">${COPY_LABEL}</button><button type="button" data-reticle-export class="reticle-ctl">${EXPORT_LABEL}</button><span data-reticle-export-msg class="reticle-export-msg"></span></div></div>`;
+export const CONTROLS_FOOT_HTML = `<div data-reticle-foot><div class="reticle-composer"><textarea data-reticle-input class="reticle-msg" rows="1" aria-label="${INPUT_ARIA_LABEL}" placeholder="${INPUT_PLACEHOLDER}"></textarea><button type="button" data-reticle-send class="reticle-send" aria-label="${CONTROL_LABEL.SEND}">${SEND_ICON}</button></div><div class="reticle-export"><button type="button" data-reticle-copy class="reticle-ctl">${COPY_LABEL}</button><button type="button" data-reticle-export class="reticle-ctl">${EXPORT_LABEL}</button><span data-reticle-export-msg class="reticle-export-msg"></span></div></div>`;
 
 /** Element refs of the control surface, queried once after the markup is in the DOM. */
 interface ControlRefs {
@@ -310,7 +318,7 @@ export class ControlPanel {
     const el = this.#refs.input;
     if (el === undefined) return;
     el.style.height = 'auto';
-    el.style.height = `${String(Math.min(el.scrollHeight, 96))}px`;
+    el.style.height = `${String(Math.min(el.scrollHeight, MSG_MAX_H))}px`;
   }
 
   /** Render the replayable-flow chips from the server push. Each ▶ click re-runs that flow, no agent.

--- a/packages/browser/src/recorder/recorder.test.ts
+++ b/packages/browser/src/recorder/recorder.test.ts
@@ -374,4 +374,15 @@ describe('compileRecording determinism', () => {
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
   });
+
+  it('records the start pathname so replay can navigate there first', () => {
+    const flow = compileRecording('f', [], [], 1, '/dashboard');
+    expect(flow.startPath).toBe('/dashboard');
+  });
+
+  it('omits startPath when none was captured (back-compat: file stays version 1)', () => {
+    const flow = compileRecording('f', [], [], 1);
+    expect(flow.startPath).toBeUndefined();
+    expect(flow.version).toBe(1);
+  });
 });

--- a/packages/browser/src/recorder/recorder.ts
+++ b/packages/browser/src/recorder/recorder.ts
@@ -142,6 +142,7 @@ export function compileRecording(
   steps: FlowStep[],
   annotations: Annotation[],
   createdAt: number,
+  startPath?: string,
 ): FlowFile {
   const out: FlowStep[] = steps.map((s) => ({ ...s }));
   const dynamic: FlowAnchor[] = [];
@@ -166,6 +167,7 @@ export function compileRecording(
   }
 
   const flow: FlowFile = { version: FLOW_FILE_VERSION, name, createdAt, steps: out };
+  if (startPath !== undefined && startPath.length > 0) flow.startPath = startPath;
   if (dynamic.length > 0) flow.dynamic = dynamic;
   if (success !== undefined) flow.success = success;
   return flow;
@@ -191,6 +193,8 @@ class Recorder implements RecorderHandle {
   readonly #deps: RecorderDeps;
   #phase: RecorderPhase = RecorderPhase.IDLE;
   #steps: FlowStep[] = [];
+  /** The pathname the recording began on, so replay can navigate here before step 1. */
+  #startPath: string | undefined;
   #annotations: Annotation[] = [];
   #pendingFill: PendingFill | undefined;
   #teardowns: (() => void)[] = [];
@@ -364,6 +368,7 @@ class Recorder implements RecorderHandle {
   #start(): void {
     // A fresh span — no leakage from a previous Record→Stop cycle.
     this.#steps = [];
+    this.#startPath = typeof location === 'undefined' ? undefined : location.pathname;
     this.#annotations = [];
     this.#pendingFill = undefined;
     this.#draft = undefined;
@@ -374,7 +379,13 @@ class Recorder implements RecorderHandle {
   #stop(): void {
     this.#flushPendingFill();
     const name = this.#nameField() ?? this.#deps.defaultName ?? DEFAULT_NAME;
-    const flow = compileRecording(name, this.#steps, this.#annotations, this.#deps.now());
+    const flow = compileRecording(
+      name,
+      this.#steps,
+      this.#annotations,
+      this.#deps.now(),
+      this.#startPath,
+    );
     this.#deps.emit(EventType.FLOW_RECORDED, { name, flow });
     this.#setStatus(this.#steps.length === 0 ? RECORDER_EMPTY_MSG : STATUS_IDLE);
     this.#setPhase(RecorderPhase.IDLE);

--- a/packages/browser/src/reticle.ts
+++ b/packages/browser/src/reticle.ts
@@ -3,7 +3,7 @@ import {
   RETICLE_DEFAULT_PORT,
   RETICLE_PROTOCOL_VERSION,
   RETICLE_URL_PARAM,
-  RETICLE_WS_PATH,
+  bridgeWsUrl,
   ReticleCommand,
   MessageKind,
   SESSION_AUTO,
@@ -237,7 +237,7 @@ export class Reticle {
       return;
     }
 
-    const url = options.url ?? `ws://localhost:${String(RETICLE_DEFAULT_PORT)}${RETICLE_WS_PATH}`;
+    const url = options.url ?? bridgeWsUrl(RETICLE_DEFAULT_PORT);
     const policy = connectionPolicy(
       window.location.hostname,
       url,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The Reticle foundation: the shared wire contract — types, zod schemas, constants, messages, and the isomorphic kernel that every Reticle package (browser SDK, server, kits, test harness) imports. Depends only on zod.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -8,6 +8,16 @@ export const RETICLE_WS_PATH = '/reticle';
 export const RETICLE_PROTOCOL_VERSION = 1;
 
 /**
+ * The one place the bridge WebSocket URL is built. The SDK connect default, the vite/next snippet
+ * generators, and the CLI's inject-connect all call this instead of hand-writing `ws://…${path}` —
+ * so the wire string can never drift across the four call sites. Host defaults to `localhost` (the
+ * dev app connects from the browser); pass it only for a non-default bind.
+ */
+export function bridgeWsUrl(port: number = RETICLE_DEFAULT_PORT, host = 'localhost'): string {
+  return `ws://${host}:${String(port)}${RETICLE_WS_PATH}`;
+}
+
+/**
  * Namespaced URL params a pooled/headless launcher appends to the app URL so the app's own SDK adopts
  * the lease's identity (session + project) on connect — no app code changes. Wire contract shared by
  * the server (BrowserPool/lease tools) and the browser SDK; namespaced to avoid clashing with the

--- a/packages/core/src/daemon-registry.test.ts
+++ b/packages/core/src/daemon-registry.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  daemonRegistryFileName,
+  daemonRegistryPort,
+  pickDaemonPort,
+  type DaemonRegistryEntry,
+} from './daemon-registry.js';
+
+const entry = (over: Partial<DaemonRegistryEntry>): DaemonRegistryEntry => ({
+  port: 4400,
+  pid: 100,
+  cwd: '/app',
+  startedAt: 1,
+  ...over,
+});
+
+describe('daemon registry filename round-trip', () => {
+  it('composes and parses the port', () => {
+    expect(daemonRegistryFileName(58432)).toBe('daemon-58432.json');
+    expect(daemonRegistryPort('daemon-58432.json')).toBe(58432);
+  });
+
+  it('rejects non-registry filenames (pid/log siblings, garbage)', () => {
+    expect(daemonRegistryPort('daemon-58432.pid')).toBeNull();
+    expect(daemonRegistryPort('daemon-abc.json')).toBeNull();
+    expect(daemonRegistryPort('pairing-token')).toBeNull();
+  });
+});
+
+describe('pickDaemonPort — match by projectId, drop the dead, never guess', () => {
+  const allAlive = (): boolean => true;
+
+  it('returns the live daemon whose projectId matches', () => {
+    const port = pickDaemonPort(
+      [entry({ port: 4400, projectId: 'other' }), entry({ port: 4460, pid: 200, projectId: 'mine' })],
+      'mine',
+      allAlive,
+    );
+    expect(port).toBe(4460);
+  });
+
+  it('lowest port wins when two live daemons match', () => {
+    const port = pickDaemonPort(
+      [entry({ port: 5000, pid: 2, projectId: 'mine' }), entry({ port: 4460, pid: 1, projectId: 'mine' })],
+      'mine',
+      allAlive,
+    );
+    expect(port).toBe(4460);
+  });
+
+  it('ignores a matching but DEAD daemon (stale entry)', () => {
+    const port = pickDaemonPort([entry({ pid: 999, projectId: 'mine' })], 'mine', () => false);
+    expect(port).toBeNull();
+  });
+
+  it('returns null when no projectId matches — caller falls back, never auto-connects wrong', () => {
+    expect(pickDaemonPort([entry({ projectId: 'other' })], 'mine', allAlive)).toBeNull();
+  });
+
+  it('returns null when the app has no projectId', () => {
+    expect(pickDaemonPort([entry({ projectId: 'mine' })], undefined, allAlive)).toBeNull();
+  });
+});

--- a/packages/core/src/daemon-registry.test.ts
+++ b/packages/core/src/daemon-registry.test.ts
@@ -32,7 +32,10 @@ describe('pickDaemonPort — match by projectId, drop the dead, never guess', ()
 
   it('returns the live daemon whose projectId matches', () => {
     const port = pickDaemonPort(
-      [entry({ port: 4400, projectId: 'other' }), entry({ port: 4460, pid: 200, projectId: 'mine' })],
+      [
+        entry({ port: 4400, projectId: 'other' }),
+        entry({ port: 4460, pid: 200, projectId: 'mine' }),
+      ],
       'mine',
       allAlive,
     );
@@ -41,7 +44,10 @@ describe('pickDaemonPort — match by projectId, drop the dead, never guess', ()
 
   it('lowest port wins when two live daemons match', () => {
     const port = pickDaemonPort(
-      [entry({ port: 5000, pid: 2, projectId: 'mine' }), entry({ port: 4460, pid: 1, projectId: 'mine' })],
+      [
+        entry({ port: 5000, pid: 2, projectId: 'mine' }),
+        entry({ port: 4460, pid: 1, projectId: 'mine' }),
+      ],
       'mine',
       allAlive,
     );

--- a/packages/core/src/daemon-registry.ts
+++ b/packages/core/src/daemon-registry.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+/**
+ * The daemon discovery registry: each live daemon drops a `daemon-<port>.json` in ~/.reticle so a
+ * build-time tool (vite/next plugin) can find the RIGHT daemon by projectId instead of forcing the
+ * user to reconcile a port in two places (the app's SDK and the daemon's RETICLE_PORT). This is the
+ * contract shared by the writer (the daemon) and the reader (the build plugins) — filename + shape +
+ * the pure selection rule live here so they can never drift.
+ */
+
+const DAEMON_REGISTRY_PREFIX = 'daemon-';
+const DAEMON_REGISTRY_SUFFIX = '.json';
+
+/** The registry filename for a daemon on `port` (sibling of daemon-<port>.pid / .log). */
+export function daemonRegistryFileName(port: number): string {
+  return `${DAEMON_REGISTRY_PREFIX}${String(port)}${DAEMON_REGISTRY_SUFFIX}`;
+}
+
+/** Extract the port from a registry filename, or null when the name isn't a registry entry. */
+export function daemonRegistryPort(fileName: string): number | null {
+  if (!fileName.startsWith(DAEMON_REGISTRY_PREFIX) || !fileName.endsWith(DAEMON_REGISTRY_SUFFIX)) {
+    return null;
+  }
+  const mid = fileName.slice(DAEMON_REGISTRY_PREFIX.length, -DAEMON_REGISTRY_SUFFIX.length);
+  return /^\d+$/.test(mid) ? Number(mid) : null;
+}
+
+/** One daemon's registry entry: enough to match it to a project and prove it's still alive. */
+export const DaemonRegistryEntrySchema = z.object({
+  port: z.number(),
+  pid: z.number(),
+  cwd: z.string(),
+  projectId: z.string().optional(),
+  startedAt: z.number(),
+});
+export type DaemonRegistryEntry = z.infer<typeof DaemonRegistryEntrySchema>;
+
+/**
+ * Pick the daemon port an app should connect to, given the registry entries, the app's projectId, and
+ * a liveness probe. Pure so both the vite and next plugins share one rule and it's unit-testable:
+ *   1. drop dead daemons (crashed, stale entry);
+ *   2. among the living, prefer the one whose projectId matches the app's — lowest port wins on a tie;
+ *   3. return null when nothing matches, so the caller falls back to the default port (never guesses a
+ *      mismatched daemon — a wrong auto-connect is worse than the honest default).
+ */
+export function pickDaemonPort(
+  entries: readonly DaemonRegistryEntry[],
+  projectId: string | undefined,
+  isAlive: (pid: number) => boolean,
+): number | null {
+  if (projectId === undefined || projectId.length === 0) return null;
+  const matches = entries
+    .filter((e) => e.projectId === projectId && isAlive(e.pid))
+    .map((e) => e.port)
+    .sort((a, b) => a - b);
+  return matches[0] ?? null;
+}

--- a/packages/core/src/flow-types.ts
+++ b/packages/core/src/flow-types.ts
@@ -267,6 +267,14 @@ export const FlowFileSchema = z.object({
    * projectId is treated as global (visible everywhere), so pre-existing files parse and still show.
    */
   projectId: z.string().optional(),
+  /**
+   * The route (pathname) the journey started on, captured at record time. Replay navigates here
+   * before step 1 so a flow whose first anchor lives on another page doesn't drift on step 1 ("a
+   * step no longer matches") just because replay began on the wrong page. Optional + back-compat: a
+   * flow without it (or recorded before this shipped) replays from the current page as before, and
+   * the on-disk version stays FLOW_FILE_VERSION 1.
+   */
+  startPath: z.string().optional(),
   // FUTURE: fixtures/preconditions — schema slot reserved, unpopulated this cut. The recorder
   // never writes it and no fixture runner exists.
   fixture: z.string().optional(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './constants.js';
+export * from './daemon-registry.js';
 export * from './session-constants.js';
 export * from './notices.js';
 export * from './messages.js';

--- a/packages/core/src/notices.ts
+++ b/packages/core/src/notices.ts
@@ -29,6 +29,15 @@ export function isPresenterTone(value: unknown): value is PresenterTone {
   );
 }
 
+/**
+ * Surfaced on observe/network/console results once the event ring buffer has evicted anything (age
+ * or size cap). Converts a silent false negative into an honest one: a "no such event" answer after
+ * eviction may be "I dropped the evidence", not "it never happened" — widen the buffer / grade
+ * sooner. Rides in a `buffer` block only when `dropped > 0` (silence ⇒ nothing lost).
+ */
+export const BUFFER_EVICTION_WARNING =
+  'event buffer evicted older events (age/size cap) — a negative result here may be a false negative; the evidence may have expired. Grade sooner or widen the buffer.';
+
 /** Surfaced on act/assert results when the target tab is throttled. */
 export const THROTTLED_WARNING =
   'tab throttled; timer/rAF/pointer gestures may silently no-op — refocus before driving';

--- a/packages/core/src/notices.ts
+++ b/packages/core/src/notices.ts
@@ -38,6 +38,14 @@ export function isPresenterTone(value: unknown): value is PresenterTone {
 export const BUFFER_EVICTION_WARNING =
   'event buffer evicted older events (age/size cap) — a negative result here may be a false negative; the evidence may have expired. Grade sooner or widen the buffer.';
 
+/**
+ * Thrown when a tool needs a live browser session and none is connected. Names the #1 real cause in a
+ * multi-repo / multi-agent setup — a PORT MISMATCH between the app's SDK and the daemon — so the agent
+ * checks the wiring instead of only the "is the SDK enabled?" dead end.
+ */
+export const NO_SESSION_CONNECTED_ERROR =
+  "no browser session connected. Two things to check: (1) your app is running with @reticlehq/browser enabled, and (2) it points at THIS daemon's port — a mismatch between the app's reticle({ port }) / VITE_RETICLE_WS_URL and the daemon's RETICLE_PORT is the usual cause. reticle_wait_ready blocks briefly for a session to appear.";
+
 /** Surfaced on act/assert results when the target tab is throttled. */
 export const THROTTLED_WARNING =
   'tab throttled; timer/rAF/pointer gestures may silently no-op — refocus before driving';

--- a/packages/core/src/upgrade.ts
+++ b/packages/core/src/upgrade.ts
@@ -53,10 +53,7 @@ export type UpgradeHint = z.infer<typeof UpgradeHintSchema>;
 
 /** Narrow an unknown wire value to a CloudCapability. */
 export function isCloudCapability(value: unknown): value is CloudCapability {
-  return (
-    typeof value === 'string' &&
-    (Object.values(CloudCapability) as string[]).includes(value)
-  );
+  return typeof value === 'string' && (Object.values(CloudCapability) as string[]).includes(value);
 }
 
 interface CapabilityCopy {
@@ -74,7 +71,8 @@ const COPY_BY_CAPABILITY: Record<CloudCapability, CapabilityCopy> = {
     unlockedBy: 'Link a free Reticle Cloud account (reticle login), then share the run.',
   },
   [CloudCapability.RUN_HISTORY]: {
-    reason: 'Run history beyond this session lives in the hosted dashboard; local keeps only a buffer.',
+    reason:
+      'Run history beyond this session lives in the hosted dashboard; local keeps only a buffer.',
     unlockedBy: 'Link a free Reticle Cloud account to keep run history and trends.',
   },
   [CloudCapability.TEAM_REVIEW]: {
@@ -82,11 +80,13 @@ const COPY_BY_CAPABILITY: Record<CloudCapability, CapabilityCopy> = {
     unlockedBy: 'Add your team to Reticle Cloud to share a review queue.',
   },
   [CloudCapability.CORPUS_HEAL]: {
-    reason: 'Corpus-ranked heal uses refactor outcomes learned across the fleet, served from the cloud.',
+    reason:
+      'Corpus-ranked heal uses refactor outcomes learned across the fleet, served from the cloud.',
     unlockedBy: 'Enable the hosted heal service on a Reticle Cloud team plan.',
   },
   [CloudCapability.CI_GATE]: {
-    reason: 'Verify-before-merge is a governance gate that runs in your CI against a hosted policy.',
+    reason:
+      'Verify-before-merge is a governance gate that runs in your CI against a hosted policy.',
     unlockedBy: 'Configure the Reticle Cloud CI gate for your repository.',
   },
 };

--- a/packages/core/src/wire-schema.test.ts
+++ b/packages/core/src/wire-schema.test.ts
@@ -40,3 +40,13 @@ describe('wire-contract JSON Schema', () => {
     expect(json).toContain('anyOf');
   });
 });
+
+describe('bridgeWsUrl — the one bridge-URL builder', () => {
+  it('composes host, port, and the ws path; defaults to localhost + the default port', () => {
+    expect(core.bridgeWsUrl(58432)).toBe(`ws://localhost:58432${core.RETICLE_WS_PATH}`);
+    expect(core.bridgeWsUrl()).toBe(
+      `ws://localhost:${String(core.RETICLE_DEFAULT_PORT)}${core.RETICLE_WS_PATH}`,
+    );
+    expect(core.bridgeWsUrl(4400, '127.0.0.1')).toBe(`ws://127.0.0.1:4400${core.RETICLE_WS_PATH}`);
+  });
+});

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/eslint-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Reticle ESLint plugin — keeps the signal layer self-enforcing (mutation-without-signal).",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/next",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Next.js helper for Reticle: keeps SWC, adds source-file mapping via a dev-only webpack pre-loader (data-reticle-source).",
   "license": "Apache-2.0",
   "author": "Reticle contributors",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/protocol",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "Deprecated alias for @reticlehq/core. The Reticle wire contract moved into the core foundation; this alias is no longer published (unpublished after v2.0.0) — import from @reticlehq/core.",
   "type": "module",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/react",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Reticle React adapter — maps a DOM ref to its component stack and source file via the fiber tree.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Reticle bridge + MCP server. Hosts the browser WS endpoint and exposes MCP tools to the coding agent.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/server/src/bridge-security.ts
+++ b/packages/server/src/bridge-security.ts
@@ -53,7 +53,13 @@ export async function resolveBridgeSecurityWithAutoToken(
   const dir = options.pairingTokenDir ?? defaultPairingTokenDir();
   const token = await readOrCreatePairingToken(dir, nodePairingTokenDeps());
   if (token === undefined) {
-    log('pairing_token_provision_failed', { dir });
+    // Fail-open is deliberate (never block a dev daemon on an unwritable $HOME), but it must be LOUD:
+    // the bridge is now trusting every loopback origin. Say so plainly, not just as a silent event.
+    log('pairing_token_provision_failed', {
+      dir,
+      warning:
+        'SECURITY: could not provision a pairing token — the bridge is running WITHOUT auth and will trust any localhost origin. Any local process/page can drive your browser sessions. Fix write access to this dir, or set RETICLE_TOKEN.',
+    });
     return security;
   }
   return { ...security, token };

--- a/packages/server/src/cli-verify.ts
+++ b/packages/server/src/cli-verify.ts
@@ -14,7 +14,7 @@ import { join, basename } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import {
   RETICLE_DEFAULT_PORT,
-  RETICLE_WS_PATH,
+  bridgeWsUrl,
   isLoopbackHostname,
   ReticleDir,
   RunAgentKind,
@@ -181,7 +181,7 @@ async function openLiveConnection(opts: LiveOpts): Promise<VerifyConnection> {
     ? {}
     : (() => {
         const token = randomUUID();
-        const bridgeUrl = `ws://localhost:${String(RETICLE_DEFAULT_PORT)}${RETICLE_WS_PATH}`;
+        const bridgeUrl = bridgeWsUrl(RETICLE_DEFAULT_PORT);
         return {
           token,
           injectConnect: { token, url: bridgeUrl },

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -11,6 +11,7 @@ import {
   removePid,
   spawnDaemon,
   discoverDaemonPort,
+  writeDaemonRegistry,
 } from './daemon.js';
 import { waitForDaemon, startMcpProxy, probeDaemon } from './mcp-proxy.js';
 import { installDaemonResilience } from './daemon-resilience.js';
@@ -20,7 +21,7 @@ import { handleVerify } from './cli-verify.js';
 import { runInit } from './init/run.js';
 import { buildNodeIo } from './init/node-io.js';
 import { describeLicense } from './license/license.js';
-import { readProjectPort } from './cli-port.js';
+import { readProjectPort, readProjectId } from './cli-port.js';
 import type { StartOptions } from './index.js';
 
 import {
@@ -217,6 +218,15 @@ function handleDaemonInner(parsed: {
   startDaemon(options)
     .then((server) => {
       log('reticle_daemon_ready', { port: parsed.port, pid: process.pid });
+      // Publish to the discovery registry so a build plugin can find this daemon by projectId — no
+      // hand-reconciled port. Written from the child (only it knows its cwd); removePid drops it.
+      const registryProjectId = readProjectId(process.cwd());
+      writeDaemonRegistry(parsed.port, {
+        pid: process.pid,
+        cwd: process.cwd(),
+        startedAt: Date.now(),
+        ...(registryProjectId !== undefined ? { projectId: registryProjectId } : {}),
+      });
       // The daemon serves many agents — keep it alive through one agent's stray async error; only a
       // genuine uncaught throw takes it down (cleanly, so the next `reticle mcp` respawns it fresh).
       installDaemonResilience(process, log, () => {

--- a/packages/server/src/daemon.ts
+++ b/packages/server/src/daemon.ts
@@ -10,11 +10,22 @@ import {
   readdirSync,
 } from 'node:fs';
 import { spawn } from 'node:child_process';
+import {
+  daemonRegistryFileName,
+  daemonRegistryPort,
+  DaemonRegistryEntrySchema,
+  pickDaemonPort,
+  type DaemonRegistryEntry,
+} from '@reticlehq/core';
 
 const RETICLE_HOME = join(homedir(), '.reticle');
 
 function pidPath(port: number): string {
   return join(RETICLE_HOME, `daemon-${port}.pid`);
+}
+
+function registryPath(port: number): string {
+  return join(RETICLE_HOME, daemonRegistryFileName(port));
 }
 
 export function logPath(port: number): string {
@@ -45,6 +56,69 @@ export function writePid(port: number): void {
 export function removePid(port: number): void {
   const path = pidPath(port);
   if (existsSync(path)) unlinkSync(path);
+  // The discovery registry entry shares this daemon's lifetime — clean both so a dead daemon never
+  // lingers in discovery. Keyed by port, so this is safe from the parent (stop) or the child (shutdown).
+  removeDaemonRegistry(port);
+}
+
+/**
+ * Publish this daemon to the discovery registry so a build-time plugin can find it by projectId. Called
+ * from the daemon CHILD on ready (only it knows its cwd/projectId). Best-effort: a write failure must
+ * never fail daemon startup — discovery just falls back to the default port.
+ */
+export function writeDaemonRegistry(
+  port: number,
+  meta: { pid: number; cwd: string; projectId?: string; startedAt: number },
+): void {
+  const entry: DaemonRegistryEntry = {
+    port,
+    pid: meta.pid,
+    cwd: meta.cwd,
+    startedAt: meta.startedAt,
+    ...(meta.projectId !== undefined ? { projectId: meta.projectId } : {}),
+  };
+  try {
+    mkdirSync(RETICLE_HOME, { recursive: true });
+    writeFileSync(registryPath(port), JSON.stringify(entry), 'utf8');
+  } catch {
+    // discovery is a convenience — never block startup on it
+  }
+}
+
+export function removeDaemonRegistry(port: number): void {
+  const path = registryPath(port);
+  try {
+    if (existsSync(path)) unlinkSync(path);
+  } catch {
+    // racing another cleaner — already gone
+  }
+}
+
+/**
+ * Discover the port of a live daemon serving `projectId` by reading the registry entries in ~/.reticle.
+ * Returns null when none matches (caller falls back to the default port — never guesses a mismatched
+ * daemon). Stale entries (crashed daemons) are ignored via the pid liveness probe.
+ */
+export function discoverDaemonPortForProject(projectId: string | undefined): number | null {
+  const entries: DaemonRegistryEntry[] = [];
+  let files: string[];
+  try {
+    files = readdirSync(RETICLE_HOME);
+  } catch {
+    return null; // no ~/.reticle yet
+  }
+  for (const file of files) {
+    if (daemonRegistryPort(file) === null) continue;
+    try {
+      const parsed = DaemonRegistryEntrySchema.safeParse(
+        JSON.parse(readFileSync(join(RETICLE_HOME, file), 'utf8')),
+      );
+      if (parsed.success) entries.push(parsed.data);
+    } catch {
+      // unreadable/corrupt entry — skip it
+    }
+  }
+  return pickDaemonPort(entries, projectId, isAlive);
 }
 
 export function isRunning(port: number): boolean {
@@ -104,6 +178,7 @@ export function reclaimStaleDaemons(
     if (pid === null || !pidAlive(pid)) {
       try {
         unlinkSync(path);
+        removeDaemonRegistry(Number(match[1])); // drop the sidecar discovery entry too
         reclaimed.push(Number(match[1]));
       } catch {
         // racing another reclaimer — fine, it's already gone

--- a/packages/server/src/flows/flow-replay-run.ts
+++ b/packages/server/src/flows/flow-replay-run.ts
@@ -6,6 +6,7 @@ import {
   ReplayStatus,
   RunKind,
   RunStatus,
+  type FlowFile,
   type FlowReplayResult,
   type FlowStepResult,
   type ReticleEvent,
@@ -73,6 +74,29 @@ async function recordReplayRun(
 }
 
 /**
+ * When a flow records the page its journey started on (`startPath`) and the tab is currently on a
+ * different route, step 1 drifts for a reason that has nothing to do with the app regressing — the
+ * anchor simply isn't on this page yet. Detect that so the decision says "navigate there first"
+ * instead of a mystifying "a step no longer matches". Returns undefined when the routes agree or the
+ * current route is unobservable (no route event) — never a false alarm. Replay itself does NOT
+ * navigate: a full-page load mid-replay tears down the session socket; the agent navigates between
+ * tool calls (reticle_navigate) where the session is re-resolved fresh.
+ */
+export function startPathMismatchHint(
+  flow: FlowFile,
+  session: { eventsSince(cursor: number): ReticleEvent[] },
+): string | undefined {
+  const startPath = flow.startPath;
+  if (startPath === undefined || startPath.length === 0) return undefined;
+  const routes = session.eventsSince(0).filter((e) => e.type === EventType.ROUTE_CHANGE);
+  const last = routes.at(-1);
+  const data = last?.data ?? {};
+  const current = asString(data['pathname']) ?? asString(data['to']);
+  if (current === undefined || current === startPath) return undefined;
+  return `this flow's journey starts on ${startPath} but the tab is on ${current} — navigate there (reticle_navigate { url: "${startPath}" }), then replay`;
+}
+
+/**
  * Replay one named flow end to end: load → re-resolve+run each step → assert the success oracle →
  * status + decision. Shared by reticle_flow_replay (single flow) and reticle_flow_verify (whole suite) so
  * both produce identical FlowReplayResults. Every exit path records a run to project.json.
@@ -103,6 +127,9 @@ export async function replayNamedFlow(
     };
   }
   const session = deps.sessions.resolve(asString(args['sessionId']));
+  // Captured before replay: if the tab isn't on the flow's start page, a step-1 drift is a wrong-page
+  // symptom, not a regression — surface that on the decision instead of a bare "a step no longer matches".
+  const startPathHint = startPathMismatchHint(loaded.value, session);
   // Floor the success oracle at the start of THIS replay so a stale signal from a prior run
   // in the same session can't fake a pass.
   const replayFloor = session.elapsed();
@@ -148,9 +175,18 @@ export async function replayNamedFlow(
       error: { code: ReplayStatus.ERROR, message: failed.error ?? 'flow action failed' },
     };
     errored.decision = buildDecision(errored, loaded.value);
+    applyStartPathHint(errored, startPathHint);
     return errored;
   }
   const result: FlowReplayResult = { name, status, steps };
   if (status !== ReplayStatus.OK) result.decision = buildDecision(result, loaded.value);
+  applyStartPathHint(result, startPathHint);
   return result;
+}
+
+/** Fold a start-page-mismatch hint onto a non-passing replay's decision (the actionable next move). */
+function applyStartPathHint(result: FlowReplayResult, hint: string | undefined): void {
+  if (hint === undefined || result.decision === undefined) return;
+  result.decision.suggestedFix = hint;
+  result.decision.nextAction = hint;
 }

--- a/packages/server/src/flows/flow-scope.ts
+++ b/packages/server/src/flows/flow-scope.ts
@@ -38,7 +38,9 @@ export function buildFlowChips(
     if (!flowInProjectScope(flow.projectId, sessionProjectId)) continue;
     const first = flow.steps[0];
     const start =
-      first !== undefined && first.anchor.kind === AnchorKind.TESTID ? first.anchor.value : undefined;
+      first !== undefined && first.anchor.kind === AnchorKind.TESTID
+        ? first.anchor.value
+        : undefined;
     chips.push(start === undefined ? { name: flow.name } : { name: flow.name, start });
   }
   return chips;

--- a/packages/server/src/flows/flow-startpath-hint.test.ts
+++ b/packages/server/src/flows/flow-startpath-hint.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { AnchorKind, EventType, FLOW_FILE_VERSION, type FlowFile, type ReticleEvent } from '@reticlehq/core';
+import { startPathMismatchHint } from './flow-replay-run.js';
+
+const flow = (startPath?: string): FlowFile => ({
+  version: FLOW_FILE_VERSION,
+  name: 'checkout',
+  createdAt: 1,
+  steps: [{ tool: 'reticle_act', anchor: { kind: AnchorKind.TESTID, value: 'pay' } }],
+  ...(startPath === undefined ? {} : { startPath }),
+});
+
+const onRoute = (pathname: string): { eventsSince(c: number): ReticleEvent[] } => ({
+  eventsSince: () => [{ t: 1, type: EventType.ROUTE_CHANGE, sessionId: 's', data: { pathname } }],
+});
+
+const noRoute = (): { eventsSince(c: number): ReticleEvent[] } => ({ eventsSince: () => [] });
+
+describe('startPathMismatchHint — wrong-page drift becomes an actionable next move', () => {
+  it('names the navigate target when the tab is on a different route', () => {
+    const hint = startPathMismatchHint(flow('/cart'), onRoute('/home'));
+    expect(hint).toContain('/cart');
+    expect(hint).toContain('reticle_navigate');
+  });
+
+  it('is silent when the tab is already on the start page', () => {
+    expect(startPathMismatchHint(flow('/cart'), onRoute('/cart'))).toBeUndefined();
+  });
+
+  it('is silent when the flow has no startPath (back-compat)', () => {
+    expect(startPathMismatchHint(flow(), onRoute('/home'))).toBeUndefined();
+  });
+
+  it('never false-alarms when the current route is unobservable', () => {
+    expect(startPathMismatchHint(flow('/cart'), noRoute())).toBeUndefined();
+  });
+});

--- a/packages/server/src/flows/flow-startpath-hint.test.ts
+++ b/packages/server/src/flows/flow-startpath-hint.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { AnchorKind, EventType, FLOW_FILE_VERSION, type FlowFile, type ReticleEvent } from '@reticlehq/core';
+import {
+  AnchorKind,
+  EventType,
+  FLOW_FILE_VERSION,
+  type FlowFile,
+  type ReticleEvent,
+} from '@reticlehq/core';
 import { startPathMismatchHint } from './flow-replay-run.js';
 
 const flow = (startPath?: string): FlowFile => ({

--- a/packages/server/src/flows/flow-tools.ts
+++ b/packages/server/src/flows/flow-tools.ts
@@ -138,7 +138,9 @@ export const FLOW_TOOLS: ToolDef[] = [
       sessionId: z
         .string()
         .optional()
-        .describe('Active session ID — scopes the list to that app. Omit to list every saved flow.'),
+        .describe(
+          'Active session ID — scopes the list to that app. Omit to list every saved flow.',
+        ),
     },
     outputSchema: {
       flows: z.array(

--- a/packages/server/src/flows/flow-tools.ts
+++ b/packages/server/src/flows/flow-tools.ts
@@ -183,6 +183,34 @@ export const FLOW_TOOLS: ToolDef[] = [
     },
   },
   {
+    name: ReticleTool.FLOW_DELETE,
+    description:
+      'Delete a saved flow file so a renamed/obsolete flow stops lingering in the replay list. Scoped ' +
+      'to the connected app. Returns { deleted: true } or a structured { error, code } (code not_found ' +
+      'when no such flow — deleting an absent flow is an error, not a silent no-op).',
+    inputSchema: {
+      flowName: z
+        .string()
+        .describe('Flow file name (without .json extension) from reticle_flow_list.'),
+      sessionId: z
+        .string()
+        .optional()
+        .describe('Active session ID — resolves the flow within that app’s scope.'),
+    },
+    outputSchema: {
+      deleted: z.boolean().optional(),
+      error: z.string().optional(),
+      code: z.string().optional(),
+    },
+    handler: (deps: ToolDeps, args) => {
+      const projectId = sessionProjectId(deps, asString(args['sessionId']));
+      return deps.flows.remove(asString(args['flowName']) ?? '', projectId).then((res) => {
+        if (!res.ok) return { error: flowErrorMessage(res.code), code: res.code };
+        return { deleted: true };
+      });
+    },
+  },
+  {
     name: ReticleTool.FLOW_REPLAY,
     description:
       "Replay a git-checked flow from .reticle/flows/<name>.json. RE-RESOLVES each step's semantic " +

--- a/packages/server/src/flows/flows.scope.test.ts
+++ b/packages/server/src/flows/flows.scope.test.ts
@@ -81,6 +81,16 @@ describe('FlowStore — per-project storage (shared-daemon isolation)', () => {
     expect(await store.list()).toEqual(['a-only', 'b-only', 'flat-one']);
   });
 
+  it('unscoped load (CLI/CI, e.g. reticle_domain) resolves a per-project flow — not just lists it', async () => {
+    // The bug: list() unioned the subdirs but load()'s resolveReadPath did not, so an unscoped
+    // caller listed a nested flow then silently dropped it on `if (loaded.ok)` (flowCount:0).
+    await store.saveFlow(flow('nested-only'), 'app-a');
+    expect(await store.list()).toContain('nested-only'); // listed
+    const loaded = await store.load('nested-only'); // and now loadable with no projectId
+    expect(loaded.ok).toBe(true);
+    expect(loaded.ok && loaded.value.projectId).toBe('app-a');
+  });
+
   it('heal rewrites the nested file in place, never forking a flat copy', async () => {
     await store.saveFlow(flow('h', 'old-testid'), 'app-a');
     const healed = await store.heal(

--- a/packages/server/src/flows/flows.scope.test.ts
+++ b/packages/server/src/flows/flows.scope.test.ts
@@ -91,6 +91,21 @@ describe('FlowStore — per-project storage (shared-daemon isolation)', () => {
     expect(loaded.ok && loaded.value.projectId).toBe('app-a');
   });
 
+  it('remove deletes a per-project flow (and a second remove is NOT_FOUND, not a silent pass)', async () => {
+    await store.saveFlow(flow('stale'), 'app-a');
+    expect(await fs.exists(flowPath(root, 'stale', 'app-a'))).toBe(true);
+    expect((await store.remove('stale', 'app-a')).ok).toBe(true);
+    expect(await fs.exists(flowPath(root, 'stale', 'app-a'))).toBe(false);
+    expect(await store.list('app-a')).not.toContain('stale');
+    expect((await store.remove('stale', 'app-a')).ok).toBe(false); // gone → NOT_FOUND
+  });
+
+  it('remove resolves a nested flow with no projectId (mirrors load)', async () => {
+    await store.saveFlow(flow('nested'), 'app-a');
+    expect((await store.remove('nested')).ok).toBe(true);
+    expect(await fs.exists(flowPath(root, 'nested', 'app-a'))).toBe(false);
+  });
+
   it('heal rewrites the nested file in place, never forking a flat copy', async () => {
     await store.saveFlow(flow('h', 'old-testid'), 'app-a');
     const healed = await store.heal(

--- a/packages/server/src/flows/flows.ts
+++ b/packages/server/src/flows/flows.ts
@@ -344,7 +344,29 @@ export class FlowStore {
       if (await this.#fs.exists(nested)) return nested;
     }
     const flat = flowPath(this.#root, name);
-    return (await this.#fs.exists(flat)) ? flat : null;
+    if (await this.#fs.exists(flat)) return flat;
+    // No projectId (CLI/CI/contract callers, e.g. reticle_domain): mirror list()'s subdir union on
+    // the read side too — a flow saved under .reticle/flows/<projectId>/ must still load, else it is
+    // listed and then silently dropped by `if (loaded.ok)` (reticle_domain reports flowCount:0).
+    if (pid === undefined) return this.#resolveNestedPath(name);
+    return null;
+  }
+
+  /** Scan the per-project subdirs for a flow by name — the read-side of list()'s no-pid union. */
+  async #resolveNestedPath(name: string): Promise<string | null> {
+    const flowsDir = reticleDirPaths(this.#root).flows;
+    if (!(await this.#fs.exists(flowsDir))) return null;
+    let entries: string[];
+    try {
+      entries = await this.#fs.readdir(flowsDir);
+    } catch {
+      return null;
+    }
+    for (const dir of entries.filter((e) => !e.endsWith(FLOW_SUFFIX))) {
+      const nested = flowPath(this.#root, name, dir);
+      if (await this.#fs.exists(nested)) return nested;
+    }
+    return null;
   }
 
   /**

--- a/packages/server/src/flows/flows.ts
+++ b/packages/server/src/flows/flows.ts
@@ -398,4 +398,18 @@ export class FlowStore {
     if (!result.success) return { ok: false, code: FlowErrorCode.PARSE_FAILED };
     return { ok: true, value: result.data };
   }
+
+  /**
+   * Delete a flow's file so a renamed/obsolete flow stops lingering in the replay list. Resolves the
+   * same path `load()` would (per-project copy, else legacy flat, else a subdir scan for the no-pid
+   * caller), then removes it. NOT_FOUND when nothing resolves — deleting an absent flow is an error,
+   * not a silent no-op, so a typo doesn't read as success.
+   */
+  async remove(name: string, projectId?: string): Promise<FlowResult<void>> {
+    if (!isValidFlowName(name)) return { ok: false, code: FlowErrorCode.INVALID_NAME };
+    const path = await this.#resolveReadPath(name, safeProjectId(projectId));
+    if (path === null) return { ok: false, code: FlowErrorCode.NOT_FOUND };
+    await this.#fs.rm(path);
+    return { ok: true, value: undefined };
+  }
 }

--- a/packages/server/src/init/snippets.ts
+++ b/packages/server/src/init/snippets.ts
@@ -3,7 +3,7 @@
  * so the runner never inlines free strings.
  */
 
-import { RETICLE_DEFAULT_PORT, RETICLE_WS_PATH } from '@reticlehq/core';
+import { RETICLE_DEFAULT_PORT, bridgeWsUrl } from '@reticlehq/core';
 
 /**
  * The connect() argument literal: a non-default port adds a `url`, and a projectId is always passed
@@ -12,7 +12,7 @@ import { RETICLE_DEFAULT_PORT, RETICLE_WS_PATH } from '@reticlehq/core';
 function connectArg(port: number | undefined, projectId?: string): string {
   const parts: string[] = [];
   if (port !== undefined && port !== RETICLE_DEFAULT_PORT) {
-    parts.push(`url: 'ws://localhost:${String(port)}${RETICLE_WS_PATH}'`);
+    parts.push(`url: '${bridgeWsUrl(port)}'`);
   }
   if (projectId !== undefined && projectId.length > 0) parts.push(`projectId: '${projectId}'`);
   return parts.length > 0 ? `{ ${parts.join(', ')} }` : '';

--- a/packages/server/src/session/output-budget.test.ts
+++ b/packages/server/src/session/output-budget.test.ts
@@ -112,6 +112,7 @@ function fakeDeps(events: ReticleEvent[]): ToolDeps {
     eventsInWindow: () => events,
     eventsSince: () => events,
     health: () => ({ lastSeenMs: 0, throttled: false, focused: true }),
+    bufferHealth: () => ({ total: events.length, dropped: 0 }),
     getState: () => SessionState.ACTIVE,
     drainInbox: () => [],
   };

--- a/packages/server/src/session/session-health.ts
+++ b/packages/server/src/session/session-health.ts
@@ -1,5 +1,22 @@
-import { THROTTLED_WARNING } from '@reticlehq/core';
+import { BUFFER_EVICTION_WARNING, THROTTLED_WARNING } from '@reticlehq/core';
 import type { Session, SessionHealth } from './session.js';
+
+/** The evidence-completeness block spliced onto observe/network/console results. */
+interface BufferEnvelope {
+  buffer?: { held: number; dropped: number; note: string };
+}
+
+/**
+ * Buffer-honesty envelope for observe/network/console. When the ring buffer has evicted anything
+ * (age/size cap), a "no such event" answer may be a false negative — so we attach the drop count and
+ * an actionable note. OMITTED entirely when nothing was dropped: silence means the buffer is intact,
+ * so a clean/empty result there is trustworthy and costs zero tokens.
+ */
+export function bufferEnvelope(session: Session): BufferEnvelope {
+  const { total, dropped } = session.bufferHealth();
+  if (dropped === 0) return {};
+  return { buffer: { held: total, dropped, note: BUFFER_EVICTION_WARNING } };
+}
 
 /** The `session` (and optional throttled `warning`) block spliced onto act/assert results. */
 interface HealthEnvelope {

--- a/packages/server/src/session/session-manager.ts
+++ b/packages/server/src/session/session-manager.ts
@@ -1,3 +1,4 @@
+import { NO_SESSION_CONNECTED_ERROR } from '@reticlehq/core';
 import { Session, type SessionInfo } from './session.js';
 
 /**
@@ -119,9 +120,7 @@ export class SessionManager {
       return found;
     }
     if (this.#sessions.size === 0) {
-      throw new Error(
-        'no browser session connected — is your app running with @reticlehq/browser enabled?',
-      );
+      throw new Error(NO_SESSION_CONNECTED_ERROR);
     }
     // Scope to the agent's active project FIRST, so a stray tab from another app/origin (e.g. a
     // leftover dashboard on a different port) is structurally unselectable — it never enters the

--- a/packages/server/src/session/session.ts
+++ b/packages/server/src/session/session.ts
@@ -293,6 +293,11 @@ export class Session {
     return this.#buffer.window(windowMs, this.elapsed());
   }
 
+  /** Buffer honesty: events currently held + cumulative evictions since connect (for false-negative detection). */
+  bufferHealth(): { total: number; dropped: number } {
+    return this.#buffer.bufferHealth();
+  }
+
   onEvent(listener: (event: ReticleEvent) => void): () => void {
     this.#listeners.add(listener);
     return () => this.#listeners.delete(listener);

--- a/packages/server/src/session/tools.session-health.test.ts
+++ b/packages/server/src/session/tools.session-health.test.ts
@@ -41,6 +41,7 @@ function fakeSession(throttled: boolean): Session {
     onEvent: () => () => undefined,
     command,
     health: () => health,
+    bufferHealth: () => ({ total: 0, dropped: 0 }),
     throttled: () => throttled,
     // Live-control: a clean active session — no pause short-circuit, no piggyback.
     getState: () => SessionState.ACTIVE,

--- a/packages/server/src/tools/invoke-tool.test.ts
+++ b/packages/server/src/tools/invoke-tool.test.ts
@@ -22,6 +22,7 @@ function throttledSession(): Session {
     url: 'http://localhost:5173/app',
     command: () => Promise.resolve({ kind: 'command_result', id: 'c', ok: true, result: {} }),
     eventsSince: () => [],
+    bufferHealth: () => ({ total: 0, dropped: 0 }),
     health: () => ({
       lastSeenMs: 99_999,
       throttled: true,

--- a/packages/server/src/tools/invoke-tool.ts
+++ b/packages/server/src/tools/invoke-tool.ts
@@ -49,6 +49,7 @@ export const SESSION_EXEMPT_TOOLS: ReadonlySet<string> = new Set([
   ReticleTool.FLOW_SAVE, // sessionId only scopes the write to the app's flow subdir; disk-side
   ReticleTool.FLOW_LIST, // sessionId only scopes which project's flows are listed; disk read
   ReticleTool.FLOW_LOAD, // sessionId only scopes which project's flow is read; disk read
+  ReticleTool.FLOW_DELETE, // sessionId only scopes which project's flow is removed; disk delete
   ReticleTool.FLOW_REPLAY, // returns its own FlowReplayResult contract (+ auto-records a run)
   ReticleTool.FLOW_VERIFY, // returns its own SuiteVerdict contract (replays the whole suite)
   ReticleTool.FLOW_SAVE_RECORDED, // reads the recording buffer, writes disk

--- a/packages/server/src/tools/observe-tools.ts
+++ b/packages/server/src/tools/observe-tools.ts
@@ -18,11 +18,24 @@ import {
   projectConsoleLog,
 } from '../events/event-filters.js';
 import { applyEventBudget, costHint, withSizeCost } from '../session/output-budget.js';
-import { healthEnvelope } from '../session/session-health.js';
+import { healthEnvelope, bufferEnvelope } from '../session/session-health.js';
 import { isPresenceOnlyAssertion, PRESENCE_ONLY_ADVICE } from './assert-grade.js';
 import { withControl } from '../session/control-envelope.js';
 import { asString, asNumber } from './tools-helpers.js';
 import { type ToolDef, sessionIdShape, commandOrThrow } from './tool-kit.js';
+
+/**
+ * Evidence-completeness block: present on observe/network/console only when the ring buffer has
+ * evicted events, so a "no such event" answer is distinguishable from "I dropped it" (issue #27).
+ */
+const bufferOutputShape = {
+  buffer: z
+    .object({ held: z.number(), dropped: z.number(), note: z.string() })
+    .optional()
+    .describe(
+      'Present only when the event buffer evicted events — a negative result may then be a false negative.',
+    ),
+};
 
 export const OBSERVE_TOOLS: ToolDef[] = [
   {
@@ -81,6 +94,7 @@ export const OBSERVE_TOOLS: ToolDef[] = [
       session: z
         .object({ lastSeenMs: z.number(), throttled: z.boolean(), focused: z.boolean() })
         .optional(),
+      ...bufferOutputShape,
     },
     handler: (deps, args) => {
       const session = deps.sessions.resolve(asString(args['sessionId']));
@@ -103,6 +117,7 @@ export const OBSERVE_TOOLS: ToolDef[] = [
           ...report,
           cost: costHint(report, budgeted.length, droppedOldest),
           ...healthEnvelope(session),
+          ...bufferEnvelope(session),
         }),
       );
     },
@@ -230,6 +245,7 @@ export const OBSERVE_TOOLS: ToolDef[] = [
       droppedOldest: z.number().optional().describe('How many older matches `limit` dropped.'),
       hint: z.object({ totalInWindow: z.number(), present: z.array(z.string()) }).optional(),
       cost: z.object({ bytes: z.number(), tokens: z.number() }).optional(),
+      ...bufferOutputShape,
     },
     handler: (deps, args) => {
       const session = deps.sessions.resolve(asString(args['sessionId']));
@@ -238,18 +254,21 @@ export const OBSERVE_TOOLS: ToolDef[] = [
       const urlContains = asString(args['urlContains']);
       const status = asNumber(args['status']);
       const limit = asNumber(args['limit']);
+      const buffer = bufferEnvelope(session);
       // Completed calls + unresolved in-flight requests (a hung request shows as pending).
       const allNet = reconcileNet(session.eventsSince(since));
       const matched = allNet.filter((e) => matchNet(e, method, urlContains, status));
       // zero-match filter returns what DID fire, not a bare [].
       if (matched.length === 0 && allNet.length > 0) {
-        return Promise.resolve(withSizeCost({ calls: matched, hint: netEmptyHint(allNet) }));
+        return Promise.resolve(withSizeCost({ calls: matched, hint: netEmptyHint(allNet), ...buffer }));
       }
       const { events: budgeted, droppedOldest } = applyEventBudget(matched, limit);
       const calls = budgeted.map(projectNetCall);
       return Promise.resolve(
         withSizeCost(
-          droppedOldest > 0 ? { calls, total: matched.length, droppedOldest } : { calls },
+          droppedOldest > 0
+            ? { calls, total: matched.length, droppedOldest, ...buffer }
+            : { calls, ...buffer },
         ),
       );
     },
@@ -286,22 +305,28 @@ export const OBSERVE_TOOLS: ToolDef[] = [
       droppedOldest: z.number().optional().describe('How many older matches `limit` dropped.'),
       hint: z.object({ totalInWindow: z.number(), byLevel: z.record(z.number()) }).optional(),
       cost: z.object({ bytes: z.number(), tokens: z.number() }).optional(),
+      ...bufferOutputShape,
     },
     handler: (deps, args) => {
       const session = deps.sessions.resolve(asString(args['sessionId']));
       const since = asNumber(args['since']) ?? 0;
       const level = asString(args['level']);
       const limit = asNumber(args['limit']);
+      const buffer = bufferEnvelope(session);
       const allConsole = session.eventsSince(since).filter(isConsoleEvent);
       const matched = allConsole.filter((e) => matchConsole(e, level));
       // zero matches at this level → report what levels ARE present (not a bare []).
       if (matched.length === 0 && allConsole.length > 0) {
-        return Promise.resolve(withSizeCost({ logs: matched, hint: consoleEmptyHint(allConsole) }));
+        return Promise.resolve(
+          withSizeCost({ logs: matched, hint: consoleEmptyHint(allConsole), ...buffer }),
+        );
       }
       const { events: budgeted, droppedOldest } = applyEventBudget(matched, limit);
       const logs = budgeted.map(projectConsoleLog);
       return Promise.resolve(
-        withSizeCost(droppedOldest > 0 ? { logs, total: matched.length, droppedOldest } : { logs }),
+        withSizeCost(
+          droppedOldest > 0 ? { logs, total: matched.length, droppedOldest, ...buffer } : { logs, ...buffer },
+        ),
       );
     },
   },

--- a/packages/server/src/tools/observe-tools.ts
+++ b/packages/server/src/tools/observe-tools.ts
@@ -260,7 +260,9 @@ export const OBSERVE_TOOLS: ToolDef[] = [
       const matched = allNet.filter((e) => matchNet(e, method, urlContains, status));
       // zero-match filter returns what DID fire, not a bare [].
       if (matched.length === 0 && allNet.length > 0) {
-        return Promise.resolve(withSizeCost({ calls: matched, hint: netEmptyHint(allNet), ...buffer }));
+        return Promise.resolve(
+          withSizeCost({ calls: matched, hint: netEmptyHint(allNet), ...buffer }),
+        );
       }
       const { events: budgeted, droppedOldest } = applyEventBudget(matched, limit);
       const calls = budgeted.map(projectNetCall);
@@ -325,7 +327,9 @@ export const OBSERVE_TOOLS: ToolDef[] = [
       const logs = budgeted.map(projectConsoleLog);
       return Promise.resolve(
         withSizeCost(
-          droppedOldest > 0 ? { logs, total: matched.length, droppedOldest, ...buffer } : { logs, ...buffer },
+          droppedOldest > 0
+            ? { logs, total: matched.length, droppedOldest, ...buffer }
+            : { logs, ...buffer },
         ),
       );
     },

--- a/packages/server/src/tools/profiles.ts
+++ b/packages/server/src/tools/profiles.ts
@@ -62,6 +62,7 @@ const STANDARD_TOOL_NAMES: ReadonlySet<string> = new Set([
   ReticleTool.FLOW_SAVE,
   ReticleTool.FLOW_LIST,
   ReticleTool.FLOW_LOAD,
+  ReticleTool.FLOW_DELETE,
   ReticleTool.FLOW_REPLAY,
   ReticleTool.FLOW_VERIFY,
   ReticleTool.FLOW_HEAL,

--- a/packages/server/src/tools/tool-names.ts
+++ b/packages/server/src/tools/tool-names.ts
@@ -29,6 +29,7 @@ export const ReticleTool = {
   FLOW_SAVE: 'reticle_flow_save',
   FLOW_LIST: 'reticle_flow_list',
   FLOW_LOAD: 'reticle_flow_load',
+  FLOW_DELETE: 'reticle_flow_delete',
   FLOW_REPLAY: 'reticle_flow_replay',
   /** replay EVERY saved flow → one consolidated suite verdict + prioritized fixes (the loop closer). */
   FLOW_VERIFY: 'reticle_flow_verify',

--- a/packages/server/src/tools/tools.near-miss.test.ts
+++ b/packages/server/src/tools/tools.near-miss.test.ts
@@ -14,6 +14,7 @@ function sessionWith(events: ReticleEvent[]): Session {
     id: 'demo',
     eventsSince: () => events,
     health: () => ({ lastSeenMs: 0, throttled: false, focused: true }),
+    bufferHealth: () => ({ total: events.length, dropped: 0 }),
     getState: () => undefined as never,
     drainInbox: () => [],
   };
@@ -123,5 +124,44 @@ describe('token budget on reticle_network / reticle_console', () => {
     expect(r.logs.map((l) => l.text)).toEqual(['c']);
     expect(r.total).toBe(3);
     expect(r.droppedOldest).toBe(2);
+  });
+});
+
+describe('buffer honesty — a negative result after eviction is not silent', () => {
+  /** A session whose ring buffer has evicted `dropped` events since connect. */
+  function depsWithDrops(events: ReticleEvent[], dropped: number): ToolDeps {
+    const stub: Partial<Session> = {
+      id: 'demo',
+      eventsSince: () => events,
+      eventsInWindow: () => events,
+      health: () => ({ lastSeenMs: 0, throttled: false, focused: true }),
+      bufferHealth: () => ({ total: events.length, dropped }),
+      elapsed: () => 0,
+      lastActCursor: () => undefined,
+      getState: () => undefined as never,
+      drainInbox: () => [],
+    };
+    const sessions: Partial<SessionManager> = { resolve: () => stub as Session };
+    return { sessions: sessions as SessionManager } as ToolDeps;
+  }
+
+  it('reticle_network: an empty result WITH evictions carries a buffer block (not a false clean no)', async () => {
+    const r = (await tool(ReticleTool.NETWORK).handler(depsWithDrops([], 12), {
+      method: 'POST',
+    })) as { calls: unknown[]; buffer?: { held: number; dropped: number; note: string } };
+    expect(r.calls).toHaveLength(0);
+    expect(r.buffer?.dropped).toBe(12);
+    expect(r.buffer?.note.length).toBeGreaterThan(0);
+  });
+
+  it('reticle_observe / console: an intact buffer (0 drops) omits the block entirely', async () => {
+    const net = (await tool(ReticleTool.NETWORK).handler(depsWithDrops([], 0), {})) as {
+      buffer?: unknown;
+    };
+    const obs = (await tool(ReticleTool.OBSERVE).handler(depsWithDrops([], 0), {})) as {
+      buffer?: unknown;
+    };
+    expect(net.buffer).toBeUndefined();
+    expect(obs.buffer).toBeUndefined();
   });
 });

--- a/packages/server/src/visual/visual-store.test.ts
+++ b/packages/server/src/visual/visual-store.test.ts
@@ -53,4 +53,10 @@ describe('VisualStore — temp dir, never touches the repo', () => {
     expect(await store.readBaseline('../escape')).toBeUndefined();
     expect(await store.hasBaseline('../escape')).toBe(false);
   });
+
+  it('6: the path-echo methods also reject a traversal name (never echo an out-of-dir path)', () => {
+    expect(() => store.baselinePath('../escape')).toThrow();
+    expect(() => store.diffPath('../escape')).toThrow();
+    expect(store.baselinePath('home').endsWith(join('.reticle', 'visual', 'home.png'))).toBe(true);
+  });
 });

--- a/packages/server/src/visual/visual-store.ts
+++ b/packages/server/src/visual/visual-store.ts
@@ -19,13 +19,16 @@ export class VisualStore {
     this.#root = root;
   }
 
-  /** The absolute baseline path for `name` (for echoing back to the agent). */
+  /** The absolute baseline path for `name` (for echoing back to the agent). Guards the name so a
+   *  crafted value can never echo a path outside .reticle/visual/ to a future caller that does IO. */
   baselinePath(name: string): string {
+    if (!isValidFlowName(name)) throw new Error(`invalid visual baseline name: ${name}`);
     return visualPath(this.#root, name);
   }
 
-  /** The absolute overlay-diff path for `name`. */
+  /** The absolute overlay-diff path for `name`. Same name guard as baselinePath. */
   diffPath(name: string): string {
+    if (!isValidFlowName(name)) throw new Error(`invalid visual diff name: ${name}`);
     return visualDiffPath(this.#root, name);
   }
 

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/test",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Reticle test runner: reticleTest spec registry + a runner that drives Reticle tools without MCP/stdio.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/vite-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Vite plugin for Reticle: dev-only source-map stamping plus auto-injected reticle.connect(). apply:'serve' guarantees it never ships to production.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/vite-plugin/src/discover-port.test.ts
+++ b/packages/vite-plugin/src/discover-port.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { daemonRegistryFileName, type DaemonRegistryEntry } from '@reticlehq/core';
+import { discoverDaemonPort } from './discover-port.js';
+
+const alive = (): boolean => true;
+
+describe('discoverDaemonPort — build-time daemon discovery by projectId', () => {
+  let home: string;
+
+  const drop = async (e: Partial<DaemonRegistryEntry> & { port: number }): Promise<void> => {
+    const entry: DaemonRegistryEntry = { pid: 1, cwd: '/app', startedAt: 1, ...e };
+    await writeFile(join(home, daemonRegistryFileName(e.port)), JSON.stringify(entry));
+  };
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'reticle-discover-'));
+  });
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it('finds the daemon whose projectId matches the app', async () => {
+    await drop({ port: 4400, projectId: 'other-app' });
+    await drop({ port: 4460, projectId: 'my-app' });
+    expect(discoverDaemonPort('my-app', home, alive)).toBe(4460);
+  });
+
+  it('returns undefined when no daemon serves this project (caller uses the default port)', async () => {
+    await drop({ port: 4400, projectId: 'other-app' });
+    expect(discoverDaemonPort('my-app', home, alive)).toBeUndefined();
+  });
+
+  it('skips a corrupt registry file instead of throwing', async () => {
+    await writeFile(join(home, daemonRegistryFileName(4400)), '{ not json');
+    await drop({ port: 4460, projectId: 'my-app' });
+    expect(discoverDaemonPort('my-app', home, alive)).toBe(4460);
+  });
+
+  it('returns undefined when ~/.reticle does not exist', () => {
+    expect(discoverDaemonPort('my-app', join(home, 'nope'), alive)).toBeUndefined();
+  });
+});

--- a/packages/vite-plugin/src/discover-port.ts
+++ b/packages/vite-plugin/src/discover-port.ts
@@ -1,0 +1,57 @@
+/**
+ * Build-time daemon discovery: when the app doesn't pin a port, find the daemon serving THIS project
+ * by reading the registry entries the daemon drops in ~/.reticle (daemon-<port>.json). Node-only and
+ * runs at dev-server request time (the daemon is up by then). The tricky selection rule — match by
+ * projectId, drop dead daemons — is the pure `pickDaemonPort` in core; this file is just the fs plumbing.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import {
+  daemonRegistryPort,
+  DaemonRegistryEntrySchema,
+  pickDaemonPort,
+  ReticleDir,
+  type DaemonRegistryEntry,
+} from '@reticlehq/core';
+
+/** process.kill(pid, 0) throws iff the process is gone — the same liveness probe the daemon uses. */
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The port of the live daemon serving `projectId`, or undefined when none matches (caller falls back
+ * to the default port — never auto-connects to a mismatched daemon). `home` and `alive` are injectable
+ * so the selection is unit-tested without a real ~/.reticle or real processes.
+ */
+export function discoverDaemonPort(
+  projectId: string | undefined,
+  home: string = join(homedir(), ReticleDir.ROOT),
+  alive: (pid: number) => boolean = isAlive,
+): number | undefined {
+  const entries: DaemonRegistryEntry[] = [];
+  let files: string[];
+  try {
+    files = readdirSync(home);
+  } catch {
+    return undefined; // no ~/.reticle yet
+  }
+  for (const file of files) {
+    if (daemonRegistryPort(file) === null) continue;
+    try {
+      const parsed = DaemonRegistryEntrySchema.safeParse(
+        JSON.parse(readFileSync(join(home, file), 'utf8')),
+      );
+      if (parsed.success) entries.push(parsed.data);
+    } catch {
+      // corrupt/unreadable entry — skip
+    }
+  }
+  return pickDaemonPort(entries, projectId, alive) ?? undefined;
+}

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -3,7 +3,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { transformSync } from '@babel/core';
 import reticleSource from '@reticlehq/babel-plugin';
-import { RETICLE_DEFAULT_PORT, RETICLE_WS_PATH, ReticleDir, ReticleEnv } from '@reticlehq/core';
+import { RETICLE_DEFAULT_PORT, bridgeWsUrl, ReticleDir, ReticleEnv } from '@reticlehq/core';
 import { resolveProjectId } from './project-id.js';
 
 export const RETICLE_VITE_PLUGIN_NAME = 'reticle';
@@ -107,8 +107,7 @@ export function readPairingToken(): string | undefined {
 function connectArgs(options: ReticleVitePluginOptions): string {
   const args: Record<string, string | number> = {};
   const port = options.port ?? RETICLE_DEFAULT_PORT;
-  if (port !== RETICLE_DEFAULT_PORT)
-    args['url'] = `ws://localhost:${String(port)}${RETICLE_WS_PATH}`;
+  if (port !== RETICLE_DEFAULT_PORT) args['url'] = bridgeWsUrl(port);
   if (options.session !== undefined) args['session'] = options.session;
   if (options.projectId !== undefined) args['projectId'] = options.projectId;
   if (options.token !== undefined) args['token'] = options.token;

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -5,6 +5,7 @@ import { transformSync } from '@babel/core';
 import reticleSource from '@reticlehq/babel-plugin';
 import { RETICLE_DEFAULT_PORT, bridgeWsUrl, ReticleDir, ReticleEnv } from '@reticlehq/core';
 import { resolveProjectId } from './project-id.js';
+import { discoverDaemonPort } from './discover-port.js';
 
 export const RETICLE_VITE_PLUGIN_NAME = 'reticle';
 
@@ -153,10 +154,15 @@ export function reticle(options: ReticleVitePluginOptions = {}): ReticleVitePlug
     },
     load(id) {
       if (!inject || id !== RETICLE_CONNECT_MODULE) return null;
+      // Resolve the daemon port lazily per request (like the token): an explicit port wins; else find
+      // the daemon serving THIS projectId in the discovery registry, so no hand-reconciled port. Falls
+      // back to the default when nothing matches (connectArgs omits url ⇒ SDK uses the default).
+      const port = resolved.port ?? discoverDaemonPort(resolved.projectId);
+      const withPort = port !== undefined ? { ...resolved, port } : resolved;
       // Read the token lazily per request: by the time the browser loads the app the daemon is up and
       // has written it. An explicit token option still wins. Undefined ⇒ omitted (page reloads once up).
-      const token = resolved.token ?? readPairingToken();
-      return connectModuleSource(token !== undefined ? { ...resolved, token } : resolved);
+      const token = withPort.token ?? readPairingToken();
+      return connectModuleSource(token !== undefined ? { ...withPort, token } : withPort);
     },
     transformIndexHtml() {
       if (!inject) return [];


### PR DESCRIPTION
## v2.0.1 — bug-fix release

Closes the open flow/verifier issues plus the audit findings from a sweep of hardcoding, install friction, security, agent experience, and the HUD. No breaking changes; on-disk flow files stay version 1.

### Correctness bugs (the verifier's honesty)
- **#27** — the event ring buffer evicted truth silently, so `observe`/`network`/`console` answered a confident "no" after the evidence expired. They now carry a `buffer: { held, dropped, note }` block when anything was evicted (omitted otherwise). A silent false negative becomes an honest one.
- **#26** — `reticle_domain` reported a fully-tested app as `flowCount: 0` because `FlowStore.load()` with no `projectId` never scanned the per-project subdirs `list()` already unioned. Fixed in one place; regression test added.

### Flow ergonomics
- **#23** — the recorder now captures the journey's `startPath`; replay turns a wrong-start-page step-1 drift into an actionable "navigate there, then replay" instead of a mystifying "a step no longer matches". (Auto-navigation is deferred — a full reload mid-replay tears down the session socket; reconnect-aware navigation is a follow-up.)
- **#25** — `reticle_flow_delete` + `FlowStore.remove()` so a renamed/obsolete flow can be pruned instead of lingering forever.

### Zero-config setup
- **#24** — daemon discovery registry: each daemon publishes `~/.reticle/daemon-<port>.json`, and the Vite plugin auto-connects to the daemon serving THIS project's id — no more hand-reconciling a port in two places. Falls back to the default; explicit port overrides. (Next plugin path + CLI discovery are follow-ups reusing the same registry.)
- One `bridgeWsUrl()` builder replaces four hand-built `ws://…/reticle` strings; the "no session connected" error now names a port mismatch as the usual cause; `apps/demo` reads its port from env.

### HUD
- The multi-line composer's default OS scrollbar is replaced with the thin styled one, content-box sizing no longer jumps on the first keystroke, and the textarea gets an accessible name.

### Security (dev-only, same-machine trust)
- `VisualStore.baselinePath`/`diffPath` reject traversal names like their siblings; a failed pairing-token provision now warns loudly that the bridge is running without auth instead of degrading silently. (No remote-exploitable issues were found — WS auth, path-traversal guards, loopback binding, and injection surfaces are all defended and tested.)

### Housekeeping
- All `@reticlehq/*` packages bumped to 2.0.1; CHANGELOG updated; ran prettier over pre-existing format drift on `main` (README/SKILL/upgrade.ts/flow-scope.ts) so `format:check` passes.

Also resolves **#22** (HUD cross-project flow bleed), which was already fixed on `main` but never closed.

Closes #23, #24, #25, #26, #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)
