### PR TITLE
fix(sdk): back off reconnects instead of retrying every second forever

### DIFF
--- a/packages/browser/src/transport/transport.backoff.test.ts
+++ b/packages/browser/src/transport/transport.backoff.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { RETICLE_PROTOCOL_VERSION, MessageKind, type HelloMessage } from '@reticlehq/core';
+import { Transport, nextReconnectDelay, RECONNECT_MAX_DELAY_MS } from './transport.js';
+
+/**
+ * Reconnect backs off instead of retrying every second forever.
+ *
+ * Every close path scheduled a reopen at a flat 1000ms with no growth and no cap, so a tab left open
+ * against a stopped daemon made ~600 failed WebSocket opens in ten minutes — CPU, and a devtools
+ * console full of ERR_CONNECTION_REFUSED.
+ *
+ * The delays are asserted through an INJECTED scheduler rather than a fake clock. The real one is
+ * `nativeSetTimeout`, bound to the true timer at module load on purpose so a frozen `reticle_clock`
+ * cannot deadlock the SDK — which also means `vi.useFakeTimers()` cannot see it. (The existing
+ * unreachable spec passes without any reconnect occurring at all: it re-closes the same socket.)
+ */
+class FakeWebSocket {
+  static readonly OPEN = 1;
+  static instances: FakeWebSocket[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onclose: ((e: { code: number; reason: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = 0;
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+  send(): void {}
+  close(): void {
+    this.readyState = 3;
+    this.onclose?.({ code: 1006, reason: '' });
+  }
+  open(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+}
+
+const hello = (): HelloMessage => ({
+  kind: MessageKind.HELLO,
+  protocolVersion: RETICLE_PROTOCOL_VERSION,
+  sessionId: 's',
+  url: 'http://localhost/',
+  title: 'T',
+  adapters: [],
+  hasCapabilities: false,
+});
+
+beforeEach(() => {
+  FakeWebSocket.instances = [];
+  (globalThis as unknown as { WebSocket: unknown }).WebSocket = FakeWebSocket;
+});
+
+/** A transport whose retries are recorded instead of timed, and run only when we say. */
+function harness(onVisibleRef?: { fire: () => void }) {
+  const delays: number[] = [];
+  const pending: (() => void)[] = [];
+  const t = new Transport({
+    url: 'ws://localhost:4400/reticle',
+    hello,
+    handleCommand: () => Promise.resolve({ ok: true }),
+    schedule: (fn, ms) => {
+      delays.push(ms);
+      pending.push(fn);
+    },
+    ...(onVisibleRef === undefined
+      ? {}
+      : {
+          onVisible: (handler: () => void) => {
+            onVisibleRef.fire = handler;
+            return () => undefined;
+          },
+        }),
+  });
+  t.connect();
+  /** Drop the live socket, then run the retry it scheduled. */
+  const failAndRetry = (): void => {
+    FakeWebSocket.instances.at(-1)?.close();
+    pending.shift()?.();
+  };
+  return { t, delays, failAndRetry };
+}
+
+describe('nextReconnectDelay', () => {
+  it('doubles', () => {
+    expect(nextReconnectDelay(1000)).toBe(2000);
+    expect(nextReconnectDelay(2000)).toBe(4000);
+  });
+
+  it('clamps at the ceiling and stays there', () => {
+    expect(nextReconnectDelay(RECONNECT_MAX_DELAY_MS)).toBe(RECONNECT_MAX_DELAY_MS);
+    expect(nextReconnectDelay(RECONNECT_MAX_DELAY_MS * 10)).toBe(RECONNECT_MAX_DELAY_MS);
+  });
+});
+
+describe('reconnect backoff', () => {
+  it('retries the FIRST failure promptly — a restarting daemon must not cost 30s', () => {
+    const { delays, failAndRetry } = harness();
+    failAndRetry();
+    expect(delays[0]).toBe(1000);
+  });
+
+  it('grows the delay while the outage persists', () => {
+    const { delays, failAndRetry } = harness();
+    for (let i = 0; i < 4; i += 1) failAndRetry();
+    expect(delays.slice(0, 4)).toEqual([1000, 2000, 4000, 8000]);
+  });
+
+  it('caps, so an overnight tab keeps retrying without hammering', () => {
+    const { delays, failAndRetry } = harness();
+    for (let i = 0; i < 20; i += 1) failAndRetry();
+    expect(Math.max(...delays)).toBe(RECONNECT_MAX_DELAY_MS);
+    expect(delays.at(-1)).toBe(RECONNECT_MAX_DELAY_MS);
+  });
+
+  it('resets after a successful connection, so one bad night does not slow the next drop', () => {
+    const { delays, failAndRetry } = harness();
+    for (let i = 0; i < 5; i += 1) failAndRetry();
+    FakeWebSocket.instances.at(-1)?.open(); // recovered
+    FakeWebSocket.instances.at(-1)?.close(); // and drops again later
+    expect(delays.at(-1), 'the drop after a recovery is prompt again').toBe(1000);
+  });
+
+  it('resets when the human comes back to the tab — what makes the 30s ceiling safe', () => {
+    const visible = { fire: () => undefined };
+    const { delays, failAndRetry } = harness(visible);
+    for (let i = 0; i < 5; i += 1) failAndRetry();
+    expect(delays.at(-1)).toBeGreaterThan(1000);
+    visible.fire(); // foregrounded: opens immediately
+    FakeWebSocket.instances.at(-1)?.close();
+    expect(delays.at(-1), 'foregrounding restarts the ladder').toBe(1000);
+  });
+
+  it('never schedules once the transport is closed', () => {
+    const { t, delays } = harness();
+    t.close();
+    const before = delays.length;
+    FakeWebSocket.instances.at(-1)?.close();
+    expect(delays.length).toBe(before);
+  });
+
+  it('does not retry a 1008 policy violation at all — backoff must not resurrect it', () => {
+    // The pre-existing terminal-refusal rule. A backoff that kept retrying a version mismatch
+    // would be strictly worse than the flat loop it replaced.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { delays } = harness();
+    FakeWebSocket.instances.at(-1)?.onclose?.({ code: 1008, reason: 'upgrade @reticlehq/browser' });
+    expect(delays).toHaveLength(0);
+    warn.mockRestore();
+  });
+});

--- a/packages/browser/src/transport/transport.ts
+++ b/packages/browser/src/transport/transport.ts
@@ -47,6 +47,12 @@ interface TransportDeps {
    * unsubscribe; injected so a test can drive visibility without a real document.
    */
   onVisible?: (handler: () => void) => () => void;
+  /**
+   * Schedule an internal retry (default: `nativeSetTimeout`). Injected for the same reason `now` and
+   * `onVisible` are — the default is bound to the real timer at module load so a frozen app clock
+   * cannot deadlock the SDK, which also means no fake clock can observe what was scheduled.
+   */
+  schedule?: (fn: () => void, ms: number) => void;
 }
 
 /** Default visibility source: fire `handler` whenever the document returns to the foreground. */
@@ -59,7 +65,28 @@ function subscribeDocumentVisible(handler: () => void): () => void {
   return () => document.removeEventListener('visibilitychange', listener);
 }
 
+/** The first retry after a drop. Kept short: the common outage is a daemon restarting. */
 const RECONNECT_DELAY_MS = 1000;
+/**
+ * The ceiling on reconnect backoff.
+ *
+ * A flat 1s retry with no growth and no cap meant a tab left open against a stopped daemon made
+ * ~600 failed WebSocket opens in ten minutes — CPU, and a devtools console full of
+ * ERR_CONNECTION_REFUSED. Backing off is only safe BECAUSE this transport also reconnects on
+ * focus/visibility, so a human returning to the tab retries immediately rather than waiting out
+ * the delay; the backoff resets on that path for the same reason.
+ */
+export const RECONNECT_MAX_DELAY_MS = 30_000;
+
+/**
+ * The next reconnect delay: double, then clamp. Pure, and exported so the POLICY is testable —
+ * the scheduling itself runs on `nativeSetTimeout`, which is bound to the real timer at module load
+ * (deliberately, so a frozen `reticle_clock` cannot deadlock the SDK) and therefore cannot be driven
+ * by a fake clock.
+ */
+export function nextReconnectDelay(previous: number): number {
+  return Math.min(previous * 2, RECONNECT_MAX_DELAY_MS);
+}
 /** Offline queue cap. Exported so tests overflow the real bound instead of a mirrored copy of it. */
 export const MAX_QUEUE = 500;
 /**
@@ -93,6 +120,8 @@ export class Transport {
   #closed = false;
   /** When the current continuous outage began (nativeNow), or undefined while connected. */
   #disconnectedSince: number | undefined;
+  /** Current reconnect delay; grows on each failure, resets on a successful open or on focus. */
+  #reconnectDelay = RECONNECT_DELAY_MS;
   /** Whether onConnectionLost has already fired for the current outage (fire-once). */
   #lost = false;
   /** True once the socket has opened at least once — gates the "unreachable" first-connect warning. */
@@ -136,7 +165,13 @@ export class Transport {
    * exists (connected or mid-connect), so we never open a duplicate racing the scheduled retry.
    */
   #onVisible(): void {
-    if (this.#closed || this.#ws !== undefined) return;
+    if (this.#closed) return;
+    // A human just came back to the tab, which is the strongest signal the outage may be over — and
+    // it is what makes a 30s ceiling safe. Reset the backoff BEFORE the mid-connect early return: if
+    // a socket is already in flight and then fails, that retry should be prompt too, rather than
+    // inheriting a delay earned while nobody was watching.
+    this.#reconnectDelay = RECONNECT_DELAY_MS;
+    if (this.#ws !== undefined) return;
     this.#open();
   }
 
@@ -153,7 +188,7 @@ export class Transport {
       // note the outage and schedule the normal retry.
       this.#noteOutage();
       this.#noteInitialFailure();
-      if (!this.#closed) nativeSetTimeout(() => this.#reopen(), RECONNECT_DELAY_MS);
+      this.#scheduleReopen();
       return;
     }
     this.#ws = ws;
@@ -161,6 +196,7 @@ export class Transport {
       this.#disconnectedSince = undefined; // healthy again — reset the loss timer
       this.#lost = false;
       this.#everConnected = true; // a real connection happened ⇒ never warn "unreachable"
+      this.#reconnectDelay = RECONNECT_DELAY_MS; // recovered — the next drop starts prompt again
       // HELLO is SDK-owned schema data. Preserve its pairing token; the generic sanitizer
       // intentionally redacts fields named "token" from app-controlled payloads.
       const greeting = this.#deps.hello();
@@ -195,7 +231,7 @@ export class Transport {
       }
       this.#noteOutage();
       this.#noteInitialFailure();
-      if (!this.#closed) nativeSetTimeout(() => this.#reopen(), RECONNECT_DELAY_MS);
+      this.#scheduleReopen();
     };
     ws.onerror = (): void => {
       ws.close();
@@ -206,6 +242,20 @@ export class Transport {
    * A scheduled reconnect — skipped if the SDK was torn down, or if a foreground-triggered reconnect
    * already opened a socket (guard against the throttled timer racing #onVisible into a duplicate).
    */
+  /**
+   * Schedule the next retry and grow the delay. Nothing is scheduled once the SDK is torn down.
+   *
+   * The delay grows AFTER scheduling, so the first retry of any outage is prompt (a daemon
+   * restarting must not cost 30 seconds) and only a persistent outage backs off.
+   */
+  #scheduleReopen(): void {
+    if (this.#closed) return;
+    const delay = this.#reconnectDelay;
+    this.#reconnectDelay = nextReconnectDelay(delay);
+    const schedule = this.#deps.schedule ?? nativeSetTimeout;
+    schedule(() => this.#reopen(), delay);
+  }
+
   #reopen(): void {
     if (this.#closed || this.#ws !== undefined) return;
     this.#open();

--- a/scripts/check-lossy-transforms.mjs
+++ b/scripts/check-lossy-transforms.mjs
@@ -135,6 +135,14 @@ export const READ_PATH = Object.freeze({
   'packages/browser/src/transport/transport.ts': {
     CommandOutcome: [Declaration.NONE, 'type'],
     MAX_QUEUE: [Declaration.NONE, 'the bound itself, exported so tests overflow the real one'],
+    RECONNECT_MAX_DELAY_MS: [
+      Declaration.NONE,
+      'a reconnect timing ceiling, not a transform — no agent-visible data passes through it',
+    ],
+    nextReconnectDelay: [
+      Declaration.NONE,
+      'pure arithmetic on a delay (double, then clamp); exported so the backoff POLICY is testable, since the scheduling itself runs on a timer bound before any fake clock',
+    ],
     Transport: [
       Declaration.SIGNAL,
       'a full offline queue evicts its oldest events and then emits TRANSPORT_OVERFLOW { dropped } to the bridge, so the gap is declared on the stream it happened to',


### PR DESCRIPTION
Addresses #116 — its first claim. **The second claim does not hold**, and that is worth reading before this merges.

## What was wrong

Every close path scheduled a reopen at a flat `1000ms`, with no growth and no cap. A tab left open against a stopped daemon makes ~600 failed WebSocket opens in ten minutes: CPU, and a devtools console full of `ERR_CONNECTION_REFUSED`.

Now doubles from 1s to a 30s ceiling. The **first** retry of any outage stays prompt — the common case is a daemon restarting, and that must not cost 30 seconds — so only a persistent outage backs off.

The ceiling is only safe because this transport already reconnects on focus/visibility: a human returning to the tab retries immediately rather than waiting it out. The backoff resets there too, and the reset sits **before** the mid-connect early return — if a socket is in flight when the tab is foregrounded and then fails, that retry should be prompt as well. A test caught that ordering; my first version reset only when no socket existed.

## The claim I could not confirm

> "Those lines land in the console ring buffer that `reticle_console` reports to the agent. Our own reconnect noise contaminates the evidence channel we ask an agent to trust, and can evict the app's real console output."

The issue calls this the cost that matters. **It is not what happens.** A failed WebSocket open is logged by the browser's network stack — it goes through neither the console API that `installConsole` patches nor `window.onerror`/`unhandledrejection`, which are the only three capture points. And the SDK's own unreachable warning uses `nativeWarn` (the deliberately unpatched console) and fires exactly once behind a `#warnedUnreachable` guard.

That channel was already protected on purpose. I would rather say so than let the PR take credit for fixing a contamination that was not occurring — the remaining cost (CPU and devtools noise) is real on its own.

## A gap in the existing coverage, found on the way

The delays are asserted through an **injected scheduler**, not a fake clock. `nativeSetTimeout` is bound to the real timer at module load on purpose, so a frozen `reticle_clock` cannot deadlock the SDK — which also means `vi.useFakeTimers()` cannot observe anything it schedules.

Consequence worth flagging: **`transport.unreachable.test.ts` passes without any reconnect occurring.** It re-closes the same socket ten times, so each close increments the failure counter, but no retry ever runs. It never exercised the path it looks like it covers. Not changed here, but somebody should know.

## Tests

RED before GREEN. Nine tests: the pure policy (doubles, clamps), and the wiring (first retry prompt, ladder `[1000, 2000, 4000, 8000]`, caps at 30s, resets on reconnect, resets on foreground, never schedules once closed).

One is a regression guard rather than a new claim: **a 1008 policy violation must still not retry at all**. A backoff that kept retrying a version mismatch would be strictly worse than the flat loop it replaces.

`pnpm lint && pnpm typecheck && pnpm test:unit && prettier --check` — 15/15 packages. The two new exports are classified in the lossy-transform registry (neither transforms anything an agent reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)