### PR TITLE
test(act): occludedBy could be nulled and no test noticed

### DIFF
--- a/packages/browser/src/actions/actions.effect.test.ts
+++ b/packages/browser/src/actions/actions.effect.test.ts
@@ -437,3 +437,69 @@ describe('action result: testid normalization', () => {
     expect(out.steps[0]?.name).toBe('Pay now');
   });
 });
+
+/**
+ * `occludedBy` is the actionable half of an occlusion report, and nothing was holding it.
+ *
+ * `hitTestOccluder` is well covered in occlusion.test.ts — it returns the overlay element. What was
+ * not covered is the PLUMBING from there to `effect.occludedBy`, and a mutation proved it: replacing
+ * `occludedBy: geometry.occludedBy` with `occludedBy: null` failed ZERO tests. `occluded: true`
+ * alone tells an agent it is blocked; only `occludedBy` tells it by what, which is the difference
+ * between "I cannot proceed" and "dismiss e16 and retry".
+ *
+ * Verified live against bench-app before writing this, so the behaviour being pinned is the observed
+ * one rather than the one I assumed:
+ *
+ *   effect: { occluded: true, occludedBy: "e16" }
+ *   warning: "target is visually occluded by another element; a real user could not click it
+ *             (synthetic dispatch still delivered the event) — dismiss the overlay or scroll clear"
+ */
+describe('action effect: occludedBy names the blocker', () => {
+  /** jsdom has no layout: give the target a real rect and put `overlay` on top of its centre. */
+  function overlayOver(target: Element, overlay: Element): void {
+    Object.defineProperty(target, 'getBoundingClientRect', {
+      value: () => new DOMRect(0, 0, 40, 20),
+      configurable: true,
+    });
+    Object.defineProperty(document, 'elementFromPoint', {
+      value: () => overlay,
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  afterEach(() => {
+    Reflect.deleteProperty(document, 'elementFromPoint');
+  });
+
+  it('reports a ref that RESOLVES to the covering element, not merely a non-null value', async () => {
+    document.body.innerHTML = '<button>Save</button><div id="sheet"></div>';
+    const button = document.querySelector('button') as HTMLButtonElement;
+    const overlay = document.querySelector('#sheet') as HTMLElement;
+    overlayOver(button, overlay);
+
+    const r = await executeAction(refs.refFor(button), 'click');
+    expect(r.effect.occluded).toBe(true);
+    const by = r.effect.occludedBy;
+    expect(by, 'an occlusion the agent cannot name is one it cannot clear').not.toBeNull();
+    // The property that makes it actionable: the ref must address the overlay itself.
+    expect(refs.resolve(String(by))).toBe(overlay);
+  });
+
+  it('is null when nothing covers the target — absence must keep meaning "clear"', async () => {
+    document.body.innerHTML = '<button>Save</button>';
+    const button = document.querySelector('button') as HTMLButtonElement;
+    Object.defineProperty(button, 'getBoundingClientRect', {
+      value: () => new DOMRect(0, 0, 40, 20),
+      configurable: true,
+    });
+    Object.defineProperty(document, 'elementFromPoint', {
+      value: () => button,
+      configurable: true,
+      writable: true,
+    });
+    const r = await executeAction(refs.refFor(button), 'click');
+    expect(r.effect.occluded).toBe(false);
+    expect(r.effect.occludedBy).toBeNull();
+  });
+});


### PR DESCRIPTION
Found by mutation sweep, not by reading.

## The gap

Replacing `occludedBy: geometry.occludedBy` with `occludedBy: null` failed **zero tests** across the whole repo.

`hitTestOccluder` is well covered in `occlusion.test.ts` — it correctly returns the overlay element. What nothing covered is the **plumbing** from there to `effect.occludedBy`.

## Why this field specifically

`occluded: true` tells an agent it is blocked. Only `occludedBy` tells it **by what** — the difference between *"I cannot proceed"* and *"dismiss e16 and retry"*.

It is also false-green-critical. A synthetic click lands on a control a real user could never reach, so this is the one signal separating "the app works" from "the harness can reach what a person cannot".

## Verified live before it was pinned

Driven against `bench-app` with the occlusion fixture, so what the test pins is the observed behaviour rather than one I assumed:

```json
{"effect": {"occluded": true, "occludedBy": "e16"},
 "warning": "target is visually occluded by another element; a real user could not click it
             (synthetic dispatch still delivered the event) — dismiss the overlay or scroll clear"}
```

That warning is worth noting for its honesty: it does not claim the click failed. It says the dispatch *did* deliver, and that a real user could not have done it.

## The assertion

That the ref **resolves to the covering element**, not merely that it is non-null. A ref that names nothing is as useless as no ref, and only the resolve check separates them.

A second test pins the negative — nothing covering the target keeps `occludedBy` null — so absence goes on meaning "clear".

## Mutation-verified both directions

| mutation | before | after |
|---|---|---|
| `occludedBy: null` | 0 tests fail | **fails** |
| `occluded: false` | 1 test fails | fails |

**No production code changed.** The behaviour was correct and undefended.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)