### PR TITLE
fix(init): say when the capabilities module will register nothing

### DIFF
--- a/apps/e2e/install-baseline.json
+++ b/apps/e2e/install-baseline.json
@@ -4,7 +4,8 @@
     "✓ Install dependencies → package.json",
     "✓ Reticle config → .reticle.json",
     "✓ Vite plugin → vite.config.ts",
-    "✓ Capabilities + store → src/reticle-dev.ts"
+    "✓ Capabilities + store → src/reticle-dev.ts",
+    "ℹ Capabilities are empty until you edit that file → src/reticle-dev.ts"
   ],
   "next-app-router": [
     "– MCP server (global) → global (claude user scope)",

--- a/packages/server/src/init/plan-framework.ts
+++ b/packages/server/src/init/plan-framework.ts
@@ -73,6 +73,7 @@ function capabilitiesStep(input: PlanInput): Step[] {
     testids.length > 0
       ? `${String(testids.length)} data-testid values`
       : 'no data-testid values yet';
+  const nothingToRegister = 0 === testids.length && 0 === stores.length;
   return [
     {
       title: CAPABILITIES_TITLE,
@@ -82,6 +83,29 @@ function capabilitiesStep(input: PlanInput): Step[] {
       write: { path: VITE_DEV_MODULE_PATH, content: viteDevModuleFile(testids, stores) },
       dependsOnInstall: true,
     },
+    // The write is real; what it registers is not. `registerCapabilities({ testids: [], signals: [],
+    // stores: [] })` registers nothing, so `hasCapabilities` stays false — correctly — and the ✓
+    // above reads as if the feature is on. Reported as exactly that confusion: "hasCapabilities false
+    // on every session while init said ✓ Capabilities + store".
+    //
+    // Beside the write rather than replacing it, for two reasons: only APPLY steps are written
+    // (run.ts), and SKILL.md tells the reader to skip ✓ lines — so a caveat carried on the ✓ is a
+    // caveat nobody reads.
+    ...(nothingToRegister
+      ? [
+          {
+            title: 'Capabilities are empty until you edit that file',
+            target: VITE_DEV_MODULE_PATH,
+            status: StepStatus.NOTICE,
+            detail:
+              'the module was written but registers nothing — no data-testid values were found and ' +
+              'no state library was detected, so `hasCapabilities` stays false and reticle_state ' +
+              'has nothing to read. Add data-testid to the elements your main flow touches, or ' +
+              'register a store in that file, and the agent gains what the app BELIEVES rather than ' +
+              'only what it rendered.',
+          } satisfies Step,
+        ]
+      : []),
   ];
 }
 

--- a/packages/server/src/init/plan.test.ts
+++ b/packages/server/src/init/plan.test.ts
@@ -311,6 +311,63 @@ describe('buildPlan — install', () => {
   });
 });
 
