### PR TITLE
fix(gate): stop turbo caching a suite whose result is not a function of its inputs

### DIFF
--- a/packages/vite-plugin/src/turbo-cache.test.ts
+++ b/packages/vite-plugin/src/turbo-cache.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * A suite that boots a REAL dev server must not have its result cached by turbo.
+ *
+ * Turbo caches `test:unit` on a hash of the package's files, which is sound only when the outcome is
+ * a function of those files. This package's integration suite starts an actual Vite dev server and
+ * binds a port, so its outcome also depends on the machine — memory pressure, a port already held,
+ * a dev server from a previous run that never closed. Caching an outcome that is not a function of
+ * its inputs is unsound in principle, and it was observed in practice (#140):
+ *
+ *   `pnpm test:unit` reported it GREEN in the same minute a direct
+ *   `pnpm --filter @reticlehq/vite-plugin test:unit` reported it RED — turbo served a cached pass
+ *   from an earlier run.
+ *
+ * That is the worst shape a gate can take: it reports success for a suite that is failing right now,
+ * which is precisely when somebody is relying on it. Re-running this package costs ~6s.
+ *
+ * The rule is tied to the EVIDENCE rather than pinned to a filename: if any test here boots a
+ * server, the opt-out must be present. Delete the integration suite and this stops demanding it;
+ * add a second one and it is already covered.
+ */
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PKG = join(HERE, '..');
+
+/** Booting a real Vite dev server — the thing that makes a suite depend on the machine. */
+const BOOTS_A_SERVER = /createServer|\.listen\(/;
+
+function testFiles(): string[] {
+  return readdirSync(HERE)
+    .filter((name) => name.endsWith('.test.ts'))
+    .map((name) => join(HERE, name));
+}
+
+describe('turbo must not cache a non-hermetic suite', () => {
+  it('this package has at least one suite that boots a real server', () => {
+    // Guards the guard: if this stops being true the rule below is vacuous, and a vacuous rule that
+    // still passes is how a check quietly stops checking.
+    const booting = testFiles().filter((f) => BOOTS_A_SERVER.test(readFileSync(f, 'utf8')));
+    expect(booting.length).toBeGreaterThan(0);
+  });
+
+  it('so test:unit caching is disabled for this package', () => {
+    const path = join(PKG, 'turbo.json');
+    expect(existsSync(path), 'packages/vite-plugin/turbo.json must exist').toBe(true);
+    const config = JSON.parse(readFileSync(path, 'utf8')) as {
+      tasks?: Record<string, { cache?: boolean }>;
+    };
+    expect(config.tasks?.['test:unit']?.cache).toBe(false);
+  });
+});

--- a/packages/vite-plugin/turbo.json
+++ b/packages/vite-plugin/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test:unit": {
+      "dependsOn": ["^build"],
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
Closes the second half of #140. The first half — the hook timeout — is already fixed on `main` in `458b1cb6` (commented there).

## A gate that can report green for a red suite

Turbo caches `test:unit` on a hash of the package's files. That is sound **only when the outcome is a function of those files**. This package's integration suite starts a real Vite dev server and binds a port, so its outcome also depends on the machine: memory pressure, a port already held, a dev server from an earlier run that never closed (#145).

Observed, not theorised — from the report:

> `pnpm test:unit` reported it **GREEN** in the same minute a direct `pnpm --filter @reticlehq/vite-plugin test:unit` reported it **RED** — turbo served a cached pass from an earlier run.

That is the worst shape a gate can take: it reports success for a suite that is failing *right now*, which is exactly when somebody is relying on it.

I should say plainly that this is not hypothetical for me: I have been quoting "15/15 green" on every change tonight with **7–9 of those 15 served from cache**. Sound for the hermetic ones; not sound for this one.

## Confirmed live

```
@reticlehq/vite-plugin:test:unit: cache bypass, force executing ddba15a122219ee6
```

Cost: **~6s** per gate run (measured), against a gate that could previously lie.

## The guard is tied to the evidence, not to a filename

If any test in this package boots a server (`createServer` / `.listen(`), the opt-out must be present. Delete the integration suite and it stops demanding one; add a second and it is already covered.

It also asserts that a booting suite **still exists** — a vacuous rule that keeps passing is how a check quietly stops checking, which is the same failure this repo has now hit in the install gate, the lossy-transform self-test, and the e2e surface drift.

## Scope

Only this package opts out. `cache: false` on the root task would make every package re-run on every gate, which is a real cost paid forever to fix one unsound entry — and the other suites genuinely are functions of their inputs.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)