### PR TITLE
fix(verdict): a window the browser dropped events in must not grade proved

### DIFF
--- a/packages/server/src/honesty/blind-spots.ts
+++ b/packages/server/src/honesty/blind-spots.ts
@@ -136,3 +136,37 @@ export function blindSpotsFromEvents(events: readonly ReticleEvent[]): BlindSpot
 export function blindSpotsFromState(state: Readonly<Record<string, number>>): BlindSpot[] {
   return Object.entries(state).map(([kind, count]) => ({ kind: kind as BlindSpotKind, count }));
 }
+
+/**
+ * Events the BROWSER's own transport queue threw away inside this window, or 0.
+ *
+ * `RATE_LIMITED` — the BRIDGE sampling because events arrived faster than its per-second cap — is
+ * already the one blind spot that `impeachesCapture`, on the reasoning that a green over a window
+ * you did not fully see "would only describe what was observed". `TRANSPORT_OVERFLOW` is the exact
+ * same loss on the other side of the wire, and it was read in journal rollups and NOWHERE on the
+ * verdict path. So the identical condition downgraded a verdict from one side of the socket and was
+ * invisible from the other: a window that dropped 34 events graded `proved`, in a sentence whose own
+ * words were "over a clean capture".
+ *
+ * `TRUNCATED` is deliberately NOT counted. It names the channel it capped (a DOM-mutation flood on
+ * any busy page) and is routine churn; treating it as lost evidence would caveat every verdict on
+ * every real app, and a caveat that is always present is one nobody reads. TRANSPORT_OVERFLOW is the
+ * honest "arbitrary events are gone" marker — it cannot say which.
+ */
+export function droppedByTransport(events: readonly ReticleEvent[]): number {
+  let dropped = 0;
+  for (const e of events) {
+    if (e.type !== EventType.TRANSPORT_OVERFLOW) continue;
+    const n = e.data['dropped'];
+    dropped += 'number' === typeof n ? n : 0;
+  }
+  return dropped;
+}
+
+/** The impeaching note for a transport gap, or undefined when the window was intact. */
+export function transportGapNote(events: readonly ReticleEvent[]): string | undefined {
+  const dropped = droppedByTransport(events);
+  return 0 === dropped
+    ? undefined
+    : `the browser dropped ${String(dropped)} event(s) in this window (transport queue overflow), so events that would have contradicted this may never have arrived`;
+}

--- a/packages/server/src/tools/act-tools.ts
+++ b/packages/server/src/tools/act-tools.ts
@@ -31,6 +31,7 @@ import { buildHonestyBlock } from '../honesty/honesty.js';
 import {
   buildCoverageStatement,
   blindSpotsFromState,
+  transportGapNote,
   Coverage,
   impeachesCapture,
 } from '../honesty/blind-spots.js';
