### PR TITLE
fix(animations): every row names the element it drives

### DIFF
--- a/packages/browser/src/commands/animations-target.test.ts
+++ b/packages/browser/src/commands/animations-target.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Nine concurrent animations came back as nine indistinguishable objects.
+ *
+ * Reported from the field, diagnosed to the line by the reporter:
+ *
+ * > `reticle_animations` advertises 'targets/timing' but the payload carries no target.
+ * > `listAnimations()` reads `a.effect` only for `getTiming()` and never reads
+ * > `(effect as KeyframeEffect).target`, so a page with nine concurrent animations returns nine
+ * > indistinguishable `{playState, currentTime, duration}` rows with no way to tell which element
+ * > each belongs to.
+ *
+ * A list you cannot index is not a list. The tool's whole purpose is answering "is THAT thing still
+ * animating", and every row was identical shape with nothing naming the subject.
+ */
+
+import { describe as vitestDescribe, expect, it, beforeEach } from 'vitest';
+import { createCommandRegistry } from './commands.js';
+import { ReticleCommand } from '@reticlehq/core';
+
+type Handler = (args: Record<string, unknown>) => unknown;
+
+function animationsHandler(): Handler {
+  const handler = createCommandRegistry().get(ReticleCommand.ANIMATIONS);
+  if (handler === undefined) throw new Error('ANIMATIONS command is not registered');
+  return handler;
+}
+
+/** A fake Animation whose effect targets a real element, the way KeyframeEffect does. */
+function fakeAnimation(target: Element | null, playState: string): Animation {
+  return {
+    playState,
+    currentTime: 100,
+    effect: {
+      target,
+      getTiming: () => ({ duration: 300 }),
+    },
+  } as unknown as Animation;
+}
+
+vitestDescribe('reticle_animations names the element each animation drives', () => {
+  beforeEach(() => {
+    document.body.innerHTML =
+      '<button id="a">Save</button><button id="b">Cancel</button><div id="c"></div>';
+  });
+
+  const rowsFor = (animations: Animation[]): Record<string, unknown>[] => {
+    (document as unknown as { getAnimations: () => Animation[] }).getAnimations = () => animations;
+    const out = animationsHandler()({}) as { animations: Record<string, unknown>[] };
+    return out.animations;
+  };
+
+  it('carries a target descriptor per row', () => {
+    const save = document.getElementById('a');
+    const rows = rowsFor([fakeAnimation(save, 'running')]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.['target'], 'no target — the row names nothing').toBeDefined();
+  });
+
+  it('two animations on two elements are distinguishable', () => {
+    const rows = rowsFor([
+      fakeAnimation(document.getElementById('a'), 'running'),
+      fakeAnimation(document.getElementById('b'), 'running'),
+    ]);
+    const targets = rows.map((r) => JSON.stringify(r['target']));
+    expect(new Set(targets).size, 'both rows describe the same thing').toBe(2);
+  });
+
+  it('the descriptor carries a ref the agent can act on, and the accessible name', () => {
+    const rows = rowsFor([fakeAnimation(document.getElementById('a'), 'running')]);
+    const target = rows[0]?.['target'] as Record<string, unknown> | undefined;
+    expect(target?.['ref'], 'a target you cannot pass to reticle_act is half an answer').toEqual(
+      expect.any(String),
+    );
+    expect(target?.['name']).toBe('Save');
+  });
+
+  it('an effect with no target reports null, not an omitted key', () => {
+    // A KeyframeEffect legitimately can have `target: null`. Omitting the key would make "no target"
+    // look identical to the bug this fixes.
+    const rows = rowsFor([fakeAnimation(null, 'running')]);
+    expect('target' in (rows[0] ?? {})).toBe(true);
+    expect(rows[0]?.['target']).toBeNull();
+  });
+
+  it('still reports the timing it always did', () => {
+    const rows = rowsFor([fakeAnimation(document.getElementById('a'), 'paused')]);
+    expect(rows[0]?.['playState']).toBe('paused');
+    expect(rows[0]?.['duration']).toBe(300);
+  });
+});

