### PR TITLE
fix(browser): forward component/source fields in QUERY command

### DIFF
--- a/packages/browser/src/commands/commands.test.ts
+++ b/packages/browser/src/commands/commands.test.ts
@@ -198,6 +198,30 @@ describe('command registry (driven by the bridge)', () => {
     unregisterStore('state_ws');
   });
 
+  it('QUERY forwards the component field into the auto-anchor resolution path', () => {
+    document.body.innerHTML = '<button>Submit</button>';
+    registerAdapter({
+      name: 'query_component_test',
+      identify: (el) => (el.tagName === 'BUTTON' ? { componentStack: ['SubmitButton'] } : null),
+      readState: () => undefined,
+    });
+    const result = run(ReticleCommand.QUERY, { component: 'SubmitButton' }) as {
+      elements: unknown[];
+      count: number;
+    };
+    expect(result.count).toBe(1);
+    expect(result.elements).toHaveLength(1);
+  });
+
+  it('QUERY forwards the source field into the auto-anchor resolution path', () => {
+    document.body.innerHTML = '<input data-reticle-source="form.tsx:42:5" placeholder="Email" />';
+    const result = run(ReticleCommand.QUERY, {
+      source: { file: 'form.tsx', line: 42 },
+    }) as { elements: unknown[]; count: number };
+    expect(result.count).toBe(1);
+    expect(result.elements).toHaveLength(1);
+  });
+
   it('CAPABILITIES returns the registered capabilities', () => {
     registerCapabilities({
       testids: ['item-list'],

--- a/packages/browser/src/commands/commands.test.ts
+++ b/packages/browser/src/commands/commands.test.ts
@@ -199,10 +199,11 @@ describe('command registry (driven by the bridge)', () => {
   });
 
   it('QUERY forwards the component field into the auto-anchor resolution path', () => {
-    document.body.innerHTML = '<button>Submit</button>';
+    const MARKER = 'data-query-component-test';
+    document.body.innerHTML = `<button ${MARKER}>Submit</button>`;
     registerAdapter({
       name: 'query_component_test',
-      identify: (el) => (el.tagName === 'BUTTON' ? { componentStack: ['SubmitButton'] } : null),
+      identify: (el) => (el.hasAttribute(MARKER) ? { componentStack: ['SubmitButton'] } : null),
       readState: () => undefined,
     });
     const result = run(ReticleCommand.QUERY, { component: 'SubmitButton' }) as {
@@ -220,6 +221,17 @@ describe('command registry (driven by the bridge)', () => {
     }) as { elements: unknown[]; count: number };
     expect(result.count).toBe(1);
     expect(result.elements).toHaveLength(1);
+  });
+
+  it('QUERY with malformed source returns empty results (no crash)', () => {
+    document.body.innerHTML = '<button>Click</button>';
+    for (const bad of [null, 'string', 42, { file: 'x' }, { line: 1 }]) {
+      const result = run(ReticleCommand.QUERY, { source: bad }) as {
+        elements: unknown[];
+        count: number;
+      };
+      expect(result.count).toBe(0);
+    }
   });
 
   it('CAPABILITIES returns the registered capabilities', () => {

--- a/packages/browser/src/commands/commands.ts
+++ b/packages/browser/src/commands/commands.ts
@@ -60,10 +60,12 @@ function queryFromArgs(args: Record<string, unknown>): ElementQuery {
     placeholder: str(args['placeholder']),
     testid: str(args['testid']),
     alt: str(args['alt']),
+    component: str(args['component']),
     scope: str(args['scope']),
     attrs: Array.isArray(args['attrs'])
       ? args['attrs'].filter((a): a is string => typeof a === 'string')
       : undefined,
+    source: args['source'] as ElementQuery['source'],
   };
 }
 

--- a/packages/browser/src/commands/commands.ts
+++ b/packages/browser/src/commands/commands.ts
@@ -49,6 +49,13 @@ function record(value: unknown): Record<string, unknown> {
   return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {};
 }
 
+function sourceLocation(value: unknown): ElementQuery['source'] {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const obj = value as Record<string, unknown>;
+  if (typeof obj['file'] !== 'string' || typeof obj['line'] !== 'number') return undefined;
+  return { file: obj['file'], line: obj['line'], column: num(obj['column']) };
+}
+
 function queryFromArgs(args: Record<string, unknown>): ElementQuery {
   return {
     by: str(args['by']) as ElementQuery['by'],
@@ -65,7 +72,7 @@ function queryFromArgs(args: Record<string, unknown>): ElementQuery {
     attrs: Array.isArray(args['attrs'])
       ? args['attrs'].filter((a): a is string => typeof a === 'string')
       : undefined,
-    source: args['source'] as ElementQuery['source'],
+    source: sourceLocation(args['source']),
   };
 }
 


### PR DESCRIPTION
## Summary

- `queryFromArgs()` omitted the `component` and `source` fields that `ElementQuerySchema` defines, so auto-anchor resolution (the durable path for component-stamped elements) was silently unreachable via the bridge QUERY command.
- Adds both fields to the returned `ElementQuery` object — `component` via the existing `str()` helper, `source` as a typed cast matching the schema's shape.
- Two tests verify the auto-anchor path fires for both `component` (adapter-based) and `source` (`data-reticle-source` attribute-based) queries.

## Test plan

- [x] `pnpm --filter @reticlehq/browser test:unit` — 19/19 pass (commands.test.ts)
- [x] `pnpm --filter @reticlehq/browser lint` — clean
- [x] `pnpm --filter @reticlehq/browser typecheck` — clean
- [x] Prettier format check — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)