### PR TITLE
feat(act): report the text the action put on the page, not just that it changed

### DIFF
--- a/packages/browser/src/actions/actions.effect.test.ts
+++ b/packages/browser/src/actions/actions.effect.test.ts
@@ -259,6 +259,33 @@ describe('action effect: appeared', () => {
     expect(r.effect.appeared).toBeUndefined();
   });
 
+  it('ignores a bare counter tick — an animated number is not the app saying something', async () => {
+    // Found by driving the Hostile fixture, which mutates a counter every 16ms. Clicking its
+    // "Fire failing request" button returned appeared:"409" — the ticker, not the fault. A
+    // fragment with no letters at all carries no message a reader can act on, and a bare number
+    // is exactly what a count-up animation emits into the settle window.
+    document.body.innerHTML = '<button>go</button><span id="tick">408</span>';
+    const button = document.querySelector('button') as HTMLButtonElement;
+    button.addEventListener('click', () => {
+      const tick = document.getElementById('tick');
+      if (null !== tick) tick.textContent = '409';
+    });
+    const r = await executeAction(refs.refFor(button), 'click');
+    expect(r.effect.domMutatedWithin).toBeGreaterThanOrEqual(1);
+    expect(r.effect.appeared).toBeUndefined();
+  });
+
+  it('keeps a number that comes WITH words — that one is a message', async () => {
+    document.body.innerHTML = '<button>go</button><span id="o"></span>';
+    const button = document.querySelector('button') as HTMLButtonElement;
+    button.addEventListener('click', () => {
+      const out = document.getElementById('o');
+      if (null !== out) out.textContent = 'status 500';
+    });
+    const r = await executeAction(refs.refFor(button), 'click');
+    expect(r.effect.appeared).toContain('status 500');
+  });
+
   it('still reports what the app said ABOUT the input it received', async () => {
     // The exclusion is exact-match only, so an app that quotes your input back inside its own
     // sentence is still reported — that IS the app talking.

--- a/packages/browser/src/actions/actions.effect.test.ts
+++ b/packages/browser/src/actions/actions.effect.test.ts
@@ -240,6 +240,37 @@ describe('action effect: appeared', () => {
     expect(r.effect.appeared).toBeDefined();
     expect((r.effect.appeared ?? '').length).toBeLessThan(300);
   });
+
+  it('does NOT echo the text the agent itself just typed', async () => {
+    // Found by driving: filling a textarea reported appeared:"<the value I passed in>". The field
+    // is meant to be what the APP said; handing the caller its own input back is noise wearing the
+    // name of evidence, and `valueChanged` already reports that the write landed.
+    // A textarea carries its value in a CHILD TEXT NODE, so a controlled one re-rendering after
+    // your keystroke mutates characterData with your own string. Filling the sibling <input> in
+    // the same live view produced no `appeared` at all, which is what identified the mechanism.
+    document.body.innerHTML = '<textarea>old</textarea>';
+    const ta = document.querySelector('textarea') as HTMLTextAreaElement;
+    ta.addEventListener('input', () => {
+      const child = ta.firstChild;
+      if (null !== child) child.textContent = ta.value;
+    });
+    const r = await executeAction(refs.refFor(ta), 'fill', { value: 'what shipped today' });
+    expect(r.effect.valueChanged).toBe(true);
+    expect(r.effect.appeared).toBeUndefined();
+  });
+
+  it('still reports what the app said ABOUT the input it received', async () => {
+    // The exclusion is exact-match only, so an app that quotes your input back inside its own
+    // sentence is still reported — that IS the app talking.
+    document.body.innerHTML = '<input /><div id="out"></div>';
+    const input = document.querySelector('input') as HTMLInputElement;
+    input.addEventListener('input', () => {
+      const out = document.getElementById('out');
+      if (null !== out) out.textContent = `No results for ${input.value}`;
+    });
+    const r = await executeAction(refs.refFor(input), 'fill', { value: 'zzz' });
+    expect(r.effect.appeared).toContain('No results for zzz');
+  });
 });
 
 describe('action effect: unresolvable ref', () => {

--- a/packages/browser/src/actions/actions.effect.test.ts
+++ b/packages/browser/src/actions/actions.effect.test.ts
@@ -187,6 +187,61 @@ describe('action effect: domMutatedWithin', () => {
   });
 });
 
