### PR TITLE
fix(replay): the anchor settle budget is wall-clock, not an attempt count

### DIFF
--- a/packages/server/src/flows/anchor-settle.test.ts
+++ b/packages/server/src/flows/anchor-settle.test.ts
@@ -79,10 +79,108 @@ describe('resolveQuery — a DOM event ends the wait early', () => {
    */
   it('still spends the full budget when nothing ever happens', async () => {
     const { session, queries } = sessionThatMountsAfter(Number.MAX_SAFE_INTEGER);
-    const result = await resolveQuery(session, { by: 'testid', value: 'x' }, () =>
-      Promise.resolve(),
-    );
+    // The clock is injected and the sleep advances it, because that is what a real 150ms sleep does.
+    // The budget is now wall-clock rather than attempt-counted, so a no-op sleep against a frozen
+    // clock would describe a page that waits for free — which is not a page.
+    let clock = 0;
+    const sleep = (ms: number): Promise<void> => {
+      clock += ms;
+      return Promise.resolve();
+    };
+    const result = await resolveQuery(session, { by: 'testid', value: 'x' }, sleep, () => clock);
     expect(result.refs).toEqual([]);
-    expect(queries(), 'one initial query plus the full retry budget').toBe(8);
+    // Nine, not the old eight. `attempt < 8` starting at 1 gave SEVEN retries — 1050ms, not the
+    // ~1.2s the docblock claimed. The wall-clock bound delivers the budget that was always written
+    // down; the attempt count had been quietly under-spending it by a tick.
+    expect(queries(), 'one initial query plus a full 1200ms of retries at 150ms each').toBe(9);
+    expect(clock, 'and it spent exactly the documented budget').toBe(1200);
+  });
+});
+
+/**
+ * The other half of the same trade, and the one that was wrong.
+ *
+ * Reported from the field, diagnosed precisely:
+ *
+ * > `ANCHOR_SETTLE_ATTEMPTS=8, ANCHOR_SETTLE_DELAY_MS=150`, intended ~1.2s. But settleTick resolves
+ * > on EITHER `session.onEvent` OR the 150ms sleep, whichever fires first. On a page emitting
+ * > continuous events (4 API calls + large form render + CSS transition anim.start/anim.end pairs),
+ * > all 8 attempts are consumed by incoming events in **224–758ms observed**, well before a newly
+ * > routed page mounts its controls.
+ *
+ * The early-return above is right; counting an event-driven tick against the ATTEMPT budget is not.
+ * An event arriving is evidence the page is still working, so it should extend the wait, not spend
+ * it. The result was that cross-route replays drifted `testid_not_found` at 278ms on a budget
+ * documented as 1.2s, while the identical flow passed on a quiet page.
+ *
+ * So the governing bound becomes WALL-CLOCK. The attempt cap survives only as a backstop against a
+ * pathological event storm spinning the loop; it is no longer what decides when to give up.
+ *
+ * Note what is asserted: the number of QUERY calls and the fact of termination — never an elapsed
+ * duration. Per CLAUDE.md, if the property is "the cost is bounded", assert the bound. The clock is
+ * injected, so this is deterministic and instant.
+ */
+describe('resolveQuery — an event extends the wait, it does not spend the budget', () => {
+  /** A page that never stops emitting: every tick is ended by an event, never by the sleep. */
+  function chattySession(appearAfter: number): {
+    session: FlowReplaySession;
+    queries: () => number;
+  } {
+    let queries = 0;
+    let onEvt: ((e: ReticleEvent) => void) | undefined;
+    const session: FlowReplaySession = {
+      command: (): Promise<CommandResult> => {
+        queries += 1;
+        const refs = queries > appearAfter ? [{ ref: 'e1' }] : [];
+        // The page is busy: something fires the moment anyone starts listening.
+        queueMicrotask(() => onEvt?.({} as ReticleEvent));
+        return Promise.resolve({
+          kind: 'command_result',
+          id: 'x',
+          ok: true,
+          result: { elements: refs },
+        } as unknown as CommandResult);
+      },
+      eventsSince: () => [],
+      onEvent: (l) => {
+        onEvt = l;
+        return () => {
+          onEvt = undefined;
+        };
+      },
+      elapsed: () => 0,
+    };
+    return { session, queries: () => queries };
+  }
+
+  it('keeps looking past 8 attempts while the clock says there is budget left', async () => {
+    // Mounts late — after more attempts than the old cap allowed.
+    const { session, queries } = chattySession(12);
+    // The clock never moves, because on a chatty page it barely does: every tick is ended by an
+    // event within a millisecond or two, not by the 150ms sleep. That is the whole reported bug —
+    // 8 attempts consumed in 224ms — so a frozen clock is the faithful model of it.
+    const FROZEN = 0;
+    const sleep = (): Promise<void> => Promise.resolve();
+    const result = await resolveQuery(session, { by: 'testid', value: 'x' }, sleep, () => FROZEN);
+
+    expect(
+      result.refs,
+      'gave up before the anchor mounted — the attempt budget was spent by events, not by waiting',
+    ).toEqual(['e1']);
+    expect(queries(), 'the old cap stopped at 8 queries').toBeGreaterThan(8);
+  });
+
+  it('still terminates when the clock runs out, even if events never stop', async () => {
+    const { session, queries } = chattySession(Number.MAX_SAFE_INTEGER);
+    let clock = 0;
+    // Each tick advances the injected clock, so the wall-clock budget is what ends this.
+    const sleep = (): Promise<void> => {
+      clock += 150;
+      return Promise.resolve();
+    };
+    const result = await resolveQuery(session, { by: 'testid', value: 'x' }, sleep, () => clock);
+
+    expect(result.refs).toEqual([]);
+    expect(queries(), 'it must stop — a runaway loop is worse than a false drift').toBeLessThan(50);
   });
 });

