### PR TITLE
test(server): resolve @reticlehq/core from source so a stale build cannot fake a pass

### DIFF
--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Resolve `@reticlehq/core` from SOURCE, so a stale build cannot turn a test into a tautology.
+ *
+ * The failure this prevents, hit for real: a test asserting on a constant newly added to
+ * `packages/core` passed *without* the production fix it was written to prove. `core/dist` was
+ * stale, so `InputModeReason.NOT_CONFIGURED` resolved to `undefined` — and the unfixed code path
+ * also returned `undefined`, so the assertion degenerated into `expect(undefined).toBe(undefined)`.
+ * The RED step of the cycle was green.
+ *
+ * It is biased in the worst direction: a missing enum member is `undefined`, and `undefined` is
+ * exactly what an unimplemented branch returns, so the stale build AGREES with the bug. And
+ * "add a constant to core, assert on it from server" is the normal shape of a change here — rule 3
+ * of CLAUDE.md requires every wire and domain string to live in core.
+ *
+ * `pnpm test:unit` was never at risk: `turbo.json` declares `test:unit` dependsOn `^build`. The hole
+ * is the inner loop — `npx vitest run <file>` bypasses turbo entirely, which is precisely what the
+ * RED step of a TDD cycle is, and CLAUDE.md positions the full gate as a PRE-COMMIT step.
+ *
+ * Exact-match on purpose. A plain string alias in Vite is a PREFIX replacement, which would also
+ * capture `@reticlehq/core/schema/*.json` and `@reticlehq/core/desktop-contract` — real export
+ * paths that only exist as build artifacts and have no source equivalent.
+ *
+ * The tradeoff, stated: unit tests now exercise core's source rather than its emitted JS. That is
+ * acceptable because the build is `tsc -b` (a faithful transpile) plus two generators whose outputs
+ * are separate export paths the main entry never imports — and `typecheck` and `build` still run
+ * against the real artifact on every gate.
+ */
+const CORE_SRC = fileURLToPath(new URL('../core/src/index.ts', import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: [{ find: /^@reticlehq\/core$/, replacement: CORE_SRC }],
+  },
+});


### PR DESCRIPTION
Closes #178.

## The failure, reproduced as a controlled A/B

Same stale `core/dist`, same missing production fix, one variable — the alias:

```
=== stale dist + NO alias  → the tautology
      Tests  14 passed (14)          ← WRONG. The fix is absent; this must be red.

=== stale dist + alias     → the truth
     → expected undefined to be 'real-input-not-configured-for-this-se…'
      Tests  1 failed | 13 passed    ← correct
```

I produced that by temporarily reverting the merged fix from #177 and corrupting `core/dist`, so the only thing separating a lying test from an honest one is this config file.

## Why it happens, and why the bias is the dangerous part

A test asserts on `InputModeReason.NOT_CONFIGURED`, a constant newly added to `packages/core`. With `core/dist` stale, that resolves to `undefined`. The unfixed production branch **also** returns `undefined`. The assertion becomes `expect(undefined).toBe(undefined)`.

**A missing enum member is `undefined`, and `undefined` is exactly what an unimplemented branch returns — so the stale build agrees with the bug.** It does not fail loudly and randomly; it confirms whatever you have not built yet.

And this is not an exotic path. `CLAUDE.md` rule 3 requires every wire and domain string to live in `core`, so "add a constant to core, assert on it from server" is the *normal* shape of a change in this repo.

## Correcting my own issue

#178 as filed claimed `pnpm test:unit` does not force a `core` build. **That was wrong** — `turbo.json` already declares `"test:unit": { "dependsOn": ["^build"] }`, verified by corrupting `dist` and watching turbo restore it. The full gate was never at risk, and suggestion (1) in the issue body was already implemented.

The hole is the **inner loop**: `npx vitest run <file>` bypasses turbo entirely, and that is precisely what the RED step of a TDD cycle is. `CLAUDE.md` positions the full gate as a pre-commit step, so every iteration in between is unguarded.

## Scope and tradeoff

Exact-match alias, deliberately: a plain string alias in Vite is a **prefix** replacement and would also capture `@reticlehq/core/schema/*.json` and `@reticlehq/core/desktop-contract` — real export paths that exist only as build artifacts with no source equivalent.

**The tradeoff, stated in the file rather than buried:** unit tests now exercise core's *source* rather than its emitted JS. Acceptable because core's build is `tsc -b` (a faithful transpile) plus two generators whose outputs are separate export paths the main entry never imports — and `typecheck` and `build` still run against the real artifact on every gate.

Scoped to `packages/server` only, which is where core constants are asserted on and where this actually bit. `browser`/`react`/`test` can get the same file if it bites there; adding four configs speculatively is not worth it.

## Verification

`pnpm lint && pnpm typecheck && pnpm test:unit` green: 2962 server, 828 browser.

The gate also caught my own temporary revert still sitting in the tree before I committed — which is a small argument for the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
