### PR TITLE
test(transport): the unreachable spec passed against a deleted retry loop

### DIFF
--- a/packages/browser/src/transport/transport.unreachable.test.ts
+++ b/packages/browser/src/transport/transport.unreachable.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { RETICLE_PROTOCOL_VERSION, MessageKind, type HelloMessage } from '@reticlehq/core';
 import { Transport } from './transport.js';
 
@@ -19,7 +19,15 @@ class FakeWebSocket {
     FakeWebSocket.instances.push(this);
   }
   send(): void {}
+  /**
+   * Idempotent, like the real thing: a WebSocket fires `onclose` ONCE.
+   *
+   * It did not, and that is what hid the vacuity. `failNTimes` re-closed the same socket ten times
+   * and collected ten failures without a single retry running, so the spec passed against a
+   * reconnect loop that had been deleted outright.
+   */
   close(): void {
+    if (3 === this.readyState) return;
     this.readyState = 3;
     this.onclose?.({ code: 1006, reason: '' });
   }
@@ -41,17 +49,35 @@ const hello = (): HelloMessage => ({
 
 beforeEach(() => {
   FakeWebSocket.instances = [];
-  vi.useFakeTimers();
   (globalThis as unknown as { WebSocket: unknown }).WebSocket = FakeWebSocket;
 });
-afterEach(() => {
-  vi.useRealTimers();
+
+/**
+ * Retries are RUN, not waited for.
+ *
+ * This spec used to call `vi.useFakeTimers()` and `advanceTimersByTime(1000)`, which drove nothing:
+ * the transport schedules through `nativeSetTimeout`, bound to the real timer at module load so a
+ * frozen `reticle_clock` cannot deadlock the SDK. So the clock never advanced anything, no retry
+ * ever ran, and `failNTimes` was re-closing the SAME socket — a sequence a real WebSocket cannot
+ * produce, since `onclose` fires once.
+ *
+ * Proven vacuous by mutation: disabling reconnect entirely (`#scheduleReopen` returning immediately)
+ * left all three tests GREEN. They asserted the failure COUNTER, never the retry loop it counts.
+ *
+ * The injected `schedule` seam records each pending retry so it can be run deliberately, which also
+ * makes each failure a genuinely new socket.
+ */
+const pending: (() => void)[] = [];
+beforeEach(() => {
+  pending.length = 0;
 });
 
 function failNTimes(n: number): void {
   for (let i = 0; i < n; i += 1) {
     FakeWebSocket.instances.at(-1)?.close();
-    vi.advanceTimersByTime(1000);
+    // Run the retry the transport scheduled. Without this the next iteration re-closes a socket
+    // that is already closed, which is what made this spec pass against a broken retry loop.
+    pending.shift()?.();
   }
 }
 
@@ -63,6 +89,7 @@ describe('transport unreachable (first-connect) warning', () => {
       hello,
       handleCommand: () => Promise.resolve({ ok: true }),
       onUnreachable: (d) => calls.push(d),
+      schedule: (fn) => void pending.push(fn),
     });
     t.connect();
 
@@ -80,11 +107,12 @@ describe('transport unreachable (first-connect) warning', () => {
       hello,
       handleCommand: () => Promise.resolve({ ok: true }),
       onUnreachable: (d) => calls.push(d),
+      schedule: (fn) => void pending.push(fn),
     });
     t.connect();
 
     FakeWebSocket.instances.at(-1)?.close(); // 1 blip
-    vi.advanceTimersByTime(1000);
+    pending.shift()?.(); // the retry runs and opens a NEW socket
     FakeWebSocket.instances.at(-1)?.open(); // connected before the 3rd failure
 
     expect(calls).toHaveLength(0);
@@ -97,6 +125,7 @@ describe('transport unreachable (first-connect) warning', () => {
       hello,
       handleCommand: () => Promise.resolve({ ok: true }),
       onUnreachable: (d) => calls.push(d),
+      schedule: (fn) => void pending.push(fn),
     });
     t.connect();
 


### PR DESCRIPTION
Found while adding reconnect backoff (#116) and flagged in that PR; this is the follow-through.

## Proven vacuous by mutation, not by reading

Deleting the reconnect loop outright — `#scheduleReopen` returning immediately — left **all three tests green**. They asserted the failure *counter* and never the retry loop that counts.

```
# with reconnect deleted, before this change
✓ src/transport/transport.unreachable.test.ts (3 tests)
```

## Two independent causes

Fixing only the first was not enough — my first attempt did exactly that and the mutation still passed:

1. **`vi.useFakeTimers()` drove nothing.** The transport schedules through `nativeSetTimeout`, bound to the real timer at module load so a frozen `reticle_clock` cannot deadlock the SDK. `advanceTimersByTime(1000)` advanced a clock nobody was waiting on.

2. **The FakeWebSocket fired `onclose` on every `close()` call.** So `failNTimes` re-closed one dead socket ten times and collected ten failures with no retry involved — a sequence a real WebSocket cannot produce, since `onclose` fires once.

The second is the one that actually hid it, and it is a fake that was *more permissive than the thing it stands in for* — which is how a fake stops being a test double and becomes a way to pass.

## After

Retries are **run** through the injected `schedule` seam (added in #116), so each failure is a genuinely new socket, and `close()` is idempotent like the real thing.

Verified by re-running the same mutation:

```
× fires onUnreachable once after repeated initial failures
  → expected [] to have a length of 1 but got +0
```

With no retries only one failure accumulates, so the threshold of three is never reached. The spec now depends on the loop it claims to cover.

## Scope

**No production code changed** — this is entirely a coverage repair.

The two "does NOT fire" tests still pass under the mutation, which is correct: a negative assertion should not depend on the mechanism being present.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)