### PR TITLE
fix(doctor): name the process holding the bridge port

### DIFF
--- a/packages/server/src/cli/cli-doctor.ts
+++ b/packages/server/src/cli/cli-doctor.ts
@@ -2,10 +2,12 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { ReticleEnv } from '@reticlehq/core';
 import { readPid, reticleStateHome } from '../daemon/daemon.js';
-import { PortPresence, probePresence, describePresence } from '../daemon/port-presence.js';
+import { PortPresence, probePresence } from '../daemon/port-presence.js';
 import { probeDaemon } from '../mcp/mcp-proxy.js';
 import { fetchStatus } from './cli-launch.js';
 import { daemonLine, type DaemonIdentity } from './doctor-daemon-line.js';
+import { describeForeignHolder, findPortHolder } from './port-holder.js';
+import { spawnSync } from 'node:child_process';
 import { SERVER_VERSION } from '../version/server-version.js';
 import { CONTRACT_FINGERPRINT } from '@reticlehq/core';
 import { diagnoseDesktop, isDesktopProject } from '../init/desktop-doctor.js';
@@ -15,6 +17,27 @@ import { diagnoseDesktop, isDesktopProject } from '../init/desktop-doctor.js';
  * Chromium install (the #1 silent failure), whether a daemon is up on the resolved bridge port, and
  * reminds the user which port the app must dial. Human-readable to stdout (not the JSON log).
  */
+
+/**
+ * Run a lookup and return its stdout, or null if it could not run.
+ *
+ * Null on ANY failure — no lsof (Windows, a slim container), a non-zero exit, a throw. This is a
+ * diagnostic nicety inside the command people run when things are already broken; it must never be
+ * the reason `doctor` fails, and `describeForeignHolder(port, null)` prints the message doctor
+ * printed before this existed.
+ */
+function runCapture(command: string, args: readonly string[]): string | null {
+  try {
+    const result = spawnSync(command, [...args], { encoding: 'utf8', timeout: LOOKUP_TIMEOUT_MS });
+    return 0 === result.status && 'string' === typeof result.stdout ? result.stdout : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Bound on the holder lookup. A hung `lsof` must not hang the command that diagnoses hangs. */
+const LOOKUP_TIMEOUT_MS = 2_000;
+
 /** Narrow the `/status` payload to the two fields the daemon line reads. */
 function asIdentity(payload: unknown): DaemonIdentity {
   if (typeof payload !== 'object' || null === payload) return {};
@@ -67,7 +90,10 @@ export async function handleDoctor(port: number): Promise<void> {
     line(built.text);
     if (built.skew !== undefined) line(`  version      ✗ ${built.skew}`);
   } else if (presence === PortPresence.FOREIGN) {
-    line(`  daemon       ✗ ${describePresence(presence, port)}`);
+    // Name the holder when we can. `doctor` exists for exactly this moment, and "another process"
+    // leaves the reader to find a shell command themselves — the obvious one being the `lsof -ti`
+    // pipeline that also kills the agent's own MCP proxy.
+    line(`  daemon       ✗ ${describeForeignHolder(port, findPortHolder(port, runCapture))}`);
   } else {
     line(
       `  daemon       ✗ not running on :${port} — your agent runs \`reticle mcp\` (or \`reticle serve\`)`,

--- a/packages/server/src/cli/port-holder.test.ts
+++ b/packages/server/src/cli/port-holder.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { parsePortHolder, describeForeignHolder } from './port-holder.js';
+
+/**
+ * Naming the process that holds the port.
+ *
+ * `doctor` is what a user runs when the agent cannot reach the bridge, and the commonest real cause
+ * is that something else is on 4400. It already stopped saying "nothing is listening" for that case
+ * — it says "held by another process" — but it does not say WHICH, so the reader's next move is a
+ * shell command they have to know. Worse, the obvious one (`lsof -ti tcp:4400 | xargs kill -9`)
+ * kills the agent's own `reticle mcp` proxy, because that proxy holds a CLIENT connection to the
+ * port and `-ti` does not filter to listeners.
+ *
+ * So the field selector below is `-sTCP:LISTEN`, and the parser is pure and tested against real
+ * `lsof -F pc` output rather than trusted.
+ */
+describe('parsePortHolder', () => {
+  it('reads pid and command from lsof -F pc output', () => {
+    expect(parsePortHolder('p90502\ncnode\n')).toEqual({ pid: 90502, command: 'node' });
+  });
+
+  it('takes the FIRST listener when several are reported', () => {
+    // Dual-stack (IPv4 + IPv6) reports the same process twice; a second `p` record starts a new one.
+    expect(parsePortHolder('p90502\ncnode\np90777\ncother\n')).toEqual({
+      pid: 90502,
+      command: 'node',
+    });
+  });
+
+  it('survives a command with spaces', () => {
+    expect(parsePortHolder('p12\ncPython 3.12\n')?.command).toBe('Python 3.12');
+  });
+
+  it('returns null for empty output — nothing is listening, which is not an error', () => {
+    expect(parsePortHolder('')).toBeNull();
+    expect(parsePortHolder('\n')).toBeNull();
+  });
+
+  it('returns null rather than guessing when the pid is not a number', () => {
+    expect(parsePortHolder('pnotanumber\ncnode\n')).toBeNull();
+  });
+
+  it('returns null when lsof reported a pid but no command', () => {
+    // Half an answer is not an answer: "(pid 90502, undefined)" is worse than saying nothing.
+    expect(parsePortHolder('p90502\n')).toBeNull();
+  });
+});
+
+describe('describeForeignHolder', () => {
+  it('names the pid and command, and does not suggest the command that kills the agent', () => {
+    const text = describeForeignHolder(4400, { pid: 90502, command: 'node' });
+    expect(text).toContain('4400');
+    expect(text).toContain('90502');
+    expect(text).toContain('node');
+    // The trap from the field: `lsof -ti tcp:4400 | xargs kill -9` also kills `reticle mcp`.
+    expect(text).not.toMatch(/-ti\b/);
+  });
+
+  it('falls back to the un-named message when the holder could not be identified', () => {
+    const text = describeForeignHolder(4400, null);
+    expect(text).toContain('another process');
+    expect(text).not.toContain('pid');
+  });
+});

--- a/packages/server/src/cli/port-holder.ts
+++ b/packages/server/src/cli/port-holder.ts
@@ -1,0 +1,79 @@
+/**
+ * Who is holding the bridge port.
+ *
+ * `doctor` is what a user runs when the agent cannot reach the bridge, and the commonest real cause
+ * is that something else is on 4400. It already stopped saying "nothing is listening" for that case,
+ * but it did not say WHICH process — so the reader's next move was a shell command they had to know.
+ *
+ * Naming the holder is also the safe answer to a trap this project has hit for real: the obvious
+ * lookup, `lsof -ti tcp:4400 | xargs kill -9`, ALSO kills the agent's own `reticle mcp` proxy,
+ * because that proxy holds a client connection to the same port and `-ti` does not filter to
+ * listeners. Every invocation here is `-sTCP:LISTEN`, and the message never suggests `-ti`.
+ *
+ * The parser is pure and the lookup takes an injected exec, so the rule is tested on every platform
+ * while the shelling out stays at the call site.
+ */
+
+export interface PortHolder {
+  pid: number;
+  command: string;
+}
+
+/** `lsof -F pc` emits one field per line, prefixed by its selector: `p<pid>`, `c<command>`. */
+const PID_FIELD = 'p';
+const COMMAND_FIELD = 'c';
+
+/**
+ * The FIRST listener in `lsof -nP -iTCP:<port> -sTCP:LISTEN -F pc` output, or null.
+ *
+ * First, not "the only one": a dual-stack listener (IPv4 + IPv6) is reported twice, and on a port
+ * conflict the answer the reader needs is "something is there, here is what" rather than an
+ * exhaustive list. A second `p` record ends the first.
+ *
+ * Null on anything incomplete. Half an answer — a pid with no command — prints worse than the
+ * un-named message it would replace, which is the same mistake as the port lie this command fixed.
+ */
+export function parsePortHolder(stdout: string): PortHolder | null {
+  let pid: number | undefined;
+  let command: string | undefined;
+  for (const raw of stdout.split('\n')) {
+    const line = raw.trim();
+    if (0 === line.length) continue;
+    const value = line.slice(1);
+    if (line.startsWith(PID_FIELD)) {
+      if (pid !== undefined) break; // a second record: the first one is the answer
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed) || parsed <= 0) return null;
+      pid = parsed;
+      continue;
+    }
+    if (line.startsWith(COMMAND_FIELD) && command === undefined) command = value;
+  }
+  return pid === undefined || command === undefined ? null : { pid, command };
+}
+
+/** What `doctor` prints for a port held by something that is not a Reticle daemon. */
+export function describeForeignHolder(port: number, holder: PortHolder | null): string {
+  const tail =
+    'a daemon cannot bind it. Stop that process, or run Reticle on a different port ' +
+    '(`--port`), then retry.';
+  if (null === holder) {
+    return `port ${String(port)} is held by another process that is not a Reticle daemon — ${tail}`;
+  }
+  return (
+    `port ${String(port)} is held by pid ${String(holder.pid)} ("${holder.command}"), which is not ` +
+    `a Reticle daemon — ${tail}`
+  );
+}
+
+/** The lookup itself. `exec` is injected so the shelling out never runs in a unit test. */
+export function findPortHolder(
+  port: number,
+  exec: (command: string, args: readonly string[]) => string | null,
+): PortHolder | null {
+  // -n/-P skip DNS and service-name lookups (slow, and irrelevant here). -sTCP:LISTEN is the part
+  // that matters: without it this also reports the agent's own MCP proxy, which is a client of the
+  // port, not its owner.
+  const out = exec('lsof', ['-nP', `-iTCP:${String(port)}`, '-sTCP:LISTEN', '-F', 'pc']);
+  return null === out ? null : parsePortHolder(out);
+}

--- a/packages/vite-plugin/src/turbo-cache.test.ts
+++ b/packages/vite-plugin/src/turbo-cache.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * A suite that boots a REAL dev server must not have its result cached by turbo.
+ *
+ * Turbo caches `test:unit` on a hash of the package's files, which is sound only when the outcome is
+ * a function of those files. This package's integration suite starts an actual Vite dev server and
+ * binds a port, so its outcome also depends on the machine — memory pressure, a port already held,
+ * a dev server from a previous run that never closed. Caching an outcome that is not a function of
+ * its inputs is unsound in principle, and it was observed in practice (#140):
+ *
+ *   `pnpm test:unit` reported it GREEN in the same minute a direct
+ *   `pnpm --filter @reticlehq/vite-plugin test:unit` reported it RED — turbo served a cached pass
+ *   from an earlier run.
+ *
+ * That is the worst shape a gate can take: it reports success for a suite that is failing right now,
+ * which is precisely when somebody is relying on it. Re-running this package costs ~6s.
+ *
+ * The rule is tied to the EVIDENCE rather than pinned to a filename: if any test here boots a
+ * server, the opt-out must be present. Delete the integration suite and this stops demanding it;
+ * add a second one and it is already covered.
+ */
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PKG = join(HERE, '..');
+
+/** Booting a real Vite dev server — the thing that makes a suite depend on the machine. */
+const BOOTS_A_SERVER = /createServer|\.listen\(/;
+
+function testFiles(): string[] {
+  return readdirSync(HERE)
+    .filter((name) => name.endsWith('.test.ts'))
+    .map((name) => join(HERE, name));
+}
+
+describe('turbo must not cache a non-hermetic suite', () => {
+  it('this package has at least one suite that boots a real server', () => {
+    // Guards the guard: if this stops being true the rule below is vacuous, and a vacuous rule that
+    // still passes is how a check quietly stops checking.
+    const booting = testFiles().filter((f) => BOOTS_A_SERVER.test(readFileSync(f, 'utf8')));
+    expect(booting.length).toBeGreaterThan(0);
+  });
+
+  it('so test:unit caching is disabled for this package', () => {
+    const path = join(PKG, 'turbo.json');
+    expect(existsSync(path), 'packages/vite-plugin/turbo.json must exist').toBe(true);
+    const config = JSON.parse(readFileSync(path, 'utf8')) as {
+      tasks?: Record<string, { cache?: boolean }>;
+    };
+    expect(config.tasks?.['test:unit']?.cache).toBe(false);
+  });
+});

--- a/packages/vite-plugin/turbo.json
+++ b/packages/vite-plugin/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test:unit": {
+      "dependsOn": ["^build"],
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
Closes the remaining half of #105. The first half — reporting the **port** rather than the pid file, so an occupied port stops reading as "nothing is listening" — shipped in `5a6e7028`.

## Before / after

```
before:  daemon  ✗ port 4400 is held by another process that is not a Reticle daemon — …
after:   daemon  ✗ port 4400 is held by pid 90502 ("node"), which is not a Reticle daemon — …
```

`doctor` is the command a user runs when the agent cannot reach the bridge, and the commonest real cause is that something else is on 4400. "Another process" is true, and leaves the reader to go find a shell command themselves.

## Why naming it is also the *safe* answer

The obvious lookup is a trap this project has hit for real:

```sh
lsof -ti tcp:4400 | xargs kill -9      # also kills the agent's own `reticle mcp`
```

That proxy holds a **client** connection to the same port, and `-ti` does not filter to listeners — so the command a user reaches for to free the port severs the agent's own link to it. Every invocation here passes `-sTCP:LISTEN`, and a test asserts the printed message never suggests `-ti`.

## Fails soft, by construction

Degrades to the exact previous message on **any** failure: no `lsof` (Windows, a slim container), a non-zero exit, a throw, or a 2s timeout. This is a diagnostic nicety inside the command people run when things are already broken — it must never be the reason `doctor` fails.

Half an answer is refused too: a pid with no command returns `null` rather than printing `(pid 90502, undefined)`. That is the same class of mistake as the port lie this command already fixed.

## Tests

RED proven **against real behaviour**, not a missing import: I created the module returning today's answers verbatim, ran the suite, and got 4 failures with 4 negative controls passing. Then implemented.

The parser is pure and tested against real `lsof -F pc` output — including the dual-stack case where one process is reported twice, a command containing spaces, a non-numeric pid, and empty output.

**Verified live**: started a real listener on 4491 and ran the built CLI —

```
holder pid 35509
  daemon  ✗ port 4491 is held by pid 35509 ("node"), which is not a Reticle daemon — …
```

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)