### PR TITLE
fix(init): correct Windows argument quoting (js/incomplete-sanitization)

### DIFF
--- a/packages/server/src/init/node-io.ts
+++ b/packages/server/src/init/node-io.ts
@@ -10,6 +10,7 @@ import { join, dirname, isAbsolute } from 'node:path';
 import { homedir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import type { InitIo } from './run.js';
+import { windowsShellArg } from './windows-quote.js';
 
 /**
  * `shell: true` ONLY where it earns its keep.
@@ -23,10 +24,15 @@ function shellOpt(): { shell?: true } {
   return NodePlatform.WINDOWS === process.platform ? { shell: true } : {};
 }
 
-/** Under a shell, quote what the shell would otherwise split. Windows only, where shell is required. */
+/**
+ * Under a shell, quote what the shell would otherwise split or interpret. Windows only, where
+ * `shell: true` is required (see shellOpt). The rule itself lives in windows-quote.ts as a pure
+ * function so it can be tested on every platform — keeping it inside this branch is why it was
+ * wrong for as long as it was.
+ */
 function shellSafe(args: readonly string[]): string[] {
   if (process.platform !== NodePlatform.WINDOWS) return [...args];
-  return args.map((arg) => (/[\s"]/.test(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg));
+  return args.map(windowsShellArg);
 }
 
 export function buildNodeIo(cwd: string): InitIo {

--- a/packages/server/src/init/windows-quote.test.ts
+++ b/packages/server/src/init/windows-quote.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { windowsShellArg } from './windows-quote.js';
+
+/**
+ * Windows argument quoting, tested on every platform because the bug only exists on one.
+ *
+ * The escaping lived inside a `process.platform` branch, so on a mac or in CI's Linux job the
+ * Windows path could not be exercised at all — which is how it stayed wrong. Pulling the rule out
+ * as a pure function is most of the fix: it can now be asserted anywhere.
+ *
+ * CodeQL `js/incomplete-sanitization` (high) on the original, and it flagged the smaller half.
+ */
+describe('windowsShellArg', () => {
+  it('leaves an ordinary argument untouched — quoting everything would be its own bug', () => {
+    expect(windowsShellArg('install')).toBe('install');
+    expect(windowsShellArg('@reticlehq/browser')).toBe('@reticlehq/browser');
+  });
+
+  it('quotes a path containing a space', () => {
+    expect(windowsShellArg('C:\\Users\\ada\\My Projects')).toBe('"C:\\Users\\ada\\My Projects"');
+  });
+
+  it('a path ending in a backslash does not swallow its own closing quote', () => {
+    // The reported bug. `"C:\Users\ada\My Projects\"` reads the trailing \" as an ESCAPED quote, so
+    // the quoted region never closes and everything after it is re-parsed by cmd.exe.
+    const quoted = windowsShellArg('C:\\Users\\ada\\My Projects\\');
+    expect(quoted).toBe('"C:\\Users\\ada\\My Projects\\\\"');
+    expect(quoted.endsWith('\\\\"'), 'the final backslash must be doubled').toBe(true);
+  });
+
+  it('escapes an interior quote and the backslashes in front of it', () => {
+    expect(windowsShellArg('a\\"b')).toBe('"a\\\\\\"b"');
+  });
+
+  it('quotes a cmd metacharacter even with no whitespace — the second injection route', () => {
+    // Not in the report. The old predicate was /[\s"]/, so `foo&whoami` contains neither a space
+    // nor a quote and was handed to cmd.exe RAW. Correct backslash escaping does nothing for this.
+    for (const arg of ['foo&whoami', 'a|b', 'a>b', 'a<b', 'a^b', 'a(b', 'a)b']) {
+      expect(windowsShellArg(arg), arg).toBe(`"${arg}"`);
+    }
+  });
+
+  it('quotes the empty string, which would otherwise vanish from the argv', () => {
+    expect(windowsShellArg('')).toBe('""');
+  });
+
+  it('round-trips through CommandLineToArgvW rules for the cases that matter', () => {
+    // Decoding half of the Windows rule, so the encoder is checked against something other than
+    // itself: 2n backslashes + `"` → n backslashes and the quote is a delimiter; 2n+1 → n
+    // backslashes and a literal quote.
+    for (const original of [
+      'plain',
+      'with space',
+      'C:\\dir\\',
+      'C:\\dir with space\\',
+      'quote"inside',
+      'back\\\\slashes',
+      'trailing\\\\',
+      '',
+    ]) {
+      expect(decodeArgv(windowsShellArg(original)), original).toBe(original);
+    }
+  });
+});
+
+/** Minimal CommandLineToArgvW decoder for a SINGLE encoded argument. */
+function decodeArgv(encoded: string): string {
+  let out = '';
+  let inQuotes = false;
+  let backslashes = 0;
+  const flush = (literalQuote: boolean): void => {
+    out += '\\'.repeat(Math.floor(backslashes / 2));
+    if (0 !== backslashes % 2 && literalQuote) out += '"';
+    backslashes = 0;
+  };
+  for (const ch of encoded) {
+    if ('\\' === ch) {
+      backslashes += 1;
+      continue;
+    }
+    if ('"' === ch) {
+      const odd = 0 !== backslashes % 2;
+      flush(true);
+      if (!odd) inQuotes = !inQuotes;
+      continue;
+    }
+    out += '\\'.repeat(backslashes);
+    backslashes = 0;
+    out += ch;
+  }
+  out += '\\'.repeat(backslashes);
+  void inQuotes;
+  return out;
+}

--- a/packages/server/src/init/windows-quote.ts
+++ b/packages/server/src/init/windows-quote.ts
@@ -1,0 +1,70 @@
+/**
+ * Quote one argument for a Windows command line. Pure, and deliberately NOT platform-gated.
+ *
+ * The rule used to live inside a `process.platform === WINDOWS` branch in node-io.ts, which meant
+ * the Windows path could not be exercised on a mac or in CI's Linux job — so it stayed wrong. A
+ * pure function is most of the fix: it can be asserted anywhere, and it is.
+ *
+ * ## What was wrong
+ *
+ * ```ts
+ * /[\s"]/.test(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg
+ * ```
+ *
+ * Two independent holes, both reachable from an ordinary directory path:
+ *
+ * 1. **Backslashes were not escaped.** `C:\Users\ada\My Projects\` became
+ *    `"C:\Users\ada\My Projects\"`, whose trailing `\"` reads as an ESCAPED quote — the quoted
+ *    region never closes and the rest of the line is re-parsed by cmd.exe. CodeQL flagged this one
+ *    (`js/incomplete-sanitization`, high).
+ * 2. **The predicate only looked for whitespace and quotes.** An argument like `foo&whoami` has
+ *    neither, so it was handed to cmd.exe completely unquoted. Correct backslash escaping does
+ *    nothing for that; it needs the metacharacters in the trigger.
+ *
+ * ## The rule implemented here
+ *
+ * `CommandLineToArgvW`: a run of backslashes is literal unless it precedes a `"`, in which case the
+ * run is doubled and the quote escaped; a run at the very end sits before the closing quote we add,
+ * so it is doubled too. Correctly-terminated quotes also neutralise cmd.exe's metacharacters, which
+ * it does not interpret inside a quoted region.
+ *
+ * ## Known limit, stated rather than papered over
+ *
+ * `%VAR%` is expanded by cmd.exe even inside quotes, and no quoting prevents it — only avoiding
+ * `shell: true` does, which Windows needs so `pnpm.cmd`/`npx.cmd` resolve (see `shellOpt`). That is
+ * variable substitution, not command execution, and every caller here passes paths and package
+ * names rather than user prose.
+ */
+
+/**
+ * Characters that make cmd.exe do something other than pass the text along.
+ *
+ * Whitespace and `"` split or delimit; the rest are the shell's control operators. An argument
+ * containing any of them must be quoted, not just one containing a space.
+ */
+const NEEDS_QUOTING = /[\s"&|<>^()!%,;=]/;
+
+export function windowsShellArg(arg: string): string {
+  // An empty argument must still occupy a slot in argv. Unquoted it disappears entirely, silently
+  // shifting every argument after it by one.
+  if (0 === arg.length) return '""';
+  if (!NEEDS_QUOTING.test(arg)) return arg;
+  let out = '"';
+  let backslashes = 0;
+  for (const ch of arg) {
+    if ('\\' === ch) {
+      backslashes += 1;
+      continue;
+    }
+    if ('"' === ch) {
+      // 2n+1 backslashes → n literal backslashes and an escaped quote.
+      out += '\\'.repeat(2 * backslashes + 1) + '"';
+      backslashes = 0;
+      continue;
+    }
+    out += '\\'.repeat(backslashes) + ch;
+    backslashes = 0;
+  }
+  // A trailing run sits immediately before the closing quote, so it must be doubled or it escapes it.
+  return `${out}${'\\'.repeat(2 * backslashes)}"`;
+}


### PR DESCRIPTION
Closes #136.

## Two holes, not one

The report names the backslash bug. Writing the test found a second, independent route.

**1. Backslashes were not escaped** — the reported half, CodeQL `js/incomplete-sanitization` (high).

**2. The predicate only looked for whitespace and quotes.** `/[\s"]/` — so an argument like `foo&whoami` has neither and was handed to `cmd.exe` **completely unquoted**. Correct backslash escaping does nothing for that one; the metacharacters have to be in the trigger.

Before and after, run against the built server:

```
input : "C:\\Users\\ada\\My Projects\\"
  was : "C:\Users\ada\My Projects\"        <- quote never closes
  now : "C:\Users\ada\My Projects\\"

input : "foo&whoami"
  was : foo&whoami                          <- raw, straight to cmd.exe
  now : "foo&whoami"

input : "C:\\x\\\" & whoami &\\"
  was : "C:\x\\" & whoami &\"               <- breaks out, appends & whoami
  now : "C:\x\\\" & whoami &\\"
```

## Why it stayed wrong

The escaping lived inside a `process.platform === WINDOWS` branch, so **neither a mac nor CI's Linux job could exercise it at all**. Pulling the rule out as a pure function is most of the fix — it is now asserted on every platform, on every run.

The rule follows `CommandLineToArgvW`: a run of backslashes doubles before a quote and before the closing quote we add. Correctly terminated quotes also neutralise cmd.exe's control operators, which it does not interpret inside a quoted region. An empty argument is quoted too — unquoted it vanishes from argv and silently shifts every later argument by one.

## Tests

RED proven **against the real logic**, not against a missing import: I first created the module with the existing implementation lifted verbatim, ran the suite, and got 5 failures with the reported bug reproducing exactly (`My Projects\"` vs `My Projects\\"`). Then replaced it. Two negative controls pass throughout — an ordinary argument must stay unquoted, since quoting everything would be its own bug.

One test round-trips through a small `CommandLineToArgvW` **decoder**, so the encoder is checked against the actual Windows rule rather than against itself.

## Known limit, stated rather than papered over

`%VAR%` is expanded by cmd.exe even inside quotes, and no quoting prevents it — only dropping `shell: true` would, and Windows needs it so `pnpm.cmd`/`npx.cmd` resolve (documented in `shellOpt`). That is variable substitution, not command execution, and every caller here passes paths and package names.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)