### PR TITLE
fix(errors): render a serialized zod array as a sentence at the boundary

### DIFF
--- a/packages/server/src/tools/error-recovery.test.ts
+++ b/packages/server/src/tools/error-recovery.test.ts
@@ -529,3 +529,59 @@ describe('a predicate that did not parse is the agent to fix, not a Reticle bug'
     );
   });
 });
+
+/**
+ * The SDK's own schema rejection arrives as a serialized zod ARRAY, and this is the one boundary
+ * every agent-visible failure crosses — so it is where the array stops being the error text.
+ *
+ * `parsePredicate` fixed this for the three predicate tools by never producing the array. It cannot
+ * help anywhere else: `action` on a merged tool is validated by the MCP SDK BEFORE our handler runs,
+ * so the friendly "unknown action … expected: [tune, yield, …]" the handler already builds is
+ * unreachable for the commonest mistake of all, calling `reticle_session` with no action. What the
+ * agent got instead was the raw array. Driven live against the shipped daemon on `reticle_assert`.
+ *
+ * Fixing it HERE rather than per-tool is the point: one boundary, every tool, including ones nobody
+ * has written yet.
+ */
+describe('a serialized zod array is rendered as a sentence', () => {
+  const ZOD_ARRAY = JSON.stringify([
+    {
+      code: 'invalid_type',
+      expected: 'string',
+      received: 'undefined',
+      path: ['action'],
+      message: 'Required',
+    },
+    {
+      code: 'unrecognized_keys',
+      keys: ['mode'],
+      path: [],
+      message: "Unrecognized key(s) in object: 'mode'",
+    },
+  ]);
+
+  it('names the parameter instead of dumping the array', () => {
+    const payload = buildErrorPayload(ZOD_ARRAY);
+    expect(payload.error).toContain('action: Required');
+    expect(payload.error).toContain('unknown field mode');
+    expect(payload.error).not.toContain('invalid_type');
+    expect(payload.error).not.toContain('[{');
+  });
+
+  it('still classifies as the agent to fix, not a Reticle defect', () => {
+    const payload = buildErrorPayload(ZOD_ARRAY);
+    expect(String(payload.recovery)).toContain("did not match the tool's schema");
+    expect(JSON.stringify(payload)).not.toMatch(/defect in Reticle|report this/i);
+  });
+
+  it('leaves an ordinary message alone — this only rewrites the array shape', () => {
+    const plain = 'ref e42 no longer resolves to an element';
+    expect(buildErrorPayload(plain).error).toBe(plain);
+  });
+
+  it('leaves JSON that is not a zod issue array alone', () => {
+    // A tool legitimately returning a JSON array must not be reworded into a schema complaint.
+    const notIssues = JSON.stringify([{ url: '/api/x', status: 500 }]);
+    expect(buildErrorPayload(notIssues).error).toBe(notIssues);
+  });
+});

--- a/packages/server/src/tools/error-recovery.ts
+++ b/packages/server/src/tools/error-recovery.ts
@@ -247,8 +247,71 @@ export function recoveryFor(message: string): string | undefined {
  * a request for a bug report. The e2e battery caught it (`no bad argument is blamed on Reticle`);
  * no unit test could, which is why one now exists below.
  */
+/** Max issues rendered — a union rejection can emit one per member, which is how the array became unreadable. */
+const MAX_RENDERED_ISSUES = 3;
+
+/** The fields a zod issue always carries. Anything without both is not an issue array. */
+interface ZodIssueShape {
+  code: string;
+  message: string;
+  path?: unknown[];
+  keys?: unknown[];
+}
+
+function isZodIssue(value: unknown): value is ZodIssueShape {
+  if (typeof value !== 'object' || null === value) return false;
+  const v = value as Record<string, unknown>;
+  return 'string' === typeof v['code'] && 'string' === typeof v['message'];
+}
+
+/** `["net","urlContains"]` → `net.urlContains`; an empty path means the object itself. */
+function issueClause(issue: ZodIssueShape): string {
+  if ('unrecognized_keys' === issue.code && Array.isArray(issue.keys)) {
+    return `unknown field ${issue.keys.map(String).join(', ')}`;
+  }
+  const path = issue.path ?? [];
+  return `${0 === path.length ? 'the arguments' : path.map(String).join('.')}: ${issue.message}`;
+}
+
+/**
+ * A serialized zod issue array, rendered as a sentence. Anything else is returned untouched.
+ *
+ * This is the one boundary every agent-visible tool failure crosses, which is why the rewrite lives
+ * here rather than in each tool. `parsePredicate` solved this for the three predicate tools by never
+ * producing the array; it cannot help anywhere else, because the MCP SDK validates a tool's schema
+ * BEFORE our handler runs. So `reticle_session` with no action — the commonest mistake there is —
+ * never reaches the friendly "unknown action … expected: [tune, yield, …]" its handler already
+ * builds, and the agent gets the raw array instead. Driven live against the shipped daemon.
+ *
+ * Conservative by construction: it only rewrites a JSON ARRAY whose every element carries both
+ * `code` and `message`. A tool that legitimately returns JSON is left alone.
+ */
+export function zodArrayAsSentence(message: string): string {
+  const text = message.trim();
+  if (!text.startsWith('[')) return message;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return message; // not JSON at all — e.g. prose that happens to open with a bracket
+  }
+  if (!Array.isArray(parsed) || 0 === parsed.length || !parsed.every(isZodIssue)) return message;
+  const shown = parsed.slice(0, MAX_RENDERED_ISSUES).map(issueClause).join('; ');
+  const rest = parsed.length - MAX_RENDERED_ISSUES;
+  return rest > 0 ? `${shown} (and ${String(rest)} more)` : shown;
+}
+
+/**
+ * `unknown field` and `<path>: Required` are the shapes `zodArrayAsSentence` produces.
+ *
+ * Added for the same reason `did not parse` was: rendering the array as a sentence REMOVES the very
+ * codes (`invalid_type`, `unrecognized_keys`) this pattern matched on, so a schema rejection fell
+ * through to the generic branch and came back as "may be a defect in Reticle" — worse than the dump
+ * it replaced, because it also asks for a bug report about the agent's own malformed call. This repo
+ * has now made that mistake twice; the second time a test caught it before CI did.
+ */
 const ARGUMENT_REJECTION =
