### PR TITLE
fix(assert): route accepts urlContains, and every predicate kind is documented

### DIFF
--- a/packages/server/src/events/predicate-eval.ts
+++ b/packages/server/src/events/predicate-eval.ts
@@ -58,7 +58,13 @@ export type Predicate =
  * the only key supplied left a predicate that asserts nothing and passes on anything.
  */
 const PREDICATE_ALIASES: Readonly<Record<string, Readonly<Record<string, string>>>> = {
-  [PredicateKind.ROUTE]: { path: 'pathname' },
+  // `urlContains`/`url` reported from the field: an agent that had just written
+  // `net { urlContains }` applied the same word to `route`, which spells it `contains`, and got
+  // `unrecognized_keys` with no list of what would have worked. The parallel it assumed is a fair
+  // one — route's `contains` matches the WHOLE route (path + query + fragment), so "the URL
+  // contains this" is precisely what it does — and asserting a redirect after login is the single
+  // most common thing an agent reaches for here.
+  [PredicateKind.ROUTE]: { path: 'pathname', urlContains: 'contains', url: 'contains' },
   [PredicateKind.NET]: { url: 'urlContains' },
   [PredicateKind.SIGNAL]: { data: 'dataMatches' },
 };

--- a/packages/server/src/events/predicate-strict.test.ts
+++ b/packages/server/src/events/predicate-strict.test.ts
@@ -53,6 +53,36 @@ describe('a predicate key that is not real is refused, never dropped', () => {
     ).toMatchObject({ kind: 'signal', name: 'order:placed', dataMatches: { id: 1 } });
   });
 
