### PR TITLE
fix(bridge): a hello the bridge REFUSED is reported, not silently absent

### DIFF
--- a/packages/server/src/bridge/bridge.security.test.ts
+++ b/packages/server/src/bridge/bridge.security.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@reticlehq/core';
 import { BlindSpotKind } from '@reticlehq/core';
 import { Bridge } from './bridge.js';
+import { WS_CLOSE_REASON } from './bridge.js';
 import { SessionManager } from '../session/session-manager.js';
 
 const bridges: Bridge[] = [];
@@ -374,5 +375,54 @@ describe('a session closed by the bridge explains itself to the agent', () => {
 
   it('keeps the plain message when nothing was closed', () => {
     expect(() => new SessionManager().resolve()).not.toThrow(/bridge closed/);
+  });
+});
+
+/**
+ * An SDK the bridge REFUSED looks exactly like an app that was never started.
+ *
+ * `noteClosure` exists, is tested directly above, and **nothing in production calls it** — the
+ * message-rate close it was built for was later replaced by sampling ("Over the cap we SAMPLE — we
+ * never disconnect"), and the mechanism was left wired to nothing. So the branch in `resolve()` that
+ * reports a bridge-initiated close has been unreachable.
+ *
+ * That matters most for the two closes that reject a would-be session with a diagnosis the bridge
+ * already knows:
+ *
+ *   PROTOCOL_MISMATCH: 'protocol version mismatch — upgrade @reticlehq/browser'
+ *   AUTH_FAILED:       'authentication failed — reload the page to pick up the current pairing token'
+ *
+ * The SDK prints those and stops retrying. The agent, meanwhile, calls a tool and is told "no
+ * browser session connected" — indistinguishable from an app nobody started. An outdated SDK and a
+ * stale pairing token are both **invisible**, which is the same shape as #127: skew that surfaces as
+ * a bare failure with nothing naming a version.
+ */
+describe('a hello the bridge rejected is reported, not silently absent', () => {
+  it('a protocol mismatch reaches the agent instead of "no session connected"', () => {
+    const sessions = new SessionManager();
+    sessions.noteClosure(WS_CLOSE_REASON.PROTOCOL_MISMATCH, 1000);
+    expect(() => sessions.resolve()).toThrow(/protocol version mismatch/);
+    expect(() => sessions.resolve()).toThrow(/@reticlehq\/browser/);
+  });
+
+  it('an auth failure names the token, not the tab', () => {
+    const sessions = new SessionManager();
+    sessions.noteClosure(WS_CLOSE_REASON.AUTH_FAILED, 1000);
+    expect(() => sessions.resolve()).toThrow(/authentication failed/);
+  });
+
+  it('does not tell the reader to reload when reloading is not the fix', () => {
+    const sessions = new SessionManager();
+    sessions.noteClosure(WS_CLOSE_REASON.PROTOCOL_MISMATCH, 1000);
+    let message = '';
+    try {
+      sessions.resolve();
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(
+      message,
+      'a reload cannot fix an SDK on the wrong protocol — the close reason already names the fix',
+    ).not.toMatch(/Reload the page to reconnect/);
   });
 });

--- a/packages/server/src/bridge/bridge.ts
+++ b/packages/server/src/bridge/bridge.ts
@@ -52,6 +52,19 @@ type ReplayRequestHandler = (sessionId: string, flowName: string) => void;
 /** Called once a browser session connects, so the daemon can push it the replayable-flow list. */
 type SessionReadyHandler = (session: Session) => void;
 
+/**
+ * The close reasons worth telling an AGENT about, not just the SDK.
+ *
+ * The SDK prints these and stops retrying. The agent then calls a tool and is told "no browser
+ * session connected" — which is indistinguishable from an app nobody started. An outdated SDK and a
+ * stale pairing token were both invisible for that reason; these two carry their own remedy, so
+ * surfacing them is strictly better than the generic answer.
+ */
+export const WS_CLOSE_REASON = {
+  PROTOCOL_MISMATCH: 'protocol version mismatch — upgrade @reticlehq/browser',
+  AUTH_FAILED: 'authentication failed — reload the page to pick up the current pairing token',
+} as const;
+
 /** WS close codes + reasons the bridge sends to the SDK (1008 = policy violation, 1013 = try again later). */
 const WS_CLOSE = {
   TOO_MANY_HANDSHAKES: [1013, 'too many pending handshakes'],
@@ -62,12 +75,9 @@ const WS_CLOSE = {
   // last thing the developer sees. The common cause is a page served before the daemon existed,
   // which carries no token; a reload re-fetches the connect module and picks the current one up.
   // Kept under the 123-byte WebSocket close-reason limit.
-  AUTH_FAILED: [
-    1008,
-    'authentication failed — reload the page to pick up the current pairing token',
-  ],
+  AUTH_FAILED: [1008, WS_CLOSE_REASON.AUTH_FAILED],
   SESSION_LIMIT: [1013, 'session limit reached'],
-  PROTOCOL_MISMATCH: [1008, 'protocol version mismatch — upgrade @reticlehq/browser'],
+  PROTOCOL_MISMATCH: [1008, WS_CLOSE_REASON.PROTOCOL_MISMATCH],
 } as const;
 
 /** Parse a positive integer env override; anything else (unset, zero, junk) falls through to the default. */
@@ -319,6 +329,10 @@ export class Bridge {
         const got = helloProtocolMismatch(text);
         if (got !== null) {
           log('protocol_version_mismatch', { got, expected: RETICLE_PROTOCOL_VERSION });
+          // Told to the AGENT too, not only to the SDK that is about to stop retrying. Without this
+          // the next tool call answers "no browser session connected", which reads as "no app is
+          // running" — so an SDK too old to connect is invisible.
+          this.sessions.noteClosure(WS_CLOSE_REASON.PROTOCOL_MISMATCH, this.#clock());
           socket.close(...WS_CLOSE.PROTOCOL_MISMATCH);
           return;
         }
@@ -374,6 +388,7 @@ export class Bridge {
             served: [...this.#servedProjects],
             ...(parsed.projectId === undefined ? {} : { helloProject: parsed.projectId }),
           });
+          this.sessions.noteClosure(WS_CLOSE_REASON.AUTH_FAILED, this.#clock());
           socket.close(WS_CLOSE.AUTH_FAILED[0], reason);
           return;
         }

--- a/packages/server/src/session/session-manager.ts
+++ b/packages/server/src/session/session-manager.ts
@@ -234,7 +234,7 @@ export class SessionManager {
       throw new Error(
         closure === undefined
           ? NO_SESSION_CONNECTED_ERROR
-          : `${NO_SESSION_CONNECTED_ERROR} NOTE: the bridge closed a session recently — "${closure.reason}". The app is probably still running; it was disconnected, and the SDK does not retry after a policy close. Reload the page to reconnect.`,
+          : `${NO_SESSION_CONNECTED_ERROR} NOTE: the bridge REFUSED or closed a connection recently — "${closure.reason}". The app is probably still running and trying to connect: it was turned away, and the SDK does not retry after a policy close. The reason above names the fix — do not go looking for a stopped dev server.`,
       );
     }
     // Scope to the agent's active project FIRST, so a stray tab from another app/origin (e.g. a


### PR DESCRIPTION
Addresses the **diagnosis** half of #157, and fixes dead code found on the way.

## `noteClosure` was wired to nothing

`SessionManager.noteClosure` exists, has direct tests, and **no production code calls it** — only `bridge.security.test.ts` does. So the branch in `resolve()` that reports a bridge-initiated close has been unreachable.

It is not that the mechanism was wrong. The close it was built for — the message-rate cap — was later **replaced by sampling**:

> Over the cap we SAMPLE — we never disconnect. Going blind is the one thing an observability layer must not do when it sees too much.

That change was right, and it left the diagnosis attached to a cause that no longer happens. **The tests kept passing because they call `noteClosure` directly** — proving the mechanism while the wiring was absent, which is a pattern I have hit three times tonight.

## What it is worth wiring to

Two closes turn away a would-be session with a diagnosis the bridge *already knows*:

```
protocol version mismatch — upgrade @reticlehq/browser
authentication failed — reload the page to pick up the current pairing token
```

The SDK prints those and stops retrying. The agent then calls a tool and gets **"no browser session connected"** — indistinguishable from an app nobody started.

So today, **an outdated SDK and a stale pairing token are both invisible.** That is the same shape as #127: skew that surfaces as a bare failure with nothing naming a version. Both now record the closure, and the next `resolve()` names the real cause.

## The message stopped over-prescribing

It ended with *"Reload the page to reconnect."* A reload cannot fix an SDK on the wrong protocol. Since each close reason already carries its own remedy, the message now points at that instead of guessing.

`"still running"` is kept deliberately — an existing test pins it, and its intent (do not send the agent off to restart a healthy dev server) is exactly right.

## Relation to #157

The reporter's complaint was that the drop message *"says the tab was closed, navigated away, or hard-reloaded — none of which is what happened"*, and that a truthful one *"would save several minutes of misdiagnosis per occurrence"*. This makes the bridge's own refusals truthful.

**It does not fix the lease TTL or cookie persistence**, which are the behaviour changes at the heart of that issue and want a deliberate decision. #157 stays open for them.

## Tests

Three, RED before the change. The third asserts the *absence* of the wrong remedy (`not.toMatch(/Reload the page to reconnect/)`) rather than only the presence of the right one — otherwise appending a correct sentence to a wrong one would pass.

## Verification

`pnpm typecheck && pnpm lint && pnpm test:unit` green: 3037 server. Plus `prettier --check`.

One unrelated flake surfaced during the full-monorepo run — a `holdMs` assertion from #201, already on `main`. It passes 9/9 in isolation and failed once under maximum parallelism; I am fixing that separately rather than folding it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
