### PR TITLE
fix(tools): refuse an oversized argument instead of running on it

### DIFF
--- a/packages/server/src/tools/invoke-tool.test.ts
+++ b/packages/server/src/tools/invoke-tool.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { SessionState, UNSCRIPTABLE_TAB_RECOMMENDATION } from '@reticlehq/core';
+import { SessionState, UNSCRIPTABLE_TAB_RECOMMENDATION, TRANSPORT_LIMITS } from '@reticlehq/core';
 import { TOOLS, type ToolDef, type ToolDeps } from './tools.js';
 import { ReticleTool } from './tool-names.js';
 import { buildDynamicTools } from './dynamic-tools.js';
@@ -227,5 +227,78 @@ describe('reticle_run carries the same session envelope as a direct call', () =>
       second['session_lease'],
       'a second call getting no lease is correct — it is once per session, not once per call',
     ).toBeUndefined();
+  });
+});
+
+/**
+ * An oversized argument must be REFUSED, not deserialised and acted on.
+ *
+ * `tool-fuzz-test` failed CI on the invariant that matters most — `every tool answers every hostile
+ * call` — for `reticle_replay/huge-string`, a ~100KB argument. Seen twice with different tools; the
+ * earlier one came back `-32001 … sse_aborted` with the tool surface dropping 48→17 afterwards,
+ * which is a RESTARTED daemon. So the shape is: oversized argument → the daemon dies → the proxy
+ * answers the in-flight call with transport loss, and the fuzz's next assertion is talking to a
+ * different daemon.
+ *
+ * An unanswered call is a hung agent, and it is the one failure the whole transport layer is shaped
+ * around. `TRANSPORT_LIMITS.MAX_STRING_LENGTH` already bounds what crosses the BRIDGE, but a tool
+ * argument arrives over MCP stdio and never met it — `reticle_replay` and `reticle_flow_verify` both
+ * deserialise their argument before any bound is applied.
+ *
+ * The guard goes in `runTool`, the one place every tool invocation routes through, so a tool added
+ * later inherits it rather than having to remember. A refusal is a normal answer: the agent learns
+ * the argument was too big, which is a thing it can fix, instead of waiting forever.
+ */
+describe('an argument larger than the transport allows is refused, not run', () => {
+  const OVERSIZED = 'x'.repeat(TRANSPORT_LIMITS.MAX_STRING_LENGTH + 1);
+
+  it('refuses before the handler ever sees it', async () => {
+    let handlerRan = false;
+    const tool = stubTool(ReticleTool.QUERY, { ok: true });
+    const spy: typeof tool = {
+      ...tool,
+      handler: () => {
+        handlerRan = true;
+        return Promise.resolve({ ok: true });
+      },
+    };
+    const r = (await runTool(spy, fakeDeps(), { value: OVERSIZED })) as Record<string, unknown>;
+
+    expect(handlerRan, 'the handler ran on a payload the transport would refuse').toBe(false);
+    expect(String(r['error'])).toMatch(/larger than/i);
+    expect(String(r['error']), 'the agent must know nothing happened').toContain('Nothing ran');
+  });
+
+  it('names the parameter and the limit, so the agent can act', async () => {
+    const r = (await runTool(stubTool(ReticleTool.QUERY, { ok: true }), fakeDeps(), {
+      value: OVERSIZED,
+    })) as Record<string, unknown>;
+    expect(String(r['error'])).toContain('value');
+    expect(String(r['error'])).toContain(String(TRANSPORT_LIMITS.MAX_STRING_LENGTH));
+  });
+
+  it('ANSWERS rather than throwing — an unanswered call is the failure being prevented', async () => {
+    await expect(
+      runTool(stubTool(ReticleTool.QUERY, { ok: true }), fakeDeps(), { value: OVERSIZED }),
+    ).resolves.toBeDefined();
+  });
+
+  it('finds an oversized string nested inside args, where the fuzz puts it', async () => {
+    const r = (await runTool(stubTool(ReticleTool.ACT, { ok: true }), fakeDeps(), {
+      ref: 'e1',
+      args: { value: OVERSIZED },
+    })) as Record<string, unknown>;
+    expect(
+      String(r['error']),
+      'the nested path must be named, not just the top-level key',
+    ).toContain('args.value');
+  });
+
+  it('lets a normal argument through untouched', async () => {
+    const r = (await runTool(stubTool(ReticleTool.QUERY, { ok: true }), fakeDeps(), {
+      value: 'Save',
+    })) as Record<string, unknown>;
+    expect(r['error']).toBeUndefined();
+    expect(r['ok']).toBe(true);
   });
 });

