### PR TITLE
fix(vite-plugin): a dev server started before the daemon served a tokenless connect module forever

### DIFF
--- a/packages/server/src/bridge.ts
+++ b/packages/server/src/bridge.ts
@@ -33,7 +33,14 @@ const WS_CLOSE = {
   HELLO_TIMEOUT: [1008, 'hello timeout'],
   INVALID_MESSAGE: [1008, 'invalid message'],
   HELLO_DUPLICATE: [1008, 'hello already received'],
-  AUTH_FAILED: [1008, 'authentication failed'],
+  // Names the recovery, because the SDK prints this reason and then stops retrying — so it is the
+  // last thing the developer sees. The common cause is a page served before the daemon existed,
+  // which carries no token; a reload re-fetches the connect module and picks the current one up.
+  // Kept under the 123-byte WebSocket close-reason limit.
+  AUTH_FAILED: [
+    1008,
+    'authentication failed — reload the page to pick up the current pairing token',
+  ],
   SESSION_LIMIT: [1013, 'session limit reached'],
   PROTOCOL_MISMATCH: [1008, 'protocol version mismatch — upgrade @reticlehq/browser'],
 } as const;

--- a/packages/vite-plugin/src/build.integration.test.ts
+++ b/packages/vite-plugin/src/build.integration.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it, beforeAll } from 'vitest';
-import { reticle, RETICLE_VITE_PLUGIN_NAME } from './index.js';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, beforeAll } from 'vitest';
+import { ReticleDir, ReticleEnv } from '@reticlehq/core';
+import { reticle, RETICLE_CONNECT_MODULE, RETICLE_VITE_PLUGIN_NAME } from './index.js';
 
 /**
  * Proves the prod-safety claim against Vite's *actual* config resolution rather than a unit
@@ -8,19 +12,33 @@ import { reticle, RETICLE_VITE_PLUGIN_NAME } from './index.js';
  * `vite` is not installed (e.g. offline local runs); CI installs it as a devDependency.
  */
 
+/** A dev server, as much of it as this suite drives. */
+interface DevServerLike {
+  listen: () => Promise<unknown>;
+  close: () => Promise<void>;
+  resolvedUrls?: { local: string[] };
+}
+type CreateServer = (inline: Record<string, unknown>) => Promise<DevServerLike>;
+
 type ResolveConfig = (
   inline: { plugins: unknown[]; configFile: false; logLevel: 'silent' },
   command: 'build' | 'serve',
 ) => Promise<{ plugins: readonly { name: string }[] }>;
 
 let resolveConfig: ResolveConfig | undefined;
+let createServer: CreateServer | undefined;
 
 beforeAll(async () => {
   try {
-    const vite = (await import('vite')) as { resolveConfig: ResolveConfig };
+    const vite = (await import('vite')) as {
+      resolveConfig: ResolveConfig;
+      createServer: CreateServer;
+    };
     resolveConfig = vite.resolveConfig;
+    createServer = vite.createServer;
   } catch {
     resolveConfig = undefined;
+    createServer = undefined;
   }
 });
 
