### PR TITLE
fix(bench-app): the "failing request" never failed — it returned 200

### DIFF
--- a/apps/bench-app/src/components/DeepPanels.tsx
+++ b/apps/bench-app/src/components/DeepPanels.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useApp } from '../store/store.js';
+import { API_BASE } from '../lib/api.js';
 
 /**
  * Deep-DOM fixture surface: one web component with an OPEN shadow root, and one same-origin
@@ -37,7 +38,7 @@ class BenchStatus extends HTMLElement {
     button.textContent = 'Refresh status';
     // A real consequence: the click makes a request, so a dead handler is observable on the network.
     button.addEventListener('click', () => {
-      void fetch('/api/health').catch(() => undefined);
+      void fetch(`${API_BASE}/api/health`).catch(() => undefined);
     });
     root.append(label, document.createTextNode(' · '), button);
   }

--- a/apps/bench-app/src/views/Hostile.tsx
+++ b/apps/bench-app/src/views/Hostile.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 import { useEffect, useRef, useState } from 'react';
+import { API_BASE } from '../lib/api.js';
 
 /**
  * The hostile fixture: a page that NEVER goes quiet on its own. Two independent churn sources —
@@ -40,7 +41,7 @@ export function Hostile(): React.ReactElement {
 
   const fireFailingRequest = (): void => {
     // The ONE scarce piece of evidence that must survive the churn.
-    void fetch('/api/broken/500')
+    void fetch(`${API_BASE}/api/broken/500`)
       .then((r) => setLastFault(`status ${String(r.status)}`))
       .catch((e: unknown) => setLastFault(e instanceof Error ? e.message : 'failed'));
   };

--- a/packages/server/src/tools/fixture-api-reachability.test.ts
+++ b/packages/server/src/tools/fixture-api-reachability.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * No bench-app source may fetch a RELATIVE `/api/...` URL.
+ *
+ * bench-app has no Vite dev-server proxy, so a relative API path never reaches `apps/api` on :8787.
+ * It hits the dev server, matches nothing, and comes back as the SPA fallback: `index.html` with
+ * **status 200**. The request does not error. It succeeds, with the wrong body, silently.
+ *
+ * That is not hypothetical. `Hostile.tsx` fired `fetch('/api/broken/500')` behind a button labelled
+ * "Fire failing request", and the fixture's own docstring named the acceptance it exists to prove:
+ *
+ *     "the single failed request must survive the flood instead of being pushed out of the
+ *      ring buffer by thousands of low-signal churn events"
+ *
+ * There was no failed request. The flood was being tested against a 200, so the acceptance was
+ * exercising a weaker claim than the one written down — and priority eviction exists specifically
+ * to protect FAILURES, which is the case that was never run. Every other call site in bench-app
+ * already used `API_BASE`; this one was the outlier, and nothing could see it, because a 200 is
+ * exactly what a passing test looks like.
+ *
+ * Placed in the unit gate rather than the e2e battery for the same reason as
+ * `e2e-surface-drift.test.ts`: the battery needs three servers and minutes, this needs a substring,
+ * and the pattern in this repo is unambiguous — every rule a machine enforces has held, and every
+ * rule left to prose has been violated.
+ */
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, '..', '..', '..', '..');
+const SRC = join(REPO, 'apps', 'bench-app', 'src');
+
+/** `fetch('/api/…')` in any quote style — the shape that silently resolves to the SPA fallback. */
+const RELATIVE_API_FETCH = /fetch\(\s*['"`]\/api\//g;
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...sourceFiles(full));
+      continue;
+    }
+    if (/\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+describe('bench-app requests reach the API', () => {
+  it('no source fetches a relative /api/ path — there is no dev-server proxy', () => {
+    const offenders = sourceFiles(SRC)
+      .filter((file) => RELATIVE_API_FETCH.test(readFileSync(file, 'utf8')))
+      .map((file) => relative(REPO, file));
+    expect(offenders).toEqual([]);
+  });
+
+  it('the guard actually matches the shape it is meant to catch', () => {
+    // Without this, a broken regex makes the check above pass forever while enforcing nothing —
+    // which is the exact failure it was written to prevent, one level up.
+    expect(/fetch\(\s*['"`]\/api\//.test("void fetch('/api/broken/500')")).toBe(true);
+    expect(/fetch\(\s*['"`]\/api\//.test('await fetch(`${API_BASE}/api/broken/500`)')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Found by driving the fixture

`reticle_network` on the Hostile page reported:

```json
{"method":"GET","url":"/api/broken/500","status":200}
```

bench-app has **no Vite dev-server proxy**, so a relative `/api` path never reaches `apps/api` on :8787. It hits the dev server, matches nothing, and comes back as the SPA fallback: `index.html` with **status 200**. The request does not error. It succeeds, with the wrong body, silently.

## Why this matters more than one bad URL

`Hostile.tsx` fired `fetch('/api/broken/500')` behind a button labelled **"Fire failing request"**, and the fixture's own docstring names the acceptance it exists to prove:

> "the single failed request must survive the flood instead of being pushed out of the ring buffer by thousands of low-signal churn events"

**There was no failed request.** The flood was being tested against a 200, so the acceptance exercised a weaker claim than the one written down — and priority eviction exists specifically to protect *failures*, which is the case that was never run.

Every other call site in bench-app already used `API_BASE`. This one was the outlier, and nothing could see it, because **a 200 is exactly what a passing test looks like.**

## The guard found a second one

I wrote the check for `Hostile.tsx` and it came back with two offenders — `DeepPanels.tsx` was fetching `/api/health` the same way, where the comment claims "the click makes a request, so a dead handler is observable on the network."

## Where the guard lives

In the **unit gate**, not the e2e battery, for the same reason as `e2e-surface-drift.test.ts`: the battery needs three servers and minutes, this needs a substring. Its own docstring makes the argument — *every rule a machine enforces has held, and every rule left to prose has been violated.*

It ships with a self-test asserting the regex matches `fetch('/api/…')` and does **not** match `` fetch(`${API_BASE}/api/…`) ``. Without it, a broken pattern makes the check pass forever while enforcing nothing — which is the same failure it exists to prevent, one level up.

## Verified live

RED before GREEN (2 offenders → `[]`). After the fix, driving the same button:

```
reticle_network → status 500, {"error":"internal server error"}
reticle_act     → effect: {domMutatedWithin: 1, appeared: "status 500"}
```

The fixture's stated acceptance is exercisable for the first time.

`pnpm lint && pnpm typecheck && pnpm test:unit && prettier --check .` — 15/15 packages, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)