### PR TITLE
fix(server): bound ref-strip regex (polynomial ReDoS)

### DIFF
--- a/packages/server/src/project/baselines.ts
+++ b/packages/server/src/project/baselines.ts
@@ -11,10 +11,14 @@ interface DiffResult {
 
 /** Strip volatile ref ids so snapshots compare by semantics, not by ref number. */
 export function normalizeLines(tree: string): string[] {
-  return tree
-    .split('\n')
-    .map((line) => line.replace(/\s*\(ref=e\d+\)/, '').trim())
-    .filter((line) => line.length > 0);
+  return (
+    tree
+      .split('\n')
+      // The separator before a ref marker is a single space; a bounded quantifier keeps this linear
+      // (an unbounded `\s*` here backtracks polynomially on a long whitespace run — a needless ReDoS).
+      .map((line) => line.replace(/\s?\(ref=e\d+\)/, '').trim())
+      .filter((line) => line.length > 0)
+  );
 }
 
 function frequency(lines: string[]): Map<string, number> {


### PR DESCRIPTION
Last of the real CodeQL findings from the security cleanup. `normalizeLines`'s `/\s*\(ref=e\d+\)/` backtracks polynomially on long whitespace runs; the ref separator is a single space, so bounded `\s?` is equivalent and linear. The other 6 CodeQL alerts were triaged as false positives and dismissed with justification (loopback IPC, atomic `wx` open, argv-array spawn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)