@@ -490,12 +491,21 @@ export const ACT_TOOLS: ToolDef[] = [
         // structural boundary (virtualized rows, a cross-origin frame) is reported as coverage and
         // must not downgrade a verdict about what WAS observed.
         const impeaching = buildCoverageStatement(spots.filter((s) => impeachesCapture(s.kind)));
+        // Same rule as reticle_assert: a browser-side transport gap means part of this window was
+        // never seen, which is what `blindSpots` exists to say. `truncated` above covers the SERVER
+        // ring buffer evicting; this covers the BROWSER queue overflowing, and they are not the same
+        // loss — an act_and_wait that graded `proved` over 34 dropped events said so in a sentence
+        // whose own words were "over a clean capture".
+        const gapNote = transportGapNote(windowEvents);
+        const impeachingNotes = [impeaching.note, gapNote].filter(
+          (n): n is string => n !== undefined,
+        );
         const honesty = buildHonestyBlock({
           grade: gradeOf(gradedLinks),
           attribution: 'window',
           truncated: session.bufferHealth().dropped > droppedBefore,
           coveragePartial: Coverage.PARTIAL === coverage.coverage,
-          ...(impeaching.note === undefined ? {} : { blindSpots: [impeaching.note] }),
+          ...(0 === impeachingNotes.length ? {} : { blindSpots: impeachingNotes }),
         });
         const capsuleSaved = await saveFailedAssertCapsule({
           deps,

--- a/packages/server/src/tools/assert-transport-gap.test.ts
+++ b/packages/server/src/tools/assert-transport-gap.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { EventType, SessionState, Verified, VerifiedReason } from '@reticlehq/core';
+import { LastAct } from '../session/last-act.js';
+import { TOOLS, type ToolDef, type ToolDeps } from './tools.js';
+import { ReticleTool } from './tool-names.js';
+import type { Session, SessionManager } from '../session/session.js';
+import type { ReticleEvent } from '@reticlehq/core';
+
+/**
+ * A window the browser dropped events in must not grade `proved`.
+ *
+ * `RATE_LIMITED` — the BRIDGE sampling because events arrived faster than its per-second cap — is
+ * already the one blind spot that `impeachesCapture`, on the reasoning that a green over a window
+ * you did not fully see "would only describe what was observed". `TRANSPORT_OVERFLOW` is the exact
+ * same loss on the other side of the wire: the browser's own queue overflowed and threw events
+ * away. It was read in journal rollups and nowhere on the verdict path, so the identical condition
+ * downgraded a verdict from one side of the socket and was invisible from the other.
+ *
+ * This is the gap-marker half of #117: the SDK knows it lost events, and none of that reached the
+ * rule that decides whether a green can be trusted.
+ */
+function depsWith(events: ReticleEvent[]): ToolDeps {
+  const session: Partial<Session> = {
+    id: 'demo',
+    lastAct: new LastAct(),
+    bufferHealth: () => ({ total: 12, dropped: 0 }),
+    blindSpots: () => ({}),
+    eventsSince: () => events,
+    queryEvents: () => Promise.resolve(events),
+    elapsed: () => 1000,
+    health: () => ({ lastSeenMs: 5, throttled: false, focused: true, hidden: false }),
+    getState: () => SessionState.ACTIVE,
+    drainInbox: () => [],
+  };
+  const sessions: Partial<SessionManager> = { resolve: () => session as Session };
+  return { sessions: sessions as SessionManager } as unknown as ToolDeps;
+}
+
+const tool = (name: string): ToolDef => {
+  const found = TOOLS.find((t) => t.name === name);
+  if (found === undefined) throw new Error(`${name} is not on the surface`);
+  return found;
+};
+
+function ev(type: EventType, data: Record<string, unknown>, t = 5): ReticleEvent {
+  return { t, type, sessionId: 'demo', data };
+}
+
+/** A signal the assertion below matches, so `pass` is true and only the VERDICT is under test. */
+const SIGNAL = ev(EventType.SIGNAL, { name: 'saved' });
+
+const assertSaved = { predicate: { kind: 'signal', name: 'saved' }, timeout_ms: 0 };
+
+interface Verdict {
+  pass: boolean;
+  verified?: string;
+  verifiedReason?: string;
+  because?: string;
+}
+
+describe('a verdict over a window the browser dropped events in', () => {
+  it('is not `proved` when the transport queue overflowed', async () => {
+    const result = (await tool(ReticleTool.ASSERT).handler(
+      depsWith([SIGNAL, ev(EventType.TRANSPORT_OVERFLOW, { dropped: 34 })]),
+      assertSaved,
+    )) as Verdict;
+    expect(result.pass, 'the assertion itself still held').toBe(true);
+    expect(result.verified).toBe(Verified.UNKNOWN);
+    expect(result.verifiedReason).toBe(VerifiedReason.UNCLEAN_CAPTURE);
+  });
+
+  it('says how many events went missing, so the caveat is actionable', async () => {
+    const result = (await tool(ReticleTool.ASSERT).handler(
+      depsWith([SIGNAL, ev(EventType.TRANSPORT_OVERFLOW, { dropped: 34 })]),
+      assertSaved,
+    )) as Verdict;
+    expect(String(result.because)).toContain('34');
+  });
+
+  it('still grades the same window `proved` when nothing was dropped', async () => {
+    // The negative control. Without it this fix could downgrade every verdict and still look green.
+    const result = (await tool(ReticleTool.ASSERT).handler(
+      depsWith([SIGNAL]),
+      assertSaved,
+    )) as Verdict;
+    expect(result.pass).toBe(true);
+    expect(result.verified).toBe(Verified.YES);
+    expect(result.verifiedReason).toBe(VerifiedReason.PROVED);
+  });
+
+  it('a TRUNCATED channel does NOT impeach — it names its channel and is routine churn', async () => {
+    // Deliberate line. A DOM-mutation flood truncates on any busy page; treating that as "I lost
+    // data" would caveat every verdict on every real app, and a caveat that is always present is
+    // one nobody reads. TRANSPORT_OVERFLOW is the honest "arbitrary events are gone" marker.
+    const result = (await tool(ReticleTool.ASSERT).handler(
+      depsWith([SIGNAL, ev(EventType.TRUNCATED, { channel: 'dom', dropped: 900 })]),
+      assertSaved,
+    )) as Verdict;
+    expect(result.verified).toBe(Verified.YES);
+  });
+});

--- a/packages/server/src/tools/assert-verdict.ts
+++ b/packages/server/src/tools/assert-verdict.ts
@@ -6,6 +6,7 @@ import {
   buildCoverageStatement,
   Coverage,
   impeachesCapture,
+  transportGapNote,
 } from '../honesty/blind-spots.js';
 import { buildHonestyBlock } from '../honesty/honesty.js';
 import { hasAcceptedWrite } from '../honesty/accepted-write.js';
@@ -71,6 +72,11 @@ export async function assertVerdict(
   // Only a spot that IMPEACHES the capture downgrades a verdict. A structural boundary (virtualized
   // rows, a cross-origin frame) is reported as coverage and must not impugn what WAS observed.
   const impeaching = buildCoverageStatement(spots.filter((sp) => impeachesCapture(sp.kind)));
+  // A gap in the WINDOW, as opposed to a standing limit of the page. Both mean the same thing to the
+  // rule — part of what happened was not seen — so both belong in `blindSpots`, which is the only
+  // input `decideVerified` reads for that.
+  const gap = transportGapNote(windowEvents);
+  const impeachingNotes = [impeaching.note, gap].filter((n): n is string => n !== undefined);
   const outcomePending = hasAcceptedWrite(windowEvents);
   const outcomeUnread = hasUnreadWriteOutcome(windowEvents);
   const decision = decideVerified({
@@ -81,7 +87,7 @@ export async function assertVerdict(
       grade: gradeOfPredicate(predicate),
       attribution: 'window',
       coveragePartial: Coverage.PARTIAL === statement.coverage,
-      ...(impeaching.note === undefined ? {} : { blindSpots: [impeaching.note] }),
+      ...(0 === impeachingNotes.length ? {} : { blindSpots: impeachingNotes }),
     }),
     contradictions,
     ...(outcomePending ? { outcomePending } : {}),

--- a/packages/server/src/tools/error-recovery.test.ts
+++ b/packages/server/src/tools/error-recovery.test.ts
@@ -529,3 +529,59 @@ describe('a predicate that did not parse is the agent to fix, not a Reticle bug'
     );
   });
 });
+
+/**
+ * The SDK's own schema rejection arrives as a serialized zod ARRAY, and this is the one boundary
+ * every agent-visible failure crosses — so it is where the array stops being the error text.
+ *
+ * `parsePredicate` fixed this for the three predicate tools by never producing the array. It cannot
+ * help anywhere else: `action` on a merged tool is validated by the MCP SDK BEFORE our handler runs,
+ * so the friendly "unknown action … expected: [tune, yield, …]" the handler already builds is
+ * unreachable for the commonest mistake of all, calling `reticle_session` with no action. What the
+ * agent got instead was the raw array. Driven live against the shipped daemon on `reticle_assert`.
+ *
+ * Fixing it HERE rather than per-tool is the point: one boundary, every tool, including ones nobody
+ * has written yet.
+ */
+describe('a serialized zod array is rendered as a sentence', () => {
+  const ZOD_ARRAY = JSON.stringify([
+    {
+      code: 'invalid_type',
+      expected: 'string',
+      received: 'undefined',
+      path: ['action'],
+      message: 'Required',
+    },
+    {
+      code: 'unrecognized_keys',
+      keys: ['mode'],
+      path: [],
+      message: "Unrecognized key(s) in object: 'mode'",
+    },
+  ]);
+
+  it('names the parameter instead of dumping the array', () => {
+    const payload = buildErrorPayload(ZOD_ARRAY);
+    expect(payload.error).toContain('action: Required');
+    expect(payload.error).toContain('unknown field mode');
+    expect(payload.error).not.toContain('invalid_type');
+    expect(payload.error).not.toContain('[{');
+  });
+
+  it('still classifies as the agent to fix, not a Reticle defect', () => {
+    const payload = buildErrorPayload(ZOD_ARRAY);
+    expect(String(payload.recovery)).toContain("did not match the tool's schema");
+    expect(JSON.stringify(payload)).not.toMatch(/defect in Reticle|report this/i);
+  });
+
+  it('leaves an ordinary message alone — this only rewrites the array shape', () => {
+    const plain = 'ref e42 no longer resolves to an element';
+    expect(buildErrorPayload(plain).error).toBe(plain);
+  });
+
+  it('leaves JSON that is not a zod issue array alone', () => {
+    // A tool legitimately returning a JSON array must not be reworded into a schema complaint.
+    const notIssues = JSON.stringify([{ url: '/api/x', status: 500 }]);
+    expect(buildErrorPayload(notIssues).error).toBe(notIssues);
+  });
+});

--- a/packages/server/src/tools/error-recovery.ts
+++ b/packages/server/src/tools/error-recovery.ts
@@ -247,8 +247,71 @@ export function recoveryFor(message: string): string | undefined {
  * a request for a bug report. The e2e battery caught it (`no bad argument is blamed on Reticle`);
  * no unit test could, which is why one now exists below.
  */
+/** Max issues rendered — a union rejection can emit one per member, which is how the array became unreadable. */
+const MAX_RENDERED_ISSUES = 3;
+
+/** The fields a zod issue always carries. Anything without both is not an issue array. */
+interface ZodIssueShape {
+  code: string;
+  message: string;
+  path?: unknown[];
+  keys?: unknown[];
+}
+
+function isZodIssue(value: unknown): value is ZodIssueShape {
+  if (typeof value !== 'object' || null === value) return false;
+  const v = value as Record<string, unknown>;
+  return 'string' === typeof v['code'] && 'string' === typeof v['message'];
+}
+
+/** `["net","urlContains"]` → `net.urlContains`; an empty path means the object itself. */
+function issueClause(issue: ZodIssueShape): string {
+  if ('unrecognized_keys' === issue.code && Array.isArray(issue.keys)) {
+    return `unknown field ${issue.keys.map(String).join(', ')}`;
+  }
+  const path = issue.path ?? [];
+  return `${0 === path.length ? 'the arguments' : path.map(String).join('.')}: ${issue.message}`;
+}
+
+/**
+ * A serialized zod issue array, rendered as a sentence. Anything else is returned untouched.
+ *
+ * This is the one boundary every agent-visible tool failure crosses, which is why the rewrite lives
+ * here rather than in each tool. `parsePredicate` solved this for the three predicate tools by never
+ * producing the array; it cannot help anywhere else, because the MCP SDK validates a tool's schema
+ * BEFORE our handler runs. So `reticle_session` with no action — the commonest mistake there is —
+ * never reaches the friendly "unknown action … expected: [tune, yield, …]" its handler already
+ * builds, and the agent gets the raw array instead. Driven live against the shipped daemon.
+ *
+ * Conservative by construction: it only rewrites a JSON ARRAY whose every element carries both
+ * `code` and `message`. A tool that legitimately returns JSON is left alone.
+ */
+export function zodArrayAsSentence(message: string): string {
+  const text = message.trim();
+  if (!text.startsWith('[')) return message;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return message; // not JSON at all — e.g. prose that happens to open with a bracket
+  }
+  if (!Array.isArray(parsed) || 0 === parsed.length || !parsed.every(isZodIssue)) return message;
+  const shown = parsed.slice(0, MAX_RENDERED_ISSUES).map(issueClause).join('; ');
+  const rest = parsed.length - MAX_RENDERED_ISSUES;
+  return rest > 0 ? `${shown} (and ${String(rest)} more)` : shown;
+}
+
+/**
+ * `unknown field` and `<path>: Required` are the shapes `zodArrayAsSentence` produces.
+ *
+ * Added for the same reason `did not parse` was: rendering the array as a sentence REMOVES the very
+ * codes (`invalid_type`, `unrecognized_keys`) this pattern matched on, so a schema rejection fell
+ * through to the generic branch and came back as "may be a defect in Reticle" — worse than the dump
+ * it replaced, because it also asks for a bug report about the agent's own malformed call. This repo
+ * has now made that mistake twice; the second time a test caught it before CI did.
+ */
 const ARGUMENT_REJECTION =
-  /Unrecognized key|unrecognized_keys|invalid_type|did not parse|Invalid arguments for tool|Unknown parameters? for|^Required |Expected \w+, received/i;
+  /Unrecognized key|unrecognized_keys|invalid_type|did not parse|unknown field|: Required\b|Invalid arguments for tool|Unknown parameters? for|^Required |Expected \w+, received/i;
 
 /**
  * What to say instead of asking for a bug report. The schema already stated the problem precisely;
@@ -292,10 +355,9 @@ interface ErrorPayload {
  * agent always gets exactly one next move.
  */
 export function buildErrorPayload(rawMessage: string): ErrorPayload {
-  // Cap FIRST, then classify on the capped text — so what the classifier reads is exactly what the
-  // agent reads. Classifying the full message and emitting a shorter one would let a recovery hint
-  // reference a phrase that is no longer there.
-  const message = capMessage(rawMessage);
+  // Render the zod array BEFORE capping: the cap would otherwise truncate the JSON mid-issue and
+  // leave an unparseable fragment as the agent's error text — the worst of both shapes.
+  const message = capMessage(zodArrayAsSentence(rawMessage));
   // A self-diagnosing message gets NEITHER a generic recovery nor the feedback ask. It already
   // inspected the machine and named the cause; a second, contradictory hint is noise, and inviting a
   // bug report about a condition Reticle diagnosed itself is exactly backwards.


### PR DESCRIPTION
Part of #117 — the gap-marker half, which is the consequence that issue is actually about.

## The asymmetry

`RATE_LIMITED` — the **bridge** sampling because events arrived faster than its per-second cap — is already the one blind spot that `impeachesCapture()`, on the stated reasoning that a green over a window you did not fully see *"would only describe what was observed"*.

`TRANSPORT_OVERFLOW` is the **exact same loss on the other side of the wire**: the browser's own queue overflowed and threw events away. It was read in journal rollups and **nowhere on the verdict path**.

So the identical condition downgraded a verdict from one side of the socket and was invisible from the other.

## What that produced

The RED run, on a window with 34 dropped events:

```
verified: "yes"
verifiedReason: "proved"
because: "assertion held at signal grade over a clean capture with no channel disagreeing"
```

The sentence asserts cleanliness over a window with a hole in it. That is the one thing this layer exists not to do — and the `because` text is the part the honesty layer promises can be trusted on its own.

## Both paths, not just the one that surfaced it

`reticle_assert` and `act_and_wait` build the honesty block the same way and had the same hole. `act_and_wait`'s existing `truncated` flag is **not** this signal: that is the *server* ring buffer evicting, this is the *browser* queue overflowing. Different side, different loss, and only one of them was reported.

## What is deliberately excluded

`TRUNCATED` does not impeach, and a test pins that. It names the channel it capped — a DOM-mutation flood on any busy page — and is routine churn. Treating it as lost evidence would caveat every verdict on every real app, and a caveat that is always present is one nobody reads. `TRANSPORT_OVERFLOW` is the honest "arbitrary events are gone" marker; it cannot even say which ones.

## Still open on #117

This does not close it. Left explicitly undone: `eventsDropped` on `lastOutage`, `gapMarkers` in the sessions block, and the **outage**-overlap case (as distinct from the overflow marker), which needs `decideVerified` to see attachment history it currently has no route to. Commented there rather than claimed.

## Tests

RED before GREEN (2 of 4 failed), with two negative controls: an intact window still grades `proved`, and a `TRUNCATED` channel does not downgrade.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)