### PR TITLE
fix(core): redact presigned S3/GCS URL credential parameters

### DIFF
--- a/packages/browser/src/observers/network-redact.presigned.test.ts
+++ b/packages/browser/src/observers/network-redact.presigned.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { REDACTED_VALUE } from '@reticlehq/core';
+import { redactUrl } from './network-redact.js';
+
+describe('redactUrl — presigned cloud storage URLs', () => {
+  const S3_URL =
+    'https://my-bucket.s3.amazonaws.com/object.pdf' +
+    '?X-Amz-Algorithm=AWS4-HMAC-SHA256' +
+    '&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request' +
+    '&X-Amz-Date=20130524T000000Z' +
+    '&X-Amz-Expires=86400' +
+    '&X-Amz-SignedHeaders=host' +
+    '&X-Amz-Signature=aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404';
+
+  const GCS_URL =
+    'https://storage.googleapis.com/my-bucket/object.pdf' +
+    '?X-Goog-Algorithm=GOOG4-RSA-SHA256' +
+    '&X-Goog-Credential=service%40project.iam.gserviceaccount.com%2F20220101%2Fauto%2Fstorage%2Fgoog4_request' +
+    '&X-Goog-Date=20220101T000000Z' +
+    '&X-Goog-Expires=900' +
+    '&X-Goog-Signature=abc123def456';
+
+  it('redacts X-Amz-Credential and X-Amz-Signature from a presigned S3 URL', () => {
+    const result = redactUrl(S3_URL);
+    const encoded = encodeURIComponent(REDACTED_VALUE);
+    expect(result).toContain(`X-Amz-Credential=${encoded}`);
+    expect(result).toContain(`X-Amz-Signature=${encoded}`);
+  });
+
+  it('preserves non-secret AWS parameters (Algorithm, Date, Expires, SignedHeaders)', () => {
+    const result = redactUrl(S3_URL);
+    expect(result).toContain('X-Amz-Algorithm=AWS4-HMAC-SHA256');
+    expect(result).toContain('X-Amz-Date=20130524T000000Z');
+    expect(result).toContain('X-Amz-Expires=86400');
+    expect(result).toContain('X-Amz-SignedHeaders=host');
+  });
+
+  it('redacts X-Goog-Credential and X-Goog-Signature from a presigned GCS URL', () => {
+    const result = redactUrl(GCS_URL);
+    const encoded = encodeURIComponent(REDACTED_VALUE);
+    expect(result).toContain(`X-Goog-Credential=${encoded}`);
+    expect(result).toContain(`X-Goog-Signature=${encoded}`);
+  });
+
+  it('preserves non-secret GCS parameters (Algorithm, Date, Expires)', () => {
+    const result = redactUrl(GCS_URL);
+    expect(result).toContain('X-Goog-Algorithm=GOOG4-RSA-SHA256');
+    expect(result).toContain('X-Goog-Date=20220101T000000Z');
+    expect(result).toContain('X-Goog-Expires=900');
+  });
+
+  it('preserves the URL path and host', () => {
+    const result = redactUrl(S3_URL);
+    expect(result).toContain('https://my-bucket.s3.amazonaws.com/object.pdf');
+  });
+});

--- a/packages/core/src/redaction.presigned.test.ts
+++ b/packages/core/src/redaction.presigned.test.ts
@@ -46,8 +46,19 @@ describe('isSensitiveKey — presigned URL credential parameters', () => {
     }
   });
 
