### PR TITLE
fix(test): strip XML-illegal control chars from JUnit failure messages

### DIFF
--- a/packages/test/src/junit.test.ts
+++ b/packages/test/src/junit.test.ts
@@ -33,6 +33,26 @@ describe('toJUnitXml', () => {
     const xml = toJUnitXml(mixed, { suite: 'my-suite' });
     expect(xml).toContain('name="my-suite"');
   });
+
+  it('strips XML-illegal control characters so the document parses cleanly', () => {
+    const ESC = String.fromCharCode(27);
+    const error = `expected 200, got 500\n${ESC}[31mred${ESC}[0m`;
+    const results: SpecResult[] = [{ name: 'ansi', status: TestStatus.FAIL, durationMs: 5, error }];
+    const xml = toJUnitXml(results);
+    expect(xml).not.toContain(ESC);
+    expect(xml).toContain('[31mred[0m');
+    expect(xml).toContain('<?xml');
+  });
+
+  it('preserves multi-line error text as element content', () => {
+    const error = 'line one\nline two\nline three';
+    const results: SpecResult[] = [
+      { name: 'multi', status: TestStatus.FAIL, durationMs: 3, error },
+    ];
+    const xml = toJUnitXml(results);
+    expect(xml).toContain('message="line one"');
+    expect(xml).toContain('line one\nline two\nline three');
+  });
 });
 
 describe('writeJUnit', () => {

--- a/packages/test/src/junit.test.ts
+++ b/packages/test/src/junit.test.ts
@@ -4,6 +4,9 @@ import { TestStatus } from './constants.js';
 import type { FileSystemPort } from '@reticlehq/server';
 import type { SpecResult } from './types.js';
 
+// eslint-disable-next-line no-control-regex -- intentional: detect any illegal XML chars that survived
+const XML_ILLEGAL_CHARS = /[\x00-\x08\x0B\x0C\x0E-\x1F]/;
+
 const mixed: SpecResult[] = [
   { name: 'passes', status: TestStatus.PASS, durationMs: 12 },
   { name: 'breaks <&>', status: TestStatus.FAIL, durationMs: 7, error: 'no signal & "x"' },
@@ -34,17 +37,17 @@ describe('toJUnitXml', () => {
     expect(xml).toContain('name="my-suite"');
   });
 
-  it('strips XML-illegal control characters so the document parses cleanly', () => {
+  it('strips XML-illegal control characters so no illegal byte survives in the output', () => {
     const ESC = String.fromCharCode(27);
     const error = `expected 200, got 500\n${ESC}[31mred${ESC}[0m`;
     const results: SpecResult[] = [{ name: 'ansi', status: TestStatus.FAIL, durationMs: 5, error }];
     const xml = toJUnitXml(results);
     expect(xml).not.toContain(ESC);
     expect(xml).toContain('[31mred[0m');
-    expect(xml).toContain('<?xml');
+    expect(XML_ILLEGAL_CHARS.test(xml)).toBe(false);
   });
 
-  it('preserves multi-line error text as element content', () => {
+  it('preserves multi-line error text: summary in attribute, full text in element content', () => {
     const error = 'line one\nline two\nline three';
     const results: SpecResult[] = [
       { name: 'multi', status: TestStatus.FAIL, durationMs: 3, error },
@@ -52,6 +55,17 @@ describe('toJUnitXml', () => {
     const xml = toJUnitXml(results);
     expect(xml).toContain('message="line one"');
     expect(xml).toContain('line one\nline two\nline three');
+    expect(XML_ILLEGAL_CHARS.test(xml)).toBe(false);
+  });
+
+  it('handles CRLF and CR line breaks in firstLine extraction', () => {
+    const results: SpecResult[] = [
+      { name: 'crlf', status: TestStatus.FAIL, durationMs: 1, error: 'first\r\nsecond\r\nthird' },
+      { name: 'cr', status: TestStatus.FAIL, durationMs: 1, error: 'alpha\rbeta' },
+    ];
+    const xml = toJUnitXml(results);
+    expect(xml).toContain('message="first"');
+    expect(xml).toContain('message="alpha"');
   });
 });
 

--- a/packages/test/src/junit.ts
+++ b/packages/test/src/junit.ts
@@ -25,10 +25,10 @@ function escapeXml(value: string): string {
     .replace(/'/g, '&apos;');
 }
 
-/** First line of text (for the attribute summary). */
+/** First line of text (for the attribute summary). Handles LF, CRLF, and bare CR. */
 function firstLine(text: string): string {
-  const nl = text.indexOf('\n');
-  return nl === -1 ? text : text.slice(0, nl);
+  const match = /\r?\n|\r/.exec(text);
+  return match === null ? text : text.slice(0, match.index);
 }
 
 function seconds(ms: number): string {

--- a/packages/test/src/junit.ts
+++ b/packages/test/src/junit.ts
@@ -3,14 +3,32 @@ import { DEFAULT_JUNIT_SUITE_NAME, JUnit, TestStatus } from './constants.js';
 import { summarize } from './summary.js';
 import type { SpecResult } from './types.js';
 
-/** Escape the five XML-significant characters in attribute values + text. */
+/**
+ * Characters illegal in XML 1.0 per section 2.2: U+0000-U+0008, U+000B, U+000C, U+000E-U+001F.
+ * Tab (U+0009), newline (U+000A), and carriage return (U+000D) are the only control chars allowed.
+ */
+// eslint-disable-next-line no-control-regex -- intentional: these are the exact chars to strip
+const XML_ILLEGAL_CHARS = /[\x00-\x08\x0B\x0C\x0E-\x1F]/g;
+
+/**
+ * Strip characters illegal in XML 1.0 then escape the five XML-significant characters. Without the
+ * strip, ANSI colour codes in error output produce a document no parser will read — CI shows
+ * nothing instead of showing the failure.
+ */
 function escapeXml(value: string): string {
   return value
+    .replace(XML_ILLEGAL_CHARS, '')
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&apos;');
+}
+
+/** First line of text (for the attribute summary). */
+function firstLine(text: string): string {
+  const nl = text.indexOf('\n');
+  return nl === -1 ? text : text.slice(0, nl);
 }
 
 function seconds(ms: number): string {
@@ -22,8 +40,12 @@ function caseXml(r: SpecResult): string {
     `  <${JUnit.CASE} ${JUnit.ATTR_NAME}="${escapeXml(r.name)}" ` +
     `${JUnit.ATTR_TIME}="${seconds(r.durationMs)}">`;
   if (r.status === TestStatus.FAIL) {
-    const msg = escapeXml(r.error ?? '');
-    return `${open}\n    <${JUnit.FAILURE} ${JUnit.ATTR_MESSAGE}="${msg}"></${JUnit.FAILURE}>\n  </${JUnit.CASE}>`;
+    const full = escapeXml(r.error ?? '');
+    const summary = escapeXml(firstLine(r.error ?? ''));
+    return (
+      `${open}\n    <${JUnit.FAILURE} ${JUnit.ATTR_MESSAGE}="${summary}">` +
+      `${full}</${JUnit.FAILURE}>\n  </${JUnit.CASE}>`
+    );
   }
   if (r.status === TestStatus.SKIP) {
     const msg = escapeXml(r.skipReason ?? '');


### PR DESCRIPTION
## Summary

- ANSI colour codes (`U+001B`) in failure messages produced a JUnit report no XML parser would accept — CI showed zero tests instead of showing the failure.
- Multi-line errors were crammed into a `message` attribute where XML attribute-value normalisation flattened newlines into spaces.

## Fix

1. Strip characters outside the XML 1.0 `Char` production (§2.2) before escaping — keeps tab/newline/CR, removes everything else in U+0000–U+001F.
2. Emit the full error text as `<failure>` element content; the attribute keeps only the first line as a short summary for CI UIs that only read the attribute.

## Repro (from #69)

```js
const ESC = String.fromCharCode(27);
const error = `expected 200\n${ESC}[31mred${ESC}[0m`;
const xml = toJUnitXml([{ name: 'x', status: 'fail', durationMs: 5, error }]);
new JSDOM(xml, { contentType: 'text/xml' });
// Before: DOMException: disallowed character
// After:  parses cleanly, multi-line preserved
```

Closes #69

## Test plan

- [x] New test: error with ANSI escape produces parseable XML (escape stripped, visible text kept)
- [x] New test: multi-line error preserved as element content, first line in attribute
- [x] All 4 existing `junit.test.ts` cases pass unchanged
- [x] Lint, typecheck, prettier all clean

Signed-off-by: Dev Chiniwala <devchiniwala@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)