### PR TITLE
fix(sessions): omit a blank title instead of shipping an empty string

### DIFF
--- a/packages/server/src/session/session-info.test.ts
+++ b/packages/server/src/session/session-info.test.ts
@@ -1,0 +1,58 @@
+/**
+ * An empty `title` is the worst answer this projection can give.
+ *
+ * Measured across three fixtures: two tabs reported "Rowy" and "Next.js Playground"; the astro one
+ * reported `""`. `title` is the field an agent and the HUD use to tell tabs apart, and `""` is not
+ * `null` — so "we sampled before the page set one" is indistinguishable from "this page is genuinely
+ * untitled", and with two such tabs the list is unusable.
+ *
+ * Sampling later does not fix it. `#hello()` already reads `document.title` at connect time, and a
+ * page that sets its title after connect (or never) will still hand us an empty string — a race
+ * cannot be won by moving the sample, only narrowed. So the fix is at the projection: never ship the
+ * empty string, and let the consumer fall back to `url`, which is in the same record already.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildSessionInfo } from './session-info.js';
+import { UNSCRIPTABLE_TAB_RECOMMENDATION } from '@reticlehq/core';
+
+const view = (title: string) => ({
+  id: 's1',
+  url: 'http://localhost:4321/docs/intro',
+  projectId: undefined,
+  title,
+  adapters: [],
+  hasCapabilities: false,
+  versionSkew: undefined,
+  hidden: false,
+  health: () => ({
+    lastSeenMs: 10,
+    throttled: false,
+    focused: true,
+    recommendation: UNSCRIPTABLE_TAB_RECOMMENDATION,
+  }),
+  staleMs: () => 0,
+  pendingMarkCount: () => 0,
+});
+
+describe('buildSessionInfo — title', () => {
+  it('passes a real title through untouched', () => {
+    expect(buildSessionInfo(view('Rowy')).title).toBe('Rowy');
+  });
+
+  it('OMITS the field rather than shipping an empty string', () => {
+    const info = buildSessionInfo(view(''));
+    expect(
+      'title' in info,
+      '"" cannot be told apart from "genuinely untitled" — omit it and let the reader use url',
+    ).toBe(false);
+  });
+
+  it('omits a whitespace-only title too — it is as useless as an empty one', () => {
+    expect('title' in buildSessionInfo(view('   '))).toBe(false);
+  });
+
+  it('still carries url, which is what a reader falls back to', () => {
+    expect(buildSessionInfo(view('')).url).toBe('http://localhost:4321/docs/intro');
+  });
+});

--- a/packages/server/src/session/session-info.ts
+++ b/packages/server/src/session/session-info.ts
@@ -13,7 +13,8 @@ export interface SessionInfo {
   url: string;
   /** Stable build-stamped project identity; absent for v1.0 SDKs that don't send it. */
   projectId?: string;
-  title: string;
+  /** Absent when the page has no title — never the empty string. Fall back to `url`. */
+  title?: string;
   adapters: string[];
   hasCapabilities: boolean;
   /** Present only when the page's SDK version differs from the daemon's — see version-skew.ts. */
@@ -60,7 +61,11 @@ export function buildSessionInfo(session: SessionView): SessionInfo {
     sessionId: session.id,
     url: session.url,
     ...(session.projectId === undefined ? {} : { projectId: session.projectId }),
-    title: session.title,
+    // Omitted when blank, never `""`. An empty title cannot be told apart from "we sampled before
+    // the page set one", and two such tabs make the listing unusable. Moving the sample later does
+    // not fix it — a page may set its title after connect, or never — so the projection refuses the
+    // bad answer and the reader falls back to `url`, which is right here in the same record.
+    ...('' === session.title.trim() ? {} : { title: session.title }),
     adapters: session.adapters,
     hasCapabilities: session.hasCapabilities,
     // On every listing, not buried in a log — skew explains failures that read as app bugs.


### PR DESCRIPTION
Closes #113.

## The measurement

```json
{"sessionId":"s1bdccddf-…","url":"http://localhost:7699/auth?redirect=%2F","title":"Rowy"}
{"sessionId":"sa3e11065-…","url":"http://localhost:3100/","title":"Next.js Playground"}
{"sessionId":"s4a795666-…","url":"http://localhost:4321/","title":""}          ← astro
```

`title` is what an agent and the HUD use to tell tabs apart. `""` is the worst answer available: it is not `null`, so *"we sampled before the page set one"* is indistinguishable from *"this page is genuinely untitled"* — and with two such tabs the listing is unusable.

## Why not the fix the issue proposes

> Read `document.title` again at HELLO time rather than at SDK construction — the astro page has a title moments later; we sample too early.

`#hello()` (`reticle.ts:487`) **already** reads `document.title` at HELLO time, not at construction. And a page that sets its title *after* connect — or never — still hands us an empty string.

**A race cannot be won by moving the sample, only narrowed.** So this takes the issue's second suggestion, which is deterministic:

> If it is still empty, omit the field or send `null`, and let the consumer fall back to the URL path. **Do not ship `""`.**

## The change

One line in `buildSessionInfo` — the single place every listing routes through, so there is no wire change and no per-caller patch:

```ts
...('' === session.title.trim() ? {} : { title: session.title }),
```

Whitespace-only is treated as blank too: `"   "` is exactly as useless for telling two tabs apart, and a page with a stray `<title> </title>` is not meaningfully titled.

`SessionInfo.title` becomes optional, which is the honest type — **absent means the page has no usable title**, and the reader falls back to `url`, which is right there in the same record.

## Why the projection and not the wire

The browser-side `HelloMessage.title` stays `string`. That is the SDK reporting what `document.title` literally was, which is true and occasionally useful. The projection is where "what should the agent see about this tab" decisions belong — the module docblock says exactly that — and it is the layer that can afford an opinion.

## Tests

New `session-info.test.ts` — the module had none. Two RED before the change, two pinning what must not regress (a real title passes through untouched; `url` still present as the fallback).

## Verification

`pnpm lint && pnpm typecheck && pnpm test:unit` green: 2999 server, 828 browser. Plus `prettier --check`.

`yoda` caught `session.title.trim() === ''` on the first pass — literal on the left, as the repo's rule requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
