### PR TITLE
test(session): buffer eviction could be silently zeroed and nothing noticed

### DIFF
--- a/packages/browser/src/actions/actions.effect.test.ts
+++ b/packages/browser/src/actions/actions.effect.test.ts
@@ -437,3 +437,69 @@ describe('action result: testid normalization', () => {
     expect(out.steps[0]?.name).toBe('Pay now');
   });
 });
+
+/**
+ * `occludedBy` is the actionable half of an occlusion report, and nothing was holding it.
+ *
+ * `hitTestOccluder` is well covered in occlusion.test.ts — it returns the overlay element. What was
+ * not covered is the PLUMBING from there to `effect.occludedBy`, and a mutation proved it: replacing
+ * `occludedBy: geometry.occludedBy` with `occludedBy: null` failed ZERO tests. `occluded: true`
+ * alone tells an agent it is blocked; only `occludedBy` tells it by what, which is the difference
+ * between "I cannot proceed" and "dismiss e16 and retry".
+ *
+ * Verified live against bench-app before writing this, so the behaviour being pinned is the observed
+ * one rather than the one I assumed:
+ *
+ *   effect: { occluded: true, occludedBy: "e16" }
+ *   warning: "target is visually occluded by another element; a real user could not click it
+ *             (synthetic dispatch still delivered the event) — dismiss the overlay or scroll clear"
+ */
+describe('action effect: occludedBy names the blocker', () => {
+  /** jsdom has no layout: give the target a real rect and put `overlay` on top of its centre. */
+  function overlayOver(target: Element, overlay: Element): void {
+    Object.defineProperty(target, 'getBoundingClientRect', {
+      value: () => new DOMRect(0, 0, 40, 20),
+      configurable: true,
+    });
+    Object.defineProperty(document, 'elementFromPoint', {
+      value: () => overlay,
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  afterEach(() => {
+    Reflect.deleteProperty(document, 'elementFromPoint');
+  });
+
+  it('reports a ref that RESOLVES to the covering element, not merely a non-null value', async () => {
+    document.body.innerHTML = '<button>Save</button><div id="sheet"></div>';
+    const button = document.querySelector('button') as HTMLButtonElement;
+    const overlay = document.querySelector('#sheet') as HTMLElement;
+    overlayOver(button, overlay);
+
+    const r = await executeAction(refs.refFor(button), 'click');
+    expect(r.effect.occluded).toBe(true);
+    const by = r.effect.occludedBy;
+    expect(by, 'an occlusion the agent cannot name is one it cannot clear').not.toBeNull();
+    // The property that makes it actionable: the ref must address the overlay itself.
+    expect(refs.resolve(String(by))).toBe(overlay);
+  });
+
+  it('is null when nothing covers the target — absence must keep meaning "clear"', async () => {
+    document.body.innerHTML = '<button>Save</button>';
+    const button = document.querySelector('button') as HTMLButtonElement;
+    Object.defineProperty(button, 'getBoundingClientRect', {
+      value: () => new DOMRect(0, 0, 40, 20),
+      configurable: true,
+    });
+    Object.defineProperty(document, 'elementFromPoint', {
+      value: () => button,
+      configurable: true,
+      writable: true,
+    });
+    const r = await executeAction(refs.refFor(button), 'click');
+    expect(r.effect.occluded).toBe(false);
+    expect(r.effect.occludedBy).toBeNull();
+  });
+});

--- a/packages/server/src/session/session-buffer-health.test.ts
+++ b/packages/server/src/session/session-buffer-health.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import type { WebSocket } from 'ws';
+import {
+  EventType,
+  MessageKind,
+  RETICLE_PROTOCOL_VERSION,
+  RING_BUFFER_DEFAULTS,
+  type HelloMessage,
+  type ReticleEvent,
+} from '@reticlehq/core';
+import { Session } from './session.js';
+
+/**
+ * `Session.bufferHealth()` must report what the ring buffer actually dropped.
+ *
+ * This one-line delegation carries the honesty signal that reaches every verdict. From a live drive:
+ *
+ *   "buffer": { "held": 2000, "dropped": 4422,
+ *               "note": "event buffer evicted older events (age/size cap) — a negative result here
+ *                        may be a false negative; the evidence may have expired." }
+ *
+ * That note is what stops an agent trusting `{ kind:'console', absent:true }` after a long flow. If
+ * `dropped` silently read 0 the note disappears and a negative result reads as clean — the precise
+ * false green this product exists to prevent, produced by the layer meant to prevent it.
+ *
+ * Found by mutation: forcing `dropped: 0` here failed ZERO tests in the repo. The two neighbours are
+ * both well covered and neither touches this seam — `ring-buffer.test.ts` asserts the buffer's own
+ * counter, and every tool test STUBS `bufferHealth` on a fake session. So the buffer was tested, the
+ * consumers were tested, and the wire between them was not.
+ */
+function hello(): HelloMessage {
+  return {
+    kind: MessageKind.HELLO,
+    protocolVersion: RETICLE_PROTOCOL_VERSION,
+    sessionId: 'demo',
+    url: 'http://localhost/',
+    title: 'Demo',
+    adapters: [],
+  };
+}
+
+const noopSocket = { send: () => undefined, close: () => undefined } as unknown as WebSocket;
+
+function evt(seq: number): ReticleEvent {
+  return { t: seq, seq, type: EventType.DOM_ADDED, sessionId: 'demo', data: {} };
+}
+
+describe('Session.bufferHealth reports real eviction', () => {
+  it('is silent on a fresh session — absence must keep meaning "nothing was lost"', () => {
+    const session = new Session(hello(), noopSocket, () => 0);
+    session.pushEvent(evt(0));
+    expect(session.bufferHealth().dropped).toBe(0);
+    expect(session.bufferHealth().total).toBeGreaterThan(0);
+  });
+
+  it('reports the drop once the buffer has evicted', () => {
+    const session = new Session(hello(), noopSocket, () => 0);
+    // One past the count cap: the oldest event is evicted and the counter must say so.
+    for (let i = 0; i <= RING_BUFFER_DEFAULTS.MAX_EVENTS; i += 1) session.pushEvent(evt(i));
+    expect(session.bufferHealth().dropped).toBeGreaterThan(0);
+  });
+
+  it('keeps counting as eviction continues, rather than latching at one', () => {
+    // A counter that reported "1" forever would still satisfy the test above while understating the
+    // gap by any margin. The disclosure is only useful if it tracks how much went missing.
+    const session = new Session(hello(), noopSocket, () => 0);
+    for (let i = 0; i <= RING_BUFFER_DEFAULTS.MAX_EVENTS; i += 1) session.pushEvent(evt(i));
+    const first = session.bufferHealth().dropped;
+    for (let i = 0; i < 50; i += 1) session.pushEvent(evt(RING_BUFFER_DEFAULTS.MAX_EVENTS + i));
+    expect(session.bufferHealth().dropped).toBe(first + 50);
+  });
+});


### PR DESCRIPTION
Found by mutation sweep: forcing `Session.bufferHealth()` to report `dropped: 0` failed **zero tests** in the repo.

## Why this line matters

It carries the honesty signal that reaches every verdict. From a live drive tonight:

```json
"buffer": { "held": 2000, "dropped": 4422,
            "note": "event buffer evicted older events (age/size cap) — a negative result here
                     may be a false negative; the evidence may have expired." }
```

That note is what stops an agent trusting `{ kind: 'console', absent: true }` after a long flow. If `dropped` silently read 0, the note disappears and **a negative result reads as clean** — the exact false green this product exists to prevent, produced by the layer meant to prevent it.

## The seam is the interesting part

Both neighbours are well covered, and neither touches it:

- `ring-buffer.test.ts` asserts the buffer's own counter (`dropped` 1, 0, 50) ✅
- every tool test **stubs** `bufferHealth` on a fake session ✅
- `Session.bufferHealth()` delegating to the real buffer ❌

The buffer was tested, the consumers were tested, and the wire between them was not. Same shape as the `occludedBy` gap in #227 — which suggests the pattern is worth looking for deliberately: *a well-tested producer plus well-stubbed consumers can leave the delegation completely bare.*

## Three tests, and why the third exists

1. Silent on a fresh session — absence keeps meaning "nothing was lost".
2. Reports the drop once the buffer has evicted.
3. Keeps **counting** rather than latching at one.

The third is not padding: a counter stuck at `1` would satisfy the second while understating the gap by any margin, and a disclosure is only useful if it tracks how much went missing.

## Mutation-verified

| mutation | result |
|---|---|
| `dropped: 0` | fails tests 2 and 3 (previously: nothing) |
| `dropped: min(1, real)` — latch | fails test 3 |

**No production code changed.** The behaviour was correct and undefended.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)