+  /**
+   * Reported from the field, and the reasoning behind the mistake is sound:
+   *
+   * > reticle_assert route predicate rejected urlContains (unrecognized_keys) while net predicate
+   * > accepts urlContains. Skill examples use route without documenting fields; I assumed parallel
+   * > URL filters. Need: which field names a route change after login?
+   *
+   * The agent had just learned `net { urlContains }` and applied the same word to `route`, which
+   * spells it `contains`. Unlike the cases above this one FAILED rather than silently weakening —
+   * strictness caught it — but a rejection with no valid-field list is still a dead end, and the
+   * agent burned a `reticle_tools` round trip to recover. `reticle_tools` is re-called on 33% of its
+   * uses, which is what "I do not know the grammar" looks like from the outside.
+   *
+   * The alias is semantically honest, not just convenient: route's `contains` matches the WHOLE
+   * route — path + query + fragment — so "the URL contains this" is exactly what it does.
+   */
+  it('route { urlContains } is accepted, because net spells the same idea that way', () => {
+    expect(PredicateSchema.parse({ kind: 'route', urlContains: '/dashboard' })).toMatchObject({
+      kind: 'route',
+      contains: '/dashboard',
+    });
+  });
+
+  it('route { url } too — the shorter spelling net also accepts', () => {
+    expect(PredicateSchema.parse({ kind: 'route', url: '?redirect=' })).toMatchObject({
+      kind: 'route',
+      contains: '?redirect=',
+    });
+  });
+
   it("a key that is nobody's spelling is rejected, not stripped", () => {
     // The agent gets a schema error naming the key. Before, it got a green.
     expect(() => PredicateSchema.parse({ kind: 'route', pathnmae: '/checkout' })).toThrow();

--- a/packages/server/src/tools/observe-tools.ts
+++ b/packages/server/src/tools/observe-tools.ts
@@ -333,7 +333,15 @@ export const OBSERVE_TOOLS: ToolDef[] = [
       'Evaluate a predicate (optionally waiting up to timeout_ms). Returns { pass, evidence, failureReason? }. The end of every verify loop. Prefer a { signal } or { net } consequence over { element }/{ text } presence — a passing presence-only assertion returns `advice` because a wrong/healed element can fake it. By default it only counts events since your last act, so a stale buffered signal can never fake a pass; pass `since` (an observe/act cursor) to set the window explicitly.',
     inputSchema: {
       predicate: PredicateSchema.optional().describe(
-        'Predicate to evaluate: { signal }, { net }, { element } or a combination.',
+        // Every kind, each with the field that carries its argument. Five of the nine were
+        // undocumented here, including `route` — and "did submitting the login form navigate away"
+        // is the most common thing an agent wants to assert. A field report reached us from an agent
+        // that guessed `urlContains` on route (net's spelling) and got unrecognized_keys.
+        'Predicate to evaluate. Kinds: { signal, name } { net, urlContains|method|status|count } ' +
+          '{ state, path|equals } { route, pathname (exact) | contains (path+query+hash) } ' +
+          '{ element, testid|role|text } { text } { console, level|absent } { animation, name } ' +
+          '{ settled } — combine with { allOf | anyOf | not }. Prefer a signal/net/state consequence ' +
+          'over element/text presence.',
       ),
       until: PredicateSchema.optional().describe("Alias for `predicate` (act_and_wait's name)."),
       timeout_ms: z

--- a/packages/server/src/tools/predicate-vocabulary.test.ts
+++ b/packages/server/src/tools/predicate-vocabulary.test.ts
@@ -1,0 +1,57 @@
+/**
+ * An agent can only use a predicate kind it knows exists.
+ *
+ * Reported from the field on 2026-08-10:
+ *
+ * > reticle_assert route predicate rejected urlContains (unrecognized_keys) while net predicate
+ * > accepts urlContains. Skill examples use route without documenting fields; I assumed parallel
+ * > URL filters. Need: which field names a route change after login?
+ *
+ * The agent was right that it was undocumented. `reticle_assert`'s `predicate` description read
+ * "{ signal }, { net }, { element } or a combination" and **did not mention `route` at all** — even
+ * though "did submitting the login form navigate away" is the single most common thing an agent
+ * wants to assert. It recovered by spending a `reticle_tools` round trip; `reticle_tools` is
+ * re-called on 33% of its uses across the whole export, which is what "I do not know the grammar"
+ * looks like from the outside.
+ *
+ * Same shape as `query-strategy.test.ts`, which asserts the query description names every `by`
+ * strategy: the schema is the source of truth, and guidance that omits part of it is a defect the
+ * schema cannot catch.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { PredicateKind } from '@reticlehq/core';
+import { TOOLS } from './tools.js';
+import { ReticleTool } from './tool-names.js';
+
+/**
+ * Combinators are grammar, not vocabulary — an agent reaches for `allOf` only once it already has
+ * two predicates to combine, and naming them in the same breath as the kinds reads as noise.
+ */
+const COMBINATORS = new Set<string>([
+  PredicateKind.ALL_OF,
+  PredicateKind.ANY_OF,
+  PredicateKind.NOT,
+]);
+
+function predicateGuidance(toolName: string): string {
+  const tool = TOOLS.find((t) => t.name === toolName);
+  expect(tool, `${toolName} is not on the surface`).toBeDefined();
+  const schema = tool?.inputSchema as Record<string, { description?: string }> | undefined;
+  const fields = ['predicate', 'until'];
+  const described = fields.map((f) => schema?.[f]?.description ?? '').join(' ');
+  return `${tool?.description ?? ''} ${described}`;
+}
+
+describe('the predicate vocabulary is discoverable from the tool that takes it', () => {
+  for (const kind of Object.values(PredicateKind)) {
+    if (COMBINATORS.has(kind)) continue;
+    it(`reticle_assert names the '${kind}' predicate`, () => {
+      expect(
+        predicateGuidance(ReticleTool.ASSERT),
+        `an agent reading reticle_assert has no way to learn '${kind}' exists, so it will either ` +
+          'not use it or guess at its spelling — which is how a field report reached us.',
+      ).toContain(kind);
+    });
+  }
+});


### PR DESCRIPTION
Closes #164.

## The report

> `reticle_assert` `route` predicate rejected `urlContains` (`unrecognized_keys`) while `net` predicate accepts `urlContains`. Skill examples use route without documenting fields; I assumed parallel URL filters. **Need: which field names a route change after login?**

Two defects, and the second is bigger than the report.

## 1. The alias was missing, and the agent's reasoning was correct

`route` spells it `contains`; `net` spells it `urlContains`. The agent applied the word it had just learned. That is not a typo — and route's `contains` matches the **whole** route (path + query + fragment), so "the URL contains this" is precisely what it does.

`PREDICATE_ALIASES` already existed for exactly this class of mistake (`route { path }` → `pathname`, `net { url }` → `urlContains`). This adds `urlContains` and `url` → `contains` for route.

Worth noting this case **failed loudly** rather than silently weakening — `.strict()` caught it, which is that mechanism working. But a rejection with no valid-field list is still a dead end, and the agent paid a `reticle_tools` round trip to escape it.

## 2. Five of nine predicate kinds were undocumented

`reticle_assert`'s `predicate` description read:

> Predicate to evaluate: `{ signal }`, `{ net }`, `{ element }` or a combination.

`route`, `state`, `console`, `animation` and `settled` are not mentioned **anywhere** on the tool that takes them. An agent reading this has no way to learn `route` exists — and asserting a redirect after login is the single most common thing it wants to do.

Now:

> Kinds: `{ signal, name }` `{ net, urlContains|method|status|count }` `{ state, path|equals }` `{ route, pathname (exact) | contains (path+query+hash) }` `{ element, testid|role|text }` `{ text }` `{ console, level|absent }` `{ animation, name }` `{ settled }` — combine with `{ allOf | anyOf | not }`. Prefer a signal/net/state consequence over element/text presence.

Each kind now carries the field that takes its argument, which is the part the reporter actually asked for. Kept to a clause: tool definitions are re-sent on every turn.

## Supporting evidence

`reticle_tools` is re-called on **33% of its uses** across the 2026-08-10 export — the signature of an agent that does not know the grammar and is going back to look it up.

## Tests

`predicate-vocabulary.test.ts` iterates `PredicateKind` and fails if the tool taking a predicate does not name it, so a kind added later cannot ship undocumented. Same shape as the existing `query-strategy.test.ts`, which does this for `by` strategies. Combinators are excluded deliberately — they are grammar, not vocabulary.

RED before GREEN on both halves:

```
× route { urlContains } is accepted, because net spells the same idea that way
× route { url } too — the shorter spelling net also accepts
× reticle_assert names the 'state' / 'route' / 'console' / 'animation' / 'settled' predicate
  Tests  5 failed | 4 passed
```

## Deliberately not in scope

#164 also asks that the rejection itself name the fields that would work. That is a change to validation-error formatting, which **#182** is already touching at the MCP boundary — left to that PR rather than solved twice in two places. The alias means the reported spelling no longer produces a rejection at all.

## Verification

`pnpm lint && pnpm typecheck && pnpm test:unit` green: 2972 server, 828 browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
