### PR TITLE
fix(init): the report names the directory its paths are relative to

### DIFF
--- a/packages/server/src/init/run.test.ts
+++ b/packages/server/src/init/run.test.ts
@@ -202,6 +202,41 @@ describe('runInit', () => {
     expect(io.written['frontend/.reticle.json']).toBeDefined();
   });
 
+  /**
+   * Reported from the field: `init` printed `[✓] Reticle config → .reticle.json` and the user then
+   * could not find the file. It did not reproduce — the write throws on failure and nothing catches
+   * it — and the likeliest explanation is that they were looking in the wrong directory.
+   *
+   * Every path in the report is printed RELATIVE (`.reticle.json`, `app/layout.tsx`) and the header
+   * says only `reticle init`. Run from a repo root against an app in `frontend/`, the redirect
+   * re-roots every write and the report still reads `.reticle.json` — which is true, and is not the
+   * `.reticle.json` the user is standing next to. The redirect does announce itself, so this is not
+   * a silent move; it is that the report never states the ground its paths are relative to.
+   *
+   * One line in the header makes every path in the report unambiguous at once.
+   */
+  it('names the directory its relative paths are relative to', () => {
+    const io = memoryIo(VITE_FILES);
+    runInit(OPTS, io);
+    expect(io.lines.join('\n'), 'the report never says which directory it wrote into').toContain(
+      OPTS.cwd,
+    );
+  });
+
+  it('and names the REDIRECTED directory when the app is one level down', () => {
+    const io = memoryIo({
+      'frontend/package.json': JSON.stringify({ dependencies: { next: '16', react: '^19' } }),
+      'frontend/app/layout.tsx': 'export default function L({ children }) { return children; }\n',
+    });
+    runInit(OPTS, io);
+    const printed = io.lines.join('\n');
+    expect(printed).toContain('frontend');
+    expect(
+      printed,
+      'after a redirect the paths are relative to the APP, not to where the user ran the command',
+    ).toContain('/app/frontend');
+  });
+
   it('honours --app when the root has no package.json', () => {
     const io = memoryIo({
       'frontend/package.json': JSON.stringify({ dependencies: { next: '16', react: '^19' } }),

--- a/packages/server/src/init/run.test.ts
+++ b/packages/server/src/init/run.test.ts
@@ -229,7 +229,11 @@ describe('runInit', () => {
       'frontend/app/layout.tsx': 'export default function L({ children }) { return children; }\n',
     });
     runInit(OPTS, io);
-    const printed = io.lines.join('\n');
+    // Normalised for the reason this file's own harness is: the redirect builds the path with
+    // `join()`, which yields backslashes on Windows, so a literal POSIX comparison passes
+    // everywhere and fails on the platform that is two thirds of our users. CI caught exactly that
+    // on the first version of this test.
+    const printed = io.lines.join('\n').replace(/\\/g, '/');
     expect(printed).toContain('frontend');
     expect(
       printed,

--- a/packages/server/src/init/run.ts
+++ b/packages/server/src/init/run.ts
@@ -503,8 +503,14 @@ function report(
   skipped: ReadonlySet<string>,
   degraded: ReadonlyMap<string, string>,
   io: InitIo,
+  projectDir: string,
 ): InitResult {
   io.print(dryRun ? 'reticle init (dry run — no files written)' : 'reticle init');
+  // Every path below is printed RELATIVE, and until now nothing said what to. Reported from the
+  // field as "[✓] Reticle config → .reticle.json" followed by the file not being there: the app was
+  // in `frontend/`, init redirected into it, and the report's `.reticle.json` was true about a
+  // directory the reader was not standing in. One line makes every path in the report unambiguous.
+  io.print(`  in ${projectDir}`);
   io.print('');
   let applied = 0;
   let manual = 0;
@@ -758,7 +764,7 @@ function runInitSteps(options: InitOptions, io: InitIo): InitResult {
     ? { failed: new Set<string>(), skipped: new Set<string>(), degraded: new Map<string, string>() }
     : spanSync('init.apply', { steps: plan.steps.length }, () => applyEffects(plan, io));
   const { failed, skipped, degraded } = effects;
-  const result = report(plan, options.dryRun, failed, skipped, degraded, io);
+  const result = report(plan, options.dryRun, failed, skipped, degraded, io, options.cwd);
   // A dry run is a preview, not an outcome — reporting it would inflate both success and failure.
   if (!options.dryRun) {
     reportInitOutcome({


### PR DESCRIPTION
Addresses #160, and closes the loose end left on #159.

## The report

> `init` reported `[✓] Reticle config → .reticle.json` but the file was missing afterward in `frontend/`.

## It does not reproduce as a lost write

Checked on shipped 2.5.0 and on `main`:

- The `[✓]` **is** formally independent of the write — mark at `run.ts:591-596`, write at `:521` — so a green mark for a failed write is structurally possible.
- But `node-io.ts:41-45` throws on a failed write and `cli.ts:89` does not catch, so a real failure aborts rather than printing `[✓]`.
- Nothing deletes `.reticle.json` after writing it.
- The config step is not `dependsOnInstall`, so the pnpm failure the same user hit (#141) could not have skipped it.

## The likeliest cause is that they were looking in the wrong directory

Every path in the report is printed **relative** — `.reticle.json`, `app/layout.tsx` — and the header said only `reticle init`. This user ran it from a repo root against an app in `frontend/`. The redirect re-roots every write into the app, and the report still reads `.reticle.json`: true, and not the `.reticle.json` they were standing next to.

Worth correcting something I wrote on #159: **the redirect is not silent.** It prints `No app in this directory — wiring frontend instead.` So this was never a hidden move — the report simply never stated the ground its paths are relative to.

## The change

```
 reticle init
+  in /Users/x/repo/frontend

   [✓] Reticle config → .reticle.json
   [✓] Vite plugin → vite.config.ts
```

One line, and every path in the report becomes unambiguous at once — not just this one. Worth doing whether or not a second bug is hiding behind the original report, because without it no future report of this shape can be diagnosed either.

## Tests

Two, both RED before the change:

```
× names the directory its relative paths are relative to
  → expected 'reticle init\n\n  [✓] MCP server…' to contain '/app'
× and names the REDIRECTED directory when the app is one level down
  → expected 'No app in this directory — wiring fro…' to contain '/app/frontend'
```

The second is the one that matters: it asserts the header follows the redirect rather than reporting where the user typed the command.

## install-gate baseline

Unchanged, and structurally so — `stepsOf()` (`install-gate.mjs:343`) matches `^\s*\[(.)\]\s+(.+?)\s+→\s+(.+)$`, and the new line has neither a mark nor an arrow. Verified by reading the parser rather than assuming.

## Verification

`pnpm lint && pnpm typecheck && pnpm test:unit` green: 2963 server, 828 browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