--- a/packages/browser/src/commands/commands.ts
+++ b/packages/browser/src/commands/commands.ts
@@ -217,16 +217,34 @@ function readState(
   return result;
 }
 
+/**
+ * Every animation, and WHICH element it drives.
+ *
+ * Reported from the field: a page with nine concurrent animations returned nine indistinguishable
+ * `{playState, currentTime, duration}` rows. `a.effect` was read only for `getTiming()`, never for
+ * its `target` — so the tool advertised "targets/timing" and shipped timing alone. A list you cannot
+ * index is not a list, and the question this tool exists to answer is "is THAT thing still
+ * animating".
+ *
+ * `describe()` is reused rather than inventing a target shape: it is what `reticle_query` returns,
+ * so the descriptor carries a `ref` the agent can pass straight to `reticle_act` — a target you
+ * cannot act on would be half an answer.
+ */
 function listAnimations(): unknown {
   const doc = document as Document & { getAnimations?: () => Animation[] };
   if (typeof doc.getAnimations !== 'function') return { animations: [] };
   const animations = doc.getAnimations().map((a) => {
     const effect = a.effect;
     const timing = effect?.getTiming();
+    // A KeyframeEffect's target is legitimately nullable, and only KeyframeEffect has one at all.
+    // `null` is reported explicitly: omitting the key would make "this animation has no element"
+    // indistinguishable from the bug above, which is the distinction the fix exists to draw.
+    const target = (effect as KeyframeEffect | null)?.target ?? null;
     return {
       playState: a.playState,
       currentTime: a.currentTime,
       duration: timing?.duration,
+      target: null === target ? null : describe(target),
     };
   });
   return { animations };


### PR DESCRIPTION
Closes #166.

## The report

Diagnosed to the line by the reporter, which made this a five-minute fix once verified:

> `reticle_animations` advertises 'targets/timing' but the payload carries no target. `listAnimations()` reads `a.effect` only for `getTiming()` and never reads `(effect as KeyframeEffect).target`, so a page with nine concurrent animations returns nine indistinguishable `{playState, currentTime, duration}` rows with no way to tell which element each belongs to.

Verified still true on `main`. `commands.ts:223`:

```ts
const effect = a.effect;
const timing = effect?.getTiming();
return { playState: a.playState, currentTime: a.currentTime, duration: timing?.duration };
```

**A list you cannot index is not a list.** The question this tool exists to answer is "is *that* thing still animating", and no row named a subject.

## The change

```ts
const target = (effect as KeyframeEffect | null)?.target ?? null;
…
target: null === target ? null : describe(target),
```

Two decisions worth stating:

**Reuse `describe()`, do not invent a target shape.** It is what `reticle_query` returns, so the descriptor carries a **`ref` the agent can pass straight to `reticle_act`** — plus role and accessible name. A target you can read but cannot act on would be half an answer, and a second element-descriptor shape would be a small schism in the surface.

**`null` is explicit, not an omitted key.** A `KeyframeEffect`'s `target` is legitimately nullable, and only `KeyframeEffect` has one at all. Omitting the key would make *"this animation has no element"* indistinguishable from *"this tool does not report targets"* — which is precisely the bug being fixed, reintroduced in a quieter form.

## Tests

The command had **no test file**. Five added, four RED before the change:

```
× carries a target descriptor per row          → expected undefined to be defined
× two animations on two elements are distinguishable → expected 1 to be 2
× the descriptor carries a ref … and the accessible name
× an effect with no target reports null, not an omitted key
```

The fifth passed before and after — timing is still reported — so the change is pinned against regressing what already worked.

The distinguishability test is the one that matters: it asserts two rows are *not equal*, which is the actual complaint. A test that merely checked `target` exists would pass on an implementation that returned the same descriptor for every row.

## Verification

`pnpm lint && pnpm typecheck && pnpm test:unit` green: 3009 server, 833 browser. Plus `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
