### PR TITLE
fix(contract): refuse to save one project's surface into another's repo

### DIFF
--- a/packages/browser/src/dom/query.name-parity.test.ts
+++ b/packages/browser/src/dom/query.name-parity.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { getAccessibleName, getRole } from './a11y.js';
+import { matchQuery } from './query.js';
+
+/**
+ * The name Reticle PRINTS must be a name Reticle can MATCH.
+ *
+ * Two accessible-name implementations were disagreeing. `getAccessibleName` — what `reticle_query`,
+ * `reticle_snapshot` and every act result report — falls back to `placeholder` and then `title`.
+ * The role matcher is Testing Library's `queryAllByRole`, whose name comes from
+ * `dom-accessibility-api`, which does not. So Reticle reported `name: "Search User"` for
+ * `<input type="search" placeholder="Search User">` and then failed to find it by that exact name.
+ *
+ * Reported as a recorder bug: the flow recorder anchors a step to the reported name, `flow_save`
+ * grades it `asserted` with `degraded: 0` — a clean bill of health — and the step drifts on the
+ * first replay, in a different session. The reporter diagnosed it as the replay resolver computing
+ * names differently. It is narrower and worse than that: the SAME query call reports a name it
+ * cannot match, so the round trip could never close for any caller.
+ *
+ * Fixed by making the matcher accept Reticle's own computed name as a fallback, rather than by
+ * dropping placeholder from the reported name — an input whose only label is its placeholder would
+ * otherwise go nameless in every snapshot, which is a readability regression for the common case.
+ */
+describe('accessible-name round trip', () => {
+  it('a placeholder-named input is findable by the name Reticle reports for it', () => {
+    document.body.innerHTML = '<input type="search" placeholder="Search User" />';
+    const el = document.querySelector('input') as HTMLInputElement;
+    const role = getRole(el);
+    const name = getAccessibleName(el);
+    expect({ role, name }).toEqual({ role: 'textbox', name: 'Search User' });
+    expect(matchQuery({ role, name }).matched, 'reported, therefore matchable').toBe(true);
+  });
+
+  it('a title-named control is findable too — same fallback chain, same promise', () => {
+    document.body.innerHTML = '<div role="button" title="Dismiss"></div>';
+    const el = document.querySelector('div') as HTMLElement;
+    expect(getAccessibleName(el)).toBe('Dismiss');
+    expect(matchQuery({ role: 'button', name: 'Dismiss' }).matched).toBe(true);
+  });
+
+  it('still does not match a name no element has', () => {
+    // The control that matters: a fallback that matches anything would turn every drift green.
+    document.body.innerHTML = '<input type="search" placeholder="Search User" />';
+    expect(matchQuery({ role: 'textbox', name: 'Search Orders' }).matched).toBe(false);
+  });
+
+  it('still does not match the right name on the wrong role', () => {
+    document.body.innerHTML = '<input type="search" placeholder="Search User" />';
+    expect(matchQuery({ role: 'button', name: 'Search User' }).matched).toBe(false);
+  });
+
+  it('the ordinary label path is unchanged', () => {
+    document.body.innerHTML = '<label>Email <input /></label>';
+    expect(matchQuery({ role: 'textbox', name: 'Email' }).matched).toBe(true);
+  });
+});

--- a/packages/browser/src/dom/query.ts
+++ b/packages/browser/src/dom/query.ts
@@ -21,7 +21,7 @@ import {
 } from '@reticlehq/core';
 import { isFrame, isHtmlElement } from './realm.js';
 import { capturedRootOf } from './shadow-registry.js';
-import { describe, getStates, isVisible } from './a11y.js';
+import { getAccessibleName, getRole, describe, getStates, isVisible } from './a11y.js';
 import { isIgnored } from './dom-ignore.js';
 import { isSensitiveKey } from '../security/serialization.js';
 import { getCapabilities } from '../registry/capabilities.js';
@@ -108,6 +108,46 @@ function findByComponent(container: HTMLElement, query: ElementQuery): HTMLEleme
   return [];
 }
 
