### PR TITLE
fix(server): format MCP validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the **`@reticlehq/*`** packages are documented here (each entry notes the package it affects). The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`@reticlehq/server` — invalid MCP arguments now produce a concise, actionable sentence** instead of exposing the validator's serialized issue array.
+
 ## [2.5.0] — 2026-08-09
 
 **One tool surface, an MCP server that stays up, and a long list of answers that were wrong.** Most of it was found by driving the shipped surface against live apps: a hostile-argument fuzz of all 48 tools, a nine-app fixture fleet under a new trace, and stress specs against every transport.

--- a/packages/server/src/mcp/mcp.test.ts
+++ b/packages/server/src/mcp/mcp.test.ts
@@ -301,6 +301,24 @@ describe('a wrong-shaped call is answered with a correct one', () => {
     await close();
   });
 
+  it('formats a missing session action without exposing the raw zod issue', async () => {
+    const { client, close } = await openServer();
+    const result = await client.callTool({
+      name: ReticleTool.SESSION,
+      arguments: {},
+    });
+    const failure = errorText(result);
+
+    expect(result.isError, 'the call must still be rejected').toBe(true);
+    expect(failure).toContain('Missing required parameter for reticle_session: action');
+    expect(failure).toContain('one of: tune, yield, end, resume, messages, review, narrate');
+    expect(failure).toContain('Nothing ran.');
+    expect(failure).toContain('A valid call looks like');
+    expect(failure, 'the internal zod issue must not reach the agent').not.toContain('"code"');
+    expect(failure).not.toContain('Input validation error');
+    await close();
+  });
+
   // The handshake is the ONLY channel that reaches an agent with no CLAUDE.md, no pasted skill and
   // no finished `reticle init` — which is the agent whose setup just broke, and whose report we would
   // otherwise never get. Asserted over a real client connection, because instructions that are set

--- a/packages/server/src/mcp/mcp.ts
+++ b/packages/server/src/mcp/mcp.ts
@@ -322,6 +322,55 @@ function unknownKeys(args: unknown, allowed?: ReadonlySet<string>): string[] {
   return Object.keys(args as Record<string, unknown>).filter((key) => !allowed.has(key));
 }
 
+type ValidationIssue = {
+  code?: unknown;
+  expected?: unknown;
+  message?: unknown;
+  options?: unknown;
+  path?: unknown;
+  received?: unknown;
+};
+
+/** Turn the SDK's serialized zod issue array into a short, agent-actionable sentence. */
+function friendlyValidationDetail(detail: string, toolName: string): string {
+  const jsonStart = detail.indexOf('[');
+  if (-1 === jsonStart) return detail;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(detail.slice(jsonStart));
+  } catch {
+    return detail;
+  }
+  if (!Array.isArray(parsed) || 0 === parsed.length) return detail;
+
+  const issue = parsed[0] as ValidationIssue;
+  const path = Array.isArray(issue.path) ? issue.path.map(String).join('.') : '';
+  if ('' === path) return detail;
+
+  const quotedOptions = [...detail.matchAll(/'([^']+)'/g)].map((match) => match[1]);
+  const expected =
+    Array.isArray(issue.options) && issue.options.every((option) => 'string' === typeof option)
+      ? ` (one of: ${issue.options.join(', ')})`
+      : 'string' === typeof issue.expected && issue.expected.includes("'")
+        ? ` (one of: ${issue.expected
+            .replaceAll("'", '')
+            .split('|')
+            .map((option) => option.trim())
+            .join(', ')})`
+        : quotedOptions.length > 0
+          ? ` (one of: ${quotedOptions.join(', ')})`
+          : '';
+  const missing =
+    ('invalid_type' === issue.code && undefined === issue.received) || 'Required' === issue.message;
+  if (missing) {
+    return `Missing required parameter for ${toolName}: ${path}${expected}. Nothing ran.`;
+  }
+
+  const message = 'string' === typeof issue.message ? issue.message : 'Invalid value';
+  return `Invalid parameter for ${toolName}: ${path} (${message}). Nothing ran.`;
+}
+
 export function installFriendlyArgErrors(
   server: McpServer,
   examples: Map<string, string>,
@@ -353,7 +402,7 @@ export function installFriendlyArgErrors(
     } catch (error) {
       // McpError.message already carries "MCP error -32602: "; re-wrapping would print it twice.
       const raw = error instanceof Error ? error.message : String(error);
-      const detail = raw.replace(/^MCP error -?\d+:\s*/, '');
+      const detail = friendlyValidationDetail(raw.replace(/^MCP error -?\d+:\s*/, ''), toolName);
       const example = examples.get(toolName);
       const help =
         example === undefined


### PR DESCRIPTION
## What & why

Missing required arguments currently expose the MCP SDK's serialized Zod issue array to the caller. For `reticle_session {}`, most of the response is validator internals rather than guidance the caller can act on.

This change parses that serialized issue at the validation boundary and turns it into a concise sentence that:

- names the missing parameter and its allowed values
- confirms that nothing ran
- retains the tool's valid-call example
- falls back to the original SDK detail if its format is not recognized

The formatter also gives other recognized invalid values a concise parameter-specific message. The user-facing fix is recorded under `[Unreleased]`.

Closes #109

## Checklist

- [x] Tests added/update; the change is covered by a test that would fail without it
- [x] `pnpm lint && pnpm typecheck && pnpm test:unit` all pass locally
- [x] No `any`, no free strings (wire strings live in `@reticlehq/core`), no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 1000-line cap
- [x] Docs and `CHANGELOG.md` updated if this is user-facing (entry under `[Unreleased]`)
- [x] Security-affecting? No — validation-message formatting only; no auth, redaction, trust-boundary, or telemetry behavior changed
