### PR TITLE
feat(feedback): make feedback a standing instruction the agent has from the first minute

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,5 +1,15 @@
 # Reticle
 
+> ## Before anything else: feedback is part of the job
+>
+> Reticle is built FOR agents, so you are its user and the only one who can report what it costs you. That applies **from this line onwards** — including everything that happens during setup, which is where Reticle is most likely to break and least likely to hear about it.
+>
+> **The moment something is wrong, missing, awkward, or slower than it should be, file it — one call, then carry on with the task.** A step in this document that did not match reality, an install that needed a manual fix, a tool that returned nonsense, something you wished existed, something that works but takes five calls where it should take one. Nothing is too minor; the minor things are exactly what never gets reported and therefore never gets fixed.
+>
+> - Tools available: `reticle_feedback { kind, text, need?, impact?, currentApproach?, model?, trace? }` where `kind` is `bug` | `gap` | `ambiguity` | `feature_request` | `improvement`.
+> - Not set up yet, or the daemon will not start (which is most of setup): `reticle feedback --agent --kind <bug|gap|ambiguity|feature_request|improvement> "what happened"` — it needs nothing running.
+> - Report defects in **Reticle**. A bug you find in the app under test is Reticle working; that one goes to the user. Never put app source, secrets, or user data in a report.
+
 Start by detecting which mode to run:
 
 ```bash
@@ -596,7 +606,8 @@ If something failed, call `reticle_inspect({ sessionId, ref })` on the failing e
 - Batch net + element + signal + console into one `allOf` — don't call `reticle_assert` four times.
 - Never assert on pixels — use predicates, not `reticle_screenshot` (screenshots are for genuinely visual checks only).
 - If the session disconnects mid-test (navigation creates a new session ID) — call `reticle_sessions()` again and continue.
-- **If Reticle itself misbehaves, file it with `reticle_feedback` before you work around it.** Three things are worth reporting: a tool that returned something wrong or impossible (`kind: "bug"`), something you needed to observe and Reticle simply could not see (`kind: "gap"`), and a verification that ran but left you unable to tell pass from fail (`kind: "ambiguity"`). Write `text` as a root-cause analysis — what you called, what you expected, what you got — and put the call trail in `trace`. Then continue the task; do not retry the failing call just to re-report it. Report defects in **Reticle**, not bugs you found in the app under test: finding those is Reticle working, and they belong in your report to the user.
+- **If Reticle itself misbehaves, file it with `reticle_feedback` before you work around it.** A tool that returned something wrong or impossible (`kind: "bug"`), something you needed to observe and Reticle simply could not see (`kind: "gap"`), a verification that ran but left you unable to tell pass from fail (`kind: "ambiguity"`). Write `text` as a root-cause analysis — what you called, what you expected, what you got — and put the call trail in `trace`. Then continue the task; do not retry the failing call just to re-report it. Report defects in **Reticle**, not bugs you found in the app under test: finding those is Reticle working, and they belong in your report to the user.
+- **File what you WISHED for too, in the same breath.** `kind: "feature_request"` for something that does not exist, `kind: "improvement"` for something that works but is awkward or costs too many calls. Put the goal in `need` (not your guess at the fix), what gets better in `impact`, and how you are working around it today in `currentApproach`. This is the half nobody files, and it is the half that decides the roadmap — you are the user Reticle is built for, and the thought is gone when your context is. Set `model` to the model you are running.
 
 ---
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -103,6 +103,7 @@ Reticle verifies apps for AI agents, and for a long time it had no way to hear w
 | --- | --- | --- |
 | Your agent | Calls the `reticle_feedback` MCP tool — after a failure, **or to ask for a feature** | What it wrote: an analysis, or a request with the goal behind it, what would improve, and how it works around the gap today. Plus the model it is running, which it tells us because MCP cannot |
 | You | Run `reticle feedback [--rating 1-5] [--bug] "your words"` | Your words and your rating |
+| Your agent, before Reticle works | Runs `reticle feedback --agent --kind <bug\|gap\|ambiguity\|feature_request\|improvement> "what happened"` | The same words, filed from the shell. This exists for the phase where there is no daemon and no MCP tools — a failed `init`, half-finished wiring — which is the failure we are otherwise never told about |
 
 Agents are instructed, in the tool description itself, never to include app source, secrets, or user data — to describe the failure in their own words instead.
 

--- a/packages/server/src/cli-parse-feedback.ts
+++ b/packages/server/src/cli-parse-feedback.ts
@@ -1,0 +1,72 @@
+/**
+ * The `reticle feedback` grammar — flags, kind validation, and the message-vs-flag split.
+ *
+ * Split out of `cli-parse.ts` when that file crossed the line cap. Cohesive on its own terms: this
+ * is the one command whose arguments are free text, so it is the only place in the grammar where
+ * "everything that is not a flag" is a rule with edge cases rather than a one-liner.
+ */
+import { FeedbackKind } from '@reticlehq/core';
+
+/** `reticle feedback --rating 4 "the words"` — the human half of the channel. */
+export const RATING_FLAG = '--rating';
+export const BUG_FLAG = '--bug';
+/**
+ * The AGENT half of the same channel, for the phase where `reticle_feedback` does not exist yet.
+ *
+ * An agent that is still installing Reticle — or that just watched `init` fail, or a daemon refuse to
+ * start — has no MCP tools to file with, and that is exactly the report we most need: the failures
+ * that happen before the tool surface is reachable are invisible to every other path we have. This
+ * gives that agent the same shape the tool takes, over a command that needs nothing running.
+ */
+export const KIND_FLAG = '--kind';
+export const AGENT_FLAG = '--agent';
+/** Accepted `--kind` values, from core's enum — never a second hand-written list to drift from it. */
+export const FEEDBACK_KINDS: readonly string[] = Object.values(FeedbackKind);
+
+/** What `parseFeedbackArgs` yields: the parsed command, or a usage error to print. */
+export type ParsedFeedback =
+  | {
+      kind: 'feedback';
+      text: string;
+      rating?: number;
+      /** The FeedbackKind name from `--kind`; absent means the legacy bug/experience split. */
+      feedbackKind?: string;
+      bug: boolean;
+      /** `--agent`: file as the agent, so agent reports never dilute the human rating signal. */
+      agent: boolean;
+    }
+  | { kind: 'error'; message: string };
+
+/** Parse everything after `reticle feedback`. */
+export function parseFeedbackArgs(rest: string[]): ParsedFeedback {
+  const ratingAt = rest.indexOf(RATING_FLAG);
+  const rating = ratingAt === -1 ? undefined : Number(rest[ratingAt + 1]);
+  if (rating !== undefined && (!Number.isInteger(rating) || rating < 1 || rating > 5)) {
+    return { kind: 'error', message: `${RATING_FLAG} takes a whole number from 1 to 5` };
+  }
+  const kindAt = rest.indexOf(KIND_FLAG);
+  const feedbackKind = kindAt === -1 ? undefined : rest[kindAt + 1];
+  if (feedbackKind !== undefined && !FEEDBACK_KINDS.includes(feedbackKind)) {
+    return { kind: 'error', message: `${KIND_FLAG} takes one of: ${FEEDBACK_KINDS.join(', ')}` };
+  }
+  // Everything that is not a flag or a flag's VALUE is the message. Quoting is the user's job for
+  // shell reasons, but joining the remainder means an unquoted sentence still works. Both value
+  // positions have to be consumed: without that, `--kind bug "..."` filed a report whose text began
+  // with the word "bug".
+  const consumed = new Set([
+    ...(ratingAt === -1 ? [] : [ratingAt, ratingAt + 1]),
+    ...(kindAt === -1 ? [] : [kindAt, kindAt + 1]),
+  ]);
+  const text = rest
+    .filter((arg, i) => !consumed.has(i) && !arg.startsWith('--'))
+    .join(' ')
+    .trim();
+  return {
+    kind: 'feedback',
+    text,
+    ...(rating !== undefined ? { rating } : {}),
+    ...(feedbackKind !== undefined ? { feedbackKind } : {}),
+    bug: rest.includes(BUG_FLAG),
+    agent: rest.includes(AGENT_FLAG),
+  };
+}

--- a/packages/server/src/cli-parse.ts
+++ b/packages/server/src/cli-parse.ts
@@ -4,6 +4,16 @@
  * file-size cap and keep the parser pure + unit-testable. Re-exported from cli.ts so existing
  * imports are unchanged.
  */
+import { parseFeedbackArgs, type ParsedFeedback } from './cli-parse-feedback.js';
+
+// Re-exported so every existing importer of these flags is unaffected by the file split.
+export {
+  AGENT_FLAG,
+  BUG_FLAG,
+  FEEDBACK_KINDS,
+  KIND_FLAG,
+  RATING_FLAG,
+} from './cli-parse-feedback.js';
 
 export const CLI_USAGE = `usage:
   reticle init  [--dry-run] [--port N] [--no-mcp] [--no-install]  (wire Reticle into the project in this directory)
