### PR TITLE
fix(init): confirm a file was written before printing its checkmark

### DIFF
--- a/packages/server/src/init/run.test.ts
+++ b/packages/server/src/init/run.test.ts
@@ -727,3 +727,57 @@ describe('runInit — a refused pin falls back instead of blocking the install',
     expect(io.written['vite.config.ts']).toContain('reticle()');
   });
 });
+
+/**
+ * A `[✓]` for a filesystem effect must be backed by a `stat`, not by the intention to write.
+ *
+ * Reported from the field (#160): `init` printed `[✓] Reticle config → .reticle.json` and the file
+ * was not there afterward. Two candidates had to be separated before changing anything — the step
+ * reporting its PLAN rather than its EFFECT, or the file landing in a different directory than the
+ * user was standing in. The second is a real hazard in a monorepo and was addressed separately by
+ * printing the project directory in the header. This is the first: nothing ever checked.
+ *
+ * It is the same shape as #139 (`✓ Capabilities + store` for a module nothing imported) and the same
+ * shape as the Next.js install that reported clean and connected 0% of the time. A checkmark that
+ * cannot fail is not a report, it is decoration — and this one is the first thing a new user reads.
+ *
+ * The write path itself is not suspected. The point is that no arrangement of the filesystem — a
+ * read-only mount, a full disk, an antivirus quarantining a new dotfile, a path the process cannot
+ * see — could ever have turned that tick into anything else.
+ */
+describe('init confirms a file it claims to have written', () => {
+  /**
+   * An IO whose writes are accepted and silently do not land — a read-only mount, a full disk, an
+   * antivirus quarantining a new dotfile. Only the config write is swallowed, so the test isolates
+   * one step rather than failing the whole install for an unrelated reason.
+   */
+  function swallowingIo(files: Record<string, string>): MemoryIo {
+    const io = memoryIo(files);
+    const realWrite = io.writeFile.bind(io);
+    return {
+      ...io,
+      writeFile: (p, c) => {
+        if (p.endsWith('.reticle.json')) return;
+        realWrite(p, c);
+      },
+    };
+  }
+
+  it('does not print ✓ for a config file that is not on disk afterward', () => {
+    const io = swallowingIo(VITE_FILES);
+    runInit(OPTS, io);
+    const report = io.lines.join('\n');
+    const configLine = report.split('\n').find((l) => l.includes('.reticle.json')) ?? '';
+    expect(configLine, 'the config step must be reported').not.toBe('');
+    expect(configLine, 'a ✓ here is a claim nothing checked').not.toContain('✓');
+  });
+
+  it('still prints ✓ when the file IS on disk — the ordinary case is untouched', () => {
+    // The control. A confirmation that fails open would silently downgrade every healthy install.
+    const io = memoryIo(VITE_FILES);
+    runInit(OPTS, io);
+    const line = io.lines.find((l) => l.includes('.reticle.json')) ?? '';
+    expect(line).toContain('✓');
+    expect(io.written['.reticle.json']).toBeDefined();
+  });
+});

--- a/packages/server/src/init/run.ts
+++ b/packages/server/src/init/run.ts
@@ -607,9 +607,23 @@ function applyEffects(
     }
     const write = s.write;
     if (write !== undefined) {
-      spanSync('init.write', { target: s.target, path: write.path }, () => {
-        io.writeFile(write.path, write.content);
+      // Confirm the EFFECT, not the intention. Reported from the field (#160): init printed
+      // `[✓] Reticle config → .reticle.json` and the file was not there afterward. Nothing checked —
+      // no arrangement of the filesystem (a read-only mount, a full disk, an antivirus quarantining
+      // a new dotfile) could have turned that tick into anything else. A checkmark that cannot fail
+      // is decoration, and this one is the first thing a new user reads. Same shape as #139.
+      const wrote = spanSync('init.write', { target: s.target, path: write.path }, () => {
+        try {
+          io.writeFile(write.path, write.content);
+        } catch {
+          return false; // a throw is the loud version of the same failure
+        }
+        return io.exists(write.path);
       });
+      if (!wrote) {
+        failed.add(s.target);
+        continue; // do not run this step's exec against a file that is not there
+      }
     }
     // Bound once so the traced call cannot need a `?? ''` fallback — a default there would turn a
     // narrowing mistake into an empty command that silently "succeeds".


### PR DESCRIPTION
Closes #160.

## The report

```
[✓] Reticle config → .reticle.json
```

…and the file was not there afterward.

The issue named two candidates and asked for them to be separated before anything changed. The second — the file landing in a directory other than the one the user was standing in — is a real monorepo hazard, and was addressed separately by printing the project directory in the header. **This is the first, and it is simpler: nothing ever checked.**

`applyEffects` called `io.writeFile` and moved on. No arrangement of the filesystem — a read-only mount, a full disk, an antivirus quarantining a new dotfile, a path the process cannot see — could have turned that tick into anything else.

A checkmark that cannot fail is decoration, and this one is the first thing a new user reads. Same shape as #139 (`✓ Capabilities + store` for a module nothing imported) and as the Next.js install that reported clean and connected 0% of the time.

## The fix

The write is confirmed with an `exists()`, and a step that cannot be confirmed is added to `failed` — which the report **already** downgrades to a manual step with its fallback command, so the honest path existed and was simply never reached. A throw is treated as the loud version of the same failure, and the step's `exec` is skipped rather than run against a file that is not there.

**The write path itself is not suspected and is unchanged. The claim is.**

## Tests

RED reproduces the reported line exactly, using an IO whose writes are accepted and silently do not land:

```
AssertionError: a ✓ here is a claim nothing checked:
  expected '  [✓] Reticle config → .reticle.json' not to contain '✓'
```

Only the config write is swallowed, so the test isolates one step rather than failing the whole install for an unrelated reason.

The control — **still prints ✓ when the file IS on disk** — passed throughout. A confirmation that failed open would silently downgrade every healthy install, which is the more expensive direction to get wrong.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages, 312/312 in the init suite.

> Note: one browser test failed transiently on a full-monorepo run and passed on two subsequent ones — the third load-only flake I have seen in that package tonight (see #210). Unrelated to this change, which touches only `packages/server/src/init`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)