### PR TITLE
fix(assert): a failed net assertion now names the status it saw

### DIFF
--- a/packages/server/src/events/predicate-eval.ts
+++ b/packages/server/src/events/predicate-eval.ts
@@ -308,6 +308,23 @@ function callSucceeded(data: Record<string, unknown>): boolean {
   return status === undefined || status < 400;
 }
 
+/**
+ * One call, as the failure report should name it: `POST /api/generate-script → 500`.
+ *
+ * The status used to be dropped here, which made the most common net failure unreadable. Asserting
+ * `{status: 200}` against a call that returned 500 reported only `POST /api/generate-script` — the
+ * very field the predicate filtered on was missing from the account of what was seen, so the agent
+ * is told the call happened and left to guess why it did not match.
+ *
+ * The arrow is OMITTED when there is no status. An in-flight or aborted request genuinely has none,
+ * and `→ undefined` would be a fabricated fact about the wire.
+ */
+function describeCall(e: ReticleEvent): string {
+  const head = `${str(e.data['method']) ?? 'GET'} ${str(e.data['url']) ?? ''}`;
+  const status = num(e.data['status']);
+  return status === undefined ? head : `${head} → ${String(status)}`;
+}
+
 export function evalNet(
   events: ReticleEvent[],
   p: Extract<Predicate, { kind: typeof PredicateKind.NET }>,
@@ -350,9 +367,7 @@ export function evalNet(
         // made no calls at all", and those need different fixes.
         observed: describeObserved(
           'calls',
-          events
-            .filter((e) => e.type === EventType.NET_REQUEST)
-            .map((e) => `${str(e.data['method']) ?? 'GET'} ${str(e.data['url']) ?? ''}`),
+          events.filter((e) => e.type === EventType.NET_REQUEST).map(describeCall),
         ),
         expected: `at least one call matching ${JSON.stringify(p)}`,
         assertion: 'net.present',

--- a/packages/server/src/events/predicate.test.ts
+++ b/packages/server/src/events/predicate.test.ts
@@ -80,6 +80,35 @@ describe('predicate engine', () => {
     expect(after.pass, 'fired BEFORE the floor — must not satisfy the assertion').toBe(false);
   });
 
+  it('a failed status assertion NAMES the status it saw, not just the call', async () => {
+    // Driven live against the swallowed-500 fixture: asserting {status:200} on a call that
+    // returned 500 reported `observed: "POST http://…/api/generate-script"` — the very field
+    // the predicate filtered on was missing from the report of what was seen. The agent is told
+    // the call happened and left to guess why it did not match.
+    const session = new FakeSession([
+      ev(EventType.NET_REQUEST, { method: 'POST', url: '/api/generate-script', status: 500 }),
+    ]);
+    const r = await evaluatePredicate(session, {
+      kind: 'net',
+      urlContains: '/api/generate-script',
+      status: 200,
+    });
+    expect(r.pass).toBe(false);
+    expect(r.observed).toContain('500');
+  });
+
+  it('omits the arrow when the call has no status yet — never invents one', async () => {
+    // An in-flight or aborted request has no status. "→ undefined" would be a fabricated fact.
+    const session = new FakeSession([
+      ev(EventType.NET_REQUEST, { method: 'GET', url: '/api/slow' }),
+    ]);
+    const r = await evaluatePredicate(session, { kind: 'net', urlContains: '/api/nope' });
+    expect(r.pass).toBe(false);
+    expect(r.observed).toContain('/api/slow');
+    expect(r.observed).not.toContain('undefined');
+    expect(r.observed).not.toContain('→');
+  });
+
   it('matches a network predicate', async () => {
     const session = new FakeSession([
       ev(EventType.NET_REQUEST, { method: 'POST', url: '/api/order', status: 200 }),


### PR DESCRIPTION
## Found by driving the flagship false-green case

Ran the `swallowed-500-generate` fixture — the "UI renders success, the wire returned 500" case. Asserting the wire correctly failed, and reported:

```
observed: "calls seen in this window: POST http://…/api/generate-script"
```

**The very field the predicate filtered on is missing from the account of what was seen.** The agent is told the call happened and left to guess why it did not match — wrong status? wrong method? Wrong URL fragment? The status was on the same event the matcher already reads (`num(d['status'])`); only the report dropped it.

```
observed: "calls seen in this window: POST http://…/api/generate-script → 500"
```

This is the most common net assertion failure there is, and it was the least readable.

## The arrow is omitted when there is no status

An in-flight or aborted request genuinely has none, and `→ undefined` would be a **fabricated fact about the wire** — in a tool whose entire value is not doing that. Pinned by its own test.

## Everything else in that drive was correct, and worth recording

The same run is the strongest end-to-end evidence I have that the core loop works. Asserting the *visible* success returned:

```json
{"verified":"no","verifiedReason":"contradicted","pass":true,
 "contradictions":[{"claim":"the app fired \"compose:generated\"",
                    "counter":"1 request(s) in the same window failed",
                    "detail":"POST /api/generate-script → 500"}],
 "advice":"This predicate only checks element/text presence… Prefer a { signal } or { net } assertion",
 "coverage":"partial — fetch was already wrapped before Reticle"}
```

`pass: true` **and** `verified: "no"`. It refused to call a passing DOM assertion verified, named the contradicting request, told the agent its predicate was too weak, and declared its own blind spot unprompted. That is the whole product thesis, on a real false green.

## Tests

RED before GREEN, plus a negative control for the no-status case.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)