-  it('does NOT match AWS non-secret presigned URL parameters', () => {
-    for (const k of ['X-Amz-Algorithm', 'X-Amz-Date', 'X-Amz-Expires', 'X-Amz-SignedHeaders']) {
+  it('does NOT match AWS/GCS non-secret presigned URL parameters', () => {
+    for (const k of [
+      'X-Amz-Algorithm',
+      'X-Amz-Date',
+      'X-Amz-Expires',
+      'X-Amz-SignedHeaders',
+      'X-Amz-SignatureVersion',
+      'X-Amz-CredentialScope',
+      'X-Goog-Algorithm',
+      'X-Goog-Date',
+      'X-Goog-Expires',
+      'X-Goog-SignatureVersion',
+    ]) {
       expect(isSensitiveKey(k), `expected "${k}" to NOT be sensitive`).toBe(false);
     }
   });

--- a/packages/core/src/redaction.presigned.test.ts
+++ b/packages/core/src/redaction.presigned.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { isSensitiveKey } from './redaction.js';
+
+describe('isSensitiveKey — presigned URL credential parameters', () => {
+  it('matches AWS presigned URL parameters', () => {
+    for (const k of [
+      'X-Amz-Credential',
+      'X-Amz-Signature',
+      'X-Amz-Security-Token',
+      'x-amz-credential',
+      'x-amz-signature',
+      'x-amz-security-token',
+    ]) {
+      expect(isSensitiveKey(k), `expected "${k}" to be sensitive`).toBe(true);
+    }
+  });
+
+  it('matches GCS presigned URL parameters', () => {
+    for (const k of ['X-Goog-Signature', 'X-Goog-Credential', 'x-goog-signature']) {
+      expect(isSensitiveKey(k), `expected "${k}" to be sensitive`).toBe(true);
+    }
+  });
+
+  it('matches bare credential/signature keys with word boundaries', () => {
+    for (const k of ['signature', 'Signature', 'sig', 'credential', 'Credential']) {
+      expect(isSensitiveKey(k), `expected "${k}" to be sensitive`).toBe(true);
+    }
+  });
+
+  it('matches hyphenated/underscored credential keys at boundaries', () => {
+    for (const k of ['access-signature', 'request_signature', 'auth-sig', 'user_credential']) {
+      expect(isSensitiveKey(k), `expected "${k}" to be sensitive`).toBe(true);
+    }
+  });
+
+  it('does NOT match keys where signature/sig/credential are embedded substrings', () => {
+    for (const k of [
+      'signatureVersion',
+      'signatureMethod',
+      'sig_algo',
+      'design-signature-v2',
+      'credentialScope',
+      'insignificant',
+    ]) {
+      expect(isSensitiveKey(k), `expected "${k}" to NOT be sensitive`).toBe(false);
+    }
+  });
+
+  it('does NOT match AWS non-secret presigned URL parameters', () => {
+    for (const k of ['X-Amz-Algorithm', 'X-Amz-Date', 'X-Amz-Expires', 'X-Amz-SignedHeaders']) {
+      expect(isSensitiveKey(k), `expected "${k}" to NOT be sensitive`).toBe(false);
+    }
+  });
+});

--- a/packages/core/src/redaction.ts
+++ b/packages/core/src/redaction.ts
@@ -19,7 +19,7 @@ import { REDACTED_VALUE } from './constants.js';
 // unredacted), NOT any key that merely contains the substring — `scopecookie`, `cookieConsent`,
 // `cookiePolicy` are legitimate app values an agent may need to read, and stay visible.
 const SENSITIVE_KEY =
-  /password|passwd|passcode|secret|(?:(?:access|refresh|auth|bearer|api|id|session|csrf|client)[-_]?tokens?|(?:^|[-_])tokens?(?=$|[-_]))|session[-_]?id|(?:^|[-_])(?:sid|pwd|jwt)(?=$|[-_])|authorization|(?:^|[-_])(?:set[-_])?cookie(?=$|[-_])|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|credit[-_]?card|card[-_]?number|cvv|cvc|ssn|(?:^|[-_])(?:signature|sig)$|(?:^|[-_])credential$|x-(?:amz|goog)-(?:signature|credential|security-token)/i;
+  /password|passwd|passcode|secret|(?:(?:access|refresh|auth|bearer|api|id|session|csrf|client)[-_]?tokens?|(?:^|[-_])tokens?(?=$|[-_]))|session[-_]?id|(?:^|[-_])(?:sid|pwd|jwt)(?=$|[-_])|authorization|(?:^|[-_])(?:set[-_])?cookie(?=$|[-_])|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|credit[-_]?card|card[-_]?number|cvv|cvc|ssn|(?:^|[-_])(?:signature|sig)$|(?:^|[-_])credential$|x-(?:amz|goog)-(?:signature|credential|security-token)$/i;
 
 export function isSensitiveKey(key: string): boolean {
   return SENSITIVE_KEY.test(key);

--- a/packages/core/src/redaction.ts
+++ b/packages/core/src/redaction.ts
@@ -19,7 +19,7 @@ import { REDACTED_VALUE } from './constants.js';
 // unredacted), NOT any key that merely contains the substring — `scopecookie`, `cookieConsent`,
 // `cookiePolicy` are legitimate app values an agent may need to read, and stay visible.
 const SENSITIVE_KEY =
-  /password|passwd|passcode|secret|(?:(?:access|refresh|auth|bearer|api|id|session|csrf|client)[-_]?tokens?|(?:^|[-_])tokens?(?=$|[-_]))|session[-_]?id|(?:^|[-_])(?:sid|pwd|jwt)(?=$|[-_])|authorization|(?:^|[-_])(?:set[-_])?cookie(?=$|[-_])|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|credit[-_]?card|card[-_]?number|cvv|cvc|ssn/i;
+  /password|passwd|passcode|secret|(?:(?:access|refresh|auth|bearer|api|id|session|csrf|client)[-_]?tokens?|(?:^|[-_])tokens?(?=$|[-_]))|session[-_]?id|(?:^|[-_])(?:sid|pwd|jwt)(?=$|[-_])|authorization|(?:^|[-_])(?:set[-_])?cookie(?=$|[-_])|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|credit[-_]?card|card[-_]?number|cvv|cvc|ssn|(?:^|[-_])(?:signature|sig)$|(?:^|[-_])credential$|x-(?:amz|goog)-(?:signature|credential|security-token)/i;
 
 export function isSensitiveKey(key: string): boolean {
   return SENSITIVE_KEY.test(key);


### PR DESCRIPTION
## Summary

- Extends `SENSITIVE_KEY` in `@reticlehq/core` to match presigned URL credential parameters: `X-Amz-Credential`, `X-Amz-Signature`, `X-Amz-Security-Token`, `X-Goog-Credential`, `X-Goog-Signature`, and bare `credential`/`signature`/`sig` at word boundaries
- Non-secret parameters (`X-Amz-Algorithm`, `X-Amz-Date`, `X-Amz-Expires`, `X-Amz-SignedHeaders`) are preserved — agents need algorithm/date context to understand request flow
- Boundary-anchored: `signatureVersion`, `sig_algo`, `credentialScope`, `insignificant` do NOT match

Closes #72

## Test plan

- [x] `packages/core/src/redaction.presigned.test.ts` — 6 tests covering positive matches (AWS, GCS, bare keys, boundary forms) and negative cases (embedded substrings, non-secret AWS params)
- [x] `packages/browser/src/observers/network-redact.presigned.test.ts` — 5 integration tests asserting a full presigned S3/GCS URL is redacted correctly via `redactUrl`
- [x] Existing `serialization.test.ts` battery passes (36 tests) — no regression on prior key matching
- [x] Fuzz test passes (5000 adversarial inputs) — no catastrophic backtracking introduced
- [x] `pnpm lint && pnpm typecheck` clean on both `core` and `browser`

🤖 Generated with [Claude Code](https://claude.com/claude-code)