--- a/packages/server/src/tools/invoke-tool.ts
+++ b/packages/server/src/tools/invoke-tool.ts
@@ -1,5 +1,10 @@
 import { healthEnvelope } from '../session/session-health.js';
-import { type BrowserBrand, TelemetryActor, TelemetryEventKind } from '@reticlehq/core';
+import {
+  type BrowserBrand,
+  TelemetryActor,
+  TelemetryEventKind,
+  TRANSPORT_LIMITS,
+} from '@reticlehq/core';
 import { getSessionMetrics } from '../telemetry/session-metrics.js';
 import { getTelemetry } from '../telemetry/telemetry.js';
 import { takeUpdateNudge } from '../update/update-nudge.js';
@@ -150,6 +155,27 @@ function reportBugsFound(toolName: string, result: Record<string, unknown>): voi
  * object that did not already include `session` — splices the health envelope on. Idempotent
  * (handlers that already add health are left untouched) and never alters non-object results.
  */
+/**
+ * The name of the first argument whose string value exceeds the transport bound, if any.
+ *
+ * One level of nesting is searched because that is where callers put payloads — `reticle_act`'s
+ * `args.value`, and the fuzz's own `huge-string` shape. Deeper recursion would cost more than it
+ * buys: the failure is a single huge string, not a deeply nested structure of small ones.
+ */
+function firstOversizedArg(args: Record<string, unknown>): string | undefined {
+  const tooLong = (value: unknown): boolean =>
+    'string' === typeof value && value.length > TRANSPORT_LIMITS.MAX_STRING_LENGTH;
+  for (const [key, value] of Object.entries(args)) {
+    if (tooLong(value)) return key;
+    if ('object' === typeof value && null !== value && !Array.isArray(value)) {
+      for (const [inner, nested] of Object.entries(value as Record<string, unknown>)) {
+        if (tooLong(nested)) return `${key}.${inner}`;
+      }
+    }
+  }
+  return undefined;
+}
+
 export async function runTool(
   tool: ToolDef,
   deps: ToolDeps,
@@ -166,6 +192,29 @@ export async function runTool(
   // closure carries this call's own identity, which is also what makes peak-concurrency measurable.
   // A daemon that has served even one tool call is doing a job for somebody; see daemon-usefulness.
   noteToolCall();
+  // An oversized argument is refused BEFORE the handler deserialises it.
+  //
+  // tool-fuzz failed CI on the invariant that matters most — `every tool answers every hostile call`
+  // — for a ~100KB string. Seen twice with different tools; the earlier one came back
+  // `-32001 sse_aborted` with the tool surface dropping 48→17, which is a RESTARTED daemon. The
+  // shape is: oversized argument → the daemon dies → the proxy answers the in-flight call with
+  // transport loss, and the next assertion is talking to a different daemon.
+  //
+  // `TRANSPORT_LIMITS.MAX_STRING_LENGTH` already bounds what crosses the bridge; a tool argument
+  // arrives over MCP stdio and never met it. Here, because this is the one place every invocation
+  // routes through, so a tool added later inherits the bound instead of having to remember it.
+  //
+  // A refusal is a normal answer. An UNANSWERED call is a hung agent, and that is the failure this
+  // prevents: the agent learns its argument was too big, which is something it can fix.
+  const oversized = firstOversizedArg(args);
+  if (oversized !== undefined) {
+    return {
+      error:
+        `argument '${oversized}' is larger than ${String(TRANSPORT_LIMITS.MAX_STRING_LENGTH)} ` +
+        'characters, which is the most Reticle moves in one call. Nothing ran. Send a smaller ' +
+        'value — a selector or an id rather than a document, or a slice of the text you need.',
+    };
+  }
   // An ACTION is what gets abandoned. Counted here, against verifications, so "the agent drove the
   // page and then wandered off" becomes a number instead of an impression.
   if (ACTION_TOOLS.has(tool.name)) getSessionMetrics().recordAction();


### PR DESCRIPTION
Addresses the defect behind #144. The title's other half — the fuzz's own timing cap — is discussed at the end and deliberately left alone.

## The failure

```
❌ every tool answers every hostile call — reticle_replay/huge-string
❌ TOOL FUZZ (7 passed, 1 failed, 285 hostile calls)
```

**An unanswered call is a hung agent** — the one failure the whole transport layer is shaped around, and the agent cannot tell "still working" from "never coming".

The issue's reading is right: seen twice with different tools, the earlier one returning `-32001 sse_aborted` with the tool surface dropping **48→17** afterwards. That is a *restarted daemon*. So the shape is: oversized argument → the daemon dies → the proxy correctly answers the in-flight call with transport loss → the fuzz's next assertion is talking to a different daemon.

## The gap

`TRANSPORT_LIMITS.MAX_STRING_LENGTH` (64KB) bounds what crosses the **bridge**. A tool argument arrives over **MCP stdio** and never met it — confirmed: `TRANSPORT_LIMITS` appears in `bridge.ts` and `error-recovery.ts` and nowhere on the tool-invocation path. So `reticle_replay` and `reticle_flow_verify` both deserialise their argument before any bound applies.

## The guard

In `runTool` — the one place every tool invocation routes through, so a tool added later inherits the bound instead of having to remember it. Same reasoning as the session envelope that lives there.

```
argument 'args.value' is larger than 65536 characters, which is the most Reticle moves in one call.
Nothing ran. Send a smaller value — a selector or an id rather than a document, or a slice of the
text you need.
```

**A refusal is a normal answer, and that is the whole point.** The agent learns its argument was too big — something it can act on — instead of waiting on a call that will never return.

One level of nesting is searched, because that is where payloads actually go: `reticle_act`'s `args.value`, and the fuzz's own `huge-string` shape. Deeper recursion would cost more than it buys — the failure is one huge string, not a deep tree of small ones.

## Tests

Five, three RED before the change. The load-bearing one asserts **the handler never ran**, not merely that an error came back — an implementation that let the tool execute and then complained would pass a weaker check while leaving the crash in place.

The nested case asserts the message names `args.value`, not just `args`, because a path the agent cannot locate is not much better than no message.

## What this does NOT do

The issue's title is about the fuzz's **hung-call cap being a timing assertion** — *"retuned four times, and it reports the machine as a defect"*. That is a real and separate complaint, and CLAUDE.md forbids exactly that pattern. I have not touched it: the cap is what detects the class of bug this PR fixes, and retuning or restructuring it in the same change would make it impossible to tell whether a future green means "fixed" or "the assertion got weaker".

Worth doing next, and worth doing as a relative bound — the same tool with a small argument, measured in the same run — rather than an absolute duration.

**I have also not run `pnpm test:e2e`** to see the fuzz go green; it is ~8 minutes and the issue notes the failure is load-sensitive, so a single local green would be inconclusive anyway. CI runs it on this PR, which is the honest check.

## Verification

`pnpm typecheck && pnpm lint && pnpm test:unit` green: 3024 server, 833 browser. Plus `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
