### PR TITLE
fix(server): reclaim settled file-lock chain entries to prevent Map leak

### DIFF
--- a/packages/server/src/project/file-lock.test.ts
+++ b/packages/server/src/project/file-lock.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { withFileLock, chainSize } from './file-lock.js';
+
+describe('withFileLock', () => {
+  it('serializes concurrent calls to the same path', async () => {
+    const order: number[] = [];
+    const gate1 = deferred();
+    const gate2 = deferred();
+
+    const task1 = withFileLock('/serial-1', async () => {
+      order.push(1);
+      await gate1.promise;
+      order.push(2);
+      return 'one';
+    });
+
+    const task2 = withFileLock('/serial-1', async () => {
+      order.push(3);
+      await gate2.promise;
+      order.push(4);
+      return 'two';
+    });
+
+    // task1 runs immediately; task2 is queued behind it.
+    await tick();
+    expect(order).toEqual([1]);
+
+    gate1.resolve();
+    await tick();
+    // task1 finished, task2 starts
+    expect(order).toEqual([1, 2, 3]);
+
+    gate2.resolve();
+    await Promise.all([task1, task2]);
+    expect(order).toEqual([1, 2, 3, 4]);
+    expect(await task1).toBe('one');
+    expect(await task2).toBe('two');
+  });
+
+  it('does NOT serialize calls to different paths', async () => {
+    const order: number[] = [];
+    const gate1 = deferred();
+    const gate2 = deferred();
+
+    const task1 = withFileLock('/indep-a', async () => {
+      order.push(1);
+      await gate1.promise;
+      return 'a';
+    });
+
+    const task2 = withFileLock('/indep-b', async () => {
+      order.push(2);
+      await gate2.promise;
+      return 'b';
+    });
+
+    await tick();
+    // Both started concurrently — no serialization across different paths.
+    expect(order).toEqual([1, 2]);
+
+    gate1.resolve();
+    gate2.resolve();
+    await Promise.all([task1, task2]);
+  });
+
+  it('a rejected task does not break the next waiter', async () => {
+    const task1 = withFileLock('/reject-1', () => Promise.reject(new Error('boom')));
+
+    const task2 = withFileLock('/reject-1', () => Promise.resolve('recovered'));
+
+    await expect(task1).rejects.toThrow('boom');
+    expect(await task2).toBe('recovered');
+  });
+
+  it('cleans up the chain entry when no successor is queued', async () => {
+    await withFileLock('/cleanup-1', () => Promise.resolve('done'));
+    await tick();
+    expect(chainSize()).toBe(0);
+  });
+
+  it('does NOT clean up while a successor is still queued', async () => {
+    const gate = deferred();
+
+    const task1 = withFileLock('/busy-1', () => gate.promise);
+
+    const task2 = withFileLock('/busy-1', () => Promise.resolve('second'));
+
+    await tick();
+    // task1 is running, task2 is queued — entry must remain.
+    expect(chainSize()).toBe(1);
+
+    gate.resolve();
+    await Promise.all([task1, task2]);
+    await tick();
+    // Both finished, no more waiters — cleaned up.
+    expect(chainSize()).toBe(0);
+  });
+});
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: () => void = () => undefined;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function tick(): Promise<void> {
+  return new Promise((r) => {
+    setTimeout(r, 0);
+  });
+}

--- a/packages/server/src/project/file-lock.ts
+++ b/packages/server/src/project/file-lock.ts
@@ -19,12 +19,20 @@ export function withFileLock<T>(path: string, fn: () => Promise<T>): Promise<T> 
   // Run after the previous holder settles, regardless of whether it resolved or rejected.
   const run = prev.then(fn, fn);
   // Keep the chain alive but swallow the outcome so one task's rejection never rejects the next waiter.
-  chains.set(
-    path,
-    run.then(
-      () => undefined,
-      () => undefined,
-    ),
+  const settled = run.then(
+    () => undefined,
+    () => undefined,
   );
+  chains.set(path, settled);
+  // Reclaim the entry once settled IF no successor queued behind us (the Map still points to our
+  // promise). Without this, every unique path leaks a Map slot for the daemon's lifetime.
+  void settled.then(() => {
+    if (chains.get(path) === settled) chains.delete(path);
+  });
   return run;
+}
+
+/** Exposed for testing — returns the number of active chain entries. */
+export function chainSize(): number {
+  return chains.size;
 }


### PR DESCRIPTION
## Summary

The module-level `chains` Map in `file-lock.ts` accumulates one entry per unique file path passed to `withFileLock`, but never deletes entries after their promise chain settles. In a long-running daemon (which stays alive for idle-shutdown), every distinct path permanently occupies a Map slot holding a resolved `Promise<undefined>` — unbounded monotonic growth.

Three callers use this lock today (`project-store.ts`, `assertion-tiers-store.ts`, `deviation-service.ts`), each operating on project-scoped paths. Across many projects or many flows, entries accumulate indefinitely.

### The fix

After the settled promise resolves, check if the Map still points to our promise (no successor queued). If so, delete the entry:

```typescript
void settled.then(() => {
  if (chains.get(path) === settled) chains.delete(path);
});
```

The identity check (`chains.get(path) === settled`) ensures a concurrent `withFileLock` call that queued behind us is never disturbed — if a successor already overwrote the entry, we leave it alone.

### Why this is safe

- The cleanup is fire-and-forget (`void`) — it never affects the caller's returned promise
- The identity check prevents deleting a live chain entry that a successor just installed
- Re-entering `withFileLock` on the same path after cleanup simply starts a fresh chain (the `?? Promise.resolve()` fallback)

## Test plan

Also adds the **first unit tests for `withFileLock`** (previously zero test coverage), pinning:

- [x] Serialization — concurrent same-path calls run sequentially
- [x] Independence — different paths run concurrently (no false serialization)
- [x] Fault tolerance — a rejected task does not break the next waiter
- [x] Cleanup — chain entry reclaimed when no successor is queued
- [x] Safety — chain entry preserved while a successor is still queued
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `prettier --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)