### PR TITLE
fix(browser): reject non-callable source in registerStore with accurate warning

### DIFF
--- a/packages/browser/src/registry/stores.test.ts
+++ b/packages/browser/src/registry/stores.test.ts
@@ -109,6 +109,34 @@ describe('store registry', () => {
   });
 });
 
+describe('registerStore — rejects non-callable, non-StoreLike sources', () => {
+  it('rejects {subscribe} without getState: warns about the missing getState, does not register', () => {
+    const warn = vi.spyOn(nativeConsole, 'nativeWarn').mockImplementation(() => undefined);
+    const svelteish = {
+      subscribe: (_fn: () => void) => () => undefined,
+      set: () => undefined,
+    };
+    registerStore('svelte-bad', svelteish as unknown as Parameters<typeof registerStore>[1]);
+    expect(storeNames()).not.toContain('svelte-bad');
+    expect(warn).toHaveBeenCalledOnce();
+    const msg = String(warn.mock.calls[0]?.[0]);
+    expect(msg).toContain('svelte-bad');
+    expect(msg).toContain('getState');
+    warn.mockRestore();
+  });
+
+  it('rejects a plain object with no subscribe and no getState', () => {
+    const warn = vi.spyOn(nativeConsole, 'nativeWarn').mockImplementation(() => undefined);
+    registerStore('bad-obj', { foo: 1 } as unknown as Parameters<typeof registerStore>[1]);
+    expect(storeNames()).not.toContain('bad-obj');
+    expect(warn).toHaveBeenCalledOnce();
+    const msg = String(warn.mock.calls[0]?.[0]);
+    expect(msg).toContain('bad-obj');
+    expect(msg).not.toContain('has subscribe but no getState');
+    warn.mockRestore();
+  });
+});
+
 /**
  * A store registered with only a getter is READABLE but SILENT: reticle_state can read it on demand,
  * yet nothing ever emits a STATE_CHANGE, so causal summaries show no state diff and a state predicate

--- a/packages/browser/src/registry/stores.ts
+++ b/packages/browser/src/registry/stores.ts
@@ -67,6 +67,16 @@ export function registerStore(
     notifyRegistered(name, getter, sub);
     return;
   }
+  if (typeof source !== 'function') {
+    const hasSubscribe = typeof source === 'object' && source !== null && 'subscribe' in source;
+    nativeWarn(
+      `[reticle] store "${name}" is neither a getter function nor a {getState, subscribe} store` +
+        (hasSubscribe
+          ? ` — it has subscribe but no getState. Wrap it with an adapter or add getState.`
+          : '.'),
+    );
+    return;
+  }
   stores.set(name, source);
   if (subscribe !== undefined) {
     subscribers.set(name, subscribe);


### PR DESCRIPTION
## Summary

- `registerStore` now rejects a non-callable, non-`StoreLike` source (e.g. a Svelte store with only `subscribe`) instead of blindly storing it as a getter that always returns `__error`
- The warning message names the actual gap: "it has subscribe but no getState" — not the old misleading "pass the store object" advice that pointed away from the fix
- The store is not registered at all, so `storeNames()` won't list a store that can never be read

Closes #68

## Test plan

- [x] Test: `{subscribe}` without `getState` is rejected, not in `storeNames()`, warning mentions `getState`
- [x] Test: plain object (no `subscribe`, no `getState`) is rejected with a different message
- [x] Existing tests pass: StoreLike path, callable Zustand hook, bare getter, silent-store warning
- [x] `pnpm lint && pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)