### PR TITLE
fix(init): the unpinned-retry note stops asserting a cause it cannot know

### DIFF
--- a/packages/server/src/init/plan.test.ts
+++ b/packages/server/src/init/plan.test.ts
@@ -592,6 +592,62 @@ describe('buildPlan — the SDK is pinned to the CLI version', () => {
 });
 
 /**
+ * Reported from nine fixture apps: every one of them got the SAME retry note, whatever their package
+ * manager and whatever actually went wrong —
+ *
+ *   the registry refused 2.5.0 (pnpm's minimumReleaseAge holds new releases back) …
+ *   pnpm config set minimumReleaseAgeExclude "@reticlehq/*"
+ *
+ * Two separate lies in one sentence. The real cause on that run was that **the version did not exist
+ * yet** — no release-age window was involved. And the remedy is a `pnpm config` command handed to a
+ * **yarn 1** project, which will never read it.
+ *
+ * The note cannot learn the true cause here: it is built at plan time, before anything runs, and
+ * `io.exec` returns a bare boolean so the apply layer has no failure text to pass back either. What
+ * it CAN stop doing is asserting a cause it does not know, and it can get the remedy right, because
+ * `pm` is in scope at the call site and the sibling `installFailureHint(pm)` already branches on it.
+ */
+describe('the unpinned-retry note does not assert a cause it cannot know', () => {
+  const noteFor = (pm: PackageManager): string => {
+    const s = step(
+      buildPlan(
+        input({
+          detection: { ...detection(Framework.VITE), packageManager: pm },
+          options: { port: undefined, mcp: true, install: true, sdkVersion: '2.5.0' },
+        }),
+      ),
+      'Install dependencies',
+    );
+    return s.retry?.note ?? '';
+  };
+
+  it('says the pinned install failed, not WHY, since it cannot know why', () => {
+    const note = noteFor(PackageManager.NPM);
+    expect(note).toContain('2.5.0');
+    expect(
+      note,
+      'minimumReleaseAge is one possible cause among several — "the version does not exist yet" was the real one',
+    ).not.toContain('minimumReleaseAge holds new releases back');
+  });
+
+  it('does not hand an npm project a pnpm config command', () => {
+    expect(noteFor(PackageManager.NPM)).not.toContain('pnpm config set');
+    expect(noteFor(PackageManager.YARN)).not.toContain('pnpm config set');
+    expect(noteFor(PackageManager.BUN)).not.toContain('pnpm config set');
+  });
+
+  it('still gives pnpm users the remedy that IS theirs', () => {
+    expect(noteFor(PackageManager.PNPM)).toContain('minimumReleaseAgeExclude');
+  });
+
+  it('always warns about the skew, whichever manager — that is the part that bites', () => {
+    for (const pm of [PackageManager.NPM, PackageManager.PNPM, PackageManager.YARN]) {
+      expect(noteFor(pm)).toContain('reticle_sessions');
+    }
+  });
+});
+
+/**
  * The generated connect component ships into a JavaScript project as `.jsx`, where SWC parses it as
  * plain JS. A TypeScript cast in the body — `(globalThis as Record<string, unknown>)` — therefore
  * failed to compile and every route served 500: installing Reticle stopped the app booting, for the

--- a/packages/server/src/init/plan.ts
+++ b/packages/server/src/init/plan.ts
@@ -589,14 +589,32 @@ function agentRuleSteps(input: PlanInput): Step[] {
  * with nothing naming a version. Pinning turns that into this loud failure, which is the better
  * trade — but only if the message says what to do about it.
  */