-  /Unrecognized key|unrecognized_keys|invalid_type|did not parse|Invalid arguments for tool|Unknown parameters? for|^Required |Expected \w+, received/i;
+  /Unrecognized key|unrecognized_keys|invalid_type|did not parse|unknown field|: Required\b|Invalid arguments for tool|Unknown parameters? for|^Required |Expected \w+, received/i;
 
 /**
  * What to say instead of asking for a bug report. The schema already stated the problem precisely;
@@ -292,10 +355,9 @@ interface ErrorPayload {
  * agent always gets exactly one next move.
  */
 export function buildErrorPayload(rawMessage: string): ErrorPayload {
-  // Cap FIRST, then classify on the capped text — so what the classifier reads is exactly what the
-  // agent reads. Classifying the full message and emitting a shorter one would let a recovery hint
-  // reference a phrase that is no longer there.
-  const message = capMessage(rawMessage);
+  // Render the zod array BEFORE capping: the cap would otherwise truncate the JSON mid-issue and
+  // leave an unparseable fragment as the agent's error text — the worst of both shapes.
+  const message = capMessage(zodArrayAsSentence(rawMessage));
   // A self-diagnosing message gets NEITHER a generic recovery nor the feedback ask. It already
   // inspected the machine and named the cause; a second, contradictory hint is noise, and inviting a
   // bug report about a condition Reticle diagnosed itself is exactly backwards.


### PR DESCRIPTION
Closes #109.

## What the agent actually got

Driving the shipped daemon, `reticle_assert` with a malformed predicate returned this **as its error text**:

```json
[{"code":"invalid_type","expected":"string","received":"undefined","path":["contains"],"message":"Required"},
 {"code":"unrecognized_keys","keys":["value"],"path":[],"message":"Unrecognized key(s) in object: 'value'"}]
```

Now:

```
contains: Required; unknown field value
```

## Why it could not be fixed per-tool

`parsePredicate` solved this for the three predicate tools by never producing the array. **It cannot help anywhere else**: the MCP SDK validates a tool's schema *before* our handler runs. So `reticle_session` with no `action` — #109, and the commonest mistake there is — never reaches the friendly `unknown action … expected: [tune, yield, …]` that `mergeTools` already builds. That message is unreachable dead code for the case it was written for.

So the rewrite goes at `buildErrorPayload`, the one boundary every agent-visible tool failure crosses. One place, every tool, including ones nobody has written yet. This is also what #108 asks for.

## Deliberately conservative

- Only a JSON **array** whose every element carries both `code` and `message` is rewritten. A tool legitimately returning JSON is left alone — pinned by a test.
- Rendered **before** the length cap. Capping first would truncate the JSON mid-issue and leave an unparseable fragment as the error text: the worst of both shapes.
- Capped at 3 issues. A union rejection emits one per member, and pasting all of them back is how the array became unreadable in the first place.

## The trap this repo has now hit twice

`ARGUMENT_REJECTION` keys on the shapes our validators produce. Rendering the sentence **removes** the codes it matched on (`invalid_type`, `unrecognized_keys`), so a schema rejection fell through to the generic branch and came back as *"may be a defect in Reticle"* — worse than the dump it replaced, because it also solicits a bug report about the agent's own malformed call.

That is verbatim the regression `did not parse` was added for when `parsePredicate` landed, and the docblock above that test says so. The difference this time is that a unit test caught it rather than the e2e battery. I have extended the comment to say the repo has made this mistake twice, so the next person changing an error's wording sees the coupling.

## Tests

RED before GREEN, with three negative controls: an ordinary message, non-issue JSON, and the "not a Reticle defect" classification.

Verified end to end by running the **exact array from the live session** through the built server:

```json
{"error":"contains: Required; unknown field value",
 "recovery":"That call did not match the tool's schema — the message above names the parameter…"}
```

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)