### PR TITLE
fix(core): teach selectPath/capDepth about Date, Map, and Set

### DIFF
--- a/packages/core/src/state-select.test.ts
+++ b/packages/core/src/state-select.test.ts
@@ -55,6 +55,68 @@ describe('selectPath', () => {
   });
 });
 
+describe('selectPath — Map support', () => {
+  it('walks into a Map by string key', () => {
+    const state = { byId: new Map([['a', { name: 'alice' }]]) };
+    expect(selectPath(state, 'byId.a.name')).toEqual({ found: true, value: 'alice' });
+  });
+
+  it('reports available Map keys on a miss', () => {
+    const state = {
+      byId: new Map([
+        ['x', 1],
+        ['y', 2],
+      ]),
+    };
+    const r = selectPath(state, 'byId.z');
+    expect(r.found).toBe(false);
+    expect(r.availableKeys).toContain('x');
+    expect(r.availableKeys).toContain('y');
+  });
+
+  it('returns the Map itself when the path stops at it', () => {
+    const m = new Map([['k', 'v']]);
+    expect(selectPath({ m }, 'm')).toEqual({ found: true, value: m });
+  });
+});
+
+describe('capDepth — Date/Map/Set handling', () => {
+  it('treats Date as a leaf and returns its ISO string at any depth', () => {
+    const d = new Date('2026-01-01T00:00:00Z');
+    expect(capDepth(d, 0)).toBe('2026-01-01T00:00:00.000Z');
+    expect(capDepth({ t: d }, 1)).toEqual({ t: '2026-01-01T00:00:00.000Z' });
+  });
+
+  it('converts a Set to an array with depth capping', () => {
+    const s = new Set(['a', 'b']);
+    expect(capDepth(s, 1)).toEqual(['a', 'b']);
+    expect(capDepth(s, 0)).toBe('[Set(2)]');
+  });
+
+  it('converts a Map to an object with depth capping', () => {
+    const m = new Map<string, unknown>([['x', { nested: 1 }]]);
+    expect(capDepth(m, 2)).toEqual({ x: { nested: 1 } });
+    expect(capDepth(m, 1)).toEqual({ x: '{…1 keys}' });
+    expect(capDepth(m, 0)).toBe('{Map(1)}');
+  });
+
+  it('recurses through nested Date/Map/Set correctly', () => {
+    const state = {
+      updatedAt: new Date('2026-01-01T00:00:00Z'),
+      selected: new Set(['a', 'b']),
+      byId: new Map([['a', 1]]),
+      n: 5,
+    };
+    const capped = capDepth(state, 3);
+    expect(capped).toEqual({
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      selected: ['a', 'b'],
+      byId: { a: 1 },
+      n: 5,
+    });
+  });
+});
+
 describe('capDepth', () => {
   it('a negative budget means no cap (value returned unchanged)', () => {
     const deep = { a: { b: { c: 1 } } };

--- a/packages/core/src/state-select.test.ts
+++ b/packages/core/src/state-select.test.ts
@@ -78,6 +78,17 @@ describe('selectPath — Map support', () => {
     const m = new Map([['k', 'v']]);
     expect(selectPath({ m }, 'm')).toEqual({ found: true, value: m });
   });
+
+  it('only reports string keys in availableKeys for a Map (non-string keys omitted)', () => {
+    const m = new Map<unknown, number>([
+      ['str', 1],
+      [42, 2],
+      [Symbol('s'), 3],
+    ]);
+    const r = selectPath({ m }, 'm.missing');
+    expect(r.found).toBe(false);
+    expect(r.availableKeys).toEqual(['str']);
+  });
 });
 
 describe('capDepth — Date/Map/Set handling', () => {
@@ -85,6 +96,11 @@ describe('capDepth — Date/Map/Set handling', () => {
     const d = new Date('2026-01-01T00:00:00Z');
     expect(capDepth(d, 0)).toBe('2026-01-01T00:00:00.000Z');
     expect(capDepth({ t: d }, 1)).toEqual({ t: '2026-01-01T00:00:00.000Z' });
+  });
+
+  it('degrades an invalid Date to null instead of throwing', () => {
+    expect(capDepth(new Date(NaN), 0)).toBeNull();
+    expect(capDepth({ t: new Date('invalid') }, 1)).toEqual({ t: null });
   });
 
   it('converts a Set to an array with depth capping', () => {

--- a/packages/core/src/state-select.ts
+++ b/packages/core/src/state-select.ts
@@ -20,8 +20,14 @@ const MAX_AVAILABLE_KEYS = 50;
 
 function keysOf(value: unknown): string[] {
   if (Array.isArray(value)) return value.slice(0, MAX_AVAILABLE_KEYS).map((_, i) => String(i));
-  if (value instanceof Map)
-    return [...value.keys()].slice(0, MAX_AVAILABLE_KEYS).map((k) => String(k));
+  if (value instanceof Map) {
+    const out: string[] = [];
+    for (const k of value.keys()) {
+      if (typeof k === 'string') out.push(k);
+      if (out.length >= MAX_AVAILABLE_KEYS) break;
+    }
+    return out;
+  }
   if (typeof value === 'object' && value !== null)
     return Object.keys(value).slice(0, MAX_AVAILABLE_KEYS);
   return [];
@@ -75,7 +81,7 @@ export function selectPath(root: unknown, path: string): PathSelection {
  */
 export function capDepth(value: unknown, maxDepth: number): unknown {
   if (maxDepth < 0) return value;
-  if (value instanceof Date) return value.toISOString();
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value.toISOString();
   if (value instanceof Set) {
     if (maxDepth === 0) return `[Set(${String(value.size)})]`;
     return [...value].map((v) => capDepth(v, maxDepth - 1));

--- a/packages/core/src/state-select.ts
+++ b/packages/core/src/state-select.ts
@@ -20,6 +20,8 @@ const MAX_AVAILABLE_KEYS = 50;
 
 function keysOf(value: unknown): string[] {
   if (Array.isArray(value)) return value.slice(0, MAX_AVAILABLE_KEYS).map((_, i) => String(i));
+  if (value instanceof Map)
+    return [...value.keys()].slice(0, MAX_AVAILABLE_KEYS).map((k) => String(k));
   if (typeof value === 'object' && value !== null)
     return Object.keys(value).slice(0, MAX_AVAILABLE_KEYS);
   return [];
@@ -46,6 +48,13 @@ export function selectPath(root: unknown, path: string): PathSelection {
       current = current[index];
       continue;
     }
+    if (current instanceof Map) {
+      if (current.has(segment)) {
+        current = current.get(segment);
+        continue;
+      }
+      return { found: false, value: null, availableKeys: keysOf(current) };
+    }
     // `Object.hasOwn`, not `in`: `in` walks the prototype, so a path segment of `constructor`,
     // `__proto__`, or `toString` reported found:true and returned a function from Object.prototype —
     // a state assertion on a typo'd path silently passed against a builtin instead of failing with
@@ -66,6 +75,17 @@ export function selectPath(root: unknown, path: string): PathSelection {
  */
 export function capDepth(value: unknown, maxDepth: number): unknown {
   if (maxDepth < 0) return value;
+  if (value instanceof Date) return value.toISOString();
+  if (value instanceof Set) {
+    if (maxDepth === 0) return `[Set(${String(value.size)})]`;
+    return [...value].map((v) => capDepth(v, maxDepth - 1));
+  }
+  if (value instanceof Map) {
+    if (maxDepth === 0) return `{Map(${String(value.size)})}`;
+    const out: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+    for (const [k, v] of value) out[String(k)] = capDepth(v, maxDepth - 1);
+    return out;
+  }
   if (Array.isArray(value)) {
     if (maxDepth === 0) return `[Array(${String(value.length)})]`;
     return value.map((v) => capDepth(v, maxDepth - 1));


### PR DESCRIPTION
## Summary

- `capDepth` now recognizes `Date` (leaf → ISO string), `Set` (array-like with `[Set(N)]` marker), and `Map` (object-like with `{Map(N)}` marker) instead of treating them as plain objects with 0 keys
- `selectPath` can walk into a `Map` via `.get(segment)` and reports available Map keys on a miss
- `keysOf` reports Map keys so the near-miss diagnostic is accurate

This aligns `state-select.ts` with the serializer's Date/Map/Set handling, so a scoped state read (`path` or `depth`) no longer contradicts the unscoped one.

Closes #73

## Test plan

- [x] `selectPath` into a Map: walks by string key, reports keys on miss, returns Map at terminal path
- [x] `capDepth` with Date: treated as leaf, ISO string at any depth
- [x] `capDepth` with Set: converts to array, proper size marker at budget 0
- [x] `capDepth` with Map: converts to object, recurses values, size marker at budget 0
- [x] Integration: nested state with all three types capped at depth 3 matches expected output
- [x] Original tests unchanged: no regression on plain-object/array behavior
- [x] `pnpm lint && pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)