### PR TITLE
fix(daemon): the exit line names WHY, not just the code

### DIFF
--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -43,7 +43,12 @@ import {
   proxyLog,
   setProxyLogPort,
 } from './mcp/mcp-proxy.js';
-import { installDaemonResilience, installProxyResilience } from './daemon/daemon-resilience.js';
+import {
+  installDaemonResilience,
+  installProxyResilience,
+  recordExitReason,
+  DaemonExitReason,
+} from './daemon/daemon-resilience.js';
 import { IdleShutdown, resolveIdleShutdownMs, resolveIdleCheckMs } from './daemon/idle-shutdown.js';
 import { DaemonHeartbeat, resolveHeartbeatMs } from './daemon/heartbeat.js';
 import { everServedToolCall } from './daemon/daemon-usefulness.js';
@@ -498,7 +503,11 @@ function handleDaemonInner(parsed: {
         removePid(parsed.port);
         process.exit(1);
       });
-      const shutdown = (): void => {
+      const shutdown = (reason: DaemonExitReason): void => {
+        // Recorded BEFORE the async chain: `installExitTrace` reads it when Node is on its way out,
+        // which is after everything below has run. Without it the exit line says `code: 0` and a
+        // reader cannot tell a tidy stop from the bridge disappearing — see #123.
+        recordExitReason(reason);
         // Awaited before the close/exit chain: `process.exit(0)` kills an in-flight POST, and this is
         // the one event carrying the whole session. A failed send resolves anyway (emit swallows its
         // own errors), so this can delay the exit by at most the send timeout, never prevent it.
@@ -516,8 +525,10 @@ function handleDaemonInner(parsed: {
             process.exit(1);
           });
       };
-      process.on('SIGTERM', shutdown);
-      process.on('SIGINT', shutdown);
+      // Wrapped rather than passed directly: a signal handler receives the signal name as its first
+      // argument, which would otherwise arrive as the reason.
+      process.on('SIGTERM', () => shutdown(DaemonExitReason.SIGNAL));
+      process.on('SIGINT', () => shutdown(DaemonExitReason.SIGNAL));
       // Self-shut-down when idle so a detached daemon (and any headless Chromium it launched) never
       // lingers on the user's machine after the editor closes. Reuses the same clean shutdown path.
       const attachedGraceEnv = process.env[ReticleEnv.IDLE_ATTACHED];
@@ -534,7 +545,7 @@ function handleDaemonInner(parsed: {
           : { attachedGraceMs: resolveIdleShutdownMs(attachedGraceEnv) }),
         onShutdown: () => {
           log('reticle_daemon_idle_exit', { port: parsed.port });
-          shutdown();
+          shutdown(DaemonExitReason.IDLE);
         },
       });
       idleShutdown.start();