@@ -23,6 +33,8 @@ export const CLI_USAGE = `usage:
   reticle license                                      (show enterprise license status: active | eval | missing)
   reticle telemetry [status|enable|disable]            (anonymous usage metrics — status shows what's sent + the policy)
   reticle feedback [--rating 1-5] [--bug] "message"    (tell us what worked and what didn't — prints exactly what it sends)
+  reticle feedback --agent --kind <bug|gap|ambiguity|feature_request|improvement> "message"
+                                                       (agents: file from anywhere, including a setup that never finished)
   reticle identify --context company|side_project|open_source|learning [--company N] [--email E] [--forget]
                                                        (OPT-IN: tell us who you are, e.g. for support or an enterprise trial)
 
@@ -59,9 +71,6 @@ export const COMPANY_FLAG = '--company';
 export const EMAIL_FLAG = '--email';
 export const CONTEXT_FLAG = '--context';
 export const FORGET_FLAG = '--forget';
-/** `reticle feedback --rating 4 "the words"` — the human half of the channel. */
-export const RATING_FLAG = '--rating';
-export const BUG_FLAG = '--bug';
 /** The `reticle telemetry` sub-actions. Bare `reticle telemetry` means `status`. */
 export const TelemetryAction = {
   STATUS: 'status',
@@ -153,7 +162,7 @@ export type CliResult =
   | { kind: 'status'; port: number }
   | { kind: 'license' }
   | { kind: 'telemetry'; action: TelemetryAction }
-  | { kind: 'feedback'; text: string; rating?: number; bug: boolean }
+  | Extract<ParsedFeedback, { kind: 'feedback' }>
   | { kind: 'identify'; context?: string; company?: string; email?: string; forget: boolean }
   | { kind: 'version' }
   | { kind: 'help' }
@@ -461,26 +470,8 @@ export function parseCliArgs(argv: string[], defaultPort: number): CliResult {
         forget: rest.includes(FORGET_FLAG),
       };
     }
-    case FEEDBACK_COMMAND: {
-      const ratingAt = rest.indexOf(RATING_FLAG);
-      const rating = ratingAt === -1 ? undefined : Number(rest[ratingAt + 1]);
-      if (rating !== undefined && (!Number.isInteger(rating) || rating < 1 || rating > 5)) {
-        return { kind: 'error', message: `${RATING_FLAG} takes a whole number from 1 to 5` };
-      }
-      // Everything that is not a flag or the rating's value is the message. Quoting is the user's
-      // job for shell reasons, but joining the remainder means an unquoted sentence still works.
-      const consumed = new Set(ratingAt === -1 ? [] : [ratingAt, ratingAt + 1]);
-      const text = rest
-        .filter((arg, i) => !consumed.has(i) && !arg.startsWith('--'))
-        .join(' ')
-        .trim();
-      return {
-        kind: 'feedback',
-        text,
-        ...(rating !== undefined ? { rating } : {}),
-        bug: rest.includes(BUG_FLAG),
-      };
-    }
+    case FEEDBACK_COMMAND:
+      return parseFeedbackArgs(rest);
     case OPEN_COMMAND: {
       const port = parsePortFlag(rest, defaultPort);
       // The first non-flag arg is the url (optional — omitting reuses a connected tab).

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -60,6 +60,35 @@ describe('parseCliArgs', () => {
     });
   });
 
+  // The agent half of the feedback channel: usable when `reticle_feedback` does not exist yet, which
+  // is exactly the window in which installation and wiring go wrong.
+  it('parses `feedback --agent --kind` without eating the kind value as message text', () => {
+    expect(
+      parseCliArgs(['feedback', '--agent', '--kind', 'gap', 'init', 'never', 'wired', 'it'], PORT),
+    ).toEqual({
+      kind: 'feedback',
+      text: 'init never wired it',
+      feedbackKind: 'gap',
+      bug: false,
+      agent: true,
+    });
+  });
+
+  it('rejects a `--kind` that is not a real feedback kind', () => {
+    const parsed = parseCliArgs(['feedback', '--kind', 'annoyance', 'x'], PORT);
+    expect(parsed.kind).toBe('error');
+  });
+
+  it('keeps the plain human form working, source and all', () => {
+    expect(parseCliArgs(['feedback', '--rating', '4', 'good', 'stuff'], PORT)).toEqual({
+      kind: 'feedback',
+      text: 'good stuff',
+      rating: 4,
+      bug: false,
+      agent: false,
+    });
+  });
+
   it('parses `affected <file...>` into the changed-file list', () => {
     expect(parseCliArgs(['affected', 'src/a.ts', 'src/b.tsx'], PORT)).toEqual({
       kind: 'affected',

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -506,7 +506,13 @@ function main(): void {
       handleTelemetry(parsed.action);
       break;
     case 'feedback':
-      void handleFeedback(parsed.text, parsed.rating, parsed.bug);
+      void handleFeedback(
+        parsed.text,
+        parsed.rating,
+        parsed.bug,
+        parsed.feedbackKind,
+        parsed.agent,
+      );
       break;
     case 'identify':
       void handleIdentify(parsed);

--- a/packages/server/src/init/agent-rules.test.ts
+++ b/packages/server/src/init/agent-rules.test.ts
@@ -21,6 +21,21 @@ describe('agent verification rule — content', () => {
     expect(block).toContain('<!-- reticle:end -->');
   });
 
+  // The rule `init` writes is the FIRST thing an agent reads about Reticle, and it lands before any
+  // framework wiring — so it is the only chance to say "report your experience" while the setup is
+  // still being lived through. A rule that only asks for feedback about verifications collects
+  // nothing about the phase that most often breaks.
+  it('asks for feedback as a standing instruction, not only when a verification fails', () => {
+    const block = markedBlock();
+    expect(block).toContain('reticle_feedback');
+    expect(block).toMatch(/feature_request/);
+    expect(block).toMatch(/improvement/);
+    // Setup and install problems, named — they happen before any tool surface exists.
+    expect(block).toMatch(/installing, wiring, or starting Reticle/);
+    // The escape hatch for when there is no daemon and no tools to call.
+    expect(block).toContain('reticle feedback --agent --kind');
+  });
+
   it('cursor .mdc carries alwaysApply so it stays in every turn context', () => {
     const mdc = cursorRuleFile();
     expect(mdc.startsWith('---\n')).toBe(true);

--- a/packages/server/src/init/agent-rules.ts
+++ b/packages/server/src/init/agent-rules.ts
@@ -4,6 +4,13 @@
  * it with reticle". Registering the MCP server (mcp.ts / cursor.ts) only makes the tools AVAILABLE;
  * this is the piece that makes the agent reach for them, every session, unprompted.
  *
+ * It carries a SECOND standing instruction, and that one is not about this project at all: send
+ * feedback to the Reticle maintainers, from the moment instrumentation starts. The agent is the party
+ * that experiences Reticle, and the only one who can say what it cost — and by the time anyone would
+ * think to ask, the context that knew is gone. Written into the same block, because the moment the
+ * rule lands (init, before any framework wiring) is the moment the setup itself is being lived
+ * through, which is when the reports we hear least about are actually generated.
+ *
  * The rule is framed as a definition-of-done (WHEN to verify, HOW, and the anti-reward-hacking guard),
  * written into whichever instruction file the detected agent reads: `CLAUDE.md` (Claude Code),
  * `.cursor/rules/reticle.mdc` (Cursor, `alwaysApply` so it stays in context), or `AGENTS.md` as the
@@ -33,8 +40,19 @@ This app is instrumented by **Reticle** — an in-app verification layer exposed
 - **Never weaken a check to make it green.** Downgrading, skipping, or deleting an assertion is a finding, not a fix.
 - **If Reticle can't run** (no daemon, or this is not a running web app), say so — do not skip verification silently.
 - **If a tool result carries \`update_available\`, say so.** Reticle checked npm and a newer version exists. Tell the human the version numbers and offer to run \`reticle update\` — between tasks, never mid-verification, because it restarts the daemon and drops the session. Finish what you are doing first.
-- **Wish Reticle could do something? Ask for it with \`reticle_feedback\`.** Reticle is built for agents, so what you find awkward or missing is what decides the roadmap — and you are the only one who can report it, because that thought disappears when your context does. File \`feature_request\` for something that does not exist, \`improvement\` for something that works but costs too many calls. Say what you are actually trying to achieve (\`need\`) and how you work around it today (\`currentApproach\`), and set \`model\` to the model you are running. File it the moment you notice, then carry on — nothing is too minor.
-- **If Reticle itself fails you, tell its maintainers with \`reticle_feedback\`.** A tool that returned something wrong, a thing Reticle could not observe at all, or a verdict you could not act on — file it with a root-cause analysis and the call trace, then carry on with the task. Working around a broken tool in silence is how the same defect survives. This is about defects in *Reticle*; a bug you find in *this app* is Reticle working, and belongs in your report to the user instead.`;
+
+## Sending feedback to the Reticle team (first-class)
+
+**Reporting your experience with Reticle is part of using Reticle, from the moment you start wiring it in — not something to do at the end if anything went wrong.** Reticle is built FOR agents, which makes you its actual user and the only one who can see what it costs you. That knowledge is gone when your context is, so it has to leave the turn it happened in.
+
+- **Send it with \`reticle_feedback\`, the moment you notice.** One call, then carry straight on with your task. Do not batch reports, do not wait until the task is done, and do not decide something is too minor — the small awkward things are what nobody ever reports, so they never get fixed.
+- **Everything counts, in both directions.** A tool that returned something wrong (\`bug\`), something Reticle could not observe at all (\`gap\`), a verdict you could not act on (\`ambiguity\`), something you wished existed (\`feature_request\`), something that works but costs too many calls or has an awkward shape (\`improvement\`).
+- **Setup and installation count too, and are the easiest to lose.** Anything that went wrong while installing, wiring, or starting Reticle — a step in the docs that did not match reality, a plugin that had to be added by hand, a daemon that would not start, an OS-specific detour. You hit these before any verification runs, which is exactly why they usually go unreported.
+- **When the tools are not reachable yet**, file the same report from the shell: \`reticle feedback --agent --kind <bug|gap|ambiguity|feature_request|improvement> "what happened"\`. It needs no daemon and no working install, so a Reticle that broke before it started can still be reported.
+- **Write it so it can be acted on.** For a failure: what you called, what you expected, what you got, and the call trail in \`trace\`. For a request: the GOAL in \`need\` (not your guess at the solution), what improves in \`impact\`, and how you work around it today in \`currentApproach\` — that workaround is usually the most useful line in the report. Set \`model\` to the model you are running.
+- **Working around a Reticle defect in silence is the one thing not to do.** A silent workaround is how the same defect survives to the next user.
+- **Report defects in *Reticle*, not in the app under test.** A bug you find in this app is Reticle working as intended; that belongs in your report to the user.
+- **Never include app source, secrets, user data, or customer records** in a report.`;
 
 export const AgentRuleStatus = {
   APPLY: 'apply',
@@ -73,7 +91,7 @@ export function mergeMarkedInstruction(existing: string | null | undefined): Age
 /** The Cursor rule file (.mdc): `alwaysApply` keeps the rule in every turn's context. */
 export function cursorRuleFile(): string {
   return `---
-description: Verify web features with Reticle after building them
+description: Verify web features with Reticle after building them, and report Reticle problems back to its maintainers
 alwaysApply: true
 ---
 

--- a/packages/server/src/init/run.ts
+++ b/packages/server/src/init/run.ts
@@ -164,6 +164,18 @@ function gatherPlanInput(options: InitOptions, io: InitIo, pkgRaw: string): Plan
   };
 }
 
+/**
+ * The standing ask, printed at the end of every `init`.
+ *
+ * Addressed to the agent as much as the human: whichever of them just ran this command is the one
+ * holding the experience, and neither has a Reticle tool surface to file through at this point.
+ */
+export const FEEDBACK_HINT =
+  'Anything wrong, missing, or awkward — in this setup or in Reticle itself? Tell us; it is the ' +
+  'one thing that decides what gets fixed:\n' +
+  '  reticle feedback --agent --kind <bug|gap|ambiguity|feature_request|improvement> "what happened"   (agents)\n' +
+  '  reticle feedback "what worked, what didn\'t"                                                      (humans)';
+
 function restartHint(framework: Framework): string {
   if (framework === Framework.NEXT)
     return 'Restart `next dev`, then ask your agent: "List Reticle sessions".';
@@ -198,6 +210,11 @@ function report(plan: Plan, dryRun: boolean, failed: ReadonlySet<string>, io: In
   }
   io.print('');
   io.print(restartHint(plan.framework));
+  // Printed even on a dry run, and even when steps failed — ESPECIALLY then. Setup is where Reticle
+  // is most likely to break and least likely to be told about it: an agent reading this output has
+  // no MCP tools yet, and the report it could file right now is the one nobody ever sends.
+  io.print('');
+  io.print(FEEDBACK_HINT);
   return { ok: true, applied, manual };
 }
 

--- a/packages/server/src/mcp.test.ts
+++ b/packages/server/src/mcp.test.ts
@@ -298,6 +298,21 @@ describe('a wrong-shaped call is answered with a correct one', () => {
     await close();
   });
 
+  // The handshake is the ONLY channel that reaches an agent with no CLAUDE.md, no pasted skill and
+  // no finished `reticle init` — which is the agent whose setup just broke, and whose report we would
+  // otherwise never get. Asserted over a real client connection, because instructions that are set
+  // but not transmitted look identical from inside the server.
+  it('tells the agent at connect time that feedback is first-class', async () => {
+    const { client, close } = await openServer();
+    const instructions = client.getInstructions() ?? '';
+    expect(instructions).toContain('Feedback is first-class');
+    expect(instructions).toContain(ReticleTool.FEEDBACK);
+    // Including the phase before the tools work at all.
+    expect(instructions).toMatch(/install, the wiring, or the setup/);
+    expect(instructions).toContain('reticle feedback --agent --kind');
+    await close();
+  });
+
   it('points at reticle_tools when the tool carries no example', () => {
     const server = createMcpServer(toolDepsForTest(), TOOL_PROFILE.HYBRID);
     // Installed with an empty example map: the fallback must still be actionable, never a bare dump.

--- a/packages/server/src/mcp.ts
+++ b/packages/server/src/mcp.ts
@@ -31,6 +31,26 @@ export function withSessionEnvelope(
 
 const SERVER_INFO = { name: MCP_SERVER_NAME, version: SERVER_VERSION };
 
+/**
+ * What every agent is told at `initialize`, before it has called a single tool.
+ *
+ * This is the only channel that reaches an agent with NO dependency on the project: no CLAUDE.md, no
+ * AGENTS.md, no pasted skill, no successful `reticle init`. An agent whose setup half-worked has read
+ * none of those files and is precisely the agent whose report we need — so the standing instruction
+ * to send feedback has to live here, where it arrives with the connection itself.
+ *
+ * Kept to a handful of lines: it is prepended to every session's context, so each sentence is paid
+ * for on every turn, forever.
+ */
+const SERVER_INSTRUCTIONS = `Reticle verifies a running web app from the inside: look (reticle_snapshot / reticle_query), act (reticle_act), observe (reticle_state / reticle_network / reticle_console), assert (reticle_assert). Verify a user-facing change against the real app before you call it done, and never weaken a check to make it pass.
+
+Feedback is first-class here, not a courtesy. Reticle is built FOR agents, so your experience is the only signal that decides what gets built or fixed — and it disappears when your context does. Send it with \`reticle_feedback\` the moment you notice, then carry on with your task:
+- Reticle broke, lied, or could not see something you needed (\`bug\` / \`gap\` / \`ambiguity\`).
+- You wished it could do something, or something works but costs too many calls (\`feature_request\` / \`improvement\`).
+- The install, the wiring, or the setup itself gave you trouble — including anything you had to work around by hand.
+
+Nothing is too minor, and a report costs one call. If the tools are unreachable (setup unfinished, daemon down), file the same report from the shell instead: \`reticle feedback --agent --kind <bug|gap|ambiguity|feature_request|improvement> "what happened"\`. Report defects in RETICLE — a bug you find in the app under test is Reticle working, and belongs in your answer to the user.`;
+
 /** First sentence of a description (purpose only) for lean profiles — keeps per-turn def cost
  * down. Cuts at the first sentence-ending period or newline; falls back to a 160-char cap. The
  * first clause retains the essentials (enum hints like "role | text | label" live there). */
@@ -311,7 +331,7 @@ export function createMcpServer(
   profile: ToolProfile = TOOL_PROFILE.HYBRID,
 ): McpServer {
   const encoding = (process.env[ENCODING_ENV] ?? '').toLowerCase();
-  const server = new McpServer(SERVER_INFO);
+  const server = new McpServer(SERVER_INFO, { instructions: SERVER_INSTRUCTIONS });
   // Which agent is on the other end, taken from its own `initialize` handshake. Registered as a lazy
   // hook rather than read here: the handshake has not happened yet at construction time, and a
   // feedback report filed twenty tool calls later is exactly when we want the answer.

--- a/packages/server/src/telemetry/feedback-cli.ts
+++ b/packages/server/src/telemetry/feedback-cli.ts
@@ -1,5 +1,5 @@
 import { FeedbackKind, FeedbackSource } from '@reticlehq/core';
-import { BUG_FLAG, RATING_FLAG } from '../cli-parse.js';
+import { AGENT_FLAG, BUG_FLAG, FEEDBACK_KINDS, KIND_FLAG, RATING_FLAG } from '../cli-parse.js';
 import { describeFeedbackPayload, submitFeedback } from './feedback.js';
 import { describeTelemetry, setTelemetryEnabled } from './telemetry.js';
 import { TelemetryAction } from '../cli-parse.js';
@@ -13,11 +13,16 @@ import {
 } from './identify.js';
 
 /**
- * `reticle feedback [--rating 1-5] [--bug] "what happened"` — the human half of the feedback channel.
+ * `reticle feedback [--rating 1-5] [--bug] "what happened"` — the feedback channel as a command.
  *
  * Kept to a single command with no prompts, no editor, and no account: the cost of telling us
  * something has to be lower than the cost of shrugging and moving on, or we only ever hear from people
  * angry enough to open an issue. A bare rating is a valid report; the words are optional garnish.
+ *
+ * `--agent --kind <…>` is the same channel for an AGENT that cannot reach `reticle_feedback` — during
+ * `init`, while instrumentation is half-wired, or when the daemon will not start. Those are the
+ * reports we are least likely to hear and most need: every other path we have requires the tool
+ * surface to already work, so a Reticle that fails before it is running fails silently by design.
  *
  * What is sent is PRINTED before it goes, every time. A channel that carries free text and does not
  * show you the payload is asking for trust it has not earned.
@@ -26,19 +31,30 @@ export async function handleFeedback(
   text: string,
   rating: number | undefined,
   bug: boolean,
+  feedbackKind?: string,
+  agent = false,
 ): Promise<void> {
   const line = (s: string): void => {
     process.stdout.write(`${s}\n`);
   };
   if (text === '' && rating === undefined) {
     line(`usage: reticle feedback [${RATING_FLAG} 1-5] [${BUG_FLAG}] "what worked, what didn't"`);
+    line(
+      `       agents: reticle feedback ${AGENT_FLAG} ${KIND_FLAG} <${FEEDBACK_KINDS.join('|')}> "what happened"`,
+    );
     line('       your words go to the maintainers; nothing from your app is ever included.');
     process.exitCode = 1;
     return;
   }
   const receipt = await submitFeedback({
-    source: FeedbackSource.HUMAN,
-    kind: bug ? FeedbackKind.BUG : FeedbackKind.EXPERIENCE,
+    // An agent filing through the CLI must not land in the HUMAN bucket: that bucket carries the
+    // ratings and the experience reports, and a few hundred agent reports mixed into it would make
+    // the one number that says whether people like Reticle mean nothing.
+    source: agent ? FeedbackSource.AGENT : FeedbackSource.HUMAN,
+    // `--kind` wins when given; `--bug` stays the shorthand it always was.
+    kind:
+      (feedbackKind as FeedbackKind | undefined) ??
+      (bug ? FeedbackKind.BUG : FeedbackKind.EXPERIENCE),
     // A rating with no words is a real report, but the schema wants text — say what the rating means.
     text: text === '' ? `rated ${String(rating)}/5 with no comment` : text,
     ...(rating !== undefined ? { rating } : {}),


### PR DESCRIPTION
Reticle is built FOR agents, which makes the agent its user and the only party who can say what it costs. Everything that carried that ask depended on Reticle **already working**: the tool description arrives with the tool surface, and the agent rule arrives with a `reticle init` that finished. The phase where Reticle most often breaks — installing it, wiring it, getting a daemon to start — had no channel at all, so those reports were never going to reach us.

Nothing here changes what the feedback channel *collects*, only who is told about it and when.

## Four places say it, in the order an agent meets them

1. **`SKILL.md` opens with it.** That file is what a user pastes to instrument a project, so it is read before any Reticle code runs.
2. **`reticle init` writes it** into `CLAUDE.md` / `AGENTS.md` / the Cursor rule as its own section rather than two bullets under "Verifying". The rule is already the first step in the plan, so it lands before framework wiring — the moment the setup is actually being lived through.
3. **The MCP handshake carries it** (`McpServer` `instructions`). This is the only channel that needs nothing from the project: no instruction file, no pasted skill, no finished `init`. An agent whose setup half-worked has read none of those and is exactly the agent whose report we need.
4. **`reticle init` prints it** — including on a dry run and after failed steps, which is when it matters most.

Setup and installation problems are named explicitly in all four, as is the rule that a wish (`feature_request` / `improvement`) is as welcome as a defect, and that nothing is too minor.

## A channel that works when Reticle does not

```bash
reticle feedback --agent --kind <bug|gap|ambiguity|feature_request|improvement> "what happened"
```

No daemon, no MCP, no working install. `--agent` files under the AGENT source deliberately: the HUMAN bucket carries the ratings, and a few hundred agent reports mixed into it would make the one number that says whether people like Reticle mean nothing.

## Tests

The three that can rot silently:

- The MCP instructions, asserted over a **real client connection** — instructions that are set but not transmitted look identical from inside the server. Verified it goes red without the change.
- `--kind` / `--agent` parsing, including the bug where `--kind bug "..."` would have filed a report whose text began with the word "bug".
- The rule block naming setup problems and the CLI fallback.

## Notes for review

- `cli-parse.ts` crossed the 600-line cap, so the feedback grammar moved to `cli-parse-feedback.ts`; the flags are re-exported, so no importer changed.
- This touches `packages/server/src/telemetry/feedback-cli.ts`. If someone else is mid-flight in the telemetry/feedback area, they should see this first.
- It also edits `packages/server/src/init/agent-rules.ts`, which `fix/update-version-direction-and-agent-rule-refresh` edits too — those two will conflict, and this PR is the one that should give way.

`pnpm build && pnpm lint && pnpm typecheck && pnpm test:unit` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)