### PR TITLE
fix(replay): a role drift that prints the same name twice says so

### DIFF
--- a/packages/server/src/flows/flow-step-runners.ts
+++ b/packages/server/src/flows/flow-step-runners.ts
@@ -27,6 +27,7 @@ import {
   testidDrift,
 } from './flow-replay.js';
 import { nearestRoleName, type RoleCandidate } from './role-anchor-nearest.js';
+import { roleDriftReason } from './role-drift-reason.js';
 
 /** Query args for a NAMED role anchor — the handle that identifies an instance, not a JSX site. */
 function roleQueryArgs(
@@ -105,10 +106,7 @@ export async function runRoleStep(
       ok: false,
       drift: {
         reasonKind: DriftReason.COMPONENT_NOT_FOUND,
-        reason:
-          null === nearest
-            ? `role anchor ${label} not found, and no surviving ${anchor.role} has a similar name — anchor this step to a data-testid`
-            : `role anchor ${label} not found; the closest surviving ${anchor.role} is "${nearest}" — confirm it is the same control before rebinding, or add a data-testid`,
+        reason: roleDriftReason(anchor.role, String(anchor.name), nearest),
         anchor: label,
         nearest,
       },

--- a/packages/server/src/flows/role-drift-reason.test.ts
+++ b/packages/server/src/flows/role-drift-reason.test.ts
@@ -1,0 +1,52 @@
+/**
+ * A drift reason that prints the same name twice and calls them different.
+ *
+ * Reported from the field, verbatim:
+ *
+ * > The drift message is self-contradictory and cost real debugging time:
+ * > `role anchor button "Add User" not found; the closest surviving button is "Add User"`.
+ *
+ * Read literally it says the control both is and is not there. What it actually means is subtler and
+ * far more useful: the anchor's stored name and the live accessible name are the SAME STRING, so
+ * this is not a rename — the query matched nothing for some other reason. In the reported case the
+ * recorded name came from a `placeholder` (`reticle_query` reports `name:"Search User"` for
+ * `<input type="search" placeholder="Search User">`), and the replay resolver computes accessible
+ * names differently, so the round trip cannot close.
+ *
+ * An agent told "the name changed" edits the wrong thing. An agent told "the names are identical, so
+ * this is not a rename" stops guessing. `flow_heal` correctly refuses either way, which is what
+ * makes the message the only thing the reader has.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { roleDriftReason } from './role-drift-reason.js';
+
+describe('roleDriftReason', () => {
+  it('says plainly that a rename is NOT what happened when the names are identical', () => {
+    const reason = roleDriftReason('button', 'Add User', 'Add User');
+    expect(reason).not.toMatch(/the closest surviving button is "Add User"/);
+    expect(reason, 'the reader must be told the names match').toMatch(/identical|same name/i);
+    expect(reason, 'and that a rename is therefore ruled out').toMatch(
+      /not a rename|did not change/i,
+    );
+  });
+
+  it('still reports a genuine rename as one', () => {
+    const reason = roleDriftReason('button', 'Add User', 'Create User');
+    expect(reason).toContain('Add User');
+    expect(reason).toContain('Create User');
+    expect(reason, 'a real rename must not be described as a matching name').not.toMatch(
+      /identical/i,
+    );
+  });
+
+  it('handles no candidate at all without inventing one', () => {
+    const reason = roleDriftReason('button', 'Add User', null);
+    expect(reason).toContain('Add User');
+    expect(reason).toMatch(/no surviving button/i);
+  });
+
+  it('treats a case- or whitespace-only difference as identical, because it is to a reader', () => {
+    expect(roleDriftReason('button', 'Add User', '  add user ')).toMatch(/identical|same name/i);
+  });
+});

--- a/packages/server/src/flows/role-drift-reason.ts
+++ b/packages/server/src/flows/role-drift-reason.ts
@@ -1,0 +1,47 @@
+/**
+ * What to say when a role+name anchor no longer resolves.
+ *
+ * The old message could contradict itself in the one case that matters most:
+ *
+ *   role anchor button "Add User" not found; the closest surviving button is "Add User"
+ *
+ * Read literally that says the control both is and is not there, and it cost a reporter real
+ * debugging time. What it means is more useful than a rename: the stored name and the live
+ * accessible name are the SAME STRING, so the name is not what changed — the query matched nothing
+ * for some other reason.
+ *
+ * In the reported case the recorded name came from a `placeholder` — `reticle_query` reports
+ * `name:"Search User"` for `<input type="search" placeholder="Search User">` with no label — and the
+ * replay resolver computes accessible names differently, so the round trip cannot close. That is a
+ * real bug in its own right (two accessible-name implementations disagreeing), and while it is open
+ * the message is the only thing the reader has, because `flow_heal` correctly refuses to rebind a
+ * role anchor on its own.
+ */
+
+/** Same name to a reader: case and surrounding whitespace are not a rename. */
+function sameName(a: string, b: string): boolean {
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+export function roleDriftReason(role: string, name: string, nearest: string | null): string {
+  const label = `${role} "${name}"`;
+  if (null === nearest) {
+    return (
+      `role anchor ${label} not found, and no surviving ${role} has a similar name — ` +
+      'anchor this step to a data-testid'
+    );
+  }
+  if (sameName(name, nearest)) {
+    // The one case the old wording made unreadable. Say what is ruled OUT — that is the information.
+    return (
+      `role anchor ${label} did not resolve, but a ${role} with an identical name is on the page — ` +
+      'so this is NOT a rename and editing the label will not fix it. The recorded name and the ' +
+      'name the resolver computes disagree, which happens when the recorded one came from a ' +
+      'placeholder or title rather than a label or aria-label. Anchor this step to a data-testid.'
+    );
+  }
+  return (
+    `role anchor ${label} not found; the closest surviving ${role} is "${nearest}" — ` +
+    'confirm it is the same control before rebinding, or add a data-testid'
+  );
+}


### PR DESCRIPTION
Addresses the **second** ask in #162. The first ask needs a decision — see the end.

## The message contradicted itself

> The drift message is self-contradictory and cost real debugging time:
> `role anchor button "Add User" not found; the closest surviving button is "Add User"`

Read literally: the control both is and is not there.

What it actually means is more useful than a rename. The stored name and the live accessible name are the **same string**, so the name is not what changed — and editing the label will not help.

## Now

```
role anchor button "Add User" did not resolve, but a button with an identical name is on the page —
so this is NOT a rename and editing the label will not fix it. The recorded name and the name the
resolver computes disagree, which happens when the recorded one came from a placeholder or title
rather than a label or aria-label. Anchor this step to a data-testid.
```

It states what is **ruled out**, which is the information. An agent told "the name changed" edits the wrong thing; an agent told "the names are identical, so this is not a rename" stops guessing. That matters more than usual here because `flow_heal` correctly refuses to rebind a role anchor on its own — the message is the only thing the reader has.

Case and surrounding whitespace count as identical, because they are to a reader. A genuine rename still reports as one, and the no-candidate case is untouched.

## The first ask is a bigger decision, and I did not take it

> do not emit a role anchor from a placeholder-derived name, mark it `degraded:true` so `flow_save` warns at record time

Correct in principle, but `anchorForStep` (`flows.ts:81`) receives only `{ by, value, name }` — **it has no provenance for the name**. Marking placeholder-derived names degraded means either threading provenance from `reticle_query` through the recorder, or having the anchor builder re-derive the name itself.

And the deeper cause is the one your report names in passing: **`reticle_query` and the replay resolver compute accessible names differently.** `query` reports `name:"Search User"` for a placeholder-only input; the resolver's strict lookup matches nothing. That is two implementations of the same spec disagreeing, and it is the actual defect — placeholder-derived names are just the case where the disagreement is visible. Fixing the message is worth doing now; fixing the round trip is worth doing deliberately, not as a rider.

Worth noting the two are already recorded as related: this is the same "two accessible-name implementations disagree" problem tracked separately.

Suggest #162 stays open for that half.

## Tests

Four, RED before the helper existed. The one that matters asserts the old wording is **gone** (`not.toMatch(/the closest surviving button is "Add User"/)`), not merely that new wording is present — otherwise an implementation that appended a clarification to the contradictory sentence would pass.

## Verification

`pnpm typecheck && pnpm lint && pnpm test:unit` green: 3013 server, 833 browser. Plus `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
