### PR TITLE
fix(predicate): a rejection is a sentence, never a serialized zod array

### DIFF
--- a/packages/server/src/events/predicate-parse.test.ts
+++ b/packages/server/src/events/predicate-parse.test.ts
@@ -1,0 +1,61 @@
+/**
+ * A raw zod array must never reach the agent.
+ *
+ * Measured on 2026-08-10: **9 of the 58 tool errors recorded that day — 16% — were a serialized zod
+ * issue array**, and every one landed on `reticle_act_and_wait` (4), `reticle_wait_for` (4) or
+ * `reticle_assert` (1). Those are precisely the three tools that produced every action-derived
+ * finding in the dataset, so the least readable error we emit lands on the highest-value path.
+ *
+ * What the agent got, redacted by the telemetry pipeline:
+ *
+ *   [ { *: *, *: [ * ], *: [], *: * } ]
+ *
+ * Unredacted it is `[{"code":"invalid_type","expected":"object","path":[],"message":"..."}]` — an
+ * agent has to JSON.parse an error string to learn which field it got wrong, and it spends tokens on
+ * a structure nobody reads. #108 asks for one shape across all argument mistakes: a sentence naming
+ * the parameter, whether anything ran, and a valid example.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parsePredicate } from './predicate-parse.js';
+
+const messageOf = (input: unknown): string => {
+  try {
+    parsePredicate(input);
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error('expected parsePredicate to reject');
+};
+
+describe('parsePredicate turns a zod rejection into a sentence', () => {
+  it('never emits a JSON array', () => {
+    const message = messageOf({ kind: 'route', pathnmae: '/checkout' });
+    expect(message.trimStart().startsWith('['), `got a raw dump: ${message}`).toBe(false);
+    expect(message).not.toContain('"code"');
+    expect(message).not.toContain('invalid_type');
+  });
+
+  it('names the offending key so the agent knows what to change', () => {
+    expect(messageOf({ kind: 'route', pathnmae: '/checkout' })).toContain('pathnmae');
+  });
+
+  it('names the kind it was trying to parse', () => {
+    expect(messageOf({ kind: 'route', pathnmae: '/x' })).toContain('route');
+  });
+
+  it('says nothing ran, because an argument rejection means exactly that', () => {
+    expect(messageOf({ kind: 'signal', naem: 'x' })).toMatch(/nothing ran|was not evaluated/i);
+  });
+
+  it('carries a valid example the agent can copy', () => {
+    expect(messageOf({ kind: 'nope' })).toContain('kind');
+  });
+
+  it('still parses a good predicate untouched, aliases included', () => {
+    expect(parsePredicate({ kind: 'route', path: '/checkout' })).toMatchObject({
+      kind: 'route',
+      pathname: '/checkout',
+    });
+  });
+});

--- a/packages/server/src/events/predicate-parse.ts
+++ b/packages/server/src/events/predicate-parse.ts
@@ -1,0 +1,61 @@
+/**
+ * One readable sentence when a predicate does not parse — never the zod array.
+ *
+ * Measured 2026-08-10: **9 of 58 tool errors that day were a serialized zod issue array**, all on
+ * `reticle_act_and_wait`, `reticle_wait_for` and `reticle_assert` — the three tools that produced
+ * every action-derived finding in the dataset. The least readable error we emit was landing on the
+ * highest-value path, and an agent had to `JSON.parse` an error string to learn which field it got
+ * wrong.
+ *
+ * `PredicateSchema.parse()` throws a `ZodError` whose `.message` IS that array, and three handlers
+ * call it directly. This wraps it once, so every caller gets the same shape rather than each
+ * growing its own catch — the pattern #108 asks for: name the parameter, say whether anything ran,
+ * show a valid call.
+ */
+
+import { z } from 'zod';
+import { PredicateSchema } from './predicate-eval.js';
+
+/** A valid call, short enough to sit inside an error without becoming the error. */
+const EXAMPLE = '{ kind: "signal", name: "todos:loaded" }';
+
+/** `path: ["net","urlContains"]` → `net.urlContains`; an empty path means the object itself. */
+function pathOf(issue: z.ZodIssue): string {
+  return 0 === issue.path.length ? 'the predicate' : issue.path.map(String).join('.');
+}
+
+/**
+ * One issue, as a clause a human or an agent can act on.
+ *
+ * `unrecognized_keys` is the common case by far and the one worth spelling out — it is what a
+ * plausible-but-wrong field name produces, and the key itself is the whole answer.
+ */
+function describeIssue(issue: z.ZodIssue): string {
+  if (z.ZodIssueCode.unrecognized_keys === issue.code) {
+    return `unknown field ${issue.keys.join(', ')}`;
+  }
+  return `${pathOf(issue)}: ${issue.message}`;
+}
+
+/**
+ * Parse a predicate, or throw an Error whose message is a sentence.
+ *
+ * Deliberately still THROWS: every call site already handles a throw, and turning this into a
+ * result type would mean touching three handlers to gain nothing the message does not already say.
+ */
+export function parsePredicate(input: unknown): z.infer<typeof PredicateSchema> {
+  const parsed = PredicateSchema.safeParse(input);
+  if (parsed.success) return parsed.data;
+  const kind =
+    'object' === typeof input && null !== input && 'kind' in input
+      ? String((input as Record<string, unknown>)['kind'])
+      : 'unknown';
+  // Bounded on purpose: a union rejection can produce one issue per member, and pasting all of them
+  // back is how the zod array became unreadable in the first place.
+  const issues = parsed.error.issues.slice(0, 3).map(describeIssue).join('; ');
+  throw new Error(
+    `that predicate did not parse (kind "${kind}"): ${issues}. Nothing ran — the predicate was ` +
+      `not evaluated, so no verdict was produced. Call reticle_tools for the fields this kind ` +
+      `accepts. A valid call looks like: ${EXAMPLE}`,
+  );
+}

