### PR TITLE
fix(query): the identity Reticle reports must be one Reticle can match

### DIFF
--- a/packages/browser/src/dom/query.name-parity.test.ts
+++ b/packages/browser/src/dom/query.name-parity.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { getAccessibleName, getRole } from './a11y.js';
+import { matchQuery } from './query.js';
+
+/**
+ * The name Reticle PRINTS must be a name Reticle can MATCH.
+ *
+ * Two accessible-name implementations were disagreeing. `getAccessibleName` — what `reticle_query`,
+ * `reticle_snapshot` and every act result report — falls back to `placeholder` and then `title`.
+ * The role matcher is Testing Library's `queryAllByRole`, whose name comes from
+ * `dom-accessibility-api`, which does not. So Reticle reported `name: "Search User"` for
+ * `<input type="search" placeholder="Search User">` and then failed to find it by that exact name.
+ *
+ * Reported as a recorder bug: the flow recorder anchors a step to the reported name, `flow_save`
+ * grades it `asserted` with `degraded: 0` — a clean bill of health — and the step drifts on the
+ * first replay, in a different session. The reporter diagnosed it as the replay resolver computing
+ * names differently. It is narrower and worse than that: the SAME query call reports a name it
+ * cannot match, so the round trip could never close for any caller.
+ *
+ * Fixed by making the matcher accept Reticle's own computed name as a fallback, rather than by
+ * dropping placeholder from the reported name — an input whose only label is its placeholder would
+ * otherwise go nameless in every snapshot, which is a readability regression for the common case.
+ */
+describe('accessible-name round trip', () => {
+  it('a placeholder-named input is findable by the name Reticle reports for it', () => {
+    document.body.innerHTML = '<input type="search" placeholder="Search User" />';
+    const el = document.querySelector('input') as HTMLInputElement;
+    const role = getRole(el);
+    const name = getAccessibleName(el);
+    expect({ role, name }).toEqual({ role: 'textbox', name: 'Search User' });
+    expect(matchQuery({ role, name }).matched, 'reported, therefore matchable').toBe(true);
+  });
+
+  it('a title-named control is findable too — same fallback chain, same promise', () => {
+    document.body.innerHTML = '<div role="button" title="Dismiss"></div>';
+    const el = document.querySelector('div') as HTMLElement;
+    expect(getAccessibleName(el)).toBe('Dismiss');
+    expect(matchQuery({ role: 'button', name: 'Dismiss' }).matched).toBe(true);
+  });
+
+  it('still does not match a name no element has', () => {
+    // The control that matters: a fallback that matches anything would turn every drift green.
+    document.body.innerHTML = '<input type="search" placeholder="Search User" />';
+    expect(matchQuery({ role: 'textbox', name: 'Search Orders' }).matched).toBe(false);
+  });
+
+  it('still does not match the right name on the wrong role', () => {
+    document.body.innerHTML = '<input type="search" placeholder="Search User" />';
+    expect(matchQuery({ role: 'button', name: 'Search User' }).matched).toBe(false);
+  });
+
+  it('the ordinary label path is unchanged', () => {
+    document.body.innerHTML = '<label>Email <input /></label>';
+    expect(matchQuery({ role: 'textbox', name: 'Email' }).matched).toBe(true);
+  });
+});

--- a/packages/browser/src/dom/query.ts
+++ b/packages/browser/src/dom/query.ts
@@ -21,7 +21,7 @@ import {
 } from '@reticlehq/core';
 import { isFrame, isHtmlElement } from './realm.js';
 import { capturedRootOf } from './shadow-registry.js';
-import { describe, getStates, isVisible } from './a11y.js';
+import { getAccessibleName, getRole, describe, getStates, isVisible } from './a11y.js';
 import { isIgnored } from './dom-ignore.js';
 import { isSensitiveKey } from '../security/serialization.js';
 import { getCapabilities } from '../registry/capabilities.js';
@@ -108,6 +108,46 @@ function findByComponent(container: HTMLElement, query: ElementQuery): HTMLEleme
   return [];
 }
 