+/**
+ * Role + name, matched the way Reticle REPORTS them — not only the way Testing Library computes them.
+ *
+ * Two implementations were disagreeing, on both axes, for the same element:
+ *
+ *   <input type="search" placeholder="Search User">
+ *     Reticle getRole            -> "textbox"      TL/dom-accessibility-api -> "searchbox"
+ *     Reticle getAccessibleName  -> "Search User"  TL                       -> "" (no placeholder)
+ *
+ * `reticle_query`, `reticle_snapshot` and every act result report Reticle's values. The matcher used
+ * TL's. So Reticle printed `textbox "Search User"` and then could not find it by that exact
+ * role and name — the same query call reporting an identity it cannot match.
+ *
+ * It surfaced through the flow recorder, which anchors a step to the reported role+name: `flow_save`
+ * graded the flow `asserted` with `degraded: 0`, a clean bill of health, and the step drifted on the
+ * first replay in a different session. The reporter diagnosed it as the replay resolver computing
+ * names differently; it is narrower and worse, because no caller could ever have closed the round
+ * trip.
+ *
+ * The fallback runs ONLY when the spec-accurate query finds nothing, so every name that resolves
+ * today keeps resolving exactly as before and this can never take a match away. Fixed on the
+ * matching side rather than by changing what is reported: dropping `placeholder` would leave an
+ * input whose only label is its placeholder nameless in every snapshot, and renaming the role would
+ * churn every stored anchor — both worse trades than a fallback that runs on the empty path.
+ */
+function queryByRoleAndName(
+  container: HTMLElement,
+  role: string,
+  name: string | undefined,
+): HTMLElement[] {
+  if (name === undefined) return queryAllByRole(container, role, { hidden: true });
+  const spec = queryAllByRole(container, role, { hidden: true, name });
+  if (spec.length > 0) return spec;
+  const wanted = name.trim();
+  // Reticle's own role AND name: the pair actually printed to the caller.
+  return [...container.querySelectorAll<HTMLElement>('*')].filter(
+    (el) => getRole(el) === role && getAccessibleName(el).trim() === wanted,
+  );
+}
+
 /** Run the appropriate Testing-Library query against ONE root (light DOM or a shadow root). */
 function findIn(container: HTMLElement, query: ElementQuery): HTMLElement[] {
   const by = query.by;
@@ -117,11 +157,7 @@ function findIn(container: HTMLElement, query: ElementQuery): HTMLElement[] {
   if (by !== undefined && value !== undefined) {
     switch (by) {
       case QueryBy.ROLE:
-        return queryAllByRole(
-          container,
-          value,
-          query.name !== undefined ? { hidden: true, name: query.name } : { hidden: true },
-        );
+        return queryByRoleAndName(container, value, query.name);
       case QueryBy.TEXT:
         return queryAllByText(container, value, { exact: false });
       case QueryBy.LABEL:
@@ -154,13 +190,10 @@ function findIn(container: HTMLElement, query: ElementQuery): HTMLElement[] {
     return findByComponent(container, query);
   }
 
-  // Structured form (role+name, or any single field).
+  // Structured form (role+name, or any single field). Same round-trip guarantee as the by+value
+  // spelling above — the two forms must not disagree about what is findable.
   if (query.role !== undefined) {
-    const options =
-      query.name !== undefined
-        ? { hidden: true as const, name: query.name }
-        : { hidden: true as const };
-    return queryAllByRole(container, query.role, options);
+    return queryByRoleAndName(container, query.role, query.name);
   }
   if (query.text !== undefined) return queryAllByText(container, query.text, { exact: false });
   if (query.label !== undefined) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -428,6 +428,9 @@ export async function start(options: StartOptions = {}): Promise<RunningServer> 
       reticleRoot,
       now,
       bridgePort: port,
+      // The daemon's OWN project, so a tool can tell "this session is mine" from "this session
+      // belongs to a sibling app under the same daemon". contract_save refuses on the second.
+      ...(activeProjectId === undefined ? {} : { projectId: activeProjectId }),
     };
     const profile = resolveToolSurface(options.toolProfile);
     const server = createMcpServer(

--- a/packages/server/src/tools/contract-tools.ts
+++ b/packages/server/src/tools/contract-tools.ts
@@ -9,13 +9,41 @@ import { ReticleTool } from './tool-names.js';
 import { asString } from './tools-helpers.js';
 import { sessionIdShape, commandOrThrow } from './tool-kit.js';
 import { reticleDirPaths, readContract, writeContract } from '../project/reticle-dir.js';
-import type { ToolDef } from './tools.js';
+import type { ToolDef, ToolDeps } from './tools.js';
 
 /**
  * The capability-contract tools. `reticle_capabilities` reads the live session, or the
  * git-checked `.reticle/contract.json` when `{ fromDisk:true }`; `reticle_contract_save` persists the
  * live registry to that file (pretty-printed, stable key order — diffable in PRs).
  */
+
+/**
+ * Refuse to persist one project's surface into another project's repo.
+ *
+ * `writeContract` writes to the DAEMON's `.reticle/`, which is the directory the daemon was started
+ * in — not the session's project. A daemon started above several apps therefore saves app A's
+ * testids into app B's checkout, reports `saved: true`, and hands back a path that looks right. A
+ * contract is git-checked and diffable, so that is a change somebody commits.
+ *
+ * Refuse rather than redirect: a session advertises a projectId, not a project DIRECTORY, so there
+ * is no honest way to work out where the correct `.reticle/` lives. Naming both ids and stopping is
+ * the whole of what can be said truthfully.
+ *
+ * Silence is not a mismatch. An unstamped build carries no projectId, and a daemon above an
+ * uninitialised directory has none either; neither is evidence of two projects.
+ */
+function assertSameProject(deps: ToolDeps, sessionId: string | undefined): void {
+  const mine = deps.projectId;
+  const theirs = deps.sessions.resolve(sessionId).projectId;
+  if (mine === undefined || theirs === undefined || mine === theirs) return;
+  throw new Error(
+    `refusing to save: this session belongs to project '${theirs}', but this daemon writes to ` +
+      `project '${mine}' (.reticle/ in the directory it was started in). Saving would put one ` +
+      "app's testable surface into another app's git-checked contract. Run a daemon from " +
+      `'${theirs}'s own directory and save there.`,
+  );
+}
+
 export const CONTRACT_TOOLS: ToolDef[] = [
   {
     name: ReticleTool.CAPABILITIES,
@@ -75,6 +103,7 @@ export const CONTRACT_TOOLS: ToolDef[] = [
         {},
       );
       const caps = CapabilitiesSchema.parse(res);
+      assertSameProject(deps, asString(args['sessionId']));
       await writeContract(deps.fs, deps.reticleRoot, caps, deps.now);
       return {
         saved: true,

--- a/packages/server/src/tools/tool-kit.ts
+++ b/packages/server/src/tools/tool-kit.ts
@@ -35,6 +35,14 @@ export interface ToolDeps {
   fs: FileSystemPort;
   /** absolute.reticle path (index.ts computes cwd/.reticle). */
   reticleRoot: string;
+  /**
+   * This daemon's OWN project id, derived from the directory it was started in.
+   *
+   * Optional because a daemon above an uninitialised directory has none, and because every existing
+   * test construction of ToolDeps predates it. Absence means "cannot tell", which must never be
+   * treated as a mismatch.
+   */
+  projectId?: string;
   /** injected clock for the contract's generatedAt stamp. */
   now: () => number;
   /**

--- a/packages/server/src/tools/tools.contract.test.ts
+++ b/packages/server/src/tools/tools.contract.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { CommandResult } from '@reticlehq/core';
 import { FROM_DISK_ARG } from '@reticlehq/core';
-import { TOOLS, type ToolDeps } from './tools.js';
+import { TOOLS, type ToolDef, type ToolDeps } from './tools.js';
 import { ReticleTool } from './tool-names.js';
 import { BaselineStore } from '../project/baselines.js';
 import { RecordingStore } from '../flows/recordings.js';
@@ -177,5 +177,75 @@ describe('reticle_contract_save / reticle_capabilities fromDisk', () => {
     const a = await fs1.readFile(reticleDirPaths(ROOT).contract);
     const b = await fs2.readFile(reticleDirPaths(ROOT).contract);
     expect(a).toBe(b);
+  });
+});
+
+/**
+ * `reticle_contract_save` writes to the DAEMON's `.reticle/`, not the session's project.
+ *
+ * Reported in #161: a daemon started above several apps scopes to its own cwd, so a call from one
+ * app can be resolved against another app's session. The cross-project REFUSAL closed the verdict
+ * half of that — a call that could touch the wrong app now refuses rather than guessing. This is
+ * the write half, which had no guard at all: the surface of app A is persisted into app B's repo,
+ * silently, and the tool reports `saved: true` with a path that looks right.
+ *
+ * A contract is git-checked and diffable. Writing the wrong app's testids into it is a change
+ * somebody commits.
+ *
+ * Refuse rather than redirect: the session advertises a projectId, not a project DIRECTORY, so
+ * there is no honest way to work out where the right `.reticle/` lives. Naming both ids and
+ * stopping is the whole of what can be said truthfully.
+ */
+describe('contract_save refuses to write one project into another', () => {
+  const save = (): ToolDef => {
+    const t = TOOLS.find((x) => x.name === ReticleTool.CONTRACT_SAVE);
+    if (t === undefined) throw new Error('contract_save is not on the surface');
+    return t;
+  };
+
+  function depsFor(
+    sessionProject: string | undefined,
+    daemonProject: string | undefined,
+  ): ToolDeps {
+    const base = fakeDeps(memoryFs());
+    const command = (): Promise<CommandResult> =>
+      Promise.resolve({ kind: 'command_result', id: 'c', ok: true, result: CAPS });
+    const session: Partial<Session> = { id: 'demo', command, projectId: sessionProject };
+    const sessions: Partial<SessionManager> = { resolve: () => session as Session };
+    return {
+      ...base,
+      sessions: sessions as SessionManager,
+      ...(daemonProject === undefined ? {} : { projectId: daemonProject }),
+    };
+  }
+
+  it('refuses when the session belongs to a different project than this daemon', async () => {
+    await expect(
+      save().handler(depsFor('rowy-d30b4137', 'next-app-router-a1'), {}),
+    ).rejects.toThrow(/rowy-d30b4137/);
+  });
+
+  it('names BOTH projects, or the reader cannot tell which way round it is', async () => {
+    await expect(
+      save().handler(depsFor('rowy-d30b4137', 'next-app-router-a1'), {}),
+    ).rejects.toThrow(/next-app-router-a1/);
+  });
+
+  it('saves normally when the session is this daemon’s own project', async () => {
+    const result = (await save().handler(depsFor('same-id', 'same-id'), {})) as { saved: boolean };
+    expect(result.saved).toBe(true);
+  });
+
+  it('saves when the daemon has no project id — the pre-existing single-app case', async () => {
+    // The guard must not break every daemon that never computed one. Absence is not a mismatch.
+    const result = (await save().handler(depsFor('anything', undefined), {})) as { saved: boolean };
+    expect(result.saved).toBe(true);
+  });
+
+  it('saves when the SESSION is untagged — an unstamped build is not another project', async () => {
+    const result = (await save().handler(depsFor(undefined, 'daemon-proj'), {})) as {
+      saved: boolean;
+    };
+    expect(result.saved).toBe(true);
   });
 });


### PR DESCRIPTION
Part of #161 — its **write** half.

## What happens today

`writeContract` writes to the **daemon's** `.reticle/` — the directory the daemon was started in — not the session's project. A daemon started above several apps therefore:

- reads app A's live capability registry,
- writes it into app B's `.reticle/contract.json`,
- returns `saved: true` with a path that looks entirely correct.

A contract is git-checked and diffable. **That is a change somebody commits.**

## Relation to the refusal already shipped

The cross-project refusal closed the *verdict* half of #161: a call that could be resolved against the wrong app now refuses rather than guessing. This half had no guard at all — the write went through silently.

## Refuse rather than redirect

A session advertises a `projectId`, not a project **directory**. There is no honest way to work out where the correct `.reticle/` lives, so writing "somewhere better" would be a guess with a filesystem side effect. Naming both ids and stopping is the whole of what can be said truthfully:

```
refusing to save: this session belongs to project 'rowy-d30b4137', but this daemon writes to
project 'next-app-router-a1' (.reticle/ in the directory it was started in). Saving would put
one app's testable surface into another app's git-checked contract. Run a daemon from
'rowy-d30b4137's own directory and save there.
```

Both ids are named because otherwise the reader cannot tell which way round it is — a test pins that.

## Silence is not a mismatch

Three negative controls, all passing throughout:

- the session is **untagged** (an unstamped build) → saves
- the daemon has **no** project id (started above an uninitialised directory) → saves
- ids **match** → saves exactly as before

A guard that fired on absence would break every single-app setup, which is nearly all of them. `deps.projectId` is optional for the same reason, and it is populated from the `activeProjectId` the daemon already computes for its default session scope — no new derivation, no new source of truth.

## Tests

RED before GREEN (2 of 5 failed; the refusals returned `saved: true`).

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages.

## Still open on #161

The root cause stands: the daemon scopes to its own cwd, so it cannot tell which app a *caller* is in. Fixing that means carrying the MCP client's cwd through the proxy handshake — a contract change, and a design call rather than a drop-in. Both guards now make the failure loud instead of silent, which is the part that could be done without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)