--- a/packages/server/src/tools/act-tools.ts
+++ b/packages/server/src/tools/act-tools.ts
@@ -19,6 +19,7 @@ import { assertNativeInputSupported } from './act-danger.js';
 import { leanActResult, mutatedWithin } from './act-view.js';
 import { ReticleTool } from './tool-names.js';
 import { buildReactionReport, summarizeReaction } from '../events/reaction.js';
+import { parsePredicate } from '../events/predicate-parse.js';
 import { causalSummary } from '../capsule/causal-summary.js';
 import { findContradictions } from '../events/contradictions.js';
 import { decideVerified } from '../honesty/verified.js';
@@ -405,7 +406,7 @@ export const ACT_TOOLS: ToolDef[] = [
       const withUntil = aliasParam(args, 'until', ['predicate']);
       const until =
         withUntil['until'] !== undefined
-          ? PredicateSchema.parse(withUntil['until'])
+          ? parsePredicate(withUntil['until'])
           : ({ kind: PredicateKind.SETTLED } as const);
       const timeout = asNumber(args['timeout_ms']) ?? DEFAULT_ASSERT_TIMEOUT_MS;
 

--- a/packages/server/src/tools/error-recovery.test.ts
+++ b/packages/server/src/tools/error-recovery.test.ts
@@ -498,3 +498,34 @@ describe('a refusal that already lists the live sessions is left alone', () => {
     expect(recoveryFor("no connected session with id 'ghost'")).toBe(RECOVERY.UNKNOWN_SESSION);
   });
 });
+
+/**
+ * A malformed predicate is the AGENT'S mistake, and must never be dressed as a Reticle defect.
+ *
+ * `ARGUMENT_REJECTION` keys on the shapes our validators produce. When `parsePredicate` replaced the
+ * raw zod array with a sentence, it removed the very codes (`invalid_type`, `unrecognized_keys`)
+ * that pattern matched — so a bad predicate fell through to the generic branch and came back as
+ * "may be a defect in Reticle", with a request for a bug report.
+ *
+ * That is worse than the dump it replaced: it spends the agent's turn and pollutes the feedback
+ * channel with reports about malformed calls. The e2e battery caught it — `no bad argument is
+ * blamed on Reticle`, on `reticle_wait_for/empty` and `reticle_assert/empty` — after a full unit
+ * gate had passed. This is that check, in the gate that runs in seconds.
+ */
+describe('a predicate that did not parse is the agent to fix, not a Reticle bug', () => {
+  const REAL_MESSAGE =
+    'that predicate did not parse (kind "route"): unknown field pathnmae. Nothing ran — the ' +
+    'predicate was not evaluated, so no verdict was produced.';
+
+  it('gets the schema-rejection recovery', () => {
+    const payload = buildErrorPayload(REAL_MESSAGE);
+    expect(String(payload.recovery)).toContain("did not match the tool's schema");
+    expect(String(payload.recovery)).toContain('Nothing ran');
+  });
+
+  it("does not invite a bug report about the agent's own call", () => {
+    expect(JSON.stringify(buildErrorPayload(REAL_MESSAGE))).not.toMatch(
+      /defect in Reticle|report this/i,
+    );
+  });
+});

