### PR TITLE
test(skew): pin that a skew sentence names BOTH versions

### DIFF
--- a/packages/server/src/version/version-skew.test.ts
+++ b/packages/server/src/version/version-skew.test.ts
@@ -78,3 +78,53 @@ describe('the daemon pair', () => {
     expect(msg).toMatch(/reticle stop/);
   });
 });
+
+/**
+ * The acceptance criterion from #127, pinned.
+ *
+ * > a test that boots an SDK one minor behind and asserts the user sees **one actionable sentence
+ * > naming both versions** — not a `-32000`.
+ *
+ * The behaviour is already right. What was missing is anything holding it there: the delivery test
+ * beside this one asserts the SDK version reaches the agent and never checks that the DAEMON's does.
+ * "Your SDK is 2.4.0" is half an answer — it does not say which direction the skew runs or how far,
+ * which is the part that decides whether you upgrade the app or the CLI.
+ *
+ * A characterisation test, not a fix. Its worth is that it fails if a future reword drops one of the
+ * two numbers, which is the cheapest way for this to regress and the hardest to notice: the sentence
+ * would still read fluently.
+ */
+describe('a skew sentence names BOTH versions, not just the peer', () => {
+  const SELF = { version: '2.5.0', contract: 'abc123' };
+
+  it('a minor behind, with a foreign contract', () => {
+    const message = describeSkew(
+      { what: 'the page', version: '2.4.0', contract: 'deadbeef', fix: 'run reticle update' },
+      SELF,
+    );
+    expect(message).toContain('2.4.0');
+    expect(message, "the daemon's own version is the half that says which way to move").toContain(
+      '2.5.0',
+    );
+  });
+
+  it('a minor behind on an SDK too old to report a contract at all', () => {
+    // The -32000 case from the report: no contract to compare, so the versions are all there is.
+    // `contract: undefined` explicitly — the field is required and "predates it" is the case here.
+    const message = describeSkew(
+      { what: 'the page', version: '2.4.0', contract: undefined, fix: 'run reticle update' },
+      SELF,
+    );
+    expect(message).toContain('2.4.0');
+    expect(message).toContain('2.5.0');
+  });
+
+  it('and it is one sentence a human can act on, not a dump', () => {
+    const message = describeSkew(
+      { what: 'the page', version: '2.4.0', contract: 'deadbeef', fix: 'run reticle update' },
+      SELF,
+    );
+    expect(message).toContain('run reticle update');
+    expect(message, 'a version-skew warning must not itself be a wall of JSON').not.toContain('{');
+  });
+});


### PR DESCRIPTION
Closes the acceptance criterion in #127. **A characterisation test, not a fix** — the behaviour is already right; nothing was holding it there.

## The criterion

> a test that boots an SDK one minor behind and asserts the user sees **one actionable sentence naming both versions** — not a `-32000`.

Current output, checked by running `describeSkew` rather than reading it:

```
version skew: the page is 2.4.0; this daemon is 2.5.0, and they speak DIFFERENT wire contracts
(deadbeef vs abc123) — so this is a real mismatch, not a harmless patch difference. Tools will
behave in ways neither side reports. run reticle update
```

That satisfies it.

## What was missing

The delivery test beside this one asserts the **SDK** version reaches the agent:

```js
expect(result.version_skew?.action).toContain('2.2.1');
```

and never checks that the **daemon's** does. *"Your SDK is 2.4.0"* is half an answer — it does not say which direction the skew runs or how far, which is exactly what decides whether you upgrade the app or the CLI.

## Proven, not assumed

A test that passes the moment you write it is worth only what it catches later, so I checked what it catches. Stripping the daemon version from the phrase:

```
× a minor behind, with a foreign contract
× a minor behind on an SDK too old to report a contract at all
  Tests  2 failed | 8 passed
```

Restored: 10 passed. **That is the regression it exists for, and it is the hardest kind to notice — the sentence would still read fluently with one number missing.**

## Both branches

`describeSkew` builds the sentence separately for each, so both are covered:

- a **foreign contract** — the real-mismatch path;
- an SDK **too old to report a contract at all** — which is literally the `-32000` case the report describes, and where the two versions are the only evidence there is.

A third test pins that it stays one actionable sentence and does not become a JSON dump, which is the other direction this could rot.

## Not in scope

The two remaining asks in #127 — refuse rather than warn, and tell the *page* as well as the agent — are a product decision and a wire change respectively. I left both and said why on the issue.

## Verification

`pnpm typecheck && pnpm lint && pnpm test:unit` green: 3040 server. Plus `prettier --check`.

`tsc` caught the first draft omitting `contract: undefined` — the field is required, and "predates the field" is a case worth stating explicitly rather than eliding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