--- a/packages/server/src/flows/flow-replay.ts
+++ b/packages/server/src/flows/flow-replay.ts
@@ -120,6 +120,22 @@ export function nearestTestid(missing: string, present: string[]): string | null
  */
 const ANCHOR_SETTLE_ATTEMPTS = 8;
 const ANCHOR_SETTLE_DELAY_MS = 150;
+/**
+ * The budget that actually governs, in wall-clock milliseconds.
+ *
+ * Attempts were the bound, and on an event-chatty page that collapsed. `settleTick` ends on EITHER
+ * an event OR the tick, so a page emitting continuously (API calls, a large form render, CSS
+ * transition start/end pairs) burned all eight attempts in **224–758ms measured** — a budget
+ * documented as 1.2s, spent in a fifth of it, before a newly routed page had mounted its controls.
+ * Cross-route replays drifted `testid_not_found` at 278ms while the same flow passed on a quiet page.
+ *
+ * An event arriving is evidence the page is still working. It should EXTEND the wait, not spend it.
+ * So the deadline decides when to give up, and the attempt cap below survives only as a backstop
+ * against a pathological storm spinning this loop hot.
+ */
+const ANCHOR_SETTLE_BUDGET_MS = ANCHOR_SETTLE_ATTEMPTS * ANCHOR_SETTLE_DELAY_MS;
+/** Backstop only. Generous on purpose: the deadline is the real bound, this just prevents a spin. */
+const ANCHOR_SETTLE_MAX_ATTEMPTS = 40;
 
 /** Injected sleeper so tests drive replay with a no-op clock; production waits on a real timer. */
 export type Sleep = (ms: number) => Promise<void>;
@@ -224,9 +240,15 @@ export async function resolveQuery(
   session: FlowReplaySession,
   queryArgs: Record<string, unknown>,
   sleep: Sleep,
+  now: () => number = Date.now,
 ): Promise<{ refs: string[]; hint?: QueryEmptyHint }> {
   let last = readQuery(await session.command(ReticleCommand.QUERY, queryArgs));
-  for (let attempt = 1; 0 === last.refs.length && attempt < ANCHOR_SETTLE_ATTEMPTS; attempt += 1) {
+  const deadline = now() + ANCHOR_SETTLE_BUDGET_MS;
+  for (
+    let attempt = 1;
+    0 === last.refs.length && now() < deadline && attempt < ANCHOR_SETTLE_MAX_ATTEMPTS;
+    attempt += 1
+  ) {
     await settleTick(session, sleep);
     last = readQuery(await session.command(ReticleCommand.QUERY, queryArgs));
   }


### PR DESCRIPTION
Closes #163.

## The report, and it was exactly right

> `ANCHOR_SETTLE_ATTEMPTS=8, ANCHOR_SETTLE_DELAY_MS=150`, intended ~1.2s. But `settleTick` resolves on EITHER `session.onEvent` OR the 150ms sleep, whichever fires first. On a page emitting continuous events (4 API calls + large form render + CSS transition anim.start/anim.end pairs), **all 8 attempts are consumed by incoming events in 224-758ms observed**, well before a newly routed page mounts its controls.
>
> Repro: Next.js 15 admin app. Step 1 drifted `testid_not_found` at 278ms, then 224ms on a later run; the same flow passed once in `flow_verify`. Same-page flows replay 3/3 stable at ~510ms.

Verified still true on `main`. The early-return-on-event is a good optimisation and stays — the docblock even argues for it correctly. What is wrong is the sentence right after it: *"the attempt budget above is untouched"*. On a chatty page the attempt budget is exactly what gets touched, and it is spent on events rather than on waiting.

## The fix, in the reporter's own words

> An event arriving is evidence the page is still working, so it should extend the wait, not consume it.

The governing bound is now **wall-clock**: `ANCHOR_SETTLE_BUDGET_MS = 8 × 150`. The attempt cap survives only as a backstop against a pathological event storm spinning the loop hot, set generously at 40 so it is never what decides a drift.

Asymmetry preserved: this can only make the loop look **longer** on a busy page. A genuinely missing anchor still spends the whole budget before drifting, which is the safety property the loop exists for.

## Two things that fell out

**The old loop under-spent its own documented budget.** `attempt < 8` starting at 1 is *seven* retries — 1050ms, not the ~1.2s the docblock claimed. The wall-clock bound delivers what was always written down. The test now asserts `clock === 1200` so that cannot drift again.

**The existing safety test needed a clock.** It used a no-op sleep, which under a wall-clock budget describes a page that waits for free. Injected a clock that the sleep advances — which is what a real 150ms sleep does. That is not weakening the test; it is making it model a page.

## On timing assertions

The issue explicitly asks for a bound rather than a duration, per the repo rule, and that is what this does. **The clock is injected and nothing asserts elapsed time** — the tests assert query counts and the fact of termination. They run in 5ms and cannot flake under parallel load.

The chatty-page test freezes the clock deliberately: on such a page every tick really is ended by an event within a millisecond or two, so a frozen clock is the faithful model of the reported bug, not a convenience.

## Verification

`pnpm typecheck && pnpm lint && pnpm test:unit` green: 3011 server, 833 browser. Plus `prettier --check`.

Ran typecheck **first** this time — `vitest` does not typecheck, and I have had three tests tonight pass vacuously against symbols that did not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