-/** Said out loud when the exact-version install was refused and the unpinned one worked. */
-function unpinnedRetryNote(version: string | undefined): string {
+/**
+ * Said out loud when the exact-version install failed and the unpinned one worked.
+ *
+ * It used to assert a cause it cannot know. Every one of nine fixture apps got the same sentence —
+ * "the registry refused 2.5.0 (pnpm's minimumReleaseAge holds new releases back)" — when the actual
+ * cause on that run was that the version did not exist yet, and the remedy offered was a `pnpm
+ * config` command handed to a yarn 1 project that will never read it.
+ *
+ * This note is built at PLAN time, before anything runs, and `io.exec` returns a bare boolean, so
+ * the apply layer has no failure text to hand back either. The honest move is therefore to report
+ * the CONSEQUENCE (which is certain and is the part that bites) and offer the remedy that belongs to
+ * the manager actually in use — rather than name a cause that is one possibility among several.
+ */
+function unpinnedRetryNote(version: string | undefined, pm: PackageManager): string {
   const wanted = version === undefined ? 'the exact version' : version;
+  // Kept verbatim for pnpm, where minimumReleaseAge is a real and common cause with a real remedy.
+  const remedy =
+    pm === PackageManager.PNPM
+      ? ' One common cause on pnpm is minimumReleaseAge holding a new release back; if pnpm ' +
+        'reported ERR_PNPM_NO_MATURE_MATCHING_VERSION, either wait out the window or allow these ' +
+        'packages: pnpm config set minimumReleaseAgeExclude "@reticlehq/*"'
+      : '';
   return (
-    `the registry refused ${wanted} (pnpm's minimumReleaseAge holds new releases back), so the ` +
-    `newest ACCEPTED version was installed instead. That may not match the daemon — if the agent ` +
-    `reports protocol errors, check \`versionSkew\` in reticle_sessions, then either wait out the ` +
-    `window or allow these packages: pnpm config set minimumReleaseAgeExclude "@reticlehq/*"`
+    `the pinned install of ${wanted} failed, so the newest version the registry WOULD accept was ` +
+    `installed instead. That may not match the daemon — if the agent reports protocol errors, check ` +
+    `\`versionSkew\` in reticle_sessions.${remedy}`
   );
 }
 
@@ -641,7 +659,7 @@ function installStep(input: PlanInput): Step {
     // release-age hold gets a working install instead of no install.
     retry: {
       ...installCommandParts(pm, frameworkPackages(input.detection.framework)),
-      note: unpinnedRetryNote(input.options.sdkVersion),
+      note: unpinnedRetryNote(input.options.sdkVersion, pm),
     },
   };
 }


### PR DESCRIPTION
Closes #104.

## The report

All nine fixture apps got the same note, whatever their package manager and whatever actually went wrong:

```
[i] Install dependencies -> package.json
    the registry refused 2.5.0 (pnpm's minimumReleaseAge holds new releases back), so the
    newest ACCEPTED version was installed instead. ... either wait out the window or allow
    these packages: pnpm config set minimumReleaseAgeExclude "@reticlehq/*"
```

Two separate lies in one sentence:

1. **The cause was invented.** On that run the version simply *did not exist yet*. No release-age window was involved.
2. **The remedy was for someone else.** A `pnpm config` command handed to a **yarn 1** project, which will never read it.

## Why it cannot just be made accurate

The issue proposes `unpinnedRetryNote(version, pm, failureText)`. The first two are easy; the third is not available here.

The note is built at **plan time**, before anything executes — and the apply layer has nothing to pass back either, because `InitIo.exec` returns a bare `boolean`:

```ts
if (retry !== undefined && spanSync('init.exec.retry', …, () => io.exec(retry.command, retry.args))) {
  degraded.set(s.target, retry.note);
```

Threading stderr through would mean widening the IO contract and every test harness that implements it. Worth doing, separately — it would also let `installFailureHint` branch on the real error — but it is not this change.

## What it does instead

**Stop asserting a cause; report the consequence, which is certain.**

```
the pinned install of 2.5.0 failed, so the newest version the registry WOULD accept was installed
instead. That may not match the daemon — if the agent reports protocol errors, check `versionSkew`
in reticle_sessions.
```

pnpm users additionally keep their remedy, now phrased as *one common cause* rather than *the* cause:

```
 One common cause on pnpm is minimumReleaseAge holding a new release back; if pnpm reported
 ERR_PNPM_NO_MATURE_MATCHING_VERSION, either wait out the window or allow these packages:
 pnpm config set minimumReleaseAgeExclude "@reticlehq/*"
```

`pm` was already in scope at the call site — the sibling `installFailureHint(pm)` on the next line has branched on it all along. The note simply never received it.

Every manager keeps the **skew warning**, because that is the consequence and it is true regardless of why the pin failed. It is also the part that actually bites: an older SDK against a newer daemon connects fine and then disagrees, surfacing as a bare `-32000`.

## Tests

Four added; **two RED before the change**, two already passing (the skew warning and the pnpm remedy — worth pinning so a future edit cannot drop them while fixing the wording).

```
× says the pinned install failed, not WHY, since it cannot know why
× does not hand an npm project a pnpm config command
```

## Verification

`pnpm lint && pnpm typecheck && pnpm test:unit` green: 2983 server, 828 browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