+describe('action effect: appeared', () => {
+  it('reports the text the action put on the page, not just that something changed', async () => {
+    // The login shape. `domMutatedWithin: 7` is true and useless: it says the click did SOMETHING
+    // without saying the app rejected you. An agent reads ok/settled/mutated and moves on.
+    document.body.innerHTML = '<button>Sign in</button>';
+    const button = document.querySelector('button') as HTMLButtonElement;
+    button.addEventListener('click', () => {
+      const err = document.createElement('div');
+      err.textContent = 'Invalid email or password';
+      document.body.appendChild(err);
+    });
+    const r = await executeAction(refs.refFor(button), 'click');
+    expect(r.effect.appeared).toContain('Invalid email or password');
+  });
+
+  it('reports text swapped in by a character-data change, not only new nodes', async () => {
+    document.body.innerHTML = '<button>Save</button><div id="s">Ready</div>';
+    const button = document.querySelector('button') as HTMLButtonElement;
+    button.addEventListener('click', () => {
+      const status = document.getElementById('s');
+      if (null !== status) status.textContent = 'Could not save';
+    });
+    const r = await executeAction(refs.refFor(button), 'click');
+    expect(r.effect.appeared).toContain('Could not save');
+  });
+
+  it('is OMITTED when the action added no text — absence means "nothing was said"', async () => {
+    document.body.innerHTML = '<button>noop</button>';
+    const r = await executeAction(refOf('button'), 'click');
+    expect(r.effect.appeared).toBeUndefined();
+  });
+
+  it('is omitted when the DOM changed but silently — a class toggle says nothing to a reader', async () => {
+    document.body.innerHTML = '<button>toggle</button>';
+    const button = document.querySelector('button') as HTMLButtonElement;
+    button.addEventListener('click', () => button.classList.add('active'));
+    const r = await executeAction(refs.refFor(button), 'click');
+    expect(r.effect.domMutatedWithin).toBeGreaterThanOrEqual(1);
+    expect(r.effect.appeared).toBeUndefined();
+  });
+
+  it('truncates a large render rather than returning a whole page of text', async () => {
+    document.body.innerHTML = '<button>load</button>';
+    const button = document.querySelector('button') as HTMLButtonElement;
+    button.addEventListener('click', () => {
+      const big = document.createElement('div');
+      big.textContent = 'x'.repeat(5000);
+      document.body.appendChild(big);
+    });
+    const r = await executeAction(refs.refFor(button), 'click');
+    expect(r.effect.appeared).toBeDefined();
+    expect((r.effect.appeared ?? '').length).toBeLessThan(300);
+  });
+});
+
 describe('action effect: unresolvable ref', () => {
   it('rejects when the ref no longer resolves (tool did not dispatch)', async () => {
     document.body.innerHTML = '<button>gone</button>';

--- a/packages/browser/src/actions/actions.ts
+++ b/packages/browser/src/actions/actions.ts
@@ -568,7 +568,7 @@ export async function executeAction(
     domMutatedWithin: mutated,
     // Omitted rather than "" when nothing was said — an empty string reads as "it said nothing
     // meaningful", where absence says "it added no text at all". Those are different findings.
-    ...said.effect(),
+    ...said.effect(valueAfter),
     occluded: geometry.occluded,
     occludedBy: geometry.occludedBy,
     scrolledIntoView: geometry.scrolledIntoView,

--- a/packages/browser/src/actions/actions.ts
+++ b/packages/browser/src/actions/actions.ts
@@ -12,6 +12,7 @@ import { getAccessibleName, getRole, isVisible, getStates } from '../dom/a11y.js
 import { elementHasHoverHandlers, identifyComponent } from '../registry/adapters.js';
 import { isForm, isHtmlElement, isInput, isSelect, isTextArea } from '../dom/realm.js';
 import { nativeSetTimeout, settle } from '../timers/native-timers.js';
+import { AppearedText } from './appeared-text.js';
 
 /**
  * Best-effort evidence of whether/why an action landed, so the agent can separate
@@ -35,6 +36,18 @@ interface ActionEffect {
   valueChanged: boolean;
   /** Mutation records counted by a short-lived MutationObserver (one microtask + rAF window). */
   domMutatedWithin: number;
+  /**
+   * Text the action put on the page, truncated. OMITTED when it added none.
+   *
+   * `domMutatedWithin` says the click did SOMETHING; it cannot say the app rejected you. A login
+   * that fails returns ok/settled/mutated and reads exactly like one that succeeded, so an agent
+   * moves on and asserts against a page it misread. The observer already receives these records
+   * and was keeping only `.length` — the message was being thrown away, not gathered.
+   *
+   * Deliberately NOT a verdict: this is what appeared, not what it means. Absence means no text
+   * was added, which is why a silent class toggle omits the key rather than reporting "".
+   */
+  appeared?: string;
   /**
    * Click-like only: the center hit-tested to a foreign element (an overlay is on top). Synthetic
    * dispatch STILL delivered the event to the target, but a real user could not click it — treat
@@ -510,8 +523,10 @@ export async function executeAction(
   const geometry = CLICK_LIKE.has(action) ? clickGeometry(el) : NO_GEOMETRY;
 
   let mutated = 0;
+  const said = new AppearedText();
   const obs = new MutationObserver((records) => {
     mutated += records.length;
+    said.collect(records);
   });
   obs.observe(el.ownerDocument.documentElement, {
     subtree: true,
@@ -551,6 +566,9 @@ export async function executeAction(
     focusMoved: prevFocus !== nextFocus ? `${prevFocus ?? 'null'}->${nextFocus ?? 'null'}` : null,
     valueChanged: isFillLike(action) ? valueBefore !== valueAfter : false,
     domMutatedWithin: mutated,
+    // Omitted rather than "" when nothing was said — an empty string reads as "it said nothing
+    // meaningful", where absence says "it added no text at all". Those are different findings.
+    ...said.effect(),
     occluded: geometry.occluded,
     occludedBy: geometry.occludedBy,
     scrolledIntoView: geometry.scrolledIntoView,

--- a/packages/browser/src/actions/appeared-text.ts
+++ b/packages/browser/src/actions/appeared-text.ts
@@ -1,0 +1,69 @@
+import { isIgnored } from '../dom/dom-ignore.js';
+
+/** Cap on the reported text. Enough for an error message, far short of a re-rendered page. */
+const APPEARED_MAX = 200;
+
+/** Separator between distinct fragments that appeared in the same window. */
+const JOIN = ' | ';
+
+const TEXT_NODE = 3;
+
+/**
+ * Gathers the text an action put on the page, from mutation records the observer already receives.
+ *
+ * `domMutatedWithin` counts records and throws their content away, so a failed login reports
+ * `ok / settled / mutated` and reads exactly like a successful one. The message the app rendered
+ * was passing through this callback the whole time.
+ *
+ * Deliberately reports what appeared, never what it means: no error/success classification, no
+ * guessing which fragment matters. Truncated, because a route change can add a whole page.
+ */
+export class AppearedText {
+  readonly #seen = new Set<string>();
+  #length = 0;
+
+  collect(records: readonly MutationRecord[]): void {
+    for (const record of records) {
+      if (this.#full()) return;
+      if ('characterData' === record.type) {
+        // The NEW value; oldValue is not requested, so this is what the reader now sees.
+        this.#add(record.target.textContent, record.target.parentElement);
+        continue;
+      }
+      for (const node of record.addedNodes) {
+        if (this.#full()) return;
+        const owner = TEXT_NODE === node.nodeType ? node.parentElement : elementOf(node);
+        this.#add(node.textContent, owner);
+      }
+    }
+  }
+
+  /** `{ appeared }` when text was added, `{}` otherwise — an absent key means none was. */
+  effect(): { appeared?: string } {
+    if (0 === this.#seen.size) return {};
+    const joined = [...this.#seen].join(JOIN);
+    return {
+      appeared:
+        joined.length > APPEARED_MAX ? `${joined.slice(0, APPEARED_MAX)}…` : joined,
+    };
+  }
+
+  #full(): boolean {
+    return this.#length > APPEARED_MAX;
+  }
+
+  #add(raw: string | null, owner: Element | null): void {
+    // Reticle's own overlay mutates constantly (the "live" panel); reporting it as the app's
+    // response would be worse than reporting nothing.
+    if (null !== owner && isIgnored(owner)) return;
+    const text = (raw ?? '').replace(/\s+/g, ' ').trim();
+    if (0 === text.length) return;
+    if (this.#seen.has(text)) return;
+    this.#seen.add(text);
+    this.#length += text.length + JOIN.length;
+  }
+}
+
+function elementOf(node: Node): Element | null {
+  return node instanceof Element ? node : node.parentElement;
+}

--- a/packages/browser/src/actions/appeared-text.ts
+++ b/packages/browser/src/actions/appeared-text.ts
@@ -43,8 +43,7 @@ export class AppearedText {
     if (0 === this.#seen.size) return {};
     const joined = [...this.#seen].join(JOIN);
     return {
-      appeared:
-        joined.length > APPEARED_MAX ? `${joined.slice(0, APPEARED_MAX)}…` : joined,
+      appeared: joined.length > APPEARED_MAX ? `${joined.slice(0, APPEARED_MAX)}…` : joined,
     };
   }
 

--- a/packages/browser/src/actions/appeared-text.ts
+++ b/packages/browser/src/actions/appeared-text.ts
@@ -8,6 +8,23 @@ const JOIN = ' | ';
 
 const TEXT_NODE = 3;
 
+/** Any letter, in any script — Latin, Cyrillic, CJK, Arabic. */
+const HAS_LETTER = /\p{L}/u;
+
+/**
+ * A fragment with no letters at all is not the app saying something.
+ *
+ * The Hostile fixture mutates a counter every 16ms, and clicking a button on that page reported
+ * `appeared: "409"` — the ticker, not the action's effect. A count-up animation is exactly what
+ * emits a bare number into the settle window, and a bare number carries no message a reader can
+ * act on. Deliberately conservative: it drops only fragments with NO letters, so "status 500",
+ * "3 items deleted" and "Could not save" all survive. An app whose only feedback is a naked
+ * numeral loses it here — the snapshot still shows it, and that is the cheaper mistake.
+ */
+function saysSomething(text: string): boolean {
+  return HAS_LETTER.test(text);
+}
+
 /**
  * Gathers the text an action put on the page, from mutation records the observer already receives.
  *
@@ -67,6 +84,7 @@ export class AppearedText {
     if (null !== owner && isIgnored(owner)) return;
     const text = (raw ?? '').replace(/\s+/g, ' ').trim();
     if (0 === text.length) return;
+    if (!saysSomething(text)) return;
     if (this.#seen.has(text)) return;
     this.#seen.add(text);
     this.#length += text.length + JOIN.length;

--- a/packages/browser/src/actions/appeared-text.ts
+++ b/packages/browser/src/actions/appeared-text.ts
@@ -38,10 +38,20 @@ export class AppearedText {
     }
   }
 
-  /** `{ appeared }` when text was added, `{}` otherwise — an absent key means none was. */
-  effect(): { appeared?: string } {
-    if (0 === this.#seen.size) return {};
-    const joined = [...this.#seen].join(JOIN);
+  /**
+   * `{ appeared }` when the APP added text, `{}` otherwise — an absent key means it added none.
+   *
+   * `wrote` is the value the action itself just set, and is excluded: a textarea carries its value
+   * in a child text node, so a controlled one re-rendering after the write mutates characterData
+   * with the caller's own string. Handing that back is noise wearing the name of evidence, and
+   * `valueChanged` already reports that the write landed. Exact-match only, so an app that quotes
+   * your input inside a sentence of its own ("No results for zzz") is still reported — that is
+   * the app talking.
+   */
+  effect(wrote?: string): { appeared?: string } {
+    const said = [...this.#seen].filter((text) => text !== wrote);
+    if (0 === said.length) return {};
+    const joined = said.join(JOIN);
     return {
       appeared: joined.length > APPEARED_MAX ? `${joined.slice(0, APPEARED_MAX)}…` : joined,
     };


### PR DESCRIPTION
## The problem

`reticle_act` on a login that **fails** returns:

```json
{"ok":true,"settled":true,"effect":{"domMutatedWithin":7}}
```

A login that **succeeds** returns the same shape. `domMutatedWithin` says the click did *something*; it cannot say the app rejected you. The agent moves on and asserts against a page it misread.

This is the mechanism behind the telemetry finding that `reticle_act` is the most-used tool in the product (179 calls) and has produced **zero** findings — not because acts succeed, but because the result cannot express failure.

## The fix

The message was **already passing through the MutationObserver callback**. It kept `records.length` and threw the content away:

```js
const obs = new MutationObserver((records) => { mutated += records.length; });
```

So this costs no new observation, only the records already arriving:

```json
{"effect":{"domMutatedWithin":7,"appeared":"Invalid email or password"}}
```

Covers new nodes *and* `characterData` swaps, so `status.textContent = 'Could not save'` is reported too.

## What it deliberately does not do

- **Not a verdict.** What appeared, never what it means. No error/success classification, no guessing which fragment matters. Reticle's job is to be the honest instrument.
- **Omitted, not `""`,** when no text was added. A class toggle mutates the DOM and says nothing; absence is the honest report of that, and a test pins it.
- **Truncated at 200 chars.** A route change adds a whole page.
- **Excludes Reticle's own overlay**, which mutates constantly — reporting it as the app's response would be worse than reporting nothing.

## Relation to #209

#209 puts live regions back into `mode:"interactive"`. That only helps apps whose errors carry `role="alert"` or `aria-live`. **This one works on a bare `<div>`**, and it puts the evidence in the *same call* as the action rather than requiring a follow-up snapshot. They are complementary; this is the general form.

## Tests

RED proven before GREEN (3 failed on the unfixed tree). Five tests, two of them negative controls — the silent class toggle, and the no-op click.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages.

> Note for the reviewer: an unrelated load-only flake surfaced twice in `packages/browser/src/dom/refs.test.ts` (9.7s, GC-dependent `registry.size` on a WeakRef registry) and did not reproduce on two subsequent full runs. Not caused by this change and not chased here, but worth someone's attention — it is not a timing assertion, so the usual fix does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)