+/**
+ * Role + name, matched the way Reticle REPORTS them — not only the way Testing Library computes them.
+ *
+ * Two implementations were disagreeing, on both axes, for the same element:
+ *
+ *   <input type="search" placeholder="Search User">
+ *     Reticle getRole            -> "textbox"      TL/dom-accessibility-api -> "searchbox"
+ *     Reticle getAccessibleName  -> "Search User"  TL                       -> "" (no placeholder)
+ *
+ * `reticle_query`, `reticle_snapshot` and every act result report Reticle's values. The matcher used
+ * TL's. So Reticle printed `textbox "Search User"` and then could not find it by that exact
+ * role and name — the same query call reporting an identity it cannot match.
+ *
+ * It surfaced through the flow recorder, which anchors a step to the reported role+name: `flow_save`
+ * graded the flow `asserted` with `degraded: 0`, a clean bill of health, and the step drifted on the
+ * first replay in a different session. The reporter diagnosed it as the replay resolver computing
+ * names differently; it is narrower and worse, because no caller could ever have closed the round
+ * trip.
+ *
+ * The fallback runs ONLY when the spec-accurate query finds nothing, so every name that resolves
+ * today keeps resolving exactly as before and this can never take a match away. Fixed on the
+ * matching side rather than by changing what is reported: dropping `placeholder` would leave an
+ * input whose only label is its placeholder nameless in every snapshot, and renaming the role would
+ * churn every stored anchor — both worse trades than a fallback that runs on the empty path.
+ */
+function queryByRoleAndName(
+  container: HTMLElement,
+  role: string,
+  name: string | undefined,
+): HTMLElement[] {
+  if (name === undefined) return queryAllByRole(container, role, { hidden: true });
+  const spec = queryAllByRole(container, role, { hidden: true, name });
+  if (spec.length > 0) return spec;
+  const wanted = name.trim();
+  // Reticle's own role AND name: the pair actually printed to the caller.
+  return [...container.querySelectorAll<HTMLElement>('*')].filter(
+    (el) => getRole(el) === role && getAccessibleName(el).trim() === wanted,
+  );
+}
+
 /** Run the appropriate Testing-Library query against ONE root (light DOM or a shadow root). */
 function findIn(container: HTMLElement, query: ElementQuery): HTMLElement[] {
   const by = query.by;
@@ -117,11 +157,7 @@ function findIn(container: HTMLElement, query: ElementQuery): HTMLElement[] {
   if (by !== undefined && value !== undefined) {
     switch (by) {
       case QueryBy.ROLE:
-        return queryAllByRole(
-          container,
-          value,
-          query.name !== undefined ? { hidden: true, name: query.name } : { hidden: true },
-        );
+        return queryByRoleAndName(container, value, query.name);
       case QueryBy.TEXT:
         return queryAllByText(container, value, { exact: false });
       case QueryBy.LABEL:
@@ -154,13 +190,10 @@ function findIn(container: HTMLElement, query: ElementQuery): HTMLElement[] {
     return findByComponent(container, query);
   }
 
-  // Structured form (role+name, or any single field).
+  // Structured form (role+name, or any single field). Same round-trip guarantee as the by+value
+  // spelling above — the two forms must not disagree about what is findable.
   if (query.role !== undefined) {
-    const options =
-      query.name !== undefined
-        ? { hidden: true as const, name: query.name }
-        : { hidden: true as const };
-    return queryAllByRole(container, query.role, options);
+    return queryByRoleAndName(container, query.role, query.name);
   }
   if (query.text !== undefined) return queryAllByText(container, query.text, { exact: false });
   if (query.label !== undefined) {


### PR DESCRIPTION
Part of #162 — and the root cause underneath it, which is not the one the report names.

## Two implementations, disagreeing on both axes

For the same element:

```
<input type="search" placeholder="Search User">

  Reticle getRole            -> "textbox"        TL / dom-accessibility-api -> "searchbox"
  Reticle getAccessibleName  -> "Search User"    TL                         -> ""  (no placeholder)
```

`reticle_query`, `reticle_snapshot` and every act result report **Reticle's** values. The matcher used **Testing Library's**. So Reticle printed `textbox "Search User"` and then could not find it by that exact role and name — the same query call reporting an identity it cannot match.

## What the report got right, and what it got wrong

Right, and it is the visible damage: the recorder anchors a step to the reported role+name, `flow_save` grades the flow `asserted` with `degraded: 0` — a clean bill of health — and the step drifts on the first replay, in a different session.

Wrong: *"the replay resolver computes accessible names differently."* Replay goes through `runRoleStep` → `resolveQuery` → the **same** `QueryBy.ROLE` path the recorder used. There is no second implementation on the replay side. The truth is narrower and worse: **no caller could ever have closed this round trip**, for any tool, at any time.

## Verified before fixing, and the first attempt was wrong

My first fix assumed name-only divergence and filtered `queryAllByRole(container, 'textbox')` by Reticle's name. It failed, because `queryAllByRole('textbox')` does not return the element **at all** — the role differs too. Probed both:

```
reticleRole: "textbox"   tlTextbox: 0   tlSearchbox: 1
```

So the fallback compares Reticle's own role *and* name — the pair actually printed to the caller.

## Why on the matching side

Dropping `placeholder` from the reported name would leave an input whose only label is its placeholder **nameless in every snapshot** — a readability regression for the common case. Renaming the role to match ARIA would churn every stored anchor. Both are worse trades than a fallback that runs only on the empty path.

The fallback runs **only when the spec-accurate query finds nothing**, so every name that resolves today keeps resolving exactly as before, and this can never take a match away.

Both spellings — `by`/`value` and the structured predicate — now go through it, because the two forms must not disagree about what is findable.

## Still open on #162

This closes the round trip, which removes the cause. It does not add the record-time `degraded: true` warning the issue also asks for — that needs name provenance on the wire, and with parity restored the anchor now resolves, so the warning has much less to warn about. Ask (2), the self-contradictory drift message, already shipped earlier in `role-drift-reason.ts`.

## Tests

RED before GREEN, with **three** negative controls that passed throughout: a name no element has must still miss, the right name on the wrong role must still miss, and the ordinary `<label>` path must be untouched. A fallback that matched too eagerly would turn every drift green, which is the failure mode worth guarding.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages, 176/176 in the DOM suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)