@@ -45,5 +63,71 @@ describe('reticle() in the real Vite config resolution', () => {
       'build',
     );
     expect(names(resolved.plugins)).not.toContain(RETICLE_VITE_PLUGIN_NAME);
+  });
+});
+
+/**
+ * The daemon may start AFTER the dev server, and this is the case that broke.
+ *
+ * `load` reads the pairing token at serve time for exactly that reason, but Vite caches the module
+ * it produced and answers every later request from that cache — including after a full page reload.
+ * So the app kept receiving the tokenless connect module it was served first, the SDK got a 1008
+ * `authentication failed` and (correctly) stopped retrying, and `reticle status` reported no session
+ * while the page demonstrably contained `/@reticle-connect`. Only restarting the dev server cleared
+ * it. Reported from a Windows Vite + React app; reproduces on every platform.
+ *
+ * Against a REAL dev server, because the whole defect lives in Vite's cache: a unit test on `load`
+ * calls it directly and passes either way, which is why nothing here caught this.
+ */
+describe('the connect module picks up a token written after the dev server started', () => {
+  const dirs: string[] = [];
+  const servers: DevServerLike[] = [];
+
+  afterEach(async () => {
+    for (const server of servers.splice(0)) await server.close();
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+    delete process.env[ReticleEnv.PAIRING_TOKEN_DIR];
+  });
+
+  it('serves the token on the next request, without a dev-server restart', async () => {
+    if (createServer === undefined) return;
+    const tokenDir = mkdtempSync(join(tmpdir(), 'reticle-token-'));
+    const root = mkdtempSync(join(tmpdir(), 'reticle-app-'));
+    dirs.push(tokenDir, root);
+    process.env[ReticleEnv.PAIRING_TOKEN_DIR] = tokenDir;
+
+    // A stand-in for the SDK: the import must RESOLVE, or Vite fails the module and re-runs `load`
+    // on every request — which hides the staleness the same way it hid it during investigation.
+    mkdirSync(join(root, 'src'), { recursive: true });
+    writeFileSync(
+      join(root, 'src/sdk.js'),
+      'export const reticle = { connect(){} };\nexport const install = () => {};\n',
+    );
+    writeFileSync(
+      join(root, 'index.html'),
+      '<html><body><script type="module" src="/src/main.js"></script></body></html>',
+    );
+    writeFileSync(join(root, 'src/main.js'), 'export const app = 1;\n');
+
+    const server = await createServer({
+      root,
+      logLevel: 'silent',
+      configFile: false,
+      server: { port: 0 },
+      resolve: { alias: { '@reticlehq/react': join(root, 'src/sdk.js') } },
+      plugins: [reticle()],
+    });
+    servers.push(server);
+    await server.listen();
+    const base = server.resolvedUrls?.local[0] ?? '';
+    const url = `${base.replace(/\/$/, '')}${RETICLE_CONNECT_MODULE}`;
+
+    // Served BEFORE the daemon exists: no token, and nothing wrong with that.
+    expect(await (await fetch(url)).text()).not.toContain('tok_');
+
+    // The daemon starts and writes its pairing token. The page is reloaded — one more request.
+    writeFileSync(join(tokenDir, ReticleDir.PAIRING_TOKEN_FILE), 'tok_written_later');
+
+    expect(await (await fetch(url)).text()).toContain('tok_written_later');
   });
 });

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -138,10 +138,26 @@ export interface ReticleVitePlugin {
   transformIndexHtml: (html: string) => HtmlTag[];
   /** Vite hands over the resolved config; used to resolve the HTML entry exactly. */
   configResolved?: (config: { root?: string; command?: string }) => void;
+  /** Dev-server hook: keeps the served connect module from outliving the token it was built without. */
+  configureServer?: (server: ViteDevServerLike) => void;
   /** Build-time post-condition: desktop injection must have happened. */
   buildEnd?: () => void;
   /** Runs the dev-mode injection check immediately. Test seam for the deferred timer. */
   checkInjectedForTest?: () => void;
+}
+
+/**
+ * The slice of Vite's dev server this plugin touches, structurally — so `vite` stays a peer the
+ * plugin never imports, the same way the Svelte compiler and Playwright are handled elsewhere.
+ */
+export interface ViteDevServerLike {
+  middlewares: {
+    use: (handler: (req: { url?: string }, res: unknown, next: () => void) => void) => void;
+  };
+  moduleGraph: {
+    getModuleById: (id: string) => object | undefined;
+    invalidateModule: (mod: object) => void;
+  };
 }
 
 interface HtmlTag {
@@ -427,6 +443,31 @@ export function reticle(options: ReticleVitePluginOptions = {}): ReticleVitePlug
     configResolved(config) {
       root = config.root;
       command = config.command;
+    },
+    /**
+     * Serve the connect module fresh, every time.
+     *
+     * `load` reads the daemon's pairing token at serve time precisely because the daemon may start
+     * after the dev server — but Vite caches the module it produced, and answers every later request
+     * from that cache, INCLUDING after a full page reload. So a dev server started first served a
+     * tokenless connect module once and then kept serving it: the SDK got a 1008 `authentication
+     * failed`, stopped retrying (correctly — a wrong token does not fix itself), and `reticle status`
+     * showed no session while the page demonstrably contained `/@reticle-connect`. Only restarting
+     * the dev server cleared it, which is not a step anybody guesses.
+     *
+     * Dropping the cached module before it is served makes `load` re-read the token, so starting the
+     * daemon and reloading the page is enough. Costs one string compare per request and re-runs a
+     * three-line module — no reason to be cleverer about when to invalidate.
+     */
+    configureServer(server) {
+      if (!inject) return;
+      server.middlewares.use((req, _res, next) => {
+        if ((req.url ?? '').split('?')[0] === RETICLE_CONNECT_MODULE) {
+          const mod = server.moduleGraph.getModuleById(RETICLE_CONNECT_MODULE);
+          if (mod !== undefined) server.moduleGraph.invalidateModule(mod);
+        }
+        next();
+      });
     },
     /**
      * Desktop injection is silent when it misses — the bundle simply has no connect() in it and the


### PR DESCRIPTION
Reported from a Windows Vite + React project. The cause is platform-independent — I reproduced it on macOS in a plain Vite dev server.

## What happens

Start the dev server, then start the daemon. The page never connects again:

```
[reticle] bridge refused the connection: authentication failed — not retrying.
```

`reticle status` shows `sessionCount: 0` while the page demonstrably contains `/@reticle-connect` and calls `reticle.connect()`. Restarting the dev server is the only thing that clears it, and nothing tells you that.

## Why

`load()` resolves the pairing token at serve time *precisely because* the daemon may start after the dev server — the comment on `readPairingToken` even promises "the page reloads once it has". But Vite caches the module `load()` produced and answers every later request from that cache, **including after a full page reload**. So the tokenless module served first is the module served forever, the SDK gets a 1008 and stops retrying (correctly — a wrong token does not fix itself), and there is no recovery short of a dev-server restart.

Nothing to do with browser caching, and nothing Windows-specific: the reproduction is a `createServer()` with the plugin, one fetch before the token file exists and one after.

## The fix

`configureServer` drops the cached connect module before it is served, so `load()` re-reads the token. Start the daemon, reload the page, done. One string compare per request and a three-line module re-run — no reason to be cleverer about when to invalidate.

The bridge's 1008 reason now names that recovery too (`authentication failed — reload the page to pick up the current pairing token`, 78 bytes, inside the 123-byte WebSocket close-reason limit). The SDK prints the reason and then stops, so it is the last thing the developer sees; `authentication failed` on its own left them nowhere to go.

## The test

Drives a **real** dev server, because the defect lives entirely in Vite's cache — a unit test that calls `load()` directly passes either way, which is exactly why nothing here caught it. It fetches the connect module before the token exists, writes the token, fetches again, and asserts the token is in the second response. Reverting the middleware turns it red; I checked both directions.

Note the stand-in SDK module in the fixture: if `@reticlehq/react` does not resolve, Vite fails the module and re-runs `load()` on every request — which masks the staleness completely. That masked it during investigation too.

## Verification

`pnpm build && pnpm lint && pnpm typecheck && pnpm test:unit` — green (vite-plugin 47 → 48).

🤖 Generated with [Claude Code](https://claude.com/claude-code)