### PR TITLE
fix(daemon): record a daemon that died without exiting

### DIFF
--- a/packages/server/src/daemon/daemon.ts
+++ b/packages/server/src/daemon/daemon.ts
@@ -11,10 +11,12 @@ import {
   readdirSync,
   statSync,
   renameSync,
+  writeSync,
 } from 'node:fs';
 import { spawn } from 'node:child_process';
 import { daemonRegistryFileName, ReticleEnv, type DaemonRegistryEntry } from '@reticlehq/core';
 import { log } from '../log.js';
+import { uncleanPredecessor } from './unclean-predecessor.js';
 
 /** Env override for the whole state directory — see ReticleEnv.STATE_DIR. */
 export const STATE_DIR_ENV = ReticleEnv.STATE_DIR;
@@ -289,12 +291,18 @@ export function spawnDaemon(
   // O_EXCL spawn-lock: only the FIRST racer to create the pidfile spawns. A concurrent second gets
   // EEXIST — if a LIVE daemon owns the port it skips (no duplicate detached daemon, no clobbered pid);
   // a stale pidfile from a crashed daemon is reclaimed. Returns false when it did not spawn.
+  /** Set when this start reclaimed a pidfile whose owner is gone — see unclean-predecessor.ts. */
+  let orphanPid: number | null = null;
   let lockFd: number;
   try {
     lockFd = deps.openFile(pidFilePath, 'wx');
   } catch {
     const existing = readPid(port, deps.home);
     if (existing !== null && deps.pidAlive(existing)) return false;
+    // This branch IS the crash detection — its own comment has always said so ("a stale pidfile from
+    // a crashed daemon is reclaimed"), it just never said it out loud. Captured before the unlink,
+    // because after it there is no trace left that the previous daemon died at all.
+    orphanPid = uncleanPredecessor(existing, false, process.pid);
     try {
       unlinkSync(pidFilePath);
       lockFd = deps.openFile(pidFilePath, 'wx');
@@ -317,6 +325,26 @@ export function spawnDaemon(
       // racing another reclaimer — fine
     }
     return false;
+  }
+  // Into the daemon log itself, not the parent's stdout: `doctor` points the reader at this file, and
+  // a death recorded anywhere else is a death they will not find. Written through the fd the child is
+  // about to inherit, so it lands immediately before that child's first line — exactly where a reader
+  // comparing two `mcp_daemon_started` entries is already looking.
+  if (null !== orphanPid) {
+    try {
+      writeSync(
+        logFd,
+        `${JSON.stringify({
+          // Same convention as log(): the clock is read at the I/O boundary, not injected.
+          t: new Date().toISOString(),
+          event: 'reticle_daemon_previous_died_unclean',
+          port,
+          pid: orphanPid,
+        })}\n`,
+      );
+    } catch {
+      // A log we cannot write is not a reason to refuse to start the daemon.
+    }
   }
   let child: SpawnedChild;
   try {

--- a/packages/server/src/daemon/unclean-predecessor.test.ts
+++ b/packages/server/src/daemon/unclean-predecessor.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { uncleanPredecessor } from './unclean-predecessor.js';
+
+/**
+ * A daemon that was KILLED leaves no exit line, because no handler runs.
+ *
+ * `DaemonExitReason` covers every departure that goes through Node — signal, idle, and the
+ * load-bearing `unknown` for a stray exit or an uncaught throw. It cannot cover SIGKILL, an OOM
+ * kill, or a lost machine: the process is simply gone, and the log's last word about it is whatever
+ * it happened to be doing.
+ *
+ * That is the first half of #123, and it is the half that read as normal:
+ *
+ *   10:49:05  mcp_daemon_started        port:4400            <- pid 2884
+ *   10:51:29  mcp_daemon_started        port:4400  pid:4900  <- a SECOND daemon binds the SAME port
+ *
+ * pid 2884 died with no exit event at all, and the only evidence was that a second daemon could bind
+ * a port the first one held. The next startup is the only place that death can be observed, because
+ * it is the only moment anything looks at the pidfile the dead process left behind.
+ *
+ * Pure: the decision is separated from the filesystem, so every branch is asserted here rather than
+ * inferred from a fixture that has to arrange a real orphan.
+ */
+describe('uncleanPredecessor', () => {
+  const SELF = 4900;
+
+  it('reports the pid when the pidfile names a DEAD process that is not us', () => {
+    expect(uncleanPredecessor(2884, false, SELF)).toBe(2884);
+  });
+
+  it('is silent when the previous daemon is still alive — that is a port conflict, not a death', () => {
+    // A losing child hitting EADDRINUSE must not accuse the winner of dying.
+    expect(uncleanPredecessor(2884, true, SELF)).toBeNull();
+  });
+
+  it('is silent when the pidfile is ours — a restart in place is not a predecessor', () => {
+    expect(uncleanPredecessor(SELF, false, SELF)).toBeNull();
+  });
+
+  it('is silent when there is no pidfile — the ordinary first start', () => {
+    // The common case by far. A first start must not log a death that never happened.
+    expect(uncleanPredecessor(null, false, SELF)).toBeNull();
+  });
+
+  it('is silent for a tidy shutdown, which removed its own pidfile', () => {
+    // removePid() unlinks on the way out, so a clean exit reaches the next start as `null` — the
+    // same shape as a first start, which is exactly why the two used to be indistinguishable.
+    expect(uncleanPredecessor(null, true, SELF)).toBeNull();
+  });
+});

--- a/packages/server/src/daemon/unclean-predecessor.ts
+++ b/packages/server/src/daemon/unclean-predecessor.ts
@@ -1,0 +1,30 @@
+/**
+ * The pid of a daemon that died without exiting, observed at the next start.
+ *
+ * `DaemonExitReason` covers every departure that goes through Node — signal, idle, and the
+ * load-bearing `unknown` for a stray exit or an uncaught throw. It cannot cover SIGKILL, an OOM
+ * kill, or a lost machine: no handler runs, so the log's last word about that daemon is whatever it
+ * happened to be doing. From the report (#123):
+ *
+ *   10:49:05  mcp_daemon_started        port:4400            <- pid 2884
+ *   10:51:29  mcp_daemon_started        port:4400  pid:4900  <- a SECOND daemon binds the SAME port
+ *
+ * pid 2884 died with no exit event at all, and the only evidence was that a second daemon could bind
+ * a port the first one held — something a reader has to notice and interpret.
+ *
+ * The next startup is the only place that death is observable, because it is the only moment
+ * anything looks at the pidfile the dead process left behind. A tidy shutdown unlinks its own, so
+ * finding one whose owner is gone IS the signal.
+ *
+ * Pure, and deliberately conservative: an owner that is still ALIVE is a port conflict, not a death,
+ * and accusing a live sibling of dying would be a new false claim in the log this exists to make
+ * honest.
+ */
+export function uncleanPredecessor(
+  owner: number | null,
+  alive: boolean,
+  self: number,
+): number | null {
+  if (null === owner || owner === self || alive) return null;
+  return owner;
+}


### PR DESCRIPTION
Closes the first half of #123. The second half — a tidy shutdown and an idle self-exit reading identically — shipped earlier as `DaemonExitReason` on the exit line.

## The gap `DaemonExitReason` cannot close

It covers every departure that goes *through Node*. It cannot cover SIGKILL, an OOM kill, or a lost machine: no handler runs, so the log's last word about that daemon is whatever it happened to be doing. From the report:

```
10:49:05  mcp_daemon_started  port:4400            <- pid 2884
10:51:29  mcp_daemon_started  port:4400  pid:4900  <- a SECOND daemon binds the SAME port
```

pid 2884 died with **no exit event at all**. The only evidence was that a second daemon could bind a port the first one held — something the reader has to notice, and then interpret.

## Where the death is observable

Exactly one place: the O_EXCL spawn-lock's reclaim branch, whose own comment has always said

> a stale pidfile from a crashed daemon is reclaimed

The code already knew. It just never said so out loud — and the `unlinkSync` one line later destroys the evidence.

## After

```
{"event":"reticle_daemon_ready","port":4494,"pid":40421}
{"event":"reticle_daemon_previous_died_unclean","port":4494,"pid":40421}   <-- names the dead one
{"event":"mcp_daemon_started","port":4494}
{"event":"reticle_daemon_ready","port":4494,"pid":40430}
```

Written into the daemon log through the fd the child is about to inherit, so it lands immediately **before** that child's first line — exactly where a reader comparing two `mcp_daemon_started` entries is already looking. `doctor` points people at that file; a death recorded anywhere else is one they will not find.

## Conservative by construction

An owner that is still **alive** is a port conflict, not a death — accusing a live sibling of dying would be a new false claim in the log this exists to make honest. Four negative controls pin it: live owner, own pid, no pidfile (ordinary first start), and a tidy shutdown (which unlinked its own, so it reaches the next start looking exactly like a first start — which is *why* the two were indistinguishable).

## What the unit tests could not have caught

**My first attempt put the check in `writePid`, which runs in the CHILD — after the parent has already reclaimed the pidfile.** It could never have fired. The unit tests were green; the live test (SIGKILL a real daemon, restart, read the log) is what caught it. Recording that because the pure decision being correct told me nothing about whether it was wired to anything.

The pure predicate is unit-tested; the placement is verified live rather than mocked, since `writeSync` to an inherited fd is the behaviour under test.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages, 3083 server tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)