### PR TITLE
fix(scripts): catch export list, default, and wildcard exports in lossy guard

### DIFF
--- a/scripts/check-lossy-transforms.mjs
+++ b/scripts/check-lossy-transforms.mjs
@@ -330,14 +330,19 @@ function selfTest() {
     ['untested', 'a lossy export with no conformance test must be flagged'],
     [MISSING_FILE, 'a registry file missing from disk must be flagged'],
     ['reexportedLocal', 'an export list entry (export { x }) must be classified'],
-    ['declaredAlias', 'an export list alias (export { x as y }) must be classified by its exported name'],
+    [
+      'declaredAlias',
+      'an export list alias (export { x as y }) must be classified by its exported name',
+    ],
     ['default', 'export default must be classified'],
     [WILDCARD_REEXPORT, 'a wildcard re-export (export * from) must fail loudly, not pass silently'],
   ];
   const missing = expected.filter(([marker]) => {
     if (marker === MISSING_FILE) return !problems.some((p) => p.file === 'fake/missing.ts');
     if (marker === WILDCARD_REEXPORT) {
-      return !problems.some((p) => p.file === 'fake/mod.ts' && p.name === undefined && p.reason.includes('wildcard'));
+      return !problems.some(
+        (p) => p.file === 'fake/mod.ts' && p.name === undefined && p.reason.includes('wildcard'),
+      );
     }
     return !problems.some((p) => p.name === marker);
   });

