### PR TITLE
test(gate): a fourth install scaffold with a different shape — monorepo-subdir

### DIFF
--- a/apps/e2e/install-baseline.json
+++ b/apps/e2e/install-baseline.json
@@ -21,5 +21,13 @@
     "✓ ReticleDev component → components/reticle-dev.tsx",
     "✓ Next config (withReticle) → next.config.ts",
     "✓ Mount ReticleDev → pages/_app.tsx"
+  ],
+  "monorepo-subdir": [
+    "– MCP server (global) → global (claude user scope)",
+    "✓ Install dependencies → package.json",
+    "✓ Reticle config → .reticle.json",
+    "✓ ReticleDev component → app/reticle-dev.tsx",
+    "✓ Next config (withReticle) → next.config.ts",
+    "✓ Mount ReticleDev → app/layout.tsx"
   ]
 }

--- a/apps/e2e/install-gate.mjs
+++ b/apps/e2e/install-gate.mjs
@@ -178,6 +178,8 @@ const PNPM_LOCK_STUB = "lockfileVersion: '9.0'\n";
  *   - `initFrom` — the directory `init` is invoked from (default: the app's)
  *   - `seed`     — extra files written into the WORKDIR after scaffolding, before install
  *   - `hidePnpm` — make `pnpm` unusable for the `init` call only
+ *   - `dropLocalLockfile` — delete the app's own lockfile after install, so package-manager
+ *     detection has to walk UP for one instead of short-circuiting on it
  */
 const SCAFFOLDS = [
   {
@@ -246,7 +248,9 @@ const SCAFFOLDS = [
     //      one a user hits without reading anything, so it is the one wired up).
     //   3. package-manager precedence: an ancestor `pnpm-lock.yaml` must NOT beat the npm-installed
     //      tree sitting in `frontend/`. With pnpm unusable, a regression here is not a cosmetic
-    //      mis-detection — `pnpm add -D` simply cannot run, and the install step goes ⚠.
+    //      mis-detection — `pnpm add -D` simply cannot run, and the install step goes ⚠. This one
+    //      only becomes reachable together with `dropLocalLockfile`: with the app's own lockfile
+    //      present, detection short-circuits on it and the ancestor is never read at all.
     //   4. and a failed install must not silently skip the downstream wiring, which the baseline
     //      diff catches: the steps after it would vanish from the plan.
     what: 'monorepo root, app in frontend/, inherited pnpm lockfile, no pnpm on PATH',
@@ -254,6 +258,7 @@ const SCAFFOLDS = [
     initFrom: '.',
     seed: { [PNPM_LOCK]: PNPM_LOCK_STUB },
     hidePnpm: true,
+    dropLocalLockfile: true,
     create: [
       'npx',
       [
@@ -409,6 +414,15 @@ async function driveScaffold(scaffold, index) {
     // the gate would measure the published SDK while reporting on local changes.
     writeFileSync(join(app, '.npmrc'), `@reticlehq:registry=${REGISTRY}\n`);
     run('npm', ['install', '--no-audit', '--no-fund'], app);
+    // The lockfile npm just wrote is the reason the inherited-lockfile trap was unreachable here.
+    // `resolveLockfiles` returns the moment it sees a LOCAL lockfile — "local is authoritative" — so
+    // an ancestor `pnpm-lock.yaml` is never consulted and a scaffold that seeds one passes whether
+    // precedence is right, wrong, or the ancestor file is absent entirely. Deleting it leaves exactly
+    // the state the user was in: no local lockfile, an npm-installed `node_modules` (whose
+    // `.package-lock.json` marker is what detection reads), and a pnpm lockfile one directory up.
+    // init writes its own package-lock.json back when it installs, so the registry check below still
+    // has one to read.
+    if (true === scaffold.dropLocalLockfile) rmSync(join(app, 'package-lock.json'), { force: true });
 
     // ── 3. the thing under test ────────────────────────────────────────────────────────────────
     // `--no-mcp` for the reason the fixtures gate uses it: registering the MCP server edits global

--- a/apps/e2e/install-gate.mjs
+++ b/apps/e2e/install-gate.mjs
@@ -12,17 +12,21 @@
 // is slower and cannot block a PR. Conflating the two gives a gate too slow to block and too shallow
 // to trust.
 //
-// Three scaffolds, because `init` has three genuinely different paths into an app, and the third is
-// the one that matters most: a Pages Router app has no `app/` root layout to patch, so connect has
+// Four scaffolds, because `init` has four genuinely different paths into an app. The third matters
+// most for framework reasons: a Pages Router app has no `app/` root layout to patch, so connect has
 // to mount through `pages/_app` — and that is the path that once did nothing at all, silently.
+//
+// The fourth is a different axis entirely: the first three are all the same SHAPE — a single-app root
+// with `init` run inside it — and that sameness is what made this gate blind to four init defects one
+// user hit in eight minutes. `monorepo-subdir` is the shape those live in.
 //
 //   pnpm gate:install                 # all scaffolds
 //   node apps/e2e/install-gate.mjs --only next-pages-router [--keep]
 //   pnpm gate:install:self-test       # negative control: every scaffold must go RED
 import { execFileSync, spawn } from 'node:child_process';
-import { mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { delimiter, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { setTimeout as sleep } from 'node:timers/promises';
 import {
@@ -159,9 +163,21 @@ async function startLocalRegistry() {
   } };
 }
 
+/** Where a scaffold's create command puts the app, relative to the workdir. */
+const DEFAULT_APP_DIR = 'app';
+/** A lockfile only has to EXIST to pick a package manager — nothing here parses it. */
+const PNPM_LOCK = 'pnpm-lock.yaml';
+const PNPM_LOCK_STUB = "lockfileVersion: '9.0'\n";
+
 /**
  * One per DISTINCT init path. Not one per framework anyone can name — a scaffold that exercises a
  * path another scaffold already covers costs two minutes a run and proves nothing new.
+ *
+ * Optional fields, all defaulting to the single-app shape the first three use:
+ *   - `appDir`   — where the create command puts the app (default `app/`)
+ *   - `initFrom` — the directory `init` is invoked from (default: the app's)
+ *   - `seed`     — extra files written into the WORKDIR after scaffolding, before install
+ *   - `hidePnpm` — make `pnpm` unusable for the `init` call only
  */
 const SCAFFOLDS = [
   {
@@ -215,7 +231,66 @@ const SCAFFOLDS = [
     ],
     dev: (port) => ['npm', ['run', 'dev', '--', '-p', String(port)]],
   },
+  {
+    id: 'monorepo-subdir',
+    // Not a fourth flavour of the same shape — the first genuinely different one. The other three are
+    // single-app roots with `init` run inside the app, and that shape is why this gate was blind to
+    // all FOUR init defects one user hit in eight minutes on 2026-08-10: the app was in `frontend/`,
+    // the repo root had no package.json, and the root carried a pnpm lockfile the app did not use.
+    //
+    // Four things are only reachable here:
+    //   1. discovery — `init` from a root with no manifest has to FIND `frontend/` (it used to bail
+    //      with "No package.json found" before discovery ever ran).
+    //   2. the same bail made `--app frontend` unreachable too, i.e. the documented workaround for
+    //      (1) failed the same way (one run can only take one of these two paths; discovery is the
+    //      one a user hits without reading anything, so it is the one wired up).
+    //   3. package-manager precedence: an ancestor `pnpm-lock.yaml` must NOT beat the npm-installed
+    //      tree sitting in `frontend/`. With pnpm unusable, a regression here is not a cosmetic
+    //      mis-detection — `pnpm add -D` simply cannot run, and the install step goes ⚠.
+    //   4. and a failed install must not silently skip the downstream wiring, which the baseline
+    //      diff catches: the steps after it would vanish from the plan.
+    what: 'monorepo root, app in frontend/, inherited pnpm lockfile, no pnpm on PATH',
+    appDir: 'frontend',
+    initFrom: '.',
+    seed: { [PNPM_LOCK]: PNPM_LOCK_STUB },
+    hidePnpm: true,
+    create: [
+      'npx',
+      [
+        'create-next-app@latest',
+        'frontend',
+        '--ts',
+        '--app',
+        '--no-src-dir',
+        '--no-tailwind',
+        '--no-eslint',
+        '--import-alias',
+        '@/*',
+        '--use-npm',
+        '--yes',
+      ],
+    ],
+    dev: (port) => ['npm', ['run', 'dev', '--', '-p', String(port)]],
+  },
 ];
+
+/**
+ * A PATH on which `pnpm` cannot run.
+ *
+ * SHADOWED, not stripped. Dropping the PATH entry that holds pnpm is the obvious move and it is a
+ * trap: on plenty of machines (the maintainer's included) `pnpm`, `npm` and `npx` share one bin
+ * directory, so removing it takes the package manager the scaffold actually needs with it and the
+ * scaffold fails for a reason that has nothing to do with the thing under test. A stub that exits
+ * 127 the way an absent binary does is indistinguishable to `init`, which never probes for pnpm — it
+ * just runs it — and leaves everything else on PATH alone.
+ */
+function pathWithoutPnpm(workdir) {
+  const binDir = join(workdir, '.gate-no-pnpm');
+  mkdirSync(binDir, { recursive: true });
+  const stub = join(binDir, 'pnpm');
+  writeFileSync(stub, '#!/bin/sh\necho "pnpm: command not found" >&2\nexit 127\n', { mode: 0o755 });
+  return `${binDir}${delimiter}${process.env.PATH ?? ''}`;
+}
 
 const run = (cmd, args, cwd, extraEnv = {}) =>
   execFileSync(cmd, args, {
@@ -301,7 +376,9 @@ async function driveScaffold(scaffold, index) {
   await freePortSafely(appPort);
 
   const workdir = mkdtempSync(join(tmpdir(), `reticle-install-${scaffold.id}-`));
-  const app = join(workdir, 'app');
+  const app = join(workdir, scaffold.appDir ?? DEFAULT_APP_DIR);
+  // Where `init` is invoked. Defaults to the app, which is the only shape that used to exist here.
+  const initFrom = scaffold.initFrom === undefined ? app : join(workdir, scaffold.initFrom);
   let daemon;
   let dev;
 
@@ -309,6 +386,11 @@ async function driveScaffold(scaffold, index) {
     // ── 1. a surface that has never seen Reticle ──────────────────────────────────────────────
     note('scaffolding…');
     run(scaffold.create[0], scaffold.create[1], workdir);
+    // Seeded AFTER the create command, never before: `create-next-app` reads the surrounding
+    // directory to pick a package manager, and a lockfile planted first would change what it builds.
+    for (const [rel, content] of Object.entries(scaffold.seed ?? {})) {
+      writeFileSync(join(workdir, rel), content);
+    }
     const pkgPath = join(app, 'package.json');
     const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
     chk(
@@ -342,8 +424,11 @@ async function driveScaffold(scaffold, index) {
       report = run(
         'node',
         [CLI, 'init', '--port', String(SELF_TEST ? bridgePort + 1 : bridgePort), '--no-mcp'],
-        app,
-        { npm_config_registry: REGISTRY },
+        initFrom,
+        {
+          npm_config_registry: REGISTRY,
+          ...(true === scaffold.hidePnpm ? { PATH: pathWithoutPnpm(workdir) } : {}),
+        },
       );
     } catch (err) {
       initExit = err.status ?? 1;

--- a/packages/server/src/init/detect.ts
+++ b/packages/server/src/init/detect.ts
@@ -115,6 +115,15 @@ function packageManagerFromNodeModules(markers: ReadonlySet<string>): PackageMan
   return undefined;
 }
 
+/**
+ * Whether an installed tree identifies the manager that built it. Callers use this to decide whether
+ * they still need weaker evidence — see `resolveLockfiles`, which stops inheriting an ancestor
+ * lockfile once the project's own tree can answer the question.
+ */
+export function namesAPackageManager(markers: ReadonlySet<string>): boolean {
+  return packageManagerFromNodeModules(markers) !== undefined;
+}
+
 export function detectPackageManager(
   lockfiles: ReadonlySet<string>,
   nodeModulesMarkers: ReadonlySet<string>,

--- a/packages/server/src/init/run.test.ts
+++ b/packages/server/src/init/run.test.ts
@@ -123,6 +123,41 @@ describe('resolveLockfiles — package-manager detection in a monorepo', () => {
     const set = resolveLockfiles(new Set(['package.json']), '/x/y', io);
     expect([...set]).toEqual(['package.json']);
   });
+
+  /**
+   * Reported from the field: `init` in a `frontend/` app whose deps were installed with npm emitted
+   * `pnpm add -D ...` — because an ancestor `pnpm-lock.yaml` outranked the npm tree sitting right
+   * there. pnpm was not even on PATH, so the install step died and every downstream wiring step was
+   * skipped with it. `detectPackageManager`'s own docblock says an installed tree is the strongest
+   * evidence there is; the walk-up was quietly overruling it.
+   */
+  it('does not inherit an ancestor lockfile when the project has its own installed tree', () => {
+    const io = { exists: (p: string) => '/repo/pnpm-lock.yaml' === p.replace(/\\/g, '/') };
+    const set = resolveLockfiles(
+      new Set(['package.json']),
+      '/repo/frontend',
+      io,
+      new Set(['.package-lock.json']),
+    );
+    expect(set.has('pnpm-lock.yaml')).toBe(false);
+  });
+
+  it('still walks up when the sub-package has no installed tree of its own', () => {
+    const io = { exists: (p: string) => '/repo/pnpm-lock.yaml' === p.replace(/\\/g, '/') };
+    const set = resolveLockfiles(new Set(['package.json']), '/repo/frontend', io, new Set());
+    expect(set.has('pnpm-lock.yaml')).toBe(true);
+  });
+
+  it('a LOCAL lockfile still beats the local installed tree', () => {
+    const io = { exists: (): boolean => false };
+    const set = resolveLockfiles(
+      new Set(['pnpm-lock.yaml']),
+      '/repo/frontend',
+      io,
+      new Set(['.package-lock.json']),
+    );
+    expect(set.has('pnpm-lock.yaml')).toBe(true);
+  });
 });
 
 const OPTS: InitOptions = {

--- a/packages/server/src/init/run.ts
+++ b/packages/server/src/init/run.ts
@@ -8,7 +8,7 @@ import { dirname, join } from 'node:path';
 import { spanSync } from '../trace.js';
 import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { detect, Framework, type DetectInput } from './detect.js';
+import { detect, Framework, namesAPackageManager, type DetectInput } from './detect.js';
 import { wasMcpRegistered } from './mcp-registered.js';
 import { pickAstroHost } from './astro-host.js';
 import { workspaceParents } from './workspace-apps.js';
@@ -75,14 +75,23 @@ const LOCKFILE_NAMES = [
  * Resolve the lockfiles set used to pick the package manager. A lockfile in the project root wins;
  * otherwise we walk UP the directory tree (monorepos keep the lockfile at the workspace root, not in
  * each package) so `reticle init` in a sub-package suggests `pnpm add` instead of defaulting to `npm i`.
+ *
+ * The walk is skipped when the project has its own installed tree, because an INHERITED lockfile is
+ * weaker evidence than a `node_modules` sitting right there — the ancestor describes the workspace,
+ * the tree describes THIS package. Reported from the field: `init` in a `frontend/` app installed
+ * with npm emitted `pnpm add -D` off a repo-root `pnpm-lock.yaml`, pnpm was not on PATH, and the
+ * failed install took every downstream wiring step with it. A LOCAL lockfile still wins over the
+ * tree — it is a deliberate statement about this package, not an inheritance.
  */
 export function resolveLockfiles(
   rootFiles: ReadonlySet<string>,
   cwd: string,
   io: Pick<InitIo, 'exists'>,
+  nodeModulesMarkers: ReadonlySet<string> = new Set(),
 ): Set<string> {
   const set = new Set(rootFiles);
   if (LOCKFILE_NAMES.some((name) => set.has(name))) return set; // local lockfile is authoritative
+  if (namesAPackageManager(nodeModulesMarkers)) return set;
   let dir = cwd;
   for (let depth = 0; depth < 50; depth++) {
     for (const name of LOCKFILE_NAMES) {
@@ -262,13 +271,15 @@ function gatherPlanInput(options: InitOptions, io: InitIo, pkgRaw: string): Plan
   // Stable identity derived from the app's package.json name + root, so it survives port changes.
   const projectId = deriveProjectId(packageName(pkg), options.cwd);
   const rootFiles = new Set(io.rootFiles());
+  const nodeModulesMarkers = new Set(io.listFiles('node_modules'));
   const detectInput: DetectInput = {
     pkg: 'object' === typeof pkg && pkg !== null ? pkg : {},
     configFiles: rootFiles,
-    // Walk up for the lockfile so a monorepo sub-package picks the workspace's package manager.
-    lockfiles: resolveLockfiles(rootFiles, options.cwd, io),
+    // Walk up for the lockfile so a monorepo sub-package picks the workspace's package manager —
+    // unless this package's own installed tree already answers it, which outranks an inherited one.
+    lockfiles: resolveLockfiles(rootFiles, options.cwd, io, nodeModulesMarkers),
     // An already-installed tree names its own manager, which matters when no lockfile is committed.
-    nodeModulesMarkers: new Set(io.listFiles('node_modules')),
+    nodeModulesMarkers,
   };
   const detection = detect(detectInput);
 


### PR DESCRIPTION
Closes #169 (the scaffold half; the "run one scaffold without `--no-mcp`" line is left for a follow-up).

> **Merge after #170.** This scaffold is RED on plain `main` — see the evidence below — because it genuinely exercises the package-manager precedence bug that #170 fixes. This branch merges `fix/pm-detection-inherited-lockfile` so it is green here.

## The shape the other three do not cover

`vite-react`, `next-app-router` and `next-pages-router` differ by framework but are the *same shape*: a single-app root at `<mkdtemp>/app`, with `init` run inside that directory. Every init defect that depends on **where you stand when you run it** is unreachable in that shape.

`monorepo-subdir` is:

- a Next app at `<workdir>/frontend`, not `<workdir>/app`
- a `pnpm-lock.yaml` at `<workdir>/` — the inherited-lockfile trap
- **no root `package.json`**
- `init` invoked from `<workdir>`, not from the app
- the app's own `package-lock.json` deleted after install, so detection has to walk up
- `pnpm` unusable for that one call

## The four defects it would have caught

One user hit all four in eight minutes on 2026-08-10.

1. **Root discovery** — `init` at a root with no manifest has to find `frontend/`. It used to bail with `No package.json found` before discovery ever ran (fixed by `73b38333`).
2. **`--app frontend` from the root** — the same bail made the documented workaround for (1) fail identically. One run can only take one of the two paths; the scaffold wires up discovery, because that is the one a user hits without reading anything.
3. **Package-manager precedence (#141 / #170)** — an ancestor `pnpm-lock.yaml` must not beat the npm-installed tree in `frontend/`. With pnpm unusable this is not a cosmetic mis-detection: `pnpm add -D` simply cannot run, and the install step goes ⚠.
4. **A failed install skipping downstream wiring** (fixed by `a7ccc3d3`) — visible in the red run below as three ⚠ steps after the failed install.

## The `dropLocalLockfile` correction

The first version of this scaffold seeded the ancestor lockfile and then asserted nothing about it. `resolveLockfiles` returns the moment it sees a **local** lockfile ("local is authoritative"), and the gate's `npm install` had just written one into `frontend/` — so the walk-up never ran and the scaffold would have passed identically with correct precedence, with broken precedence, and with the ancestor file absent entirely. That is the same blindness this scaffold exists to end, one level down.

`dropLocalLockfile` deletes it after install and before `init`, leaving the state the user was actually in: no local lockfile, an npm-installed `node_modules` whose `.package-lock.json` marker is what detection reads, and a pnpm lockfile one directory up. init writes its own lockfile back when it installs, so the local-registry assertion still has one to read.

## Evidence: red on main, green with #170

Red, on `main` with only the scaffold applied:

```
      pnpm: command not found
   ❌ init exits 0  — exit 1
   ❌ init leaves ZERO manual steps  — [⚠] Install dependencies → package.json
                                     | [⚠] ReticleDev component → app/reticle-dev.tsx
                                     | [⚠] Next config (withReticle) → next.config.ts
                                     | [⚠] Mount ReticleDev → app/layout.tsx
   ❌ a session actually appears — the bridge was up for the whole window and no session ever appeared
   ✗ monorepo-subdir: 4 passed, 5 failed
```

Defects 3 and 4 in one run: pnpm was chosen and could not run, and the three steps after the failed install were skipped rather than warned about.

Green, with `fix/pm-detection-inherited-lockfile` merged in — baseline unchanged, so no re-record was needed.

## How it is wired

Optional scaffold fields, each defaulting to today's behaviour so the existing three scaffolds are byte-for-byte unchanged in what they do: `appDir` (default `app`), `initFrom` (default: the app dir), `seed` (files written into the workdir after scaffolding, before install), `hidePnpm`, `dropLocalLockfile`.

pnpm is **shadowed** by a stub that exits 127, not stripped from `PATH`. Dropping the PATH entry holding pnpm is the obvious move and a trap: on plenty of machines (including the maintainer's) `pnpm`, `npm` and `npx` share one bin directory, so removing it takes the package manager the scaffold needs with it. `init` never probes for pnpm — it just runs it — so a 127 stub is indistinguishable from absence.

## Measured

| run | result | wall clock |
| --- | --- | --- |
| `--only monorepo-subdir`, plain `main` | ❌ 4 passed, 5 failed — the guard works | 71s |
| `--only monorepo-subdir`, with #170 | ✅ 9 passed, 0 failed, zero ⚠, baseline unchanged | 42s |
| `gate:install:self-test --only monorepo-subdir` | ✅ SELF-TEST PASSED (the mis-wire was detected) | 77s |
| `--only vite-react` (shared path unchanged) | ✅ 9 passed, 0 failed | 31s |

Roughly a minute added to the full gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)