### PR TITLE
fix(init): an inherited lockfile no longer outranks the project's own installed tree

### DIFF
--- a/packages/server/src/init/detect.ts
+++ b/packages/server/src/init/detect.ts
@@ -115,6 +115,15 @@ function packageManagerFromNodeModules(markers: ReadonlySet<string>): PackageMan
   return undefined;
 }
 
+/**
+ * Whether an installed tree identifies the manager that built it. Callers use this to decide whether
+ * they still need weaker evidence — see `resolveLockfiles`, which stops inheriting an ancestor
+ * lockfile once the project's own tree can answer the question.
+ */
+export function namesAPackageManager(markers: ReadonlySet<string>): boolean {
+  return packageManagerFromNodeModules(markers) !== undefined;
+}
+
 export function detectPackageManager(
   lockfiles: ReadonlySet<string>,
   nodeModulesMarkers: ReadonlySet<string>,

--- a/packages/server/src/init/run.test.ts
+++ b/packages/server/src/init/run.test.ts
@@ -123,6 +123,41 @@ describe('resolveLockfiles — package-manager detection in a monorepo', () => {
     const set = resolveLockfiles(new Set(['package.json']), '/x/y', io);
     expect([...set]).toEqual(['package.json']);
   });
+
+  /**
+   * Reported from the field: `init` in a `frontend/` app whose deps were installed with npm emitted
+   * `pnpm add -D ...` — because an ancestor `pnpm-lock.yaml` outranked the npm tree sitting right
+   * there. pnpm was not even on PATH, so the install step died and every downstream wiring step was
+   * skipped with it. `detectPackageManager`'s own docblock says an installed tree is the strongest
+   * evidence there is; the walk-up was quietly overruling it.
+   */
+  it('does not inherit an ancestor lockfile when the project has its own installed tree', () => {
+    const io = { exists: (p: string) => '/repo/pnpm-lock.yaml' === p.replace(/\\/g, '/') };
+    const set = resolveLockfiles(
+      new Set(['package.json']),
+      '/repo/frontend',
+      io,
+      new Set(['.package-lock.json']),
+    );
+    expect(set.has('pnpm-lock.yaml')).toBe(false);
+  });
+
+  it('still walks up when the sub-package has no installed tree of its own', () => {
+    const io = { exists: (p: string) => '/repo/pnpm-lock.yaml' === p.replace(/\\/g, '/') };
+    const set = resolveLockfiles(new Set(['package.json']), '/repo/frontend', io, new Set());
+    expect(set.has('pnpm-lock.yaml')).toBe(true);
+  });
+
+  it('a LOCAL lockfile still beats the local installed tree', () => {
+    const io = { exists: (): boolean => false };
+    const set = resolveLockfiles(
+      new Set(['pnpm-lock.yaml']),
+      '/repo/frontend',
+      io,
+      new Set(['.package-lock.json']),
+    );
+    expect(set.has('pnpm-lock.yaml')).toBe(true);
+  });
 });
 
 const OPTS: InitOptions = {

--- a/packages/server/src/init/run.ts
+++ b/packages/server/src/init/run.ts
@@ -8,7 +8,7 @@ import { dirname, join } from 'node:path';
 import { spanSync } from '../trace.js';
 import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { detect, Framework, type DetectInput } from './detect.js';
+import { detect, Framework, namesAPackageManager, type DetectInput } from './detect.js';
 import { wasMcpRegistered } from './mcp-registered.js';
 import { pickAstroHost } from './astro-host.js';
 import { workspaceParents } from './workspace-apps.js';
@@ -75,14 +75,23 @@ const LOCKFILE_NAMES = [
  * Resolve the lockfiles set used to pick the package manager. A lockfile in the project root wins;
  * otherwise we walk UP the directory tree (monorepos keep the lockfile at the workspace root, not in
  * each package) so `reticle init` in a sub-package suggests `pnpm add` instead of defaulting to `npm i`.
+ *
+ * The walk is skipped when the project has its own installed tree, because an INHERITED lockfile is
+ * weaker evidence than a `node_modules` sitting right there — the ancestor describes the workspace,
+ * the tree describes THIS package. Reported from the field: `init` in a `frontend/` app installed
+ * with npm emitted `pnpm add -D` off a repo-root `pnpm-lock.yaml`, pnpm was not on PATH, and the
+ * failed install took every downstream wiring step with it. A LOCAL lockfile still wins over the
+ * tree — it is a deliberate statement about this package, not an inheritance.
  */
 export function resolveLockfiles(
   rootFiles: ReadonlySet<string>,
   cwd: string,
   io: Pick<InitIo, 'exists'>,
+  nodeModulesMarkers: ReadonlySet<string> = new Set(),
 ): Set<string> {
   const set = new Set(rootFiles);
   if (LOCKFILE_NAMES.some((name) => set.has(name))) return set; // local lockfile is authoritative
+  if (namesAPackageManager(nodeModulesMarkers)) return set;
   let dir = cwd;
   for (let depth = 0; depth < 50; depth++) {
     for (const name of LOCKFILE_NAMES) {
@@ -262,13 +271,15 @@ function gatherPlanInput(options: InitOptions, io: InitIo, pkgRaw: string): Plan
   // Stable identity derived from the app's package.json name + root, so it survives port changes.
   const projectId = deriveProjectId(packageName(pkg), options.cwd);
   const rootFiles = new Set(io.rootFiles());
+  const nodeModulesMarkers = new Set(io.listFiles('node_modules'));
   const detectInput: DetectInput = {
     pkg: 'object' === typeof pkg && pkg !== null ? pkg : {},
     configFiles: rootFiles,
-    // Walk up for the lockfile so a monorepo sub-package picks the workspace's package manager.
-    lockfiles: resolveLockfiles(rootFiles, options.cwd, io),
+    // Walk up for the lockfile so a monorepo sub-package picks the workspace's package manager —
+    // unless this package's own installed tree already answers it, which outranks an inherited one.
+    lockfiles: resolveLockfiles(rootFiles, options.cwd, io, nodeModulesMarkers),
     // An already-installed tree names its own manager, which matters when no lockfile is committed.
-    nodeModulesMarkers: new Set(io.listFiles('node_modules')),
+    nodeModulesMarkers,
   };
   const detection = detect(detectInput);
 


### PR DESCRIPTION
Closes the open half of #141.

## The field report

From telemetry on 2026-08-10, a human user filed **four reports in eight minutes** during a failing install and never reached a session that day:

> init reported [✓] Reticle config → .reticle.json but the file was missing afterward in frontend/. Also init chose pnpm (pnpm add -D ...) though pnpm is not on PATH and the project uses npm (npm install succeeded). **Install step failed solely due to wrong package manager detection.**

> After `npm install --save-dev @reticlehq/react@2.5.0 @reticlehq/next@2.5.0` succeeded and packages were in node_modules, re-running init still failed Install dependencies with pnpm (not on PATH) and **skipped ReticleDev/withReticle/layout wiring**.

Their repo is a monorepo laid out as `frontend/` + backend, with a `pnpm-lock.yaml` at the root.

## Root cause

`resolveLockfiles` (`run.ts:79`) walks up to 50 directories looking for a lockfile, and that inherited `pnpm-lock.yaml` reached `detectPackageManager` (`detect.ts:118`) as if it were local. Lockfiles are checked first there, so pnpm won over the npm-installed `node_modules` sitting in `frontend/`.

That contradicts the function's own docblock, twenty lines above the code that does it (`detect.ts:97-104`):

> Markers each package manager leaves INSIDE `node_modules`. **An installed tree is the strongest evidence there is — stronger than a lockfile, which may simply not be committed.**

The docblock is right. The walk-up was quietly overruling it.

## The fix

One guard: skip the walk when the project has its own installed tree. The ancestor lockfile describes the *workspace*; the tree describes *this package*.

Three orderings, all now tested:

| evidence | wins | why |
|---|---|---|
| local lockfile | **local lockfile** | a deliberate statement about this package |
| local installed tree vs *inherited* lockfile | **installed tree** | the tree is about this package, the ancestor is not |
| inherited lockfile, no local tree | **inherited lockfile** | the monorepo case the walk was added for, unchanged |

`namesAPackageManager` is exported from `detect.ts` rather than duplicating the marker list, so `NODE_MODULES_MARKERS` stays the single source of truth. The new parameter defaults to an empty set, so `cli-update-commands.ts` — which passes root files directly and never walks — is unaffected.

## Not in this PR

- **A PATH probe for the chosen manager.** A project that genuinely uses pnpm on a machine without pnpm still hard-fails with a confusing message. Real, but a separate defect from precedence.
- **The install step taking every downstream wiring step with it** — fixed separately on main by `a7ccc3d3` (`run.ts:629` gates on `sdkPackagesPresent`), unreleased.
- **`[✓] .reticle.json` for an absent file** — #160; did not reproduce on either build.

## Coverage

`pnpm gate:install` would not have caught this and still would not: all three scaffolds are single-app roots, `npm install` runs before `init` so a local lockfile always short-circuits the walk, and pnpm is always on PATH in CI. **#169** proposes the `monorepo-subdir` scaffold that closes it — worth landing before this is called done.

## Verification

`pnpm lint && pnpm typecheck && pnpm test:unit` — all green (2960 server tests, 828 browser). Three new unit tests, one of which was RED before the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)