--- a/packages/server/src/tools/error-recovery.ts
+++ b/packages/server/src/tools/error-recovery.ts
@@ -240,9 +240,15 @@ export function recoveryFor(message: string): string | undefined {
  *
  * Matched by the SHAPES the validators actually produce (zod's codes, and the MCP layer's wrapper),
  * because these are our own machinery talking, not the app.
+ *
+ * `did not parse` is the shape `parsePredicate` produces. It was added because removing the raw zod
+ * array from that path ALSO removed the codes this pattern keys on — so a malformed predicate
+ * stopped being recognised as the agent's mistake and started being blamed on Reticle, complete with
+ * a request for a bug report. The e2e battery caught it (`no bad argument is blamed on Reticle`);
+ * no unit test could, which is why one now exists below.
  */
 const ARGUMENT_REJECTION =
-  /Unrecognized key|unrecognized_keys|invalid_type|Invalid arguments for tool|Unknown parameters? for|^Required |Expected \w+, received/i;
+  /Unrecognized key|unrecognized_keys|invalid_type|did not parse|Invalid arguments for tool|Unknown parameters? for|^Required |Expected \w+, received/i;
 
 /**
  * What to say instead of asking for a bug report. The schema already stated the problem precisely;

--- a/packages/server/src/tools/observe-tools.ts
+++ b/packages/server/src/tools/observe-tools.ts
@@ -15,6 +15,7 @@ import { ReticleTool } from './tool-names.js';
 import { buildReactionReport } from '../events/reaction.js';
 import { findContradictions } from '../events/contradictions.js';
 import { evaluatePredicate, waitForPredicate, PredicateSchema } from '../events/predicate.js';
+import { parsePredicate } from '../events/predicate-parse.js';
 import {
   matchNet,
   matchConsole,
@@ -305,9 +306,7 @@ export const OBSERVE_TOOLS: ToolDef[] = [
     handler: async (deps, args) => {
       const session = deps.sessions.resolve(asString(args['sessionId']));
       // `until` is act_and_wait's name for this — see alias-args.ts.
-      const predicate = PredicateSchema.parse(
-        aliasParam(args, 'predicate', ['until'])['predicate'],
-      );
+      const predicate = parsePredicate(aliasParam(args, 'predicate', ['until'])['predicate']);
       // Honesty: explicit since wins; else default to the last act's cursor; else the whole buffer.
       const since = asNumber(args['since']) ?? session.lastAct.cursor() ?? 0;
       const verdict = await waitForPredicate(
@@ -414,9 +413,7 @@ export const OBSERVE_TOOLS: ToolDef[] = [
     handler: async (deps, args) => {
       const session = deps.sessions.resolve(asString(args['sessionId']));
       // `until` is act_and_wait's name for this — see alias-args.ts.
-      const predicate = PredicateSchema.parse(
-        aliasParam(args, 'predicate', ['until'])['predicate'],
-      );
+      const predicate = parsePredicate(aliasParam(args, 'predicate', ['until'])['predicate']);
       const timeout = asNumber(args['timeout_ms']) ?? 0;
       // Honesty: explicit since wins; else default to the last act's cursor; else the whole buffer.
       const since = asNumber(args['since']) ?? session.lastAct.cursor() ?? 0;


### PR DESCRIPTION
Covers **shape 2** of #108.

## The telemetry backs this one hard

From the 2026-08-10 export — **9 of the 58 tool errors recorded that day, 16%, were a raw zod issue array**:

| tool | occurrences |
|---|---|
| `reticle_act_and_wait` | 4 |
| `reticle_wait_for` | 4 |
| `reticle_assert` | 1 |

Those are **exactly the three tools that produced every action-derived finding in the dataset**. The least readable error we emit was landing on the highest-value path in the product.

What the agent received, as the telemetry pipeline redacted it:

```
[ { *: *, *: [ * ], *: [], *: * } ]
```

Unredacted: `[{"code":"invalid_type","expected":"object","path":[],"message":"…"}]`. An agent had to `JSON.parse` an error string to find out which field it got wrong, and paid tokens for a structure nobody reads.

## Cause

`PredicateSchema.parse()` throws a `ZodError` whose `.message` **is** that array, and three handlers call it directly (`observe-tools.ts:308`, `:417`, `act-tools.ts:408`). Nothing between there and the wire reshapes it.

## The change

One wrapper, `parsePredicate`, used by all three — so the shape is fixed once rather than each handler growing its own catch:

```
that predicate did not parse (kind "route"): unknown field pathnmae. Nothing ran — the predicate
was not evaluated, so no verdict was produced. Call reticle_tools for the fields this kind accepts.
A valid call looks like: { kind: "signal", name: "todos:loaded" }
```

That is the shape #108 asks for: **name the parameter, state whether anything ran, show a valid example.**

Two deliberate details:

- **`unrecognized_keys` is spelled out specially.** It is the common case by far — what a plausible-but-wrong field name produces — and the key itself is the entire answer.
- **The issue list is capped at three.** A union rejection emits one issue per member; pasting all of them back is precisely how the zod array became unreadable in the first place. Fixing verbosity with different verbosity would be no fix.

It still **throws**, rather than becoming a result type: every call site already handles a throw, and changing that would mean touching three handlers to gain nothing the message does not already carry.

## Scope

**Shape 3 of #108 — the MCP-boundary validation dump — is PR #182's**, at a different layer (`mcp/mcp.ts`, closing #109). Left alone rather than solved twice in two places. Shape 1 was already correct and is what both are converging on.

## Tests

Six, RED before the helper existed. They assert the negative directly — the message must not start with `[`, must not contain `"code"` or `invalid_type` — because "is it readable" is otherwise a matter of opinion, and one that drifts.

## A note on the gate

`tsc` caught `z.core.$ZodIssue` in my first draft: this repo is on **zod v3**, where that namespace does not exist. `vitest` passed all 775 tests against the broken types, because it does not typecheck. Worth remembering that green tests are not a green build here.

## Verification

`pnpm lint && pnpm typecheck && pnpm test:unit` green: 3005 server, 828 browser. Plus `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