--- a/packages/server/src/daemon/daemon-resilience.ts
+++ b/packages/server/src/daemon/daemon-resilience.ts
@@ -145,9 +145,49 @@ function reportCrash(kind: CrashKind, value: unknown): void {
  * is the point: after this, silence in the log is itself the finding, because every other door is
  * now instrumented.
  */
+/**
+ * Why the daemon is going away — carried ON the exit line, not left to be inferred.
+ *
+ * From the field (#123): a real gate log read `reticle_daemon_signalled SIGTERM` then
+ * `reticle_daemon_exiting code:0`, then 21 seconds with nothing listening. `code: 0` is the last
+ * line before the port goes dark and it cannot distinguish "shut down tidily" from "the bridge every
+ * app on this machine needs is now gone". A correct install was written up as a failure naming the
+ * fixture because of it.
+ *
+ * `UNKNOWN` is the load-bearing member, not a fallback: it means the process left through Node
+ * WITHOUT passing a shutdown path — an uncaught throw, a stray `process.exit`. That is a different
+ * fact from an idle exit, and the one worth noticing.
+ */
+export const DaemonExitReason = {
+  /** A shutdown signal arrived (SIGTERM/SIGINT). */
+  SIGNAL: 'signal',
+  /** The idle timer fired and the daemon retired itself. */
+  IDLE: 'idle',
+  /** Left through Node, but not via any shutdown path we own. */
+  UNKNOWN: 'unknown',
+} as const;
+export type DaemonExitReason = (typeof DaemonExitReason)[keyof typeof DaemonExitReason];
+
+/**
+ * Set by whichever shutdown path is running, read once by the exit handler.
+ *
+ * A module-level value rather than a parameter because the two are separated by the whole process
+ * lifetime: the reason is known when shutdown STARTS and the exit line is written when Node is on
+ * its way out. Exit runs once, on one thread, after everything else — so there is nothing to race.
+ */
+let exitReason: DaemonExitReason = DaemonExitReason.UNKNOWN;
+
+/** Record why the daemon is shutting down. Called by a shutdown path before it exits. */
+export function recordExitReason(reason: DaemonExitReason): void {
+  exitReason = reason;
+}
+
 export function installExitTrace(proc: ProcessLike, log: LogFn): void {
   proc.on('exit', (code: unknown) => {
-    log('reticle_daemon_exiting', { code: 'number' === typeof code ? code : null });
+    log('reticle_daemon_exiting', {
+      code: 'number' === typeof code ? code : null,
+      reason: exitReason,
+    });
   });
   for (const signal of ['SIGTERM', 'SIGINT', 'SIGHUP'] as const) {
     proc.on(signal, () => {

--- a/packages/server/src/daemon/exit-trace.test.ts
+++ b/packages/server/src/daemon/exit-trace.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { installExitTrace } from './daemon-resilience.js';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { installExitTrace, recordExitReason, DaemonExitReason } from './daemon-resilience.js';
 
 /**
  * A daemon that dies must leave a line saying so.
@@ -12,26 +12,28 @@ import { installExitTrace } from './daemon-resilience.js';
  * With every in-process door instrumented, the NEXT occurrence is decisive either way: a line names
  * the exit, or the absence of one narrows it to SIGKILL / OOM, which nothing in-process can log.
  */
-describe('installExitTrace — every door out is instrumented', () => {
-  const wire = () => {
-    const handlers = new Map<string, (arg: unknown) => void>();
-    const logged: { event: string; data: Record<string, unknown> }[] = [];
-    installExitTrace(
-      {
-        on(event: string, listener: (arg: unknown) => void) {
-          handlers.set(event, listener);
-          return undefined;
-        },
+const wire = () => {
+  const handlers = new Map<string, (arg: unknown) => void>();
+  const logged: { event: string; data: Record<string, unknown> }[] = [];
+  installExitTrace(
+    {
+      on(event: string, listener: (arg: unknown) => void) {
+        handlers.set(event, listener);
+        return undefined;
       },
-      (event, data) => void logged.push({ event, data }),
-    );
-    return { handlers, logged };
-  };
+    },
+    (event, data) => void logged.push({ event, data }),
+  );
+  return { handlers, logged };
+};
 
+describe('installExitTrace — every door out is instrumented', () => {
   it('logs the exit code on a normal or explicit exit', () => {
     const { handlers, logged } = wire();
     handlers.get('exit')?.(0);
-    expect(logged).toEqual([{ event: 'reticle_daemon_exiting', data: { code: 0 } }]);
+    expect(logged).toEqual([
+      { event: 'reticle_daemon_exiting', data: { code: 0, reason: DaemonExitReason.UNKNOWN } },
+    ]);
   });
 
   it('carries a non-zero code, which is what distinguishes a crash from a clean stop', () => {
@@ -58,5 +60,58 @@ describe('installExitTrace — every door out is instrumented', () => {
     handlers.get('SIGINT')?.(undefined);
     // Only a log. Exiting here would race the shutdown that sends the session summary.
     expect(logged).toHaveLength(1);
+  });
+});
+
+/**
+ * `code: 0` is the last line before the port goes dark, and it does not say why.
+ *
+ * From #123, a real gate log:
+ *
+ *   10:51:40  reticle_daemon_signalled  SIGTERM
+ *   10:51:40  reticle_daemon_exiting    code:0
+ *             ... 21 seconds with nothing listening ...
+ *
+ * A reader cannot tell "the daemon shut down tidily" from "the bridge every app on this machine
+ * needs is now gone". The consequence was not academic: a CORRECT install was written up as a
+ * failure naming the fixture — `sveltekit` reported as "app booted but NO session appeared" when
+ * the daemon simply was not there.
+ *
+ * `heartbeat.ts:25` states the gap outright: the signal event is "a CAUSE the exit line does not
+ * carry". Correlating two lines is possible and is exactly the inference the issue says a reader
+ * should not have to make.
+ *
+ * `unknown` is load-bearing rather than a fallback: it means the process left through Node WITHOUT
+ * going through a shutdown path — an uncaught throw, a stray `process.exit`. That is a different
+ * fact from an idle exit, and the one worth noticing.
+ */
+describe('the exit line names WHY, not just the code', () => {
+  // The reason is module state by design (see recordExitReason), so tests must not inherit each
+  // other's. Reset explicitly rather than relying on declaration order, which is the kind of
+  // dependency that passes locally and reorders in CI.
+  beforeEach(() => {
+    recordExitReason(DaemonExitReason.UNKNOWN);
+  });
+
+  it('says unknown when nothing recorded a reason — the process left by some other door', () => {
+    const { handlers, logged } = wire();
+    handlers.get('exit')?.(0);
+    expect(logged[0]?.data['reason']).toBe('unknown');
+  });
+
+  it('carries the reason a shutdown path recorded', () => {
+    const { handlers, logged } = wire();
+    recordExitReason(DaemonExitReason.IDLE);
+    handlers.get('exit')?.(0);
+    expect(logged[0]?.data['reason']).toBe(DaemonExitReason.IDLE);
+    expect(logged[0]?.data['code']).toBe(0);
+  });
+
+  it('distinguishes a signal from an idle timeout', () => {
+    const { handlers, logged } = wire();
+    recordExitReason(DaemonExitReason.SIGNAL);
+    handlers.get('exit')?.(0);
+    expect(logged[0]?.data['reason']).toBe(DaemonExitReason.SIGNAL);
+    expect(logged[0]?.data['reason']).not.toBe(DaemonExitReason.IDLE);
   });
 });


### PR DESCRIPTION
Addresses the second ask in #123. The first (a heartbeat) already exists; the fourth is #126. Scope at the end.

## The line that could not be read

```
10:51:40  reticle_daemon_signalled  SIGTERM
10:51:40  reticle_daemon_exiting    code:0
          ... 21 seconds with nothing listening ...
```

`code: 0` is the last line before the port goes dark. A reader cannot tell *"the daemon shut down tidily"* from *"the bridge every app on this machine needs is now gone"*.

`heartbeat.ts:25` already stated the gap in writing — the signal event is *"a CAUSE the exit line does not carry"*.

**The consequence was not academic.** A *correct* install was written up as a failure naming the fixture: `sveltekit` reported as "app booted but NO session appeared" when the daemon simply was not there, with `ERR_CONNECTION_REFUSED` ×15 and `astro` connecting fine minutes later as the control.

## The change

Each of the three shutdown paths records its reason — SIGTERM and SIGINT as `signal`, the idle timer as `idle` — and `installExitTrace` carries it:

```
reticle_daemon_exiting  code:0  reason:idle
```

Correlating two lines was always *possible*. It is exactly the inference the report says a reader should not have to make, and the one that was not made when it mattered.

## `unknown` is the load-bearing member

Not a fallback. It means the process left through Node **without passing a shutdown path** — an uncaught throw, a stray `process.exit`. That is a different fact from an idle exit, and it is the one worth noticing. The existing "logs the exit code" test now asserts it.

## On the module-level state

The reason is known when shutdown *starts*; the line is written when Node is on its way *out*. Those are separated by the whole process lifetime, so a parameter cannot span them. Exit runs once, on one thread, after everything else — there is nothing to race.

The tests reset it in `beforeEach` rather than relying on declaration order. Order-dependent state is the kind of thing that passes locally and reorders in CI, which is a lesson this repo has already paid for more than once.

## Scope

- **Ask 1** (heartbeat, so a gap in the log reads as a death) — already exists: `heartbeat.ts`, `DAEMON_HEARTBEAT_EVENT`, `classifyDaemonLife`. Unreleased like everything else.
- **Ask 3** (log a second daemon binding a port a previous one held) and **ask 4** (arbitrate ownership rather than race) — both belong with **#126**, which is about the arbitration itself. Logging the takeover without arbitrating it would describe the race more precisely rather than remove it.

Suggest #123 stays open for ask 3 until #126 is decided.

## Verification

`pnpm typecheck && pnpm lint && pnpm test:unit` green: 3033 server, 837 browser. Plus `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