+/**
+ * `✓ Capabilities + store` on an app where nothing will ever register.
+ *
+ * From #139: `hasCapabilities: false` on every session while `init` reported `✓ Capabilities +
+ * store`. The report offered three hypotheses and asked for them to be separated before anyone
+ * touched code. They now can be.
+ *
+ * It is NOT "the app never imports the generated module" — the Vite plugin resolves it at load
+ * (`findDevModule`, `index.ts:634`) and `VITE_DEV_MODULE_PATH` is `src/reticle-dev.ts`, which is the
+ * first candidate it looks for. And it is not a broken re-announce: a live drive of `apps/bench-app`
+ * tonight reported `hasCapabilities: true`.
+ *
+ * The answer is simpler and is the artifact-versus-effect gap the report itself names. The generated
+ * module always calls `registerCapabilities({ testids: [...], signals: [], stores: [] })`. On an app
+ * with **no data-testid values and no detected store, that call registers nothing** — so
+ * `hasCapabilities: false` is CORRECT, and the `✓` is what is wrong.
+ *
+ * bench-app is full of testids, which is why it reported true and the reporter's app did not.
+ *
+ * The step must stay APPLY — `run.ts:603` only writes APPLY steps, so demoting it would stop writing
+ * the file. Same shape as the CRA token notice: a NOTICE beside the write, because `SKILL.md` tells
+ * the reader to skip `✓` lines.
+ */
+describe('buildPlan — capabilities that will register nothing say so', () => {
+  const vitePlan = (partial: Partial<PlanInput> = {}) =>
+    buildPlan(
+      input({
+        detection: detection(Framework.VITE),
+        viteConfig: { path: 'vite.config.ts', source: 'export default {};' },
+        ...partial,
+      }),
+    );
+
+  it('raises a NOTICE when the scan found no testids and no store', () => {
+    const plan = vitePlan({ testids: [], storeHints: [] });
+    const written = maybeStep(plan, 'Capabilities + store');
+    expect(StepStatus.APPLY, 'the step must still WRITE the module').toBe(written?.status);
+
+    const notice = plan.steps.find(
+      (s) => s.status === StepStatus.NOTICE && /capabilit/i.test(s.detail),
+    );
+    expect(
+      notice,
+      'nothing tells the reader that hasCapabilities will stay false until they edit this file',
+    ).toBeDefined();
+    expect(notice?.detail).toMatch(/hasCapabilities/);
+  });
+
+  it('stays quiet when the scan actually found something to register', () => {
+    const plan = vitePlan({ testids: ['save-btn', 'row-1'], storeHints: [] });
+    const notice = plan.steps.find(
+      (s) => s.status === StepStatus.NOTICE && /hasCapabilities/.test(s.detail),
+    );
+    expect(notice, 'testids were found — there is nothing to warn about').toBeUndefined();
+  });
+});
+
 describe('buildPlan — CRA pairing token', () => {
   const TOKEN_STEP = 'Pairing token';
   const craPlan = (partial: Partial<PlanInput> = {}): ReturnType<typeof buildPlan> =>


### PR DESCRIPTION
Closes #139 — and the useful part is the diagnosis, because the report explicitly asked for the three hypotheses to be separated before anyone touched code.

## Separating them

> 1. the app never imports the generated module;
> 2. registration happens but `onChanged` is not wired;
> 3. the re-announce fires but the bridge does not update the stored session identity.

**Not (1).** The Vite plugin resolves the module at load — `findDevModule` (`index.ts:634`) — and `VITE_DEV_MODULE_PATH` is `src/reticle-dev.ts`, the **first** candidate it looks for. Written path and searched path agree.

**Not (2) or (3).** A live drive of `apps/bench-app` tonight reported `hasCapabilities: true`, so registration, re-announce and the bridge update all work.

## What it actually is

The artifact-versus-effect gap the report names in its own second paragraph. The generated module always ends with:

```js
registerCapabilities({
  testids: [],   // none found — add data-testid to your key elements
  signals: [],
  stores: [],
});
```

On an app with **no `data-testid` values and no detected state library, that call registers nothing.** So `hasCapabilities: false` is *correct* — and the `✓ Capabilities + store` is what is wrong.

That also explains why bench-app disagreed with the report: it is a dogfood fixture full of testids.

## The fix

The file is still written and the step stays `APPLY` — only APPLY steps are written (`run.ts:603`), so demoting it would stop writing the module, which is the trap I hit in #192. A `NOTICE` goes beside it:

```
[✓] Capabilities + store → src/reticle-dev.ts
    no data-testid values yet; no state library detected
[ℹ] Capabilities are empty until you edit that file → src/reticle-dev.ts
    the module was written but registers nothing — no data-testid values were found and no state
    library was detected, so `hasCapabilities` stays false and reticle_state has nothing to read.
    Add data-testid to the elements your main flow touches, or register a store in that file, and
    the agent gains what the app BELIEVES rather than only what it rendered.
```

Same shape as the CRA token notice (#192), for the same reason: `SKILL.md` tells the reader *"If every line is ✓, · or –, skip to Step 4"*, so a caveat carried on a `✓` is a caveat nobody reads.

## Baseline

`install-baseline.json` was **regenerated by running the gate**, not edited by hand — a hand-written baseline makes the diff check meaningless.

```
✓ vite-react: 8 passed, 0 failed        (5 steps → 6, zero ⚠)
✅ INSTALL GATE PASSED (1/1 scaffolds)
```

The diff is one added line; the `✓` write is untouched.

## Tests

Two, one RED before the change. The other is the negative control — **an app that DID find testids must not get the notice**, since a warning that always fires is the noise this repo keeps removing.

## Verification

`pnpm typecheck && pnpm lint && pnpm test:unit` green: 3042 server. Plus `prettier --check` and the install gate above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
