### PR TITLE
fix(diagnosis): an eleven-port scan is not evidence the app is down

### DIFF
--- a/packages/server/src/init/node-io.ts
+++ b/packages/server/src/init/node-io.ts
@@ -10,6 +10,7 @@ import { join, dirname, isAbsolute } from 'node:path';
 import { homedir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import type { InitIo } from './run.js';
+import { windowsShellArg } from './windows-quote.js';
 
 /**
  * `shell: true` ONLY where it earns its keep.
@@ -23,10 +24,15 @@ function shellOpt(): { shell?: true } {
   return NodePlatform.WINDOWS === process.platform ? { shell: true } : {};
 }
 
-/** Under a shell, quote what the shell would otherwise split. Windows only, where shell is required. */
+/**
+ * Under a shell, quote what the shell would otherwise split or interpret. Windows only, where
+ * `shell: true` is required (see shellOpt). The rule itself lives in windows-quote.ts as a pure
+ * function so it can be tested on every platform — keeping it inside this branch is why it was
+ * wrong for as long as it was.
+ */
 function shellSafe(args: readonly string[]): string[] {
   if (process.platform !== NodePlatform.WINDOWS) return [...args];
-  return args.map((arg) => (/[\s"]/.test(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg));
+  return args.map(windowsShellArg);
 }
 
 export function buildNodeIo(cwd: string): InitIo {

--- a/packages/server/src/init/windows-quote.test.ts
+++ b/packages/server/src/init/windows-quote.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { windowsShellArg } from './windows-quote.js';
+
+/**
+ * Windows argument quoting, tested on every platform because the bug only exists on one.
+ *
+ * The escaping lived inside a `process.platform` branch, so on a mac or in CI's Linux job the
+ * Windows path could not be exercised at all — which is how it stayed wrong. Pulling the rule out
+ * as a pure function is most of the fix: it can now be asserted anywhere.
+ *
+ * CodeQL `js/incomplete-sanitization` (high) on the original, and it flagged the smaller half.
+ */
+describe('windowsShellArg', () => {
+  it('leaves an ordinary argument untouched — quoting everything would be its own bug', () => {
+    expect(windowsShellArg('install')).toBe('install');
+    expect(windowsShellArg('@reticlehq/browser')).toBe('@reticlehq/browser');
+  });
+
+  it('quotes a path containing a space', () => {
+    expect(windowsShellArg('C:\\Users\\ada\\My Projects')).toBe('"C:\\Users\\ada\\My Projects"');
+  });
+
+  it('a path ending in a backslash does not swallow its own closing quote', () => {
+    // The reported bug. `"C:\Users\ada\My Projects\"` reads the trailing \" as an ESCAPED quote, so
+    // the quoted region never closes and everything after it is re-parsed by cmd.exe.
+    const quoted = windowsShellArg('C:\\Users\\ada\\My Projects\\');
+    expect(quoted).toBe('"C:\\Users\\ada\\My Projects\\\\"');
+    expect(quoted.endsWith('\\\\"'), 'the final backslash must be doubled').toBe(true);
+  });
+
+  it('escapes an interior quote and the backslashes in front of it', () => {
+    expect(windowsShellArg('a\\"b')).toBe('"a\\\\\\"b"');
+  });
+
+  it('quotes a cmd metacharacter even with no whitespace — the second injection route', () => {
+    // Not in the report. The old predicate was /[\s"]/, so `foo&whoami` contains neither a space
+    // nor a quote and was handed to cmd.exe RAW. Correct backslash escaping does nothing for this.
+    for (const arg of ['foo&whoami', 'a|b', 'a>b', 'a<b', 'a^b', 'a(b', 'a)b']) {
+      expect(windowsShellArg(arg), arg).toBe(`"${arg}"`);
+    }
+  });
+
+  it('quotes the empty string, which would otherwise vanish from the argv', () => {
+    expect(windowsShellArg('')).toBe('""');
+  });
+
+  it('round-trips through CommandLineToArgvW rules for the cases that matter', () => {
+    // Decoding half of the Windows rule, so the encoder is checked against something other than
+    // itself: 2n backslashes + `"` → n backslashes and the quote is a delimiter; 2n+1 → n
+    // backslashes and a literal quote.
+    for (const original of [
+      'plain',
+      'with space',
+      'C:\\dir\\',
+      'C:\\dir with space\\',
+      'quote"inside',
+      'back\\\\slashes',
+      'trailing\\\\',
+      '',
+    ]) {
+      expect(decodeArgv(windowsShellArg(original)), original).toBe(original);
+    }
+  });
+});
+
+/** Minimal CommandLineToArgvW decoder for a SINGLE encoded argument. */
+function decodeArgv(encoded: string): string {
+  let out = '';
+  let inQuotes = false;
+  let backslashes = 0;
+  const flush = (literalQuote: boolean): void => {
+    out += '\\'.repeat(Math.floor(backslashes / 2));
+    if (0 !== backslashes % 2 && literalQuote) out += '"';
+    backslashes = 0;
+  };
+  for (const ch of encoded) {
+    if ('\\' === ch) {
+      backslashes += 1;
+      continue;
+    }
+    if ('"' === ch) {
+      const odd = 0 !== backslashes % 2;
+      flush(true);
+      if (!odd) inQuotes = !inQuotes;
+      continue;
+    }
+    out += '\\'.repeat(backslashes);
+    backslashes = 0;
+    out += ch;
+  }
+  out += '\\'.repeat(backslashes);
+  void inQuotes;
+  return out;
+}

--- a/packages/server/src/init/windows-quote.ts
+++ b/packages/server/src/init/windows-quote.ts
@@ -1,0 +1,70 @@
+/**
+ * Quote one argument for a Windows command line. Pure, and deliberately NOT platform-gated.
+ *
+ * The rule used to live inside a `process.platform === WINDOWS` branch in node-io.ts, which meant
+ * the Windows path could not be exercised on a mac or in CI's Linux job — so it stayed wrong. A
+ * pure function is most of the fix: it can be asserted anywhere, and it is.
+ *
+ * ## What was wrong
+ *
+ * ```ts
+ * /[\s"]/.test(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg
+ * ```
+ *
+ * Two independent holes, both reachable from an ordinary directory path:
+ *
+ * 1. **Backslashes were not escaped.** `C:\Users\ada\My Projects\` became
+ *    `"C:\Users\ada\My Projects\"`, whose trailing `\"` reads as an ESCAPED quote — the quoted
+ *    region never closes and the rest of the line is re-parsed by cmd.exe. CodeQL flagged this one
+ *    (`js/incomplete-sanitization`, high).
+ * 2. **The predicate only looked for whitespace and quotes.** An argument like `foo&whoami` has
+ *    neither, so it was handed to cmd.exe completely unquoted. Correct backslash escaping does
+ *    nothing for that; it needs the metacharacters in the trigger.
+ *
+ * ## The rule implemented here
+ *
+ * `CommandLineToArgvW`: a run of backslashes is literal unless it precedes a `"`, in which case the
+ * run is doubled and the quote escaped; a run at the very end sits before the closing quote we add,
+ * so it is doubled too. Correctly-terminated quotes also neutralise cmd.exe's metacharacters, which
+ * it does not interpret inside a quoted region.
+ *
+ * ## Known limit, stated rather than papered over
+ *
+ * `%VAR%` is expanded by cmd.exe even inside quotes, and no quoting prevents it — only avoiding
+ * `shell: true` does, which Windows needs so `pnpm.cmd`/`npx.cmd` resolve (see `shellOpt`). That is
+ * variable substitution, not command execution, and every caller here passes paths and package
+ * names rather than user prose.
+ */
+
+/**
+ * Characters that make cmd.exe do something other than pass the text along.
+ *
+ * Whitespace and `"` split or delimit; the rest are the shell's control operators. An argument
+ * containing any of them must be quoted, not just one containing a space.
+ */
+const NEEDS_QUOTING = /[\s"&|<>^()!%,;=]/;
+
+export function windowsShellArg(arg: string): string {
+  // An empty argument must still occupy a slot in argv. Unquoted it disappears entirely, silently
+  // shifting every argument after it by one.
+  if (0 === arg.length) return '""';
+  if (!NEEDS_QUOTING.test(arg)) return arg;
+  let out = '"';
+  let backslashes = 0;
+  for (const ch of arg) {
+    if ('\\' === ch) {
+      backslashes += 1;
+      continue;
+    }
+    if ('"' === ch) {
+      // 2n+1 backslashes → n literal backslashes and an escaped quote.
+      out += '\\'.repeat(2 * backslashes + 1) + '"';
+      backslashes = 0;
+      continue;
+    }
+    out += '\\'.repeat(backslashes) + ch;
+    backslashes = 0;
+  }
+  // A trailing run sits immediately before the closing quote, so it must be doubled or it escapes it.
+  return `${out}${'\\'.repeat(2 * backslashes)}"`;
+}

--- a/packages/server/src/session/no-session-diagnosis.test.ts
+++ b/packages/server/src/session/no-session-diagnosis.test.ts
@@ -151,3 +151,49 @@ describe('diagnoseNoSession', () => {
     }
   });
 });
+
+/**
+ * An empty result from an eleven-port scan is not evidence of absence.
+ *
+ * Reported from a scripted drive of published 2.5.0: the diagnosis asserted the app was not running
+ * while it was serving 200 on `:7699`. `DEV_SERVER_PORTS` is a fixed set of eleven, and it does not
+ * contain 7699 — nor 4310 (our own bench-app), 3100 (next-smoke), 5175 (a second Vite on a machine
+ * already running one), 1420 (Tauri), 4173 (`vite preview`), or anything a user passed to --port.
+ *
+ * The narrow claim was true. The two sentences built on top of it — "the app is almost certainly not
+ * running" and "this is not a Reticle wiring problem" — are neither, and the message is DIRECTIVE:
+ * the agent is the audience and it is being told to stop looking. That is the expensive part. A
+ * caveat costs a sentence; sending an agent away from a working app costs the session.
+ */
+describe('the no-listener branch does not overclaim what an eleven-port scan proved', () => {
+  const scanned = diagnoseNoSession({
+    everConnected: false,
+    initialized: true,
+    listening: [],
+    port: 4400,
+  });
+
+  it('does not assert the app is not running', () => {
+    expect(scanned).not.toMatch(/almost certainly not running/i);
+  });
+
+  it('does not tell the agent this cannot be a Reticle problem', () => {
+    // The directive half. Reticle cannot know this, and saying it ends the investigation.
+    expect(scanned).not.toMatch(/not a Reticle wiring problem/i);
+  });
+
+  it('says what it actually checked, so the reader can judge the gap', () => {
+    expect(scanned).toMatch(/\b5173\b/);
+    expect(scanned).toMatch(/scan|checked|only|these ports/i);
+  });
+
+  it('gives the agent a way to proceed when the app IS running elsewhere', () => {
+    expect(scanned).toMatch(/reticle_lease|url/i);
+  });
+
+  it('still leads with the likeliest cause — a caveat must not bury the common case', () => {
+    // The scan is usually right. This must stay useful for the user whose server really is down,
+    // not become a hedge that says nothing.
+    expect(scanned).toMatch(/dev server|npm run dev/i);
+  });
+});

--- a/packages/server/src/session/no-session-diagnosis.ts
+++ b/packages/server/src/session/no-session-diagnosis.ts
@@ -19,6 +19,8 @@
  * the hot resolve() path and this stays unit-testable.
  */
 
+import { DEV_SERVER_PORTS } from '../cli/cli-port.js';
+
 interface NoSessionFacts {
   /** Whether ANY session has connected to this daemon since it booted. */
   everConnected: boolean;
@@ -58,6 +60,15 @@ const SELF_SERVE =
   'Reticle drives itself, and returns a sessionId you can use immediately (reach it with ' +
   'reticle_run {tool:"reticle_lease"} if it is not advertised directly; release it when you finish).';
 
+/**
+ * The ports the scan actually covers, rendered for the message.
+ *
+ * Derived from DEV_SERVER_PORTS rather than re-typed: a message that lists ports the scan does not
+ * check, or omits ones it does, is a new version of the same defect — a confident claim about
+ * evidence that was never gathered.
+ */
+const SCANNED_PORTS = [...DEV_SERVER_PORTS].join(', ');
+
 export function diagnoseNoSession(facts: NoSessionFacts): string {
   const { everConnected, initialized, listening, port } = facts;
   const ports = listening.join(', ');
@@ -72,9 +83,19 @@ export function diagnoseNoSession(facts: NoSessionFacts): string {
 
   if (0 === listening.length) {
     return (
-      'no browser session connected, and nothing is listening on any of the usual dev-server ports ' +
-      '— so the app is almost certainly not running. This is not a Reticle wiring problem: ask the ' +
-      `human to start their dev server (\`npm run dev\`), then open the app in a browser. ${RETRY}`
+      'no browser session connected, and nothing is listening on the ports Reticle scans ' +
+      `(${SCANNED_PORTS}). The likeliest cause by far is that the dev server is not running: ask ` +
+      'the human to start it (`npm run dev`), then open the app in a browser. ' +
+      // The caveat is here rather than omitted because the scan is NARROW, and the old sentence
+      // spent its confidence as though an empty result from eleven ports were proof of absence.
+      // Reported from a scripted drive of 2.5.0: this branch asserted the app was not running while
+      // it served 200 on :7699. A dev server on any other port — 4173 from `vite preview`, 1420
+      // from Tauri, 5175 from a second Vite, anything passed to --port — is invisible to it.
+      'That scan is narrow, so it is not proof: a server on any other port is invisible to it. If ' +
+      // Deliberately NOT offering reticle_lease here, and a test pins that: a lease opens a URL, and
+      // if nothing is listening there is nothing at any URL to open. Asking for the real one is the
+      // only move that can recover the :7699 case.
+      `the app IS running, ask the human for its URL rather than assuming it is down. ${RETRY}`
     );
   }
 


### PR DESCRIPTION
Closes #138.

## The claim outran the evidence

Reported from a scripted drive of published 2.5.0: the no-session diagnosis asserted the app was not running **while it was serving 200 on `:7699`**.

The narrow claim was true — nothing was listening on the eleven ports in `DEV_SERVER_PORTS`. The two sentences built on top of it were not:

> "so the app is almost certainly not running. **This is not a Reticle wiring problem**"

`7699` is not in the set. Neither is `4310` (our own bench-app), `3100` (next-smoke), `5175` (a second Vite on a machine already running one), `1420` (Tauri), `4173` (`vite preview`), or whatever a user passed to `--port`.

## Why this one is worth more than a wording change

The message is **directive**, and the agent is the audience. It tells the agent to stop looking at Reticle. A caveat costs a sentence; sending an agent away from a working app costs the session — and this is already, by the module's own docblock, the message that ends most of them.

## After

```
no browser session connected, and nothing is listening on the ports Reticle scans
(3000, 3001, 4200, 4321, 5000, 5173, 5174, 8000, 8080, 8100, 9000). The likeliest
cause by far is that the dev server is not running: ask the human to start it
(`npm run dev`), then open the app in a browser. That scan is narrow, so it is not
proof: a server on any other port is invisible to it. If the app IS running, ask the
human for its URL rather than assuming it is down. Then call reticle_sessions again…
```

It still **leads with the likeliest cause**. The scan is usually right, and a hedge that buries the common case would be its own regression — pinned by a test that fails if `npm run dev` stops being the headline.

The port list is **derived from `DEV_SERVER_PORTS`**, not re-typed. A message listing ports the scan does not check is a new version of the same defect: a confident claim about evidence that was never gathered.

## One thing an existing test caught me on

I initially added the `reticle_lease` self-serve escape to this branch. A test already pinned that it must **not** appear here: a lease opens a URL, and if nothing is listening there is nothing at any URL to open. Reverted, and the reasoning is now a comment at the site so the next person does not re-add it.

## Tests

RED before GREEN (4 of 5 failed). The fifth is the negative control — the message must still lead with the dev-server cause — and it passed throughout, which is what makes the other four safe.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages, including the import-boundary check on the new `cli-port` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)