### PR TITLE
test(transport): a second spec was asleep, found by generalising #223

### DIFF
--- a/packages/browser/src/transport/transport.backoff.test.ts
+++ b/packages/browser/src/transport/transport.backoff.test.ts
@@ -26,7 +26,9 @@ class FakeWebSocket {
     FakeWebSocket.instances.push(this);
   }
   send(): void {}
+  /** Idempotent, like the real thing: a WebSocket fires `onclose` ONCE. */
   close(): void {
+    if (3 === this.readyState) return;
     this.readyState = 3;
     this.onclose?.({ code: 1006, reason: '' });
   }

--- a/packages/browser/src/transport/transport.bridge-loss.test.ts
+++ b/packages/browser/src/transport/transport.bridge-loss.test.ts
@@ -26,7 +26,9 @@ class FakeWebSocket {
   send(text: string): void {
     this.sent.push(text);
   }
+  /** Idempotent, like the real thing: a WebSocket fires `onclose` ONCE. */
   close(): void {
+    if (3 === this.readyState) return;
     this.readyState = 3;
     this.onclose?.({ code: 1006, reason: '' });
   }
@@ -47,10 +49,21 @@ const hello = (): HelloMessage => ({
 });
 
 let now = 0;
+/**
+ * Retries the transport scheduled, run deliberately.
+ *
+ * `vi.advanceTimersByTime` drives nothing here: the transport schedules on `nativeSetTimeout`, bound
+ * to the real timer at module load so a frozen `reticle_clock` cannot deadlock the SDK. Without
+ * running these, the loops below re-closed one DEAD socket and only looked like repeated
+ * reconnects — the first test's own comment says "drive several failed reconnects", which is
+ * exactly what it believed and exactly what was not happening.
+ */
+const pending: (() => void)[] = [];
 
 beforeEach(() => {
   FakeWebSocket.instances = [];
   now = 0;
+  pending.length = 0;
   vi.useFakeTimers();
   (globalThis as unknown as { WebSocket: unknown }).WebSocket = FakeWebSocket;
 });
@@ -67,6 +80,7 @@ describe('transport bridge-loss self-end', () => {
       hello,
       handleCommand: () => Promise.resolve({ ok: true }),
       now: () => now,
+      schedule: (fn) => void pending.push(fn),
       onConnectionLost: () => {
         lost += 1;
       },
@@ -78,7 +92,7 @@ describe('transport bridge-loss self-end', () => {
     for (let i = 0; i < 20; i += 1) {
       FakeWebSocket.instances.at(-1)?.close();
       now += 1000;
-      vi.advanceTimersByTime(1000);
+      pending.shift()?.(); // the retry runs and opens a NEW socket to fail next round
     }
 
     expect(lost).toBeGreaterThanOrEqual(1);
@@ -90,6 +104,7 @@ describe('transport bridge-loss self-end', () => {
       hello,
       handleCommand: () => Promise.resolve({ ok: true }),
       now: () => now,
+      schedule: (fn) => void pending.push(fn),
     });
     t.connect();
     const ws = FakeWebSocket.instances.at(-1);
@@ -111,6 +126,7 @@ describe('transport bridge-loss self-end', () => {
       hello,
       handleCommand: () => Promise.resolve({ ok: true }),
       now: () => now,
+      schedule: (fn) => void pending.push(fn),
       onConnectionLost: () => {
         lost += 1;
       },
@@ -119,7 +135,7 @@ describe('transport bridge-loss self-end', () => {
 
     FakeWebSocket.instances.at(-1)?.close(); // brief blip
     now += 1000;
-    vi.advanceTimersByTime(1000);
+    pending.shift()?.();
     FakeWebSocket.instances.at(-1)?.open(); // reconnected well within the window
 
     expect(lost).toBe(0);
@@ -132,6 +148,7 @@ describe('transport bridge-loss self-end', () => {
       hello,
       handleCommand: () => Promise.resolve({ ok: true }),
       now: () => now,
+      schedule: (fn) => void pending.push(fn),
       onConnectionLost: () => {
         lost += 1;
       },
@@ -141,7 +158,7 @@ describe('transport bridge-loss self-end', () => {
     for (let i = 0; i < 40; i += 1) {
       FakeWebSocket.instances.at(-1)?.close();
       now += 1000;
-      vi.advanceTimersByTime(1000);
+      pending.shift()?.(); // the retry runs and opens a NEW socket to fail next round
     }
 
     expect(lost).toBe(1);

--- a/packages/browser/src/transport/transport.churn-eviction.test.ts
+++ b/packages/browser/src/transport/transport.churn-eviction.test.ts
@@ -24,7 +24,9 @@ class FakeWebSocket {
   send(text: string): void {
     this.sent.push(text);
   }
+  /** Idempotent, like the real thing: a WebSocket fires `onclose` ONCE. */
   close(): void {
+    if (3 === this.readyState) return;
     this.readyState = 3;
     this.onclose?.({ code: 1006, reason: '' });
   }

--- a/packages/browser/src/transport/transport.overflow-marker.test.ts
+++ b/packages/browser/src/transport/transport.overflow-marker.test.ts
@@ -33,7 +33,9 @@ class FakeWebSocket {
   send(text: string): void {
     this.sent.push(text);
   }
+  /** Idempotent, like the real thing: a WebSocket fires `onclose` ONCE. */
   close(): void {
+    if (3 === this.readyState) return;
     this.readyState = 3;
     this.onclose?.({ code: 1006, reason: '' });
   }

--- a/packages/browser/src/transport/transport.reconnect-on-focus.test.ts
+++ b/packages/browser/src/transport/transport.reconnect-on-focus.test.ts
@@ -15,7 +15,9 @@ class FakeWebSocket {
     FakeWebSocket.instances.push(this);
   }
   send(): void {}
+  /** Idempotent, like the real thing: a WebSocket fires `onclose` ONCE. */
   close(): void {
+    if (3 === this.readyState) return;
     this.readyState = 3;
     this.onclose?.({ code: 1006, reason: '' });
   }


### PR DESCRIPTION
**Stacked on #223** — please merge that first; this targets its branch, so the diff here is only the new work.

## Generalising the finding, not just fixing the instance

#223 found **one** dead spec. The cause was a `FakeWebSocket` firing `onclose` on **every** `close()` call, where a real socket fires it once — a fake more permissive than the thing it stands in for. So the obvious question was: how many copies of that fake exist?

**Nine. Six carrying the identical defect.**

Rather than reason about which might be affected, I made `close()` idempotent everywhere and ran the suite. Whatever broke was, by construction, a spec relying on a sequence no browser can produce.

## Two broke

Both in `transport.bridge-loss.test.ts` — `onConnectionLost`, the behaviour that ends a session when the bridge is gone. Its loop closed one dead socket twenty times, under a comment reading:

```ts
// First socket never opens; it closes → schedules reconnect. Drive several failed reconnects
// while advancing the injected clock past the loss threshold.
for (let i = 0; i < 20; i += 1) {
  FakeWebSocket.instances.at(-1)?.close();
  now += 1000;
  vi.advanceTimersByTime(1000);
}
```

Exactly what it believed, and exactly what was not happening.

## The repair

Same as #223: retries are **run** through the injected `schedule` seam, so each iteration fails a genuinely new socket. `vi.advanceTimersByTime` was driving nothing — the transport schedules on `nativeSetTimeout`, bound to the real timer at module load so a frozen `reticle_clock` cannot deadlock the SDK.

Worth separating: the injected `now` **was** real, so the outage *duration* was never in doubt. Only the reconnects were imaginary.

## Verified by mutation, both directions

With the reconnect loop deleted (`#scheduleReopen` returning immediately):

```
× fires onConnectionLost after a continuous outage past BRIDGE_LOST_MS
  → expected 0 to be greater than or equal to 1
× fires onConnectionLost only once per outage
  → expected +0 to be 1
```

Before this change, both passed.

## Scope

**No production code changed.** The remaining four fakes gain idempotency with no test change — which is the evidence they were not relying on it, rather than an assumption that they weren't.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages, 46/46 transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)