### PR TITLE
fix(init): the CRA token caveat becomes a NOTICE, not detail on a line readers skip

### DIFF
--- a/packages/server/src/init/cra.ts
+++ b/packages/server/src/init/cra.ts
@@ -35,6 +35,24 @@ export const CRA_TOKEN_MISSING_NOTE =
   `The pairing token is per-machine and ${CRA_ENV_PATH} is gitignored by CRA's template, ` +
   'so it does not survive a clone. Run `npx reticle init` in this project to write it for this machine.';
 
+/**
+ * Said as its own NOTICE line, beside the write — not inside it.
+ *
+ * The caveat has always been in the write step's `detail`, and the write step renders `[✓]`. But
+ * `SKILL.md` tells whoever reads the report: *"If every line is `✓`, `·` or `–`, skip to Step 4 and
+ * validate."* So the one fact that makes this install conditional sat in the one place the reading
+ * protocol says to ignore — which is exactly how it was reported to us as "4 OK marks and no
+ * warning". The words were on screen; the reader was following instructions.
+ *
+ * It cannot simply be promoted: `run.ts` only writes steps whose status is APPLY, so demoting the
+ * token step to NOTICE would stop it writing the token and break the install outright.
+ */
+export const CRA_TOKEN_PER_MACHINE_NOTICE =
+  `${CRA_ENV_PATH} is in CRA's own .gitignore, so the token just written does not travel. ` +
+  'It works on THIS machine and nowhere else: a teammate cloning the repo, CI, or a container ' +
+  'gets an app that boots, never pairs, and reports it only in the browser console. ' +
+  'Each developer runs `npx reticle init` once locally.';
+
 /** Add the import after the last existing one, or null when it is already present. */
 export function craImportPatch(source: string): string | null {
   if (source.includes(CRA_DEV_MODULE_IMPORT)) return null;

--- a/packages/server/src/init/plan-framework.ts
+++ b/packages/server/src/init/plan-framework.ts
@@ -11,6 +11,7 @@ import {
   CRA_DEV_MODULE_IMPORT,
   CRA_DEV_MODULE_PATH,
   CRA_ENV_PATH,
+  CRA_TOKEN_PER_MACHINE_NOTICE,
   TOKEN_VAR,
   craDevModuleFile,
   craEnvPatch,
@@ -276,6 +277,14 @@ export function craSteps(input: PlanInput): Step[] {
       // has to run init once or their clone is dead with no explanation.
       detail: `set ${TOKEN_VAR} (the only channel CRA inlines) — ${CRA_ENV_PATH} is gitignored, so each teammate must run \`reticle init\` on their own machine`,
       write: { path: CRA_ENV_PATH, content: env },
+    });
+    // Beside the write, not inside it. A ✓ line is one SKILL.md tells the reader to skip, and this
+    // is the fact that decides whether the install works for anyone but the person running it.
+    steps.push({
+      title: 'Pairing token is per-machine',
+      target: CRA_ENV_PATH,
+      status: StepStatus.NOTICE,
+      detail: CRA_TOKEN_PER_MACHINE_NOTICE,
     });
   } else if ('' === token) {
     // No daemon has ever run here, so there is no token to inline. Omitting the step entirely made

--- a/packages/server/src/init/plan.test.ts
+++ b/packages/server/src/init/plan.test.ts
@@ -340,6 +340,51 @@ describe('buildPlan — CRA pairing token', () => {
     const plan = craPlan({ pairingToken: 'tok-1', craEnv: 'REACT_APP_RETICLE_TOKEN=tok-1\n' });
     expect(undefined).toBe(maybeStep(plan, TOKEN_STEP));
   });
+
+  /**
+   * The caveat was already written — and attached to a line the reader is told to skip.
+   *
+   * `SKILL.md` instructs whoever reads the report: *"If every line is `✓`, `·` or `–`, skip to Step 4
+   * and validate. The manual sections below exist for the `⚠` lines only."* The gitignore warning
+   * lives in the `detail` of an APPLY step, which renders `[✓]`. So the install is documented as
+   * conditional in a place the documented reading protocol says to ignore.
+   *
+   * That is why the report reached us as "4 OK marks and no warning": the words were on screen and
+   * the reader was following instructions.
+   *
+   * The step itself must STAY `APPLY` — `run.ts:603` is `if (s.status !== StepStatus.APPLY) continue`,
+   * so a NOTICE step never writes, and demoting it would silently stop writing the token and break
+   * the install outright. The fix is a SEPARATE notice beside it, the same shape
+   * `unverifiedUiLibraryNote` already uses.
+   */
+  it('raises a NOTICE beside the write, because a caveat on a ✓ line is one the reader is told to skip', () => {
+    const plan = craPlan({ pairingToken: 'tok-1' });
+    const written = maybeStep(plan, TOKEN_STEP);
+    expect(StepStatus.APPLY, 'the step must still WRITE — only APPLY steps do').toBe(
+      written?.status,
+    );
+
+    const notice = plan.steps.find((s) => s.status === StepStatus.NOTICE);
+    expect(
+      notice,
+      'nothing tells a reader who skips ✓ lines that this install is per-machine',
+    ).toBeDefined();
+    expect(notice?.detail).toContain('gitignore');
+    expect(notice?.detail, 'name the consequence: a fresh clone cannot pair').toMatch(
+      /clone|teammate|CI/i,
+    );
+  });
+
+  it('the notice does not appear when there is no token to write', () => {
+    const plan = craPlan({ pairingToken: '', craEnv: null });
+    const notice = plan.steps.find(
+      (s) => s.status === StepStatus.NOTICE && s.detail.includes('gitignore'),
+    );
+    expect(
+      notice,
+      'nothing was written, so there is nothing per-machine to warn about',
+    ).toBeUndefined();
+  });
 });
 
 describe('buildPlan — Next', () => {


### PR DESCRIPTION
Closes #111.

## The report, and why it was true even though the warning existed

> On the `cra-redux-saga` fixture, `init` completes with **4 OK marks and no warning**. The app boots. Nothing ever connects.

The warning **was** already there — added in `cfdeb2ae`, which is in `v2.5.0`. The issue was filed 9½ hours after that landed. So the words were on screen when it was reported.

They were in the `detail` of the write step, and the write step renders `[✓]`. And `SKILL.md` tells whoever reads the report:

> **If every line is `✓`, `·` or `–`, skip to Step 4 and validate.** The manual sections below exist for the `⚠` lines only.

**The one fact that decides whether this install works for anyone but the person running it sat in the one place the documented reading protocol says to ignore.** The reader was following instructions.

That is worth stating plainly because it generalises: a caveat attached to a success line is not a caveat. We tell readers to skip those lines, and we are right to — the alternative is reading every line of every install.

## The trap I nearly walked into

The obvious fix is to make the token step a `NOTICE`. That would have been a regression, and a silent one:

```ts
// run.ts:603
for (const s of plan.steps) {
  if (s.status !== StepStatus.APPLY) continue;   // ← a NOTICE never writes
  const write = s.write;
```

Demoting the step stops it writing the token entirely — turning "install works only on this machine" into "install works on no machine", while the report looks *more* informative. Caught by the test asserting the step is still `APPLY`.

## What it does instead

A separate `NOTICE` beside the write — the shape `unverifiedUiLibraryNote` already uses:

```
  [✓] Pairing token → .env.development.local
      set REACT_APP_RETICLE_TOKEN (the only channel CRA inlines) — …
  [i] Pairing token is per-machine → .env.development.local
      .env.development.local is in CRA's own .gitignore, so the token just written does not travel.
      It works on THIS machine and nowhere else: a teammate cloning the repo, CI, or a container
      gets an app that boots, never pairs, and reports it only in the browser console.
      Each developer runs `npx reticle init` once locally.
```

`NOTICE` prints in full and is **not** counted as applied, so it cannot inflate the "init applied something" count.

It names the **consequence** rather than the mechanism. "This file is gitignored" is a fact about a file; "a clone boots and never pairs, and only says so in the browser console" is the thing the reader needs.

Suppressed when there was no token to write — nothing was written, so there is nothing per-machine to warn about. That case already has its own `MANUAL` step.

## Tests

Two added; one RED before the change. The other pins the suppression case.

The RED one also asserts the step remains `APPLY`, which is what makes the trap above impossible to reintroduce.

## Verification

`pnpm lint && pnpm typecheck && pnpm test:unit` green: 2997 server, 828 browser. Plus `prettier --check`, which caught this branch before CI did — it is not in the documented gate, and that gap is worth closing separately (see the note on #190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
