### PR TITLE
fix(snapshot): interactive mode dropped the error the app just rendered

### DIFF
--- a/apps/bench-app/src/components/Login.tsx
+++ b/apps/bench-app/src/components/Login.tsx
@@ -71,6 +71,7 @@ export function Login(): React.ReactElement {
         {error !== '' ? (
           <div
             data-testid="login-error"
+            role="alert"
             style={{ color: 'var(--danger)', fontSize: 12.5, marginTop: 12 }}
           >
             {error}

--- a/packages/browser/src/dom/browser.test.ts
+++ b/packages/browser/src/dom/browser.test.ts
@@ -123,6 +123,30 @@ describe('snapshot', () => {
     expect(snap.tree).toContain('button "Go"');
   });
 
+  it('interactive mode keeps live regions: an alert is the app SAYING the action failed', () => {
+    // Drove a real login against bench-app: the click returned ok/settled with a DOM mutation, and
+    // interactive mode — the mode the tool description recommends for being ~3x smaller — showed
+    // the same three controls as before. The error text was only in FULL. An agent that follows
+    // the advice it is given is structurally blind to the failure it just caused.
+    render('<form><input aria-label="Email"><button>Sign in</button></form><div role="alert">Invalid email or password</div>');
+    const snap = buildSnapshot({ mode: SnapshotMode.INTERACTIVE });
+    expect(snap.tree).toContain('Invalid email or password');
+  });
+
+  it('interactive mode keeps an aria-live region even when the role is not alert', () => {
+    render('<div aria-live="polite">Saved 3 of 5</div><button>Go</button>');
+    const snap = buildSnapshot({ mode: SnapshotMode.INTERACTIVE });
+    expect(snap.tree).toContain('Saved 3 of 5');
+  });
+
+  it('interactive mode still drops ordinary text: the exemption is announcements only', () => {
+    render('<div aria-live="off">Muted</div><div>Chatter</div><button>Go</button>');
+    const snap = buildSnapshot({ mode: SnapshotMode.INTERACTIVE });
+    expect(snap.tree).not.toContain('Chatter');
+    expect(snap.tree).not.toContain('Muted'); // aria-live="off" is explicitly NOT an announcement
+    expect(snap.tree).toContain('button "Go"');
+  });
+
   it('emits a layout signature for grid containers so a CLS/layout regression is visible', () => {
     // A layout regression (column count change) leaves the role+text tree identical — only
     // the computed layout differs. The signature makes that visible (a11y-only tools cannot).

--- a/packages/browser/src/dom/browser.test.ts
+++ b/packages/browser/src/dom/browser.test.ts
@@ -128,7 +128,9 @@ describe('snapshot', () => {
     // interactive mode — the mode the tool description recommends for being ~3x smaller — showed
     // the same three controls as before. The error text was only in FULL. An agent that follows
     // the advice it is given is structurally blind to the failure it just caused.
-    render('<form><input aria-label="Email"><button>Sign in</button></form><div role="alert">Invalid email or password</div>');
+    render(
+      '<form><input aria-label="Email"><button>Sign in</button></form><div role="alert">Invalid email or password</div>',
+    );
     const snap = buildSnapshot({ mode: SnapshotMode.INTERACTIVE });
     expect(snap.tree).toContain('Invalid email or password');
   });

--- a/packages/browser/src/dom/snapshot.ts
+++ b/packages/browser/src/dom/snapshot.ts
@@ -23,6 +23,25 @@ const INTERACTIVE = new Set([
 
 const SKIP_TAGS = new Set(['script', 'style', 'noscript', 'template', 'head', 'meta', 'link']);
 
+/** Roles whose whole purpose is announcing a change; both imply an implicit aria-live. */
+const ANNOUNCE_ROLES = new Set(['alert', 'status']);
+
+/**
+ * Is this element the app SAYING something changed?
+ *
+ * INTERACTIVE mode keeps only actionable elements, which silently drops the one node that explains
+ * why an action did nothing — the error the app just rendered. An agent told to prefer the cheaper
+ * mode was structurally blind to the failure it had caused: the click reports settled with a DOM
+ * mutation, and the lean snapshot shows the same controls as before. Live regions exist precisely
+ * to announce state changes to a consumer that cannot see the screen, which is exactly the agent,
+ * so they are the principled exception — and a bounded one, since a page has very few.
+ */
+function announces(el: Element, role: string): boolean {
+  if (ANNOUNCE_ROLES.has(role)) return true;
+  const live = el.getAttribute('aria-live');
+  return live !== null && 'off' !== live;
+}
+
 /** Cap on inlined text content so a verbose node can't blow up the snapshot. */
 const TEXT_MAX = 80;
 
@@ -163,7 +182,7 @@ function pierceChildren(parent: Element): Element[] {
   return out;
 }
 
-function walk(parent: Element, depth: number, ctx: WalkCtx): void {
+function walk(parent: Element, depth: number, ctx: WalkCtx, inLive = false): void {
   if (depth > ctx.maxDepth) return;
   for (const child of pierceChildren(parent)) {
     if (ctx.nodes >= ctx.maxNodes) {
@@ -179,9 +198,12 @@ function walk(parent: Element, depth: number, ctx: WalkCtx): void {
     const role = getRole(child);
     const name = getAccessibleName(child);
     const interactive = INTERACTIVE.has(role);
+    // Announcements are exempt from leanness, and so is everything inside one: a live region whose
+    // message sits in a child element would otherwise be included as a contentless `- generic`.
+    const announce = inLive || announces(child, role);
+    const lean = ctx.mode === SnapshotMode.INTERACTIVE && !announce;
     // A generic, unnamed container's own text content — only consulted outside INTERACTIVE mode,
     // so the actionable-only view stays lean while FULL/meaningful views see content regressions.
-    const lean = ctx.mode === SnapshotMode.INTERACTIVE;
     const text = !lean && 'generic' === role && 0 === name.length ? directText(child) : '';
     // Layout signature for grid/flex containers — makes CLS/layout regressions visible.
     const layout = lean ? '' : layoutSignature(style);
@@ -195,9 +217,9 @@ function walk(parent: Element, depth: number, ctx: WalkCtx): void {
           ? formatTextLine(depth, text)
           : formatLine(child, depth, role, name, layout),
       );
-      walk(child, depth + 1, ctx);
+      walk(child, depth + 1, ctx, announce);
     } else {
-      walk(child, depth, ctx);
+      walk(child, depth, ctx, announce);
     }
   }
 }


### PR DESCRIPTION
## Found by driving, not by reading

Drove a real login against `bench-app` tonight to check tonight's merged fixes still work together. The click reported success:

```
{"ok":true,"dispatched":true,"settled":true,"effect":{"domMutatedWithin":7}}
```

Then `reticle_snapshot {mode:"interactive"}` — the mode the tool description recommends for being **~3x smaller** — returned the same three controls as before the click. Only `mode:"full"` carried `text "Invalid email or password"`.

**An agent that follows the advice Reticle itself gives is structurally blind to the failure it just caused.** Its next call is a confident assertion about a page it misread. This is one mechanism behind the telemetry finding that `reticle_act` is the most-used tool in the product (179 calls) and has produced **zero** findings.

## The fix

`INTERACTIVE` keeps only actionable elements, so live regions were filtered out — the nodes whose entire purpose is announcing a state change *to a consumer that cannot see the screen*, which is exactly the agent. They are the principled exception and a bounded one: a page has very few, and being few is what lets leanness survive the change.

- `role="alert"` / `role="status"`, or any `aria-live` that is not `"off"`.
- Everything **inside** a region is exempt too, or a region whose message sits in a child element is included as a contentless `- generic`.

## Proven live, not just in unit tests

Same drive, same mode, after rebuilding the SDK:

```
- textbox "Email" (ref=e1) [value="admin@reticle.dev"]
- textbox "Password" (ref=e2) [value="[REDACTED]"]
- alert "Invalid email or password" (ref=e4)     <-- new
- button "Sign in" (ref=e3)
```

**Cost: 61 → 73 tokens.** The failure an agent was blind to costs 12 tokens to see.

## Honest limit

This helps apps whose errors are marked up correctly. An app that renders its error as a bare `<div>` with no role and no `aria-live` is **still** hidden from interactive mode. The general fix is for `reticle_act` to report *what text appeared* alongside `domMutatedWithin`, which is a larger change and not this PR.

`bench-app` was exactly that bare-div case — its only failure message was announced to nobody, a real a11y defect in the fixture. Second commit fixes it, which is also what made the SDK fix demonstrable end-to-end.

## Tests

RED proven before GREEN (2 failed on the unfixed tree), including a negative control pinning that ordinary text and `aria-live="off"` stay out.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages, 840 browser tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)