### PR TITLE
test(cli): every reticle command we suggest must be one we dispatch

### DIFF
--- a/packages/server/src/cli/doctor-daemon-line.ts
+++ b/packages/server/src/cli/doctor-daemon-line.ts
@@ -30,7 +30,7 @@ export interface DaemonLine {
 }
 
 const FIX =
-  'Restart it so both ends are the same build: `reticle kill` then let your agent reconnect.';
+  'Restart it so both ends are the same build: `reticle stop`, then let your agent reconnect.';
 
 /**
  * Build the daemon line for a port that answered `/status`.

--- a/packages/server/src/cli/suggested-commands-exist.test.ts
+++ b/packages/server/src/cli/suggested-commands-exist.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Every `reticle <verb>` we suggest to a human must be a verb we dispatch.
+ *
+ * I shipped one that was not. The version-skew line in `doctor` told the reader to run
+ * `reticle kill` — a PROPOSAL (#114), described accurately as a gap in `docs/system-map.md`, which I
+ * read as if it shipped. It reached `main` in #190 before anyone noticed.
+ *
+ * That failure is not specific to one string. Every one of these messages is written by someone
+ * reading the codebase, and the codebase contains proposals, retired verbs, and a second CLI —
+ * so "a plausible verb" and "a real verb" are easy to confuse. `doctor`, `status` and the install
+ * report are also precisely the surfaces a human reads *while already stuck*, where a command that
+ * errors is a second dead end on top of the first.
+ *
+ * The verb set comes from `knownCommand()` — the parser's own union of local and cloud verbs — not
+ * a list copied into this file. A copied list is the same mistake one level up: it would go stale,
+ * and a stale allow-list fails green.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { knownCommand } from './cli-parse.js';
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * A backticked span that LOOKS like a command line.
+ *
+ * The closing backtick alone cannot separate advice from prose, because in TypeScript a backtick is
+ * also a string delimiter: `` `reticle daemon did not become ready on port ${port}` `` is a template
+ * literal, not a suggestion. An earlier draft flagged two of those, and a guard that cries wolf is
+ * one people learn to ignore — worse than no guard.
+ *
+ * So the discriminator is SHAPE: after the verb, a real suggestion contains only command tokens —
+ * flags, placeholders, simple paths. Prose brings `${...}`, punctuation and sentences, and fails.
+ * Backslashes are stripped first, because inside a template literal the markdown backticks are
+ * escaped (`` \`reticle serve\` ``) and the true positive I was hunting hides behind exactly that.
+ */
+const SUGGESTION = /`reticle ([a-z][a-z-]*)([^`]*)`/g;
+const COMMANDLIKE = /^(?:\s+(?:--?[a-z][a-z-]*|<[a-z-]+>|[a-z0-9./@:-]+))*$/;
+
+/** A comment is a note to a maintainer, not an instruction to a user. */
+const IS_COMMENT = /^\s*(?:\/\/|\*|\/\*)/;
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if ('node_modules' === entry || 'dist' === entry) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...sourceFiles(full));
+    else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) out.push(full);
+  }
+  return out;
+}
+
+describe('every reticle command we suggest is a command we dispatch', () => {
+  const files = sourceFiles(SRC);
+
+  it('finds source to scan (a guard over zero files proves nothing)', () => {
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  it('names no verb the parser would call unknown', () => {
+    const bad: string[] = [];
+    for (const file of files) {
+      for (const raw of readFileSync(file, 'utf8').split('\n')) {
+        if (IS_COMMENT.test(raw)) continue;
+        const line = raw.replaceAll('\\', '');
+        for (const match of line.matchAll(SUGGESTION)) {
+          const verb = match[1] ?? '';
+          if (!COMMANDLIKE.test(match[2] ?? '')) continue; // prose, not advice
+          if ('unknown' === knownCommand(verb)) bad.push(`${file.slice(SRC.length + 1)}: ${verb}`);
+        }
+      }
+    }
+    expect(
+      [...new Set(bad)],
+      'these strings tell a human to run a command this CLI does not dispatch',
+    ).toEqual([]);
+  });
+});

--- a/packages/server/src/init/plan-framework.ts
+++ b/packages/server/src/init/plan-framework.ts
@@ -284,7 +284,10 @@ export function craSteps(input: PlanInput): Step[] {
       title: 'Pairing token',
       target: CRA_ENV_PATH,
       status: StepStatus.MANUAL,
-      detail: `no pairing token yet — run \`reticle start\`, then \`reticle init\` again to write ${TOKEN_VAR}`,
+      // `reticle serve`, not `reticle start` — the latter is not a verb this CLI dispatches, and
+      // this message is read by someone whose app boots and never pairs. Handing them a command
+      // that errors is a second dead end on the first.
+      detail: `no pairing token yet — the daemon writes one on first run. Start it with \`reticle serve\` (or let your agent run \`reticle mcp\`), then \`reticle init\` again to write ${TOKEN_VAR}`,
     });
   }
   if (null === entry) {

--- a/packages/server/src/init/plan.test.ts
+++ b/packages/server/src/init/plan.test.ts
@@ -333,7 +333,10 @@ describe('buildPlan — CRA pairing token', () => {
     // omit the step: init read all-green and the app could never pair.
     const missing = maybeStep(craPlan({ pairingToken: '' }), TOKEN_STEP);
     expect(StepStatus.MANUAL).toBe(missing?.status);
-    expect(missing?.detail).toContain('reticle start');
+    // Was `reticle start`, which this CLI does not dispatch — the test pinned the wrong command and
+    // so kept it alive. `reticle serve` is the verb that starts a daemon; see
+    // suggested-commands-exist.test.ts, which now catches the class rather than this instance.
+    expect(missing?.detail).toContain('reticle serve');
   });
 
   it('stays quiet when the correct token is already in the env file', () => {


### PR DESCRIPTION
Generalises the fix in #195, and **found a second, older instance of the same bug.**

## Why a guard and not just a string fix

I shipped `reticle kill` in #190 — a proposal (#114), described accurately as a gap in `docs/system-map.md`, which I read as though it existed. #195 fixes that one string. But the failure is not specific to it: these messages are written by people reading a codebase that contains proposals, retired verbs, and **a second CLI**, so "a plausible verb" and "a real verb" are genuinely easy to confuse.

## What it found

```
× names no verb the parser would call unknown
  → "cli/doctor-daemon-line.ts: kill"          ← mine, #195
  → "init/plan-framework.ts: start"            ← older, and worse placed
```

**`reticle start` is not a verb either.** It is in the CRA no-token step — the message read by someone whose *app boots and never pairs*. So the remedy for a silent failure was itself a dead end.

Now: `` no pairing token yet — the daemon writes one on first run. Start it with `reticle serve` (or let your agent run `reticle mcp`), then `reticle init` again … ``

**An existing test asserted the detail contained `'reticle start'`.** The test pinned the wrong command and kept it alive — updated to assert a real one.

## Source of truth

The verb set comes from `knownCommand()` — the parser's own union of local and cloud verbs — not a list copied into the test. A copied list is the same mistake one level up: it goes stale, and a stale allow-list fails green.

That distinction mattered here. My first instinct was to hardcode the local verbs, which would have false-positived on `login`, `link`, `project`, `whoami` and `push` — 27 references to a **cloud CLI** (`cloud-cli.ts`) that dispatches before the local parser.

## Two wrong matchers, recorded because they are instructive

1. **Bare backtick** → flagged prose (`reticle daemon did not become ready…`, `reticle already registered with…`). A guard that cries wolf is one people learn to ignore — worse than no guard.
2. **Require a closing backtick** → *missed the real bug*. In TypeScript a backtick is a string delimiter, so the markdown backticks inside a template literal are escaped (`` \`reticle start\` ``) and the true positive hid behind exactly that.

The rule that works is **shape**: strip backslashes, then require what follows the verb to be command tokens — flags, placeholders, simple paths. `daemon did not become ready on port ${port}` fails; `init --app frontend` passes.

Comments are skipped: a note to a maintainer is not an instruction to a user.

## Verification

`pnpm lint && pnpm typecheck && pnpm test:unit` green: 3005 server, 828 browser. Plus `prettier --check`.

Includes the `reticle kill` → `reticle stop` fix so this branch is green standalone; #195 can merge first or be closed in favour of this, either is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
