### PR TITLE
fix(server): close leaked logFd and handle failed spawn in spawnDaemon

### DIFF
--- a/packages/server/src/daemon-spawn.test.ts
+++ b/packages/server/src/daemon-spawn.test.ts
@@ -1,0 +1,107 @@
+/**
+ * spawnDaemon: verifies the parent closes the log fd, reports failure when spawn yields no pid, and
+ * handles synchronous spawn errors without leaving ghost pidfiles.
+ *
+ * These tests operate against the REAL ~/.reticle directory (RETICLE_HOME is a module-level constant
+ * computed at import time, not injectable). Unique high port numbers avoid collisions with any live
+ * daemon. Each test cleans up its pidfile + log + registry entry in afterEach.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, unlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnDaemon, readPid, logPath, removePid } from './daemon.js';
+import { tmpdir } from 'node:os';
+
+/** Ports far above any plausible daemon — avoids collisions with real instances. */
+const BASE_PORT = 59_100;
+let nextPort = BASE_PORT;
+function uniquePort(): number {
+  return nextPort++;
+}
+
+/** Tracks spawned children so we can kill them even if the test fails mid-way. */
+const spawnedPorts: number[] = [];
+
+afterEach(() => {
+  for (const port of spawnedPorts) {
+    const pid = readPid(port);
+    if (pid !== null) {
+      try {
+        process.kill(pid, 'SIGTERM');
+      } catch {
+        // already exited — fine
+      }
+    }
+    removePid(port, pid ?? process.pid);
+    // Clean up the log file best-effort.
+    try {
+      const log = logPath(port);
+      if (existsSync(log)) unlinkSync(log);
+    } catch {
+      // non-critical
+    }
+  }
+  spawnedPorts.length = 0;
+});
+
+describe('spawnDaemon', () => {
+  it('spawns a real process and writes its pid', () => {
+    const port = uniquePort();
+    spawnedPorts.push(port);
+    const script = join(tmpdir(), `reticle-test-${port}.mjs`);
+    writeFileSync(script, 'setTimeout(() => process.exit(0), 200);', 'utf8');
+
+    const ok = spawnDaemon(process.execPath, script, [], port);
+    expect(ok).toBe(true);
+
+    const pid = readPid(port);
+    expect(pid).not.toBeNull();
+    expect(typeof pid).toBe('number');
+    expect(pid).toBeGreaterThan(0);
+  });
+
+  it('returns false when the executable does not exist (spawn fails)', () => {
+    const port = uniquePort();
+    spawnedPorts.push(port);
+
+    const ok = spawnDaemon('/nonexistent/node', '/nonexistent/script.mjs', [], port);
+    // On most platforms, spawn with a missing executable sets child.pid to undefined.
+    // On platforms where spawn throws synchronously, the catch path returns false.
+    // Either way: no ghost pidfile left behind.
+    expect(ok).toBe(false);
+  });
+
+  it('closes the log fd in the parent (no leaked descriptors)', () => {
+    const port = uniquePort();
+    spawnedPorts.push(port);
+    const script = join(tmpdir(), `reticle-test-${port}.mjs`);
+    writeFileSync(script, 'process.exit(0);', 'utf8');
+
+    const ok = spawnDaemon(process.execPath, script, [], port);
+    expect(ok).toBe(true);
+
+    // The log file exists and is writable from the parent (not locked by a leaked fd).
+    const log = logPath(port);
+    expect(existsSync(log)).toBe(true);
+    expect(() => writeFileSync(log, 'test\n', { flag: 'a' })).not.toThrow();
+  });
+
+  it('does not spawn a duplicate when a live daemon already owns the port', () => {
+    const port = uniquePort();
+    spawnedPorts.push(port);
+    // A script that stays alive until killed — the afterEach hook sends SIGTERM.
+    const script = join(tmpdir(), `reticle-test-${port}.mjs`);
+    writeFileSync(
+      script,
+      'setInterval(() => {}, 1000); process.on("SIGTERM", () => process.exit(0));',
+      'utf8',
+    );
+
+    const first = spawnDaemon(process.execPath, script, [], port);
+    expect(first).toBe(true);
+
+    // Second attempt on the same port — pidfile exists with a live pid.
+    const second = spawnDaemon(process.execPath, script, [], port);
+    expect(second).toBe(false);
+  });
+});

--- a/packages/server/src/daemon.ts
+++ b/packages/server/src/daemon.ts
@@ -234,14 +234,54 @@ export function spawnDaemon(
       return false; // lost a concurrent reclaim race
     }
   }
-  const logFd = openSync(logPath(port), 'a');
-  const child = spawn(nodeExec, [scriptPath, ...args], {
-    detached: true,
-    stdio: ['ignore', logFd, logFd],
-  });
-  if (child.pid !== undefined) {
-    writeFileSync(lockFd, String(child.pid), 'utf8');
+  let logFd: number;
+  try {
+    logFd = openSync(logPath(port), 'a');
+  } catch {
+    // Log path unwritable (permissions, disk full). Clean up the lock so we don't leave a ghost.
+    closeSync(lockFd);
+    try {
+      unlinkSync(path);
+    } catch {
+      // racing another reclaimer — fine
+    }
+    return false;
   }
+  let child: ReturnType<typeof spawn>;
+  try {
+    child = spawn(nodeExec, [scriptPath, ...args], {
+      detached: true,
+      stdio: ['ignore', logFd, logFd],
+    });
+  } catch {
+    // spawn can throw synchronously on some platforms (e.g. ENOMEM, invalid args).
+    closeSync(logFd);
+    closeSync(lockFd);
+    try {
+      unlinkSync(path);
+    } catch {
+      // racing another reclaimer — fine
+    }
+    return false;
+  }
+  // The parent's copy of logFd is no longer needed — spawn duplicated it into the child.
+  closeSync(logFd);
+  // Suppress the async ENOENT/EACCES that fires when the executable is missing or unexecutable.
+  // The failure is already detected synchronously via `child.pid === undefined`; without this
+  // handler the error propagates as an uncaught exception and crashes the parent process.
+  child.on('error', () => undefined);
+  if (child.pid === undefined) {
+    // Spawn failed silently (resource exhaustion, invalid executable on some platforms). The pidfile
+    // is empty — clean it up so discovery doesn't see a ghost, and report failure honestly.
+    closeSync(lockFd);
+    try {
+      unlinkSync(path);
+    } catch {
+      // racing another reclaimer — fine
+    }
+    return false;
+  }
+  writeFileSync(lockFd, String(child.pid), 'utf8');
   closeSync(lockFd);
   child.unref();
   return true;


### PR DESCRIPTION
## Summary

- Close the parent's copy of `logFd` after `spawn()` duplicates it into the child (file descriptor leak)
- Return `false` and clean up the empty pidfile when `child.pid` is `undefined` (silent spawn failure creates a ghost daemon)
- Suppress the async `ENOENT` error event that would otherwise crash the parent process

## Motivation

`spawnDaemon` had two bugs that surface during normal development:

1. **fd leak:** Every `spawnDaemon` call leaked one file descriptor in the parent process. Node's `spawn` duplicates the fd into the child, so the parent must close its own copy. Over repeated daemon spawns (port changes, restarts), this accumulated leaked descriptors.

2. **Ghost daemon:** When `spawn` fails silently (invalid executable, resource exhaustion), `child.pid` is `undefined`. The function wrote nothing to the pidfile but returned `true` — so the caller believed a daemon was running, while `readPid()` returns `null` for the empty file. Discovery sees a ghost, and the next spawn hits `EEXIST` on the empty pidfile.

## Changes

| File | What |
|------|------|
| `packages/server/src/daemon.ts` | Close `logFd` after spawn; attach `error` handler; return `false` + unlink on undefined pid |
| `packages/server/src/daemon-spawn.test.ts` | New test covering: successful spawn, failed spawn cleanup, fd closure, and duplicate-spawn guard |

## Testing

- ✅ 4 new unit tests in `daemon-spawn.test.ts`
- ✅ All existing daemon tests pass (`daemon-reclaim`, `daemon-parity`, `daemon-resilience`)
- ✅ `pnpm lint` (0 errors)
- ✅ `pnpm typecheck` (0 errors)
- ✅ `pnpm format:check` (passes)

## Compatibility

No breaking changes. The only behavioral change is that `spawnDaemon` now returns `false` (instead of `true`) when spawn fails — a strictly more correct return value that no caller currently branches on (they treat `true` as "attempted", not "confirmed running").

🤖 Generated with [Claude Code](https://claude.com/claude-code)