### PR TITLE
fix: svelteStore ate a real change, and the Tauri spec trusted whichever app connected first

### DIFF
--- a/apps/e2e/specs/tauri-desktop-test.mjs
+++ b/apps/e2e/specs/tauri-desktop-test.mjs
@@ -67,11 +67,19 @@ try {
   // Both are the packaged app. What this check exists to exclude is a DEV SERVER
   // (`http://localhost:5173`), because testing one of those would prove nothing about the binary.
   const PACKAGED_TAURI_ORIGINS = ['tauri://localhost', 'http://tauri.localhost/'];
-  const connectedUrl = String(server.bridge.sessions.list()[0]?.url);
+  // Find the Tauri session, never `list()[0]`. Any Reticle-instrumented app running on the developer's
+  // machine can dial this bridge and take slot 0 — an ordinary dev server on localhost:3000 did
+  // exactly that and failed this check while the packaged binary had connected perfectly, which is a
+  // red that belongs to nobody's change. Asserting on the session we are actually testing keeps the
+  // check just as strict: a spec driving a DEV SERVER still finds no packaged origin here.
+  const sessions = server.bridge.sessions.list();
+  const tauriSession = sessions.find((s) => PACKAGED_TAURI_ORIGINS.includes(String(s?.url)));
   chk(
     'it connected from the packaged Tauri origin, not a dev server',
-    PACKAGED_TAURI_ORIGINS.includes(connectedUrl),
-    connectedUrl,
+    tauriSession !== undefined,
+    tauriSession === undefined
+      ? `no packaged-origin session among ${JSON.stringify(sessions.map((s) => String(s?.url)))}`
+      : String(tauriSession.url),
   );
 
   for (let i = 0; i < 40; i++) {

--- a/packages/browser/src/registry/store-adapters.test.ts
+++ b/packages/browser/src/registry/store-adapters.test.ts
@@ -379,6 +379,28 @@ describe('svelteStore', () => {
     expect(svelte.runCount()).toBe(0);
   });
 
+  it('delivers the FIRST change of a store that never called back synchronously', () => {
+    // The registration callback is swallowed by POSITION (it arrives during the subscribe call), not
+    // by count. A store that calls back late — an RxJS Observable that is not a BehaviorSubject, the
+    // same store getState warns about — has no registration callback to drop, so swallowing "the
+    // first one" ate a real change instead: no STATE_CHANGE, and a {kind:"state"} assertion left
+    // with nothing to match. A silently missed state change is the false green this project exists
+    // to prevent.
+    let emit: ((value: unknown) => void) | undefined;
+    const lazy = {
+      subscribe: (run: (value: unknown) => void): (() => void) => {
+        emit = run; // deliberately NOT called here
+        return () => undefined;
+      },
+    };
+    const listener = vi.fn();
+    svelteStore(lazy, vi.fn()).subscribe(listener);
+    expect(listener).not.toHaveBeenCalled();
+
+    emit?.('the first real change');
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
   it('accepts a subscribe that returns an {unsubscribe} object, not only a function', () => {
     const unsubscribe = vi.fn();
     const store = svelteStore({

--- a/packages/browser/src/registry/store-adapters.ts
+++ b/packages/browser/src/registry/store-adapters.ts
@@ -362,17 +362,22 @@ export function svelteStore(
       return value;
     },
     subscribe: (listener: () => void): (() => void) => {
-      // Swallow the immediate call. Forwarding it would emit a STATE_CHANGE at REGISTRATION time for
-      // a change that never happened — a diff of nothing that shows up in causal summaries and that
-      // a {kind:'state'} predicate could satisfy without the app doing anything at all.
-      let primed = false;
+      // Swallow whatever arrives DURING the subscribe call. Forwarding it would emit a STATE_CHANGE
+      // at REGISTRATION time for a change that never happened — a diff of nothing that shows up in
+      // causal summaries and that a {kind:'state'} predicate could satisfy without the app doing
+      // anything at all.
+      //
+      // The window is what makes this correct, rather than "swallow the first callback whenever it
+      // arrives". A store that does NOT call back synchronously (an RxJS Observable that is not a
+      // BehaviorSubject — the exact store `getState` warns about) has no registration callback to
+      // drop, so counting callbacks ate its first REAL change: no STATE_CHANGE, and a
+      // {kind:'state'} assertion with nothing to match. A silently missed state change is the false
+      // green this project exists to prevent, so the rule is positional, not ordinal.
+      let inSubscribeCall = true;
       const handle = readable.subscribe(() => {
-        if (!primed) {
-          primed = true;
-          return;
-        }
-        listener();
+        if (!inSubscribeCall) listener();
       });
+      inSubscribeCall = false;
       return () => stopSubscription(handle);
     },
   };


### PR DESCRIPTION
Two follow-ups from the review of #90. Neither is a user-visible failure today; both are the shape that becomes one quietly.

## `svelteStore` swallowed the first callback by COUNT, not by position

For a compliant Svelte store the first callback IS the registration call, and dropping it is right — forwarding it would emit a `STATE_CHANGE` for a change that never happened, a diff of nothing a `{kind:"state"}` predicate could satisfy.

But a store that calls back **late** — an RxJS `Observable` that is not a `BehaviorSubject`, the exact store `getState` already warns about — has no registration callback to drop. The counter ate its first *real* change instead: no `STATE_CHANGE`, and an assertion left with nothing to match. A silently missed state change is the false green this project exists to prevent.

The rule is now positional rather than ordinal — swallow what arrives *during* the subscribe call, forward everything after:

```ts
let inSubscribeCall = true;
const handle = readable.subscribe(() => { if (!inSubscribeCall) listener(); });
inSubscribeCall = false;
```

Same size, and no counter to get wrong. The new test drives a store that never calls back synchronously and asserts its first emission reaches the listener; it fails on the old implementation.

## The Tauri spec asserted on `sessions.list()[0]`

Any Reticle-instrumented app on the developer's machine can dial the bridge and take slot 0. An ordinary dev server on `localhost:3000` did exactly that and failed the check **while the packaged binary had connected perfectly** — a red belonging to nobody's change, sitting behind an Electron install and a Rust build, which is the worst possible place to put one: a first-time contributor pays for the whole setup before meeting it.

It now selects the session whose origin is a packaged Tauri one. No weaker than before — a spec driving a dev server still finds no packaged origin, which is the thing the check exists to exclude.

## Verification

- `pnpm build && pnpm lint && pnpm typecheck && pnpm test:unit` — green (browser 782 → 783).
- `pnpm test:e2e:desktop` **with the offending app still running on :3000** — the condition that produced the original red: Electron 20/20, Tauri 14/14, 2/2 specs.

Related: the third review finding — the lossy-transform guard's `exportedNames` regex missing `export { x }` / `export default` — is filed separately as a good first issue rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)