### PR TITLE
refactor(server): make spawnDaemon injectable for deterministic testing

### DIFF
--- a/packages/server/src/daemon-spawn.test.ts
+++ b/packages/server/src/daemon-spawn.test.ts
@@ -56,11 +56,11 @@ describe('spawnDaemon with injectable deps', () => {
   }
 
   it('spawns successfully and writes the pid to the pidfile', () => {
-    const { deps, wasSpawned } = makeDeps();
-    const ok = spawnDaemon('node', 'script.mjs', ['--port', '4000'], 4000, deps);
+    const harness = makeDeps();
+    const ok = spawnDaemon('node', 'script.mjs', ['--port', '4000'], 4000, harness.deps);
 
     expect(ok).toBe(true);
-    expect(wasSpawned()).toBe(true);
+    expect(harness.wasSpawned()).toBe(true);
     const pidFile = join(home, 'daemon-4000.pid');
     expect(existsSync(pidFile)).toBe(true);
     expect(readFileSync(pidFile, 'utf8')).toBe('12345');

--- a/packages/server/src/daemon-spawn.test.ts
+++ b/packages/server/src/daemon-spawn.test.ts
@@ -56,10 +56,11 @@ describe('spawnDaemon with injectable deps', () => {
   }
 
   it('spawns successfully and writes the pid to the pidfile', () => {
-    const { deps } = makeDeps();
+    const { deps, wasSpawned } = makeDeps();
     const ok = spawnDaemon('node', 'script.mjs', ['--port', '4000'], 4000, deps);
 
     expect(ok).toBe(true);
+    expect(wasSpawned()).toBe(true);
     const pidFile = join(home, 'daemon-4000.pid');
     expect(existsSync(pidFile)).toBe(true);
     expect(readFileSync(pidFile, 'utf8')).toBe('12345');

--- a/packages/server/src/daemon-spawn.test.ts
+++ b/packages/server/src/daemon-spawn.test.ts
@@ -1,107 +1,174 @@
-/**
- * spawnDaemon: verifies the parent closes the log fd, reports failure when spawn yields no pid, and
- * handles synchronous spawn errors without leaving ghost pidfiles.
- *
- * These tests operate against the REAL ~/.reticle directory (RETICLE_HOME is a module-level constant
- * computed at import time, not injectable). Unique high port numbers avoid collisions with any live
- * daemon. Each test cleans up its pidfile + log + registry entry in afterEach.
- */
-import { afterEach, describe, expect, it } from 'vitest';
-import { existsSync, unlinkSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { spawnDaemon, readPid, logPath, removePid } from './daemon.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  openSync,
+  closeSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnDaemon, type SpawnDaemonDeps, type SpawnedChild } from './daemon.js';
 
-/** Ports far above any plausible daemon — avoids collisions with real instances. */
-const BASE_PORT = 59_100;
-let nextPort = BASE_PORT;
-function uniquePort(): number {
-  return nextPort++;
-}
+describe('spawnDaemon with injectable deps', () => {
+  let home: string;
 
-/** Tracks spawned children so we can kill them even if the test fails mid-way. */
-const spawnedPorts: number[] = [];
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'reticle-spawn-test-'));
+  });
 
-afterEach(() => {
-  for (const port of spawnedPorts) {
-    const pid = readPid(port);
-    if (pid !== null) {
-      try {
-        process.kill(pid, 'SIGTERM');
-      } catch {
-        // already exited — fine
-      }
-    }
-    removePid(port, pid ?? process.pid);
-    // Clean up the log file best-effort.
-    try {
-      const log = logPath(port);
-      if (existsSync(log)) unlinkSync(log);
-    } catch {
-      // non-critical
-    }
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function makeDeps(overrides?: Partial<SpawnDaemonDeps>): {
+    deps: SpawnDaemonDeps;
+    opened: Array<{ path: string; flags: string; fd: number }>;
+    closed: number[];
+    wasSpawned(): boolean;
+  } {
+    const opened: Array<{ path: string; flags: string; fd: number }> = [];
+    const closed: number[] = [];
+    let spawned = false;
+
+    const deps: SpawnDaemonDeps = {
+      home,
+      openFile: (path, flags) => {
+        const fd = openSync(path, flags);
+        opened.push({ path, flags, fd });
+        return fd;
+      },
+      closeFile: (fd) => {
+        closed.push(fd);
+        closeSync(fd);
+      },
+      spawnChild: () => {
+        spawned = true;
+        return { pid: 12345, on: () => undefined, unref: () => undefined };
+      },
+      pidAlive: () => false,
+      ...overrides,
+    };
+
+    return { deps, opened, closed, wasSpawned: () => spawned };
   }
-  spawnedPorts.length = 0;
-});
 
-describe('spawnDaemon', () => {
-  it('spawns a real process and writes its pid', () => {
-    const port = uniquePort();
-    spawnedPorts.push(port);
-    const script = join(tmpdir(), `reticle-test-${port}.mjs`);
-    writeFileSync(script, 'setTimeout(() => process.exit(0), 200);', 'utf8');
+  it('spawns successfully and writes the pid to the pidfile', () => {
+    const { deps } = makeDeps();
+    const ok = spawnDaemon('node', 'script.mjs', ['--port', '4000'], 4000, deps);
 
-    const ok = spawnDaemon(process.execPath, script, [], port);
     expect(ok).toBe(true);
-
-    const pid = readPid(port);
-    expect(pid).not.toBeNull();
-    expect(typeof pid).toBe('number');
-    expect(pid).toBeGreaterThan(0);
+    const pidFile = join(home, 'daemon-4000.pid');
+    expect(existsSync(pidFile)).toBe(true);
+    expect(readFileSync(pidFile, 'utf8')).toBe('12345');
   });
 
-  it('returns false when the executable does not exist (spawn fails)', () => {
-    const port = uniquePort();
-    spawnedPorts.push(port);
+  it('closes the log fd in the parent after spawn', () => {
+    const { deps, opened, closed } = makeDeps();
+    spawnDaemon('node', 'script.mjs', [], 4001, deps);
 
-    const ok = spawnDaemon('/nonexistent/node', '/nonexistent/script.mjs', [], port);
-    // On most platforms, spawn with a missing executable sets child.pid to undefined.
-    // On platforms where spawn throws synchronously, the catch path returns false.
-    // Either way: no ghost pidfile left behind.
+    const logEntry = opened.find((e) => e.flags === 'a');
+    expect(logEntry).toBeDefined();
+    expect(closed).toContain(logEntry?.fd);
+  });
+
+  it('closes the lock fd after writing the pid', () => {
+    const { deps, opened, closed } = makeDeps();
+    spawnDaemon('node', 'script.mjs', [], 4002, deps);
+
+    const lockEntry = opened.find((e) => e.flags === 'wx');
+    expect(lockEntry).toBeDefined();
+    expect(closed).toContain(lockEntry?.fd);
+  });
+
+  it('returns false and cleans up when openFile(log) throws', () => {
+    const realOpened: Array<{ path: string; flags: string; fd: number }> = [];
+    let callCount = 0;
+    const { deps, closed } = makeDeps({
+      openFile: (path, flags) => {
+        callCount += 1;
+        if (callCount === 2) throw new Error('disk full');
+        const fd = openSync(path, flags);
+        realOpened.push({ path, flags, fd });
+        return fd;
+      },
+    });
+
+    const ok = spawnDaemon('node', 'script.mjs', [], 4003, deps);
+
     expect(ok).toBe(false);
+    expect(realOpened.length).toBe(1);
+    expect(closed).toContain(realOpened[0]?.fd);
+    expect(existsSync(join(home, 'daemon-4003.pid'))).toBe(false);
   });
 
-  it('closes the log fd in the parent (no leaked descriptors)', () => {
-    const port = uniquePort();
-    spawnedPorts.push(port);
-    const script = join(tmpdir(), `reticle-test-${port}.mjs`);
-    writeFileSync(script, 'process.exit(0);', 'utf8');
+  it('returns false and cleans up when spawnChild throws', () => {
+    const { deps, opened, closed } = makeDeps({
+      spawnChild: () => {
+        throw new Error('ENOMEM');
+      },
+    });
 
-    const ok = spawnDaemon(process.execPath, script, [], port);
+    const ok = spawnDaemon('node', 'script.mjs', [], 4004, deps);
+
+    expect(ok).toBe(false);
+    const lockEntry = opened.find((e) => e.flags === 'wx');
+    const logEntry = opened.find((e) => e.flags === 'a');
+    expect(lockEntry).toBeDefined();
+    expect(logEntry).toBeDefined();
+    expect(closed).toContain(lockEntry?.fd);
+    expect(closed).toContain(logEntry?.fd);
+    expect(existsSync(join(home, 'daemon-4004.pid'))).toBe(false);
+  });
+
+  it('returns false and cleans up when child.pid is undefined', () => {
+    const undefinedPidChild: SpawnedChild = {
+      pid: undefined,
+      on: () => undefined,
+      unref: () => undefined,
+    };
+    const { deps, opened, closed } = makeDeps({
+      spawnChild: () => undefinedPidChild,
+    });
+
+    const ok = spawnDaemon('node', 'script.mjs', [], 4005, deps);
+
+    expect(ok).toBe(false);
+    const lockEntry = opened.find((e) => e.flags === 'wx');
+    const logEntry = opened.find((e) => e.flags === 'a');
+    expect(closed).toContain(lockEntry?.fd);
+    expect(closed).toContain(logEntry?.fd);
+    expect(existsSync(join(home, 'daemon-4005.pid'))).toBe(false);
+  });
+
+  it('returns false without spawning when a live daemon owns the port', () => {
+    let spawned = false;
+    const { deps } = makeDeps({
+      pidAlive: () => true,
+      spawnChild: () => {
+        spawned = true;
+        return { pid: 12345, on: () => undefined, unref: () => undefined };
+      },
+    });
+    const pidFile = join(home, 'daemon-4006.pid');
+    writeFileSync(pidFile, '99999', 'utf8');
+
+    const ok = spawnDaemon('node', 'script.mjs', [], 4006, deps);
+
+    expect(ok).toBe(false);
+    expect(spawned).toBe(false);
+  });
+
+  it('reclaims a stale pidfile and spawns successfully', () => {
+    const pidFile = join(home, 'daemon-4007.pid');
+    writeFileSync(pidFile, '11111', 'utf8');
+
+    const { deps } = makeDeps({ pidAlive: () => false });
+    const ok = spawnDaemon('node', 'script.mjs', [], 4007, deps);
+
     expect(ok).toBe(true);
-
-    // The log file exists and is writable from the parent (not locked by a leaked fd).
-    const log = logPath(port);
-    expect(existsSync(log)).toBe(true);
-    expect(() => writeFileSync(log, 'test\n', { flag: 'a' })).not.toThrow();
-  });
-
-  it('does not spawn a duplicate when a live daemon already owns the port', () => {
-    const port = uniquePort();
-    spawnedPorts.push(port);
-    // A script that stays alive until killed — the afterEach hook sends SIGTERM.
-    const script = join(tmpdir(), `reticle-test-${port}.mjs`);
-    writeFileSync(
-      script,
-      'setInterval(() => {}, 1000); process.on("SIGTERM", () => process.exit(0));',
-      'utf8',
-    );
-
-    const first = spawnDaemon(process.execPath, script, [], port);
-    expect(first).toBe(true);
-
-    // Second attempt on the same port — pidfile exists with a live pid.
-    const second = spawnDaemon(process.execPath, script, [], port);
-    expect(second).toBe(false);
+    expect(readFileSync(pidFile, 'utf8')).toBe('12345');
   });
 });

--- a/packages/server/src/daemon.ts
+++ b/packages/server/src/daemon.ts
@@ -33,8 +33,8 @@ export function logPath(port: number): string {
   return join(RETICLE_HOME, `daemon-${port}.log`);
 }
 
-export function readPid(port: number): number | null {
-  const path = pidPath(port);
+export function readPid(port: number, home: string = RETICLE_HOME): number | null {
+  const path = join(home, `daemon-${port}.pid`);
   if (!existsSync(path)) return null;
   const n = parseInt(readFileSync(path, 'utf8').trim(), 10);
   return isNaN(n) ? null : n;
@@ -205,67 +205,103 @@ export function reclaimStaleDaemons(
   return reclaimed;
 }
 
+/** The minimal shape of a spawned child that spawnDaemon uses. */
+export interface SpawnedChild {
+  readonly pid?: number | undefined;
+  on(event: string, handler: (...args: unknown[]) => void): unknown;
+  unref(): void;
+}
+
+/** Injectable deps for spawnDaemon — the testability seam. Defaults to the real implementations. */
+export interface SpawnDaemonDeps {
+  readonly home: string;
+  openFile(path: string, flags: string): number;
+  closeFile(fd: number): void;
+  spawnChild(
+    command: string,
+    args: readonly string[],
+    options: { detached: boolean; stdio: readonly ('ignore' | number)[] },
+  ): SpawnedChild;
+  pidAlive(pid: number): boolean;
+}
+
+export function defaultSpawnDaemonDeps(): SpawnDaemonDeps {
+  return {
+    home: RETICLE_HOME,
+    openFile: openSync,
+    closeFile: closeSync,
+    spawnChild: (command, args, options) =>
+      spawn(command, [...args], { detached: options.detached, stdio: [...options.stdio] }),
+    pidAlive: isAlive,
+  };
+}
+
 /**
  * Spawn the reticle daemon as a detached background process, redirecting output to the log file.
  * Writes the PID file from the parent before returning so callers can call isRunning
  * immediately without a race window.
+ *
+ * `deps` is injectable for testing (default: real fs/spawn against ~/.reticle). The same seam
+ * pattern as reclaimStaleDaemons(home, pidAlive).
  */
 export function spawnDaemon(
   nodeExec: string,
   scriptPath: string,
   args: string[],
   port: number,
+  deps: SpawnDaemonDeps = defaultSpawnDaemonDeps(),
 ): boolean {
-  mkdirSync(RETICLE_HOME, { recursive: true });
-  const path = pidPath(port);
+  mkdirSync(deps.home, { recursive: true });
+  const pidFilePath = join(deps.home, `daemon-${port}.pid`);
+  const logFilePath = join(deps.home, `daemon-${port}.log`);
   // O_EXCL spawn-lock: only the FIRST racer to create the pidfile spawns. A concurrent second gets
   // EEXIST — if a LIVE daemon owns the port it skips (no duplicate detached daemon, no clobbered pid);
   // a stale pidfile from a crashed daemon is reclaimed. Returns false when it did not spawn.
   let lockFd: number;
   try {
-    lockFd = openSync(path, 'wx');
+    lockFd = deps.openFile(pidFilePath, 'wx');
   } catch {
-    const existing = readPid(port);
-    if (existing !== null && isAlive(existing)) return false;
+    const existing = readPid(port, deps.home);
+    if (existing !== null && deps.pidAlive(existing)) return false;
     try {
-      unlinkSync(path);
-      lockFd = openSync(path, 'wx');
+      unlinkSync(pidFilePath);
+      lockFd = deps.openFile(pidFilePath, 'wx');
     } catch {
       return false; // lost a concurrent reclaim race
     }
   }
   let logFd: number;
   try {
-    logFd = openSync(logPath(port), 'a');
+    logFd = deps.openFile(logFilePath, 'a');
   } catch {
     // Log path unwritable (permissions, disk full). Clean up the lock so we don't leave a ghost.
-    closeSync(lockFd);
+    deps.closeFile(lockFd);
     try {
-      unlinkSync(path);
+      unlinkSync(pidFilePath);
     } catch {
       // racing another reclaimer — fine
     }
     return false;
   }
-  let child: ReturnType<typeof spawn>;
+  let child: SpawnedChild;
   try {
-    child = spawn(nodeExec, [scriptPath, ...args], {
+    child = deps.spawnChild(nodeExec, [scriptPath, ...args], {
       detached: true,
       stdio: ['ignore', logFd, logFd],
     });
   } catch {
     // spawn can throw synchronously on some platforms (e.g. ENOMEM, invalid args).
-    closeSync(logFd);
-    closeSync(lockFd);
+    deps.closeFile(logFd);
+    deps.closeFile(lockFd);
     try {
-      unlinkSync(path);
+      unlinkSync(pidFilePath);
     } catch {
       // racing another reclaimer — fine
     }
     return false;
   }
   // The parent's copy of logFd is no longer needed — spawn duplicated it into the child.
-  closeSync(logFd);
+  deps.closeFile(logFd);
   // Suppress the async ENOENT/EACCES that fires when the executable is missing or unexecutable.
   // The failure is already detected synchronously via `child.pid === undefined`; without this
   // handler the error propagates as an uncaught exception and crashes the parent process.
@@ -273,16 +309,16 @@ export function spawnDaemon(
   if (child.pid === undefined) {
     // Spawn failed silently (resource exhaustion, invalid executable on some platforms). The pidfile
     // is empty — clean it up so discovery doesn't see a ghost, and report failure honestly.
-    closeSync(lockFd);
+    deps.closeFile(lockFd);
     try {
-      unlinkSync(path);
+      unlinkSync(pidFilePath);
     } catch {
       // racing another reclaimer — fine
     }
     return false;
   }
   writeFileSync(lockFd, String(child.pid), 'utf8');
-  closeSync(lockFd);
+  deps.closeFile(lockFd);
   child.unref();
   return true;
 }

--- a/packages/server/src/daemon.ts
+++ b/packages/server/src/daemon.ts
@@ -21,8 +21,8 @@ import {
 
 const RETICLE_HOME = join(homedir(), '.reticle');
 
-function pidPath(port: number): string {
-  return join(RETICLE_HOME, `daemon-${port}.pid`);
+function pidPath(port: number, home: string = RETICLE_HOME): string {
+  return join(home, `daemon-${port}.pid`);
 }
 
 function registryPath(port: number): string {
@@ -34,7 +34,7 @@ export function logPath(port: number): string {
 }
 
 export function readPid(port: number, home: string = RETICLE_HOME): number | null {
-  const path = join(home, `daemon-${port}.pid`);
+  const path = pidPath(port, home);
   if (!existsSync(path)) return null;
   const n = parseInt(readFileSync(path, 'utf8').trim(), 10);
   return isNaN(n) ? null : n;


### PR DESCRIPTION
## Summary

- Adds `SpawnDaemonDeps` interface + `defaultSpawnDaemonDeps()` factory to `spawnDaemon`, following the same injectable seam pattern as `reclaimStaleDaemons(home, pidAlive)`.
- Rewrites `daemon-spawn.test.ts` with 8 deterministic tests using spy deps in a `mkdtempSync` tmpdir — no real processes spawned, no real `~/.reticle` touched.
- **Fixes the false-green** flagged in #58 review: the "closes the log fd" test now directly asserts `closeFile` was called on the log fd — reverting that line breaks the test deterministically.

## Motivation

From the #58 review:

> *"daemon-spawn.test.ts — the 'closes the log fd' test is a false-green. writeFileSync(log, …, { flag:'a' }) succeeds whether or not the parent's logFd is closed [...] Giving spawnDaemon the same seam (inject home + spawn/openSync) lets these assertions be tested directly."*

## Design

`SpawnDaemonDeps` is a deps object (not positional params) because there are 5 injectable items:

```typescript
export interface SpawnDaemonDeps {
  readonly home: string;
  openFile(path: string, flags: string): number;
  closeFile(fd: number): void;
  spawnChild(command: string, args: readonly string[], options: {...}): SpawnedChild;
  pidAlive(pid: number): boolean;
}
```

The 5th parameter is optional with a production default — **zero changes required to existing callers** (cli.ts has 3 call sites, all pass 4 args).

## Test plan

- [x] All 8 new tests pass (`pnpm --filter @reticlehq/server test:unit`)
- [x] Regression guard verified: commenting out `deps.closeFile(logFd)` breaks test #2
- [x] Lint clean (`pnpm --filter @reticlehq/server lint`)
- [x] Typecheck clean (`pnpm --filter @reticlehq/server typecheck`)
- [x] Prettier clean (`prettier --check`)
- [x] No changes to cli.ts call sites (backward-compatible)

Signed-off-by: Dev Chiniwala <devchiniwala@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)