--- a/scripts/check-lossy-transforms.mjs
+++ b/scripts/check-lossy-transforms.mjs
@@ -85,6 +85,14 @@ export const READ_PATH = Object.freeze({
       Declaration.SILENT,
       'wraps sanitizeForTransport and so inherits its dropped report, and additionally collapses a throwing value to "[UNSERIALIZABLE]". Log/diagnostic use only',
     ],
+    isSensitiveKey: [
+      Declaration.NONE,
+      're-exported from @reticlehq/core — a predicate over a key name, reads and drops nothing',
+    ],
+    scrubKnownSecrets: [
+      Declaration.MARKER,
+      're-exported from @reticlehq/core — replaces a high-confidence secret shape in place with REDACTED_VALUE, so the returned text carries an in-band sentinel over any redacted span',
+    ],
   },
   'packages/core/src/state-select.ts': {
     PathSelection: [Declaration.NONE, 'the selection result type'],
@@ -154,23 +162,70 @@ export const READ_PATH = Object.freeze({
  * Two of these predate the registry. `Transport` and `RingBuffer` each already had a suite whose
  * whole subject was the declared gap, written when the drop was found by hand; pointing at them
  * beats copying them, and a registry that forced a duplicate would be teaching the wrong lesson. The
- * two `lossy-conformance` files cover the transforms that had no such suite.
+ * two `lossy-conformance` files cover the transforms that had no such suite. `serialization.test.ts`
+ * is a third: its "scrubKnownSecrets" describe block already asserts REDACTED_VALUE replaces a
+ * detected secret shape, so it is the existing fixture for that MARKER declaration, not a new one.
  */
 export const CONFORMANCE_TESTS = Object.freeze([
   'packages/core/src/lossy-conformance.test.ts',
   'packages/browser/src/security/lossy-conformance.test.ts',
+  'packages/browser/src/security/serialization.test.ts',
   'packages/browser/src/transport/transport.overflow-marker.test.ts',
   'packages/server/src/events/ring-buffer.test.ts',
 ]);
 
+const IDENTIFIER = '[A-Za-z_$][\\w$]*';
+const INLINE_EXPORT_PATTERN = new RegExp(
+  `^export\\s+(?:declare\\s+)?(?:abstract\\s+)?(?:async\\s+)?(?:function|const|let|var|class|interface|type|enum)\\s+(${IDENTIFIER})`,
+  'gm',
+);
+const DEFAULT_EXPORT_PATTERN = /^export\s+default\b/gm;
+// Matches `export { a, b as c };` and, deliberately, `export { a, b as c } from '...'` the same way:
+// a named re-export creates a binding under THIS module's name (`c`), which is exactly what the guard
+// tracks. `export * from '...'` cannot be resolved this way — see hasWildcardReexport below.
+const EXPORT_LIST_PATTERN = /^export\s*\{([\s\S]*?)\}/gm;
+const EXPORT_LIST_ENTRY_PATTERN = new RegExp(`^(${IDENTIFIER})(?:\\s+as\\s+(${IDENTIFIER}))?$`);
+
 /** Every top-level export name in a TypeScript source, read as text. */
 export function exportedNames(source) {
   const names = [];
-  const pattern =
-    /^export\s+(?:declare\s+)?(?:abstract\s+)?(?:async\s+)?(?:function|const|let|var|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/gm;
+
+  // Each pattern is a shared `g`-flag RegExp reused across calls, so `lastIndex` must be reset before
+  // every scan — otherwise a call on a later (or shorter) source silently resumes mid-string or finds
+  // nothing at all.
+  INLINE_EXPORT_PATTERN.lastIndex = 0;
   let match;
-  while ((match = pattern.exec(source)) !== null) names.push(match[1]);
+  while ((match = INLINE_EXPORT_PATTERN.exec(source)) !== null) names.push(match[1]);
+
+  // The external name of a default export is literally `default`, per the ES module spec
+  // (`import { default as x }` is equivalent to `import x`) — there is no better name to report,
+  // named or anonymous.
+  DEFAULT_EXPORT_PATTERN.lastIndex = 0;
+  while ((match = DEFAULT_EXPORT_PATTERN.exec(source)) !== null) names.push('default');
+
+  EXPORT_LIST_PATTERN.lastIndex = 0;
+  while ((match = EXPORT_LIST_PATTERN.exec(source)) !== null) {
+    for (const rawEntry of match[1].split(',')) {
+      const entry = rawEntry.trim();
+      if (entry.length === 0) continue;
+      const entryMatch = entry.match(EXPORT_LIST_ENTRY_PATTERN);
+      if (entryMatch === null) continue;
+      const [, localName, alias] = entryMatch;
+      names.push(alias ?? localName);
+    }
+  }
+
   return names;
+}
+
+// `export * from '...'` re-exports every name from another module. Nothing textual can resolve those
+// names without reading and evaluating that module too, so the guard does not try — it fails loudly
+// instead, per the issue's "resolve it or fail loudly, but do not let it pass silently" choice.
+const WILDCARD_REEXPORT_PATTERN = /^export\s*\*\s*(?:as\s+[A-Za-z_$][\w$]*\s+)?from\s+['"]/m;
+
+/** Whether a source contains a wildcard re-export the guard cannot resolve textually. */
+export function hasWildcardReexport(source) {
+  return WILDCARD_REEXPORT_PATTERN.test(source);
 }
 
 /**
@@ -186,6 +241,15 @@ export function findDrift(readPath, readSource, conformanceSources) {
     if (source === null) {
       problems.push({ file, reason: 'listed in the registry but not found on disk' });
       continue;
+    }
+    if (hasWildcardReexport(source)) {
+      problems.push({
+        file,
+        reason:
+          "contains a wildcard re-export (export * from '...'); the re-exported names cannot be " +
+          'resolved by reading this file alone — replace it with explicit named exports so each one ' +
+          'can be classified, or remove it from the read path',
+      });
     }
     const actual = exportedNames(source);
     for (const name of actual) {
@@ -230,6 +294,8 @@ function readFromDisk(file) {
 
 /** In-memory proof that the guard catches real drift — an unproven guard is its own false green. */
 function selfTest() {
+  const MISSING_FILE = Symbol('missing-file');
+  const WILDCARD_REEXPORT = Symbol('wildcard-reexport');
   const registry = {
     'fake/mod.ts': {
       declared: [Declaration.REPORT, 'returns a report'],
@@ -246,6 +312,11 @@ function selfTest() {
     'export function badStyle() {}',
     'export function untested() {}',
     'export function unclassified() {}',
+    'function reexportedLocal() {}',
+    'export { reexportedLocal };',
+    'export { declared as declaredAlias };',
+    'export default function () {}',
+    "export * from './helpers.js';",
   ].join('\n');
   const problems = findDrift(registry, (file) => (file === 'fake/mod.ts' ? source : null), [
     'expect(declared()).toBeDefined(); noReason(); badStyle();',
@@ -257,13 +328,19 @@ function selfTest() {
     ['noReason', 'a classification with no reason must be flagged'],
     ['badStyle', 'an unknown declaration style must be flagged'],
     ['untested', 'a lossy export with no conformance test must be flagged'],
-    [undefined, 'a registry file missing from disk must be flagged'],
+    [MISSING_FILE, 'a registry file missing from disk must be flagged'],
+    ['reexportedLocal', 'an export list entry (export { x }) must be classified'],
+    ['declaredAlias', 'an export list alias (export { x as y }) must be classified by its exported name'],
+    ['default', 'export default must be classified'],
+    [WILDCARD_REEXPORT, 'a wildcard re-export (export * from) must fail loudly, not pass silently'],
   ];
-  const missing = expected.filter(([name]) =>
-    name === undefined
-      ? !problems.some((p) => p.file === 'fake/missing.ts')
-      : !problems.some((p) => p.name === name),
-  );
+  const missing = expected.filter(([marker]) => {
+    if (marker === MISSING_FILE) return !problems.some((p) => p.file === 'fake/missing.ts');
+    if (marker === WILDCARD_REEXPORT) {
+      return !problems.some((p) => p.file === 'fake/mod.ts' && p.name === undefined && p.reason.includes('wildcard'));
+    }
+    return !problems.some((p) => p.name === marker);
+  });
   if (missing.length > 0) {
     console.error('self-test FAILED — guard missed:', missing.map(([, why]) => why).join('; '));
     process.exit(1);


### PR DESCRIPTION
## What & why

`exportedNames()` in `scripts/check-lossy-transforms.mjs` read source as text with a single regex that only matches an **inline** export (`export function foo() {}`). It missed:

```ts
function capDepthV2() { /* silently truncates */ }
export { capDepthV2 };          // invisible to the guard
export default capDepthV2;      // also invisible
export * from './helpers.js';   // and anything re-exported this way
```

So a lossy transform added to a read-path module in one of those styles would keep `pnpm lint` green — the exact case the guard's header says it exists to prevent.

Closes #92

## What changed

- `export { a, b as c }` is now matched, reporting the **exported** binding name (`c`, not `a`) — this also applies to `export { a, b as c } from '...'`, since that syntax creates a binding under this module's name regardless of where the value originally came from.
- `export default` is now matched, reported as the name `"default"` — the ES module spec's own external binding name for a default export (`import { default as x }` ≡ `import x`), so it works whether or not the default export itself has an identifier.
- `export * from '...'` cannot be resolved by reading one file's text — nothing textual can know what names another module exports. Per the issue ("resolve it or fail loudly, but do not let it pass silently — say which you chose"), I chose **fail loudly**: `hasWildcardReexport()` now flags any read-path module containing one, with a reason asking for it to be replaced with named exports or removed from the read path.
- Fixed a bug this surfaced along the way: the new patterns are shared `g`-flag `RegExp` objects reused across calls (`exportedNames` runs once per read-path module in `findDrift`'s loop). A `g`-flag regex keeps `lastIndex` between calls, so without resetting it, the second and later files in the loop would silently resume mid-string or match nothing. Each pattern's `lastIndex` is now reset to `0` before every scan.

Per the issue's step 3, I ran the fixed guard against the real tree and it found two exports newly discovered by the export-list pattern in `packages/browser/src/security/serialization.ts`:

```ts
export { isSensitiveKey, scrubKnownSecrets };
```

Both are imported from `@reticlehq/core` and re-exported here. Classified:

- `isSensitiveKey` → `NONE` — a predicate over a key name; reads and drops nothing.
- `scrubKnownSecrets` → `MARKER` — replaces a detected high-confidence secret shape in place with `REDACTED_VALUE`, so the returned text carries an in-band sentinel over any redacted span.

`MARKER` is a lossy declaration, so it requires a conformance-test fixture naming it. `packages/browser/src/security/serialization.test.ts` already has a `describe('scrubKnownSecrets — high-confidence shapes, no prose corruption')` block asserting exactly that (input containing a secret → output containing `REDACTED_VALUE`), so rather than duplicate it, I registered that existing file in `CONFORMANCE_TESTS`.

## How it was verified

Per the issue's acceptance criteria — "the self-test fails on the current `exportedNames` and passes after the fix — please show both":

**RED** (`selfTest()` updated with the four new cases, before fixing `exportedNames`):
```
self-test FAILED — guard missed: an export list entry (export { x }) must be classified; an export list alias (export { x as y }) must be classified by its exported name; export default must be classified; a wildcard re-export (export * from) must fail loudly, not pass silently
```

**GREEN** (after the fix):
```
$ node scripts/check-lossy-transforms.mjs --self-test
lossy-transform guard self-test passed (10 synthetic problems caught: 10)

$ node scripts/check-lossy-transforms.mjs
Lossy transforms OK (29 exports classified across 6 read-path modules).
```

I also ran `node scripts/check-boundaries.mjs` (the other check `pnpm lint` runs before `turbo run lint`) — passes unaffected.

**One thing I could not verify:** this environment doesn't have `pnpm`/`corepack` set up, so I could not run the full `pnpm lint && pnpm typecheck && pnpm test:unit` gate. The only file changed is `scripts/check-lossy-transforms.mjs`, a plain `.mjs` script at the repo root (not inside any `packages/*` workspace, so `typecheck`/`test:unit` via `turbo run` don't cover it either way), and both checks that `pnpm lint` runs directly against it (`check-boundaries.mjs`, `check-lossy-transforms.mjs --self-test`, and the real-tree run) pass as shown above. Happy to run the full gate if a maintainer flags something CI catches that this didn't.

## Checklist

- [x] Tests added/updated (RED → GREEN); the change is covered by a test that would fail without it
- [ ] `pnpm lint && pnpm typecheck && pnpm test:unit` all pass locally — see note above; ran the two checks `pnpm lint` invokes directly against this file instead, both pass
- [x] No `any`, no free strings (wire strings live in `@reticlehq/core`) — this script isn't part of the wire contract; the new patterns/markers are named constants, no ad hoc string literals
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 600-line cap (389 lines)
- [ ] Docs and `CHANGELOG.md` updated if this is user-facing — not user-facing (internal lint-time guard script), no `CHANGELOG.md` entry added
- [ ] Security-affecting? — n/a, no auth/redaction/trust-boundary behavior changed; the redaction functions themselves are untouched, only their classification in the lint guard