### PR TITLE
feat(doctor): name WHICH daemon is on the port, and flag version skew there

### DIFF
--- a/packages/server/src/cli/cli-doctor.ts
+++ b/packages/server/src/cli/cli-doctor.ts
@@ -5,6 +5,9 @@ import { readPid, reticleStateHome } from '../daemon/daemon.js';
 import { PortPresence, probePresence, describePresence } from '../daemon/port-presence.js';
 import { probeDaemon } from '../mcp/mcp-proxy.js';
 import { fetchStatus } from './cli-launch.js';
+import { daemonLine, type DaemonIdentity } from './doctor-daemon-line.js';
+import { SERVER_VERSION } from '../version/server-version.js';
+import { CONTRACT_FINGERPRINT } from '@reticlehq/core';
 import { diagnoseDesktop, isDesktopProject } from '../init/desktop-doctor.js';
 
 /**
@@ -12,6 +15,24 @@ import { diagnoseDesktop, isDesktopProject } from '../init/desktop-doctor.js';
  * Chromium install (the #1 silent failure), whether a daemon is up on the resolved bridge port, and
  * reminds the user which port the app must dial. Human-readable to stdout (not the JSON log).
  */
+/** Narrow the `/status` payload to the two fields the daemon line reads. */
+function asIdentity(payload: unknown): DaemonIdentity {
+  if (typeof payload !== 'object' || null === payload) return {};
+  const record = payload as Record<string, unknown>;
+  const pick = (key: string): string | undefined => {
+    const value = record[key];
+    return 'string' === typeof value && value.length > 0 ? value : undefined;
+  };
+  // Keys are OMITTED rather than set to undefined: `exactOptionalPropertyTypes` is on, and the
+  // distinction is the point — "this daemon did not say" is not the same as "this daemon said none".
+  const version = pick('version');
+  const contract = pick('contract');
+  return {
+    ...(version === undefined ? {} : { version }),
+    ...(contract === undefined ? {} : { contract }),
+  };
+}
+
 export async function handleDoctor(port: number): Promise<void> {
   const line = (s: string): void => {
     process.stdout.write(`${s}\n`);
@@ -35,7 +56,16 @@ export async function handleDoctor(port: number): Promise<void> {
   const pid = readPid(port);
   const presence = await probePresence(port, { tcpOpen: probeDaemon, status: fetchStatus });
   if (presence === PortPresence.DAEMON) {
-    line(`  daemon       ✓ running on :${port}${null === pid ? '' : ` (pid ${pid})`}`);
+    // Name WHICH daemon. The /status payload already carries version + contract, and doctor was
+    // throwing both away — while skew is invisible everywhere else, reaching the agent as a bare
+    // -32000 naming no version. This is the command a human runs at exactly that moment.
+    const status = asIdentity(await fetchStatus(port));
+    const built = daemonLine(port, pid, status, {
+      version: SERVER_VERSION,
+      contract: CONTRACT_FINGERPRINT,
+    });
+    line(built.text);
+    if (built.skew !== undefined) line(`  version      ✗ ${built.skew}`);
   } else if (presence === PortPresence.FOREIGN) {
     line(`  daemon       ✗ ${describePresence(presence, port)}`);
   } else {

--- a/packages/server/src/cli/doctor-daemon-line.test.ts
+++ b/packages/server/src/cli/doctor-daemon-line.test.ts
@@ -29,7 +29,10 @@ describe('the daemon line names which daemon, not just that there is one', () =>
 
   it('flags a daemon on a different contract as skew', () => {
     const out = daemonLine(4400, 1, { version: '2.5.0', contract: 'oldfp' }, SELF);
-    expect(out.skew, 'a contract mismatch is exactly the -32000-with-no-version case').toBeDefined();
+    expect(
+      out.skew,
+      'a contract mismatch is exactly the -32000-with-no-version case',
+    ).toBeDefined();
     expect(String(out.skew)).toContain('2.5.0');
   });
 

--- a/packages/server/src/cli/doctor-daemon-line.test.ts
+++ b/packages/server/src/cli/doctor-daemon-line.test.ts
@@ -1,0 +1,47 @@
+/**
+ * `doctor` is what we tell people to run when the agent cannot reach the bridge, and it was the one
+ * place that could see version skew and did not look.
+ *
+ * It already stopped lying about the port — `probePresence` distinguishes "a daemon is here", "a
+ * stranger holds it" and "nothing is listening", which was the load-bearing half of #105. What it
+ * still did not do is say WHICH daemon: the `/status` payload it already fetches carries `version`
+ * and `contract`, and doctor discarded both.
+ *
+ * That matters because skew is invisible by design at the other end. Per #127, a CLI and a daemon on
+ * different versions connect anyway and then disagree about behaviour, which surfaces to the agent
+ * as "a bare -32000 with nothing naming a version". Doctor is the command a human runs precisely
+ * when that is happening.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { daemonLine } from './doctor-daemon-line.js';
+
+const SELF = { version: '2.6.0', contract: 'abc123' };
+
+describe('the daemon line names which daemon, not just that there is one', () => {
+  it('reports the running version', () => {
+    const out = daemonLine(4400, 90210, { version: '2.6.0', contract: 'abc123' }, SELF);
+    expect(out.text).toContain('4400');
+    expect(out.text).toContain('90210');
+    expect(out.text, 'the version is in the payload doctor already fetches').toContain('2.6.0');
+    expect(out.skew).toBeUndefined();
+  });
+
+  it('flags a daemon on a different contract as skew', () => {
+    const out = daemonLine(4400, 1, { version: '2.5.0', contract: 'oldfp' }, SELF);
+    expect(out.skew, 'a contract mismatch is exactly the -32000-with-no-version case').toBeDefined();
+    expect(String(out.skew)).toContain('2.5.0');
+  });
+
+  it('still reports cleanly when the daemon is too old to state a version', () => {
+    const out = daemonLine(4400, 1, {}, SELF);
+    expect(out.text).toContain('4400');
+    expect(out.text, 'an unknown version must not print as "undefined"').not.toContain('undefined');
+  });
+
+  it('omits the pid rather than printing null when there is no pid file', () => {
+    const out = daemonLine(4400, null, { version: '2.6.0', contract: 'abc123' }, SELF);
+    expect(out.text).not.toContain('null');
+    expect(out.text).toContain('4400');
+  });
+});

--- a/packages/server/src/cli/doctor-daemon-line.ts
+++ b/packages/server/src/cli/doctor-daemon-line.ts
@@ -29,7 +29,8 @@ export interface DaemonLine {
   skew?: string;
 }
 
-const FIX = 'Restart it so both ends are the same build: `reticle kill` then let your agent reconnect.';
+const FIX =
+  'Restart it so both ends are the same build: `reticle kill` then let your agent reconnect.';
 
 /**
  * Build the daemon line for a port that answered `/status`.

--- a/packages/server/src/cli/doctor-daemon-line.ts
+++ b/packages/server/src/cli/doctor-daemon-line.ts
@@ -1,0 +1,57 @@
+/**
+ * What `doctor` says about the daemon it found — pure, so it can be tested without a socket.
+ *
+ * Doctor already stopped lying about the PORT: `probePresence` separates "a daemon is here" from "a
+ * stranger holds it" from "nothing is listening", which was the load-bearing half of the report. It
+ * still did not say WHICH daemon, though the `/status` payload it already fetches carries `version`
+ * and `contract` and it discarded both.
+ *
+ * That is the gap worth closing, because skew is invisible everywhere else: a CLI and a daemon on
+ * different contracts connect anyway and then disagree about behaviour, which reaches the agent as a
+ * bare `-32000` naming no version at all. Doctor is the command a human runs at exactly that moment.
+ *
+ * Same split as `classifyPort`/`probePresence`: the rule lives here and is tested; the fetching stays
+ * at the call site.
+ */
+
+import { describeSkew } from '../version/version-skew.js';
+
+/** The fields of `/status` this line cares about. Both optional — an old daemon reports neither. */
+export interface DaemonIdentity {
+  version?: string;
+  contract?: string;
+}
+
+export interface DaemonLine {
+  /** The `daemon ✓ …` line itself. */
+  text: string;
+  /** A skew sentence to print underneath, when this CLI and that daemon disagree. */
+  skew?: string;
+}
+
+const FIX = 'Restart it so both ends are the same build: `reticle kill` then let your agent reconnect.';
+
+/**
+ * Build the daemon line for a port that answered `/status`.
+ *
+ * `pid` comes from the pid file and is genuinely optional — a daemon started by another user, or one
+ * whose pid file was cleaned up, still answers. Printing `(pid null)` would be worse than printing
+ * nothing, which is the same class of mistake as the port lie this command already fixed.
+ */
+export function daemonLine(
+  port: number,
+  pid: number | null,
+  peer: DaemonIdentity,
+  self: { version: string; contract: string },
+): DaemonLine {
+  const parts: string[] = [];
+  if (null !== pid) parts.push(`pid ${String(pid)}`);
+  if (peer.version !== undefined) parts.push(`v${peer.version}`);
+  const detail = 0 === parts.length ? '' : ` (${parts.join(', ')})`;
+  const skew = describeSkew(
+    { what: 'the daemon on this port', version: peer.version, contract: peer.contract, fix: FIX },
+    self,
+  );
+  const line: DaemonLine = { text: `  daemon       ✓ running on :${String(port)}${detail}` };
+  return skew === undefined ? line : { ...line, skew };
+}


### PR DESCRIPTION
Addresses the remaining half of #105.

## What was already done

#105's load-bearing complaint — *"not running on :4400" is produced from the pid file, not the port* — **has landed**. `probePresence` now distinguishes three states and `doctor` prints the right one:

```
daemon  ✗ port 4400 is held by another process that is not a Reticle daemon — a daemon cannot bind it.
```

So the lie is gone. This PR takes the part that is left.

## What was still missing

> Same probe when the port IS a healthy daemon: **report its version, so version skew is visible here too.**

`doctor` already fetches `/status` to classify the port. That payload carries `version` and `contract`. It threw both away.

That matters because **skew is invisible everywhere else by construction**. Per #127, a CLI and a daemon on different contracts connect anyway and then disagree about behaviour, which reaches the agent as *"a bare -32000 with nothing naming a version"*. `doctor` is the command a human runs at precisely that moment, and it was the one surface positioned to answer.

```
  daemon       ✓ running on :4400 (pid 90210, v2.6.0)
  version      ✗ version skew: the daemon on this port is 2.5.0, this CLI is 2.6.0 … Restart it so
                 both ends are the same build: `reticle kill` then let your agent reconnect.
```

Reuses `describeSkew` — the same describer the daemon-launch path already uses — rather than writing a second opinion about what skew means.

## Structure

The decision is a pure function (`doctor-daemon-line.ts`) tested without a socket; fetching stays at the call site. That is the split `port-presence.ts` already established with `classifyPort` / `probePresence`, and it is there for the reason that module states: *"a probe that starts lying is a separate failure from a rule that does."*

Four tests, covering the two cases that would otherwise print garbage into a diagnostic command:

- a daemon too old to state a version — must not render `v undefined`
- no pid file (another user's daemon, or a cleaned-up file) — must not render `(pid null)`

Both are the same class as the port lie this command already fixed: a diagnostic that prints a placeholder is worse than one that stays quiet.

## Deliberately NOT doing the other half

#105 also asks doctor to name the PID and command of a process holding a **foreign** port. `port-presence.ts` already considered and deferred that, in writing:

> Deliberately probe-based rather than lsof-based … they work on Windows, where every `lsof` recipe in this repo does not. **Naming the holding process is a nicer message and a strictly harder problem; it is not needed to stop lying.**

That call still looks right, and there is a sharper reason to leave it alone: the `lsof` recipe people reach for here (`lsof -ti tcp:4400 | xargs kill -9`) **SIGKILLs the agent's own MCP proxy**, which is the documented root cause of a good share of "MCP disconnected" reports (#110, #114). Adding process-naming means adding platform-specific lookup to the command people run *while already confused about that port*. Worth doing deliberately, not as a rider on this.

Suggest #105 stays open for that half, or splits.

## Verification

`pnpm lint && pnpm typecheck && pnpm test:unit` green: 2981 server, 828 browser.

`exactOptionalPropertyTypes` caught the first draft setting `version: undefined` instead of omitting the key — kept the omission, since "this daemon did not say" and "this daemon said none" are genuinely different facts here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
