### PR TITLE
fix(browser): preserve query string when only path/userinfo was redacted

### DIFF
--- a/packages/browser/src/observers/network-redact.ts
+++ b/packages/browser/src/observers/network-redact.ts
@@ -36,13 +36,17 @@ export function redactUrl(raw: string): string {
   let newQuery = query;
   if (query !== '') {
     const params = new URLSearchParams(query);
+    let queryChanged = false;
     for (const key of [...params.keys()]) {
       if (isSensitiveKey(key)) {
         params.set(key, REDACTED_VALUE);
-        changed = true;
+        queryChanged = true;
       }
     }
-    newQuery = params.toString();
+    if (queryChanged) {
+      newQuery = params.toString();
+      changed = true;
+    }
   }
 
   const segments = authority.split('/');

--- a/packages/browser/src/observers/network.test.ts
+++ b/packages/browser/src/observers/network.test.ts
@@ -109,6 +109,9 @@ describe('redactUrl', () => {
     expect(redactUrl('https://alice:s3cr3t@api.example.com/data?page=1&q=hello%20world')).toBe(
       'https://[REDACTED]@api.example.com/data?page=1&q=hello%20world',
     );
+    expect(
+      redactUrl('https://app.example.com/callback?next=%2Fdashboard&lang=en#access_token=abc123'),
+    ).toBe('https://app.example.com/callback?next=%2Fdashboard&lang=en#access_token=[REDACTED]');
   });
 });
 

--- a/packages/browser/src/observers/network.test.ts
+++ b/packages/browser/src/observers/network.test.ts
@@ -99,6 +99,17 @@ describe('redactUrl', () => {
     );
     expect(redactUrl('https://app.com/page#section-two')).toBe('https://app.com/page#section-two');
   });
+  it('preserves the query byte-for-byte when only path/userinfo/fragment was redacted', () => {
+    expect(
+      redactUrl('https://app.example.com/reset/abcdefghijklmnop?next=/a%20b&sort=name%3Aasc'),
+    ).toBe('https://app.example.com/reset/[REDACTED]?next=/a%20b&sort=name%3Aasc');
+    expect(redactUrl('https://app.example.com/reset/abcdefghijklmnop?debug')).toBe(
+      'https://app.example.com/reset/[REDACTED]?debug',
+    );
+    expect(redactUrl('https://alice:s3cr3t@api.example.com/data?page=1&q=hello%20world')).toBe(
+      'https://[REDACTED]@api.example.com/data?page=1&q=hello%20world',
+    );
+  });
 });
 
 describe('extractTiming (PerformanceResourceTiming → TTFB/transferSize)', () => {


### PR DESCRIPTION
## Summary

- `redactUrl` re-encoded the query string through `URLSearchParams.toString()` whenever *any* part of the URL was redacted (path token, userinfo, fragment) — even if no query param was sensitive.
- This turned `?next=/a%20b` into `?next=%2Fa+b` and `?debug` into `?debug=`, breaking `urlContains` predicates written against the URL the app actually sent.
- Fix: track whether a query key actually matched `isSensitiveKey`, and keep the raw query substring when it didn't.

## Repro (from #67)

```js
redactUrl('https://app.example.com/reset/abcdefghijklmnop?next=/a%20b&sort=name%3Aasc')
// Before: ...?next=%2Fa+b&sort=name%3Aasc    (re-encoded)
// After:  ...?next=/a%20b&sort=name%3Aasc     (byte-for-byte preserved)
```

Closes #67

## Test plan

- [x] New test: path-only redaction preserves query byte-for-byte (`/a%20b`, `?debug`, `hello%20world`)
- [x] Regression guard: reverting the fix breaks the new test with the exact re-encoding (`%2Fa+` vs `/a%20`)
- [x] All 42 existing network tests pass unchanged
- [x] Lint, typecheck, prettier all clean

Signed-off-by: Dev Chiniwala <devchiniwala@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)