### PR TITLE
fix(browser): use pre-bound native console.warn for SDK-internal diagnostics

### DIFF
--- a/packages/browser/src/registry/stores.test.ts
+++ b/packages/browser/src/registry/stores.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import * as nativeConsole from '../timers/native-console.js';
 import {
   registerStore,
   unregisterStore,
@@ -118,7 +119,7 @@ describe('store registry', () => {
  */
 describe('silent store registration', () => {
   it('warns when a store is registered without any way to observe changes', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const warn = vi.spyOn(nativeConsole, 'nativeWarn').mockImplementation(() => undefined);
     registerStore('getter-only', () => ({ count: 1 }));
     expect(warn).toHaveBeenCalledOnce();
     expect(String(warn.mock.calls[0]?.[0])).toContain('getter-only');
@@ -126,7 +127,7 @@ describe('silent store registration', () => {
   });
 
   it('does NOT warn when a subscribe function is supplied', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const warn = vi.spyOn(nativeConsole, 'nativeWarn').mockImplementation(() => undefined);
     registerStore(
       'observable',
       () => ({ count: 1 }),
@@ -137,7 +138,7 @@ describe('silent store registration', () => {
   });
 
   it('warns ONCE per store — a repeat on every HMR cycle or remount is just noise', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const warn = vi.spyOn(nativeConsole, 'nativeWarn').mockImplementation(() => undefined);
     registerStore('remounted', () => ({ n: 1 }));
     registerStore('remounted', () => ({ n: 2 }));
     registerStore('remounted', () => ({ n: 3 }));
@@ -147,14 +148,14 @@ describe('silent store registration', () => {
 
   it("stays silent for Reticle's OWN read-only store — telling a user to fix our code is absurd", () => {
     // @reticlehq/react registers a render-stats getter the app developer never wrote and cannot change.
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const warn = vi.spyOn(nativeConsole, 'nativeWarn').mockImplementation(() => undefined);
     registerStore('__reticle_renders', () => ({ commits: 0 }));
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
   });
 
   it('does NOT warn for a store-like object, which carries its own subscribe', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const warn = vi.spyOn(nativeConsole, 'nativeWarn').mockImplementation(() => undefined);
     registerStore('zustand-like', {
       getState: () => ({ count: 1 }),
       subscribe: () => () => undefined,

--- a/packages/browser/src/registry/stores.ts
+++ b/packages/browser/src/registry/stores.ts
@@ -1,4 +1,5 @@
 import { RETICLE_RENDERS_STORE } from '@reticlehq/core';
+import { nativeWarn } from '../timers/native-console.js';
 import { sanitizeWithReport, type TruncationReport } from '../security/serialization.js';
 
 /** Store registry — lets the agent pull live framework/store state on demand. */
@@ -168,7 +169,7 @@ const RETICLE_OWNED_STORES = new Set<string>([RETICLE_RENDERS_STORE]);
 function warnSilentStoreOnce(name: string): void {
   if (RETICLE_OWNED_STORES.has(name) || warnedSilent.has(name)) return;
   warnedSilent.add(name);
-  console.warn(
+  nativeWarn(
     `[reticle] store "${name}" was registered without a subscribe function. It can be READ, but its ` +
       `changes are invisible: no STATE_CHANGE events, no state diffs in causal summaries, and a state ` +
       `predicate will never see it update. Pass the store object (or a subscribe callback) to fix.`,

--- a/packages/browser/src/reticle.ts
+++ b/packages/browser/src/reticle.ts
@@ -49,6 +49,7 @@ import {
 import { actionVerb } from './presenter/presenter-verbs.js';
 import { str, refLabel, modeForCommand, presentStatus } from './reticle-presenter-helpers.js';
 import { resetClock } from './timers/clock.js';
+import { nativeWarn } from './timers/native-console.js';
 import { installRecorder, type RecorderHandle } from './recorder/recorder.js';
 import { Annotator } from './review/annotator.js';
 import type { Teardown } from './observers/types.js';
@@ -341,7 +342,7 @@ export class Reticle {
       // First-connect never succeeded ⇒ the bridge is unreachable at this URL. Tell the developer
       // exactly what went wrong and how to fix it, instead of retrying silently forever.
       onUnreachable: ({ url: tried, attempts }) => {
-        globalThis.console.warn(
+        nativeWarn(
           `[Reticle] could not reach the bridge at ${tried} after ${String(attempts)} attempts. ` +
             `Is the Reticle daemon running on that port? If your app runs in a container/devcontainer/WSL, ` +
             `the daemon is on a different host — set the WS URL explicitly (Vite: VITE_RETICLE_WS_URL, ` +

--- a/packages/browser/src/timers/native-console.test.ts
+++ b/packages/browser/src/timers/native-console.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventType } from '@reticlehq/core';
+import { installConsole } from '../observers/console.js';
+import type { Emit, Teardown } from '../observers/types.js';
+import { nativeWarn } from './native-console.js';
+
+interface Emitted {
+  type: EventType;
+  data: Record<string, unknown>;
+}
+
+function collect(): { emit: Emit; events: Emitted[] } {
+  const events: Emitted[] = [];
+  const emit: Emit = (type, data) => {
+    events.push({ type, data });
+  };
+  return { emit, events };
+}
+
+describe('nativeWarn — SDK-internal diagnostics bypass the observer', () => {
+  let teardown: Teardown | undefined;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    teardown?.();
+    teardown = undefined;
+    warnSpy.mockRestore();
+  });
+
+  it('nativeWarn does NOT emit a CONSOLE_WARN event through the patched observer', () => {
+    const { emit, events } = collect();
+    teardown = installConsole(emit);
+
+    nativeWarn('[reticle] bridge refused the connection — not retrying.');
+
+    expect(events.filter((e) => e.type === EventType.CONSOLE_WARN)).toHaveLength(0);
+  });
+
+  it('nativeWarn still reaches the real console (developer sees it)', () => {
+    const { emit } = collect();
+    teardown = installConsole(emit);
+
+    // After installConsole, console.warn is the patched wrapper. nativeWarn bypasses it
+    // and calls through the original bound reference — which IS the real console.warn.
+    // Verify by checking nativeWarn does NOT resolve to the patched wrapper (it's pre-bound).
+    expect(nativeWarn).not.toBe(console.warn);
+
+    // And it runs without throwing — reaching the underlying console output.
+    expect(() => nativeWarn('[reticle] unreachable after 5 attempts')).not.toThrow();
+  });
+
+  it('bare console.warn DOES emit CONSOLE_WARN (the bug this fix prevents)', () => {
+    const { emit, events } = collect();
+    teardown = installConsole(emit);
+
+    console.warn('[reticle] this should be captured');
+
+    expect(events.filter((e) => e.type === EventType.CONSOLE_WARN)).toHaveLength(1);
+  });
+});

--- a/packages/browser/src/timers/native-console.ts
+++ b/packages/browser/src/timers/native-console.ts
@@ -1,0 +1,11 @@
+// Native console.warn captured at module load, BEFORE installConsole patches console.
+// SDK-internal diagnostics (transport failures, unreachable-bridge, store registration warnings)
+// MUST use this instead of bare `console.warn` — otherwise they emit spurious CONSOLE_WARN
+// events to the agent, polluting the observation stream with SDK internals.
+const g: typeof globalThis = globalThis;
+
+const realWarn = typeof g.console?.warn === 'function' ? g.console.warn.bind(g.console) : null;
+
+export const nativeWarn = (...args: unknown[]): void => {
+  realWarn?.(...args);
+};

--- a/packages/browser/src/transport/transport.close-codes.test.ts
+++ b/packages/browser/src/transport/transport.close-codes.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { RETICLE_PROTOCOL_VERSION, MessageKind, type HelloMessage } from '@reticlehq/core';
+import * as nativeConsole from '../timers/native-console.js';
 import { Transport } from './transport.js';
 
 /**
@@ -79,7 +80,7 @@ describe('transport handles a synchronous WebSocket constructor throw', () => {
 
 describe('transport stops retrying on a 1008 policy-violation close', () => {
   it('does not reconnect after 1008, fires onConnectionLost, and warns with the reason', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const warn = vi.spyOn(nativeConsole, 'nativeWarn').mockImplementation(() => undefined);
     let lost = 0;
     const t = new Transport({
       url: 'ws://x',

--- a/packages/browser/src/transport/transport.ts
+++ b/packages/browser/src/transport/transport.ts
@@ -7,6 +7,7 @@ import {
   type ReticleEvent,
 } from '@reticlehq/core';
 import { nativeSetTimeout, nativeNow } from '../timers/native-timers.js';
+import { nativeWarn } from '../timers/native-console.js';
 import { safeStringify } from '../security/serialization.js';
 
 export interface CommandOutcome {
@@ -163,7 +164,7 @@ export class Transport {
       if (event.code === WS_POLICY_VIOLATION) {
         this.#closed = true;
         const reason = event.reason.length > 0 ? event.reason : 'policy violation';
-        console.warn(`[reticle] bridge refused the connection: ${reason} — not retrying.`);
+        nativeWarn(`[reticle] bridge refused the connection: ${reason} — not retrying.`);
         this.#deps.onConnectionLost?.();
         return;
       }


### PR DESCRIPTION
## Summary

After `installConsole(emit)` patches `console.warn` to observe the app, three SDK-internal diagnostic sites still called the patched `console.warn` — emitting spurious `CONSOLE_WARN` events to the agent whenever the bridge was unreachable, refused the connection, or a store was registered without a subscribe function.

This follows the established `native-timers.ts` pattern (capture native globals at module load before any patching). A new `native-console.ts` module captures the real `console.warn` bound at import time and exports `nativeWarn`. SDK diagnostics use `nativeWarn` so they reach the developer console without polluting the agent's observation stream.

### Sites fixed

| File | Line | Trigger |
|------|------|---------|
| `transport.ts` | 166 | Bridge 1008 policy-violation close |
| `reticle.ts` | 344 | `onUnreachable` callback (bridge unreachable after N attempts) |
| `stores.ts` | 171 | `warnSilentStoreOnce` (store registered without subscribe) |

### Why this matters

The SDK's contract is "never pollute the app it observes." These three warnings violated that contract by injecting SDK-internal noise into the `CONSOLE_WARN` event stream the agent relies on for diagnosing the *app's* behavior. An agent seeing `[reticle] bridge refused the connection` in the console events cannot distinguish it from an app-level warning.

### Design

- `native-console.ts` mirrors the existing `native-timers.ts` architecture
- Pre-`connect()` guards (`reticle.ts:282,302`) are left as `globalThis.console.warn` — they fire synchronously *before* `installConsole` installs, so they never self-pollute
- Existing tests for transport close-codes and store registration warnings updated to spy on `nativeWarn` instead of `console.warn`

## Test plan

- [x] New `native-console.test.ts` — verifies `nativeWarn` does NOT emit through patched observer
- [x] New test — verifies bare `console.warn` DOES emit (proving the distinction)
- [x] Updated `transport.close-codes.test.ts` — 1008 refusal still warns via `nativeWarn`
- [x] Updated `stores.test.ts` — silent store warnings still fire via `nativeWarn`
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `prettier --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)