### PR TITLE
fix(act): native:true no longer downgrades to synthetic in total silence

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -455,6 +455,14 @@ export const InputModeReason = {
   DRAG_TARGET_UNRESOLVED: 'drag-target-unresolved', // drag toRef missing or not locatable
   PROVIDER_DECLINED: 'provider-declined', // provider chose not to perform
   PROVIDER_ERROR: 'provider-error', // provider threw → fell back to synthetic
+  /**
+   * No real-input provider is configured at all, and the caller explicitly asked for one with
+   * `native:true`. Only emitted on that explicit ask: without a provider EVERY action is synthetic,
+   * so annotating all of them would put a reason on the most-used tool in the product for no gain.
+   * An agent that asked for a trusted click, though, has an expectation to correct — and this is
+   * permanent for the session, not a transient downgrade, so it should stop asking.
+   */
+  NOT_CONFIGURED: 'real-input-not-configured-for-this-session',
 } as const;
 export type InputModeReason = (typeof InputModeReason)[keyof typeof InputModeReason];
 

--- a/packages/server/src/input/tools.real-input.test.ts
+++ b/packages/server/src/input/tools.real-input.test.ts
@@ -219,12 +219,36 @@ describe('reticle_act real-input routing', () => {
     expect(state.actCalls).toBe(1);
   });
 
-  it('uses synthetic when no provider is configured', async () => {
+  it('uses synthetic, and stays SILENT, when no provider is configured and none was asked for', async () => {
+    // Deliberately no reason. Without a provider every action is synthetic, and reticle_act is the
+    // most-called tool in the product — a reason on all of them is noise, not information.
     const state: FakeSessionState = { actCalls: 0, inspectRefs: [] };
     const res = await runAct(fakeDeps(undefined, state), { ref: 'e1', action: 'click' });
 
     expect(res.inputMode).toBe(InputMode.SYNTHETIC);
     expect(res.inputModeReason).toBeUndefined();
+    expect(state.actCalls).toBe(1);
+  });
+
+  /**
+   * Reported from the field: on a session with `realInputAvailable:false`, `native:true` came back
+   * `inputMode:"synthetic"` with no reason and no warning, and the agent could not tell "your
+   * request was honoured" from "this session will never do that". It spent the rest of the task
+   * probing `realInputAvailable` by hand. The tool description promises the opposite in as many
+   * words: "inputModeReason explains any real→synthetic choice so it is never silent."
+   *
+   * Silence stays the default (the test above). Asking explicitly is what earns an answer.
+   */
+  it('explains itself when native:true is asked for and no provider exists', async () => {
+    const state: FakeSessionState = { actCalls: 0, inspectRefs: [] };
+    const res = await runAct(fakeDeps(undefined, state), {
+      ref: 'e1',
+      action: 'click',
+      args: { native: true },
+    });
+
+    expect(res.inputMode).toBe(InputMode.SYNTHETIC);
+    expect(res.inputModeReason).toBe(InputModeReason.NOT_CONFIGURED);
     expect(state.actCalls).toBe(1);
   });
 

--- a/packages/server/src/tools/real-input-attempt.ts
+++ b/packages/server/src/tools/real-input-attempt.ts
@@ -47,18 +47,22 @@ export async function tryRealInput(
   args: Record<string, unknown>,
 ): Promise<RealActResult> {
   const provider = deps.realInput;
-  if (provider === undefined) return synthetic(); // real input not configured — no diagnostic
+  const inner = asRecord(args['args']);
+  const askedForNative = true === inner[NATIVE_INPUT_ARG];
+  if (provider === undefined) {
+    // Silent by default: with no provider EVERY action is synthetic, and a reason on all of them is
+    // noise on the most-used tool in the product. But an agent that passed native:true asked a
+    // question and got the opposite answer — reported from the field as a silent downgrade that cost
+    // real debugging time, because the tool description promises a reason is "never silent".
+    return askedForNative ? synthetic(InputModeReason.NOT_CONFIGURED) : synthetic();
+  }
   if (!isPointerAction(action)) return synthetic(InputModeReason.NOT_POINTER); // fill/type stay synthetic
 
-  const inner = asRecord(args['args']);
   // "Don't click, run the code": a click/dblclick runs the occlusion-honest SYNTHETIC path by default
   // even with a provider configured — no coordinate gesture to be intercepted by the HUD or missed
   // off-screen. Opt into a trusted native click with args.native:true (file pickers, clipboard,
   // isTrusted-gated handlers). hover/drag genuinely need native pointer state, so they stay real.
-  if (
-    (action === ActionType.CLICK || action === ActionType.DBLCLICK) &&
-    inner[NATIVE_INPUT_ARG] !== true
-  ) {
+  if ((action === ActionType.CLICK || action === ActionType.DBLCLICK) && !askedForNative) {
     return synthetic(InputModeReason.SYNTHETIC_CLICK_PREFERRED);
   }
 


### PR DESCRIPTION
Closes the confirmed half of #158.

## Reproduced live

Against `apps/bench-app` (Vite 8 + React) on a session with `realInputAvailable: false` — the exact condition from the field report:

```
reticle_act { ref: "e3", action: "click", args: { native: true } } →
  { "inputMode": "synthetic", "dispatched": true, "settled": true, … }
```

No `inputModeReason`. No `warning`. The agent asked for a trusted native click, got a synthetic one, and was told nothing — so it cannot tell *"your request was honoured"* from *"this session will never do that"*. The reporter's workaround was to probe `realInputAvailable` by hand on every call; they could not submit a login form at all.

The tool description promises the opposite in as many words (`act-tools.ts:84`):

> `inputModeReason` explains any real→synthetic choice **so it is never silent.**

## The change, and what deliberately does not change

`tryRealInput` returned `synthetic()` with no reason whenever no provider was configured. **That default is right and it stays.** Without a provider every action is synthetic, and `reticle_act` is the most-called tool in the product (179 of 1049 calls in one day of telemetry) — a reason on every one of them is noise, not information. There is an existing test asserting that silence and it still passes, now with a comment explaining why it is deliberate.

What changes is the **explicit ask**. An agent that passed `native:true` asked a question and got the opposite answer. It now gets `inputModeReason: "real-input-not-configured-for-this-session"` — which also tells it this is a property of the session rather than a transient downgrade, so it stops asking.

Silence stays the default. Asking earns an answer.

Three lines of behaviour, one new `InputModeReason` member, and the `native:true` check hoisted so both branches share it.

## Verification

- **RED then GREEN, proven by stashing the source fix and re-running** — not assumed.
- `pnpm lint && pnpm typecheck && pnpm test:unit` green: 2958 server, 828 browser, 103 vite-plugin, 101 test.

### A false green I hit on the way, worth someone else knowing

My new test initially passed **without** the source fix. Cause: it asserts against `InputModeReason.NOT_CONFIGURED`, a new member of a `packages/core` constant, and `packages/core/dist` was stale — so the value resolved to `undefined` and the assertion degenerated into `expect(undefined).toBe(undefined)`.

**Any test in `packages/server` that asserts on a newly-added `core` constant will silently pass against a stale `core` build.** `pnpm test:unit` does not appear to force a `core` rebuild first. That is a live false-green generator in our own harness and it is exactly the failure mode this product exists to catch. Filed separately rather than smuggled into this PR.

## Not in scope

The other half of #158 — *"click on Sign In returned `effect.domMutatedWithin:0` and no POST fired"* — **did not reproduce**: `domMutatedWithin` was 7, so the synthetic click did reach the controlled React form. That may be specific to their Next app or fixed since; #158 stays open for it with the evidence attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)