### PR TITLE
fix(session): a dead sessionId names the live ones instead of sending the agent away

### DIFF
--- a/packages/server/src/session/session-manager.scope.test.ts
+++ b/packages/server/src/session/session-manager.scope.test.ts
@@ -149,3 +149,51 @@ describe('project-scoped resolve()', () => {
     expect(bridge.sessions.resolve(undefined, { projectId: 'showcase' }).id).toBe('stray');
   });
 });
+
+/**
+ * A dead `sessionId` used to be a dead end, and the telemetry shows what that costs.
+ *
+ * On 2026-08-10 one agent called `reticle_navigate` twelve times against a sessionId that was no
+ * longer connected — **12 of the 58 tool errors recorded that whole day, 21%, from one loop.** The
+ * message it got each time was `no connected session with id 'x'`, and the attached recovery hint
+ * said "Call reticle_sessions for the current ids and retry with a valid one". The agent never did.
+ *
+ * The daemon already knows the live ids at the moment it refuses. Making the agent spend a round
+ * trip to learn something the refusal could have told it is the defect: an agent that has to make
+ * two extra calls to recover will often just retry the one it made.
+ */
+describe('a dead sessionId names the live ones instead of sending the agent away', () => {
+  it('names the connected sessions in the error', async () => {
+    await connect({ sessionId: 'alive-1', url: 'http://localhost:3000/', projectId: 'p' });
+    await connect({ sessionId: 'alive-2', url: 'http://localhost:3001/', projectId: 'p' });
+    await waitForSessions(2);
+
+    let message = '';
+    try {
+      bridge.sessions.resolve('ghost');
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+
+    expect(message).toContain('ghost');
+    expect(message, 'the refusal must name the live sessions — the daemon knows them').toContain(
+      'alive-1',
+    );
+    expect(message).toContain('alive-2');
+  });
+
+  it('when nothing is connected at all, it says so rather than implying a retry would help', () => {
+    let message = '';
+    try {
+      bridge.sessions.resolve('ghost');
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+
+    expect(message).toContain('ghost');
+    expect(
+      message,
+      'with zero sessions, "retry with a valid one" is advice the agent cannot act on',
+    ).toMatch(/no sessions are connected/i);
+  });
+});

--- a/packages/server/src/session/session-manager.ts
+++ b/packages/server/src/session/session-manager.ts
@@ -188,11 +188,40 @@ export class SessionManager {
     return this.#recentClosures[this.#recentClosures.length - 1];
   }
 
+  /**
+   * A dead `sessionId`, answered with what the caller needs to recover — not with an errand.
+   *
+   * Telemetry, 2026-08-10: one agent called `reticle_navigate` twelve times against an id that was
+   * no longer connected. That single loop is **12 of the 58 tool errors recorded all day, 21%**. The
+   * refusal said only `no connected session with id 'x'`, and the recovery hint told it to call
+   * `reticle_sessions` and retry — two extra round trips to learn something this method already
+   * knows at the moment it refuses. An agent charged two calls to recover will often just repeat the
+   * one it made.
+   *
+   * So: name the live ids inline, and when there are none say that instead, because "retry with a
+   * valid one" is advice nobody can act on when no valid one exists.
+   */
+  #unknownSessionError(sessionId: string): string {
+    const live = [...this.#sessions.values()];
+    if (0 === live.length) {
+      return (
+        `no connected session with id '${sessionId}', and no sessions are connected at all — so ` +
+        'there is no other id to retry with. The app is not dialling this daemon; call ' +
+        'reticle_sessions for the diagnosis rather than retrying this call.'
+      );
+    }
+    const named = live.map((s) => `'${s.id}' (${s.url})`).join(', ');
+    return (
+      `no connected session with id '${sessionId}'. Connected right now: ${named}. ` +
+      'Retry with one of those, or omit sessionId entirely and let Reticle scope to your project.'
+    );
+  }
+
   resolve(sessionId?: string, scope?: ResolveScope): Session {
     if (sessionId !== undefined) {
       const found = this.#sessions.get(sessionId);
       if (found === undefined) {
-        throw new Error(`no connected session with id '${sessionId}'`);
+        throw new Error(this.#unknownSessionError(sessionId));
       }
       found.markAgentActivity(); // liveness — a targeted tool keeps the session alive / revives it
       return found;

--- a/packages/server/src/tools/error-recovery.test.ts
+++ b/packages/server/src/tools/error-recovery.test.ts
@@ -478,3 +478,23 @@ describe("a select with no such option is the caller's to fix", () => {
     expect(RECOVERY.NO_SUCH_OPTION).toMatch(/label/i);
   });
 });
+
+/**
+ * The unknown-session refusal now names the live ids inline (see `SessionManager` — one agent
+ * looped twelve times against a dead id, 21% of a whole day's tool errors). Appending "call
+ * reticle_sessions for the current ids" to a message that just listed them is not merely redundant:
+ * it contradicts the shorter path the message offers, and a contradicted instruction is how the
+ * loop started.
+ */
+describe('a refusal that already lists the live sessions is left alone', () => {
+  it('adds no generic hint when the message names connected sessions', () => {
+    const message =
+      "no connected session with id 'ghost'. Connected right now: 'a' (http://localhost:3000/). " +
+      'Retry with one of those, or omit sessionId entirely and let Reticle scope to your project.';
+    expect(recoveryFor(message)).toBeUndefined();
+  });
+
+  it('still helps when the id is unknown and the message carries no list', () => {
+    expect(recoveryFor("no connected session with id 'ghost'")).toBe(RECOVERY.UNKNOWN_SESSION);
+  });
+});

--- a/packages/server/src/tools/error-recovery.ts
+++ b/packages/server/src/tools/error-recovery.ts
@@ -43,7 +43,13 @@ function capMessage(message: string): string {
  * it was still collecting the defect ask, inviting a bug report about a refusal that had just told
  * the agent precisely what to do.
  */
-const SELF_RECOVERING: readonly RegExp[] = [/cannot drive native input/i];
+const SELF_RECOVERING: readonly RegExp[] = [
+  /cannot drive native input/i,
+  // The unknown-session refusal now lists the live ids inline. Appending "call reticle_sessions for
+  // the current ids" to a message that just named them contradicts the shorter path it offers, and
+  // a contradicted instruction is how one agent came to retry a dead id twelve times.
+  /Connected right now:/i,
+];
 
 /** A message that already carries its own concrete next action, so nothing should be appended. */
 function isSelfRecovering(message: string): boolean {


### PR DESCRIPTION
Closes #175.

## The cost

Telemetry, 2026-08-10 (58 tool errors across the whole day):

| n | tool | message |
|---|---|---|
| **12** | `reticle_navigate` | `no connected session with id *` |

**All twelve are one agent, in one session, looping against one dead id — 21% of every tool error in the day.**

`reticle_navigate` is also the least reliable tool we ship: **31 errors per 100 calls**, worst on the surface. Almost none of its failures are about navigation; they are session resolution.

## Why the loop happened

`SessionManager.resolve()` threw `no connected session with id 'x'`, and `error-recovery.ts` appended:

> That sessionId is not connected. Call `reticle_sessions` for the current ids and retry with a valid one.

Correct advice that costs **two extra round trips** to act on — one to list, one to retry. An agent charged two calls to recover will often just repeat the one it already made. Meanwhile `resolve()` is holding the live session map at the exact moment it refuses.

## The change

The refusal now answers the question instead of assigning an errand:

```
no connected session with id 'ghost'. Connected right now: 'alive-1' (http://localhost:3000/),
'alive-2' (http://localhost:3001/). Retry with one of those, or omit sessionId entirely and let
Reticle scope to your project.
```

And when there are none, it says so rather than implying a retry would help:

```
no connected session with id 'ghost', and no sessions are connected at all — so there is no other
id to retry with. The app is not dialling this daemon; call reticle_sessions for the diagnosis
rather than retrying this call.
```

The second branch points at the *right* next call — `reticle_sessions` runs the four-way `diagnoseNoSession` triage — rather than at a retry that cannot work.

The generic `UNKNOWN_SESSION` hint is suppressed on the listing form, reusing the existing `SELF_RECOVERING` mechanism. A message that just named the live sessions must not then be told to go look them up; **a contradicted instruction is how the loop started.**

## Scope

One private helper on `SessionManager`, at the single place every caller routes through — so `navigate`, `act`, `query`, `snapshot` and the rest get it without a per-call-site patch.

## Tests

Three added, **all RED before the change**, proven by running them first:

```
× names the connected sessions in the error
  → expected 'no connected session with id \'ghost\'' to contain 'alive-1'
× when nothing is connected at all, it says so rather than implying a retry would help
  → expected … to match /no sessions are connected/i
× adds no generic hint when the message names connected sessions
  → expected 'That sessionId is not connected. Call…' to be undefined
```

They reuse the existing real-bridge harness in `session-manager.scope.test.ts` — actual WebSocket sessions, not a mock of the map.

## Verification

`pnpm lint && pnpm typecheck && pnpm test:unit` green: 2965 server, 828 browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
