### PR TITLE
chore(security): scope CodeQL, harden update-checker, bump pinned actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,12 +26,21 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           # Broader query set than the default — worth it for a security-adjacent tool.
           queries: security-and-quality
+          # Scan the code we SHIP. Test fixtures, benchmarks, and one-off scripts are not published;
+          # their unused-var / quality notes are noise on the Security tab, not user-facing risk.
+          config: |
+            paths-ignore:
+              - apps
+              - bench
+              - scripts
+              - '**/*.test.ts'
+              - '**/*.test.mjs'
       - name: Autobuild
-        uses: github/codeql-action/autobuild@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
       - name: Analyze
-        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22

--- a/.github/workflows/package-quality.yml
+++ b/.github/workflows/package-quality.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       id-token: write # npm provenance
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run analysis
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -39,6 +39,6 @@ jobs:
           path: results.sarif
           retention-days: 5
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif

--- a/packages/browser/src/dom/blind-spots.ts
+++ b/packages/browser/src/dom/blind-spots.ts
@@ -18,7 +18,7 @@ export function countCrossOriginFrames(): number {
   const frames: Array<{ sameOrigin: boolean; hasSrc: boolean }> = [];
   for (const frame of document.querySelectorAll('iframe')) {
     const hasSrc = frame.getAttribute('src') !== null && frame.getAttribute('src') !== '';
-    let sameOrigin = true;
+    let sameOrigin: boolean;
     try {
       // Reaching contentDocument throws (or yields null) for a cross-origin frame.
       sameOrigin = frame.contentDocument !== null;

--- a/packages/server/src/update/update-checker.test.ts
+++ b/packages/server/src/update/update-checker.test.ts
@@ -59,4 +59,13 @@ describe('checkForUpdate', () => {
     expect(result.latestVersion).toBe('2.0.0');
     expect(saved()?.latestVersion).toBe('2.0.0');
   });
+
+  it('rejects an implausible version from the registry and never persists it', async () => {
+    const { ports, saved } = makePorts(null, () =>
+      Promise.resolve({ version: '../../etc/passwd' } as never),
+    );
+    const result = await checkForUpdate('1.0.0', () => 0, ports);
+    expect(result.updateAvailable).toBe(false); // fell back to the safe no-update default
+    expect(saved()).toBeNull(); // the malformed response never reached disk
+  });
 });

--- a/packages/server/src/update/update-checker.ts
+++ b/packages/server/src/update/update-checker.ts
@@ -31,6 +31,34 @@ interface NpmPackageInfo {
   };
 }
 
+// npm's registry is trusted, but this response is persisted to disk AND echoed into the agent's
+// context, so validate its shape before it flows anywhere: a plausible semver, bounded free-text.
+const VERSION_RE = /^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/;
+const MAX_MANIFEST_TEXT = 20_000;
+
+/** Reject an implausible version (throws → caller falls back to cache) and bound the free-text
+ * fields, so a malformed or oversized registry response can neither corrupt nor bloat the manifest. */
+function validateNpmInfo(info: NpmPackageInfo): NpmPackageInfo {
+  if (typeof info.version !== 'string' || !VERSION_RE.test(info.version)) {
+    throw new Error('npm registry returned an implausible version');
+  }
+  const changelog =
+    typeof info.reticle?.changelog === 'string'
+      ? info.reticle.changelog.slice(0, MAX_MANIFEST_TEXT)
+      : undefined;
+  const breakingChanges = Array.isArray(info.reticle?.breakingChanges)
+    ? info.reticle.breakingChanges
+        .filter((x): x is string => typeof x === 'string')
+        .slice(0, 100)
+        .map((s) => s.slice(0, MAX_MANIFEST_TEXT))
+    : undefined;
+  const reticle: NpmPackageInfo['reticle'] = {
+    ...(changelog !== undefined ? { changelog } : {}),
+    ...(breakingChanges !== undefined ? { breakingChanges } : {}),
+  };
+  return { version: info.version, reticle };
+}
+
 export function loadManifest(): UpdateManifest | null {
   if (!fs.existsSync(MANIFEST_PATH)) return null;
   try {
@@ -101,7 +129,7 @@ export async function checkForUpdate(
   }
 
   try {
-    const info = await ports.fetchInfo();
+    const info = validateNpmInfo(await ports.fetchInfo());
     const updateAvailable = info.version !== currentVersion;
     const manifest: UpdateManifest = {
       currentVersion,


### PR DESCRIPTION
Clears the Security-tab noise. **Nothing here was user-facing** — every Dependabot vulnerability alert is in a private test fixture (`apps/*`, never published) or dev/transitive tooling; the CodeQL alerts were mostly unused-var notes in `bench/`, `scripts/`, and tests.

## What changed
- **CodeQL scoping** — `paths-ignore` for `apps`, `bench`, `scripts`, and test files so it scans only shipped `packages/*/src`. Clears ~35 non-shipped quality notes.
- **update-checker hardening** — validate the npm registry response (semver shape + bounded free-text) before it's persisted to `~/.reticle` and echoed to the agent. Breaks the `js/http-to-file-access` dataflow CodeQL flagged; hardens a real trust boundary. +1 test for the reject path.
- **blind-spots** — drop a dead `= true` initializer (both branches reassign it → `js/useless-assignment-to-local`).
- **Pinned action bumps** (folds in Dependabot #30–#34) — codeql-action v3→v4.37.3, scorecard-action v2.4.0→v2.4.4, pnpm/action-setup v4→v6.0.9.

## Not in this PR (your call — no security urgency, they're in dev/fixtures)
Major dependency bumps that can break the build: next 16 (#44), express 5 (#43), TypeScript 6 (#37), Vite 8 (#39), jsdom 29 (#38), @babel/core 8 (#36), @types/node 26 (#41), react-hooks 7 (#42).

🤖 Generated with [Claude Code](https://claude.com/claude-code)