### PR TITLE
test(observe): the window half of the act-attribution guard had no cover

### DIFF
--- a/packages/server/src/tools/act-truncated-window.test.ts
+++ b/packages/server/src/tools/act-truncated-window.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { SessionState, Verified, VerifiedReason } from '@reticlehq/core';
+import type { CommandResult, ReticleEvent } from '@reticlehq/core';
+import { LastAct } from '../session/last-act.js';
+import { TOOLS, type ToolDeps } from './tools.js';
+import { ReticleTool } from './tool-names.js';
+import { BaselineStore } from '../project/baselines.js';
+import { createNodeFileSystem } from '../project/fs-port.js';
+import { RecordingStore } from '../flows/recordings.js';
+import { FlowStore } from '../flows/flows.js';
+import { ProjectStore } from '../project/project-store.js';
+import { AnnotationStore } from '../flows/annotation-store.js';
+import type { Session, SessionManager } from '../session/session.js';
+
+/**
+ * A verdict whose window LOST events must not grade `proved`.
+ *
+ * `act_and_wait` marks its window truncated with
+ * `truncated: session.bufferHealth().dropped > droppedBefore` — the delta across this one action.
+ * That feeds `integrity.issues`, and `!integrity.clean` is what makes `decideVerified` answer
+ * UNCLEAN_CAPTURE: "a green here would only describe what was observed".
+ *
+ * Found by mutation: hardcoding that flag to `false` failed ZERO tests. So a verdict reached over a
+ * window the server buffer had evicted during would have come back `proved`, with no trace that
+ * part of the window was never seen.
+ *
+ * Distinct from the Session-level gap (`Session.bufferHealth` delegating to the ring buffer, covered
+ * separately): this is act_and_wait's USE of it — the per-action delta — and it had its own hole.
+ *
+ * Fourth instance of one pattern: a well-tested producer, consumers that stub it, and nothing on the
+ * delegation between them.
+ */
+function fakeSession(drops: number[]): Session {
+  const command = (): Promise<CommandResult> =>
+    Promise.resolve({
+      kind: 'command_result',
+      id: 'c',
+      ok: true,
+      result: { dispatched: true, settled: true, effect: { domMutatedWithin: 1 } },
+    });
+  // Successive reads walk the list, so the SECOND read (after the act) can exceed the first —
+  // which is exactly the "the buffer evicted while this action ran" condition.
+  let read = 0;
+  const noEvents: ReticleEvent[] = [];
+  const stub: Partial<Session> = {
+    id: 'demo',
+    url: 'http://localhost:5173/app',
+    elapsed: () => 1000,
+    lastAct: new LastAct(),
+    beginAction: () => 'a1',
+    finishAction: () => undefined,
+    command,
+    queryEvents: () => Promise.resolve(noEvents),
+    eventsSince: () => noEvents,
+    bufferHealth: () => ({ total: 10, dropped: drops[Math.min(read++, drops.length - 1)] ?? 0 }),
+    blindSpots: () => ({}),
+    health: () => ({ lastSeenMs: 0, throttled: false, focused: true }),
+    throttled: () => false,
+    getState: () => SessionState.ACTIVE,
+    drainInbox: () => [],
+    inboxSize: () => 0,
+    onEvent: () => () => undefined,
+    ambientCounts: () => ({}),
+  };
+  return stub as Session;
+}
+
+function fakeDeps(session: Session): ToolDeps {
+  const sessions: Partial<SessionManager> = { resolve: () => session };
+  return {
+    sessions: sessions as SessionManager,
+    baselines: new BaselineStore(),
+    recordings: new RecordingStore(),
+    flows: new FlowStore(createNodeFileSystem(), '/tmp/reticle-test/.reticle', { now: () => 0 }),
+    project: new ProjectStore(createNodeFileSystem(), '/tmp/reticle-test/.reticle', {
+      now: () => 0,
+    }),
+    annotations: new AnnotationStore(),
+    fs: createNodeFileSystem(),
+    reticleRoot: '/tmp/reticle-test/.reticle',
+    now: () => 0,
+  };
+}
+
+function tool(name: string) {
+  const found = TOOLS.find((t) => t.name === name);
+  if (found === undefined) throw new Error(`no ${name} tool`);
+  return found;
+}
+
+const ACT = { ref: 'e1', action: 'click', until: { kind: 'settled' } };
+
+interface Verdict {
+  verified?: string;
+  verifiedReason?: string;
+  because?: string;
+}
+
+describe('act_and_wait declares a window that lost events', () => {
+  it('does not grade proved when the buffer evicted DURING the action', async () => {
+    // 0 dropped before the act, 12 after: the window this verdict covers has a hole in it.
+    const deps = fakeDeps(fakeSession([0, 12]));
+    const r = (await tool(ReticleTool.ACT_AND_WAIT).handler(deps, ACT)) as Verdict;
+    expect(r.verified).toBe(Verified.UNKNOWN);
+    expect(r.verifiedReason).toBe(VerifiedReason.UNCLEAN_CAPTURE);
+  });
+
+  it('still grades proved when nothing was evicted — the ordinary window is untouched', async () => {
+    // The control. A flag stuck ON would caveat every verdict, which is the opposite failure and
+    // just as damaging: a warning that is always present is one nobody reads.
+    const deps = fakeDeps(fakeSession([3, 3]));
+    const r = (await tool(ReticleTool.ACT_AND_WAIT).handler(deps, ACT)) as Verdict;
+    expect(r.verifiedReason).toBe(VerifiedReason.PROVED);
+  });
+
+  it('reads the DELTA, not the total — a buffer that evicted BEFORE this act is not its problem', async () => {
+    // 9 already dropped before the action and none during it. Marking that window unclean would
+    // blame this verdict for a gap that predates it, and every later act in a long session would
+    // inherit a caveat it did not earn.
+    const deps = fakeDeps(fakeSession([9, 9]));
+    const r = (await tool(ReticleTool.ACT_AND_WAIT).handler(deps, ACT)) as Verdict;
+    expect(r.verifiedReason).toBe(VerifiedReason.PROVED);
+  });
+});

--- a/packages/server/src/tools/observe-act-attribution.test.ts
+++ b/packages/server/src/tools/observe-act-attribution.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { SessionState, type ReticleEvent } from '@reticlehq/core';
+import { LastAct } from '../session/last-act.js';
+import { TOOLS, type ToolDeps } from './tools.js';
+import { ReticleTool } from './tool-names.js';
+import { BaselineStore } from '../project/baselines.js';
+import { createNodeFileSystem } from '../project/fs-port.js';
+import { RecordingStore } from '../flows/recordings.js';
+import { FlowStore } from '../flows/flows.js';
+import { ProjectStore } from '../project/project-store.js';
+import { AnnotationStore } from '../flows/annotation-store.js';
+import type { Session, SessionManager } from '../session/session.js';
+
+/**
+ * `reticle_observe` must only judge an act that happened INSIDE the window it is observing.
+ *
+ * The guard is `actCursor !== undefined && actCursor >= since`. Found by mutation: dropping the
+ * `actCursor >= since` half failed ZERO tests, while dropping the whole guard fails one. So the
+ * half that decides WHICH window the act belongs to was completely undefended.
+ *
+ * Without it, an act from an earlier window has its effect fed to the contradiction engine on a
+ * later, unrelated observe — which produces `action-had-no-effect`: "the click was dispatched and
+ * the page settled … the target does not react to this action". A confident accusation about a
+ * control that is fine, derived from an action the window does not contain.
+ *
+ * That is not hypothetical. `refused-act-leaves-nothing.test.ts` exists because the same
+ * contradiction was reported from the field for the adjacent reason (act state surviving a REFUSED
+ * act). This is the other way to reach it: act state surviving into a later WINDOW.
+ */
+function fakeSession(lastAct: LastAct): Session {
+  const noEvents: ReticleEvent[] = [];
+  const stub: Partial<Session> = {
+    id: 'demo',
+    url: 'http://localhost:5173/app',
+    elapsed: () => 1000,
+    lastAct,
+    queryEvents: () => Promise.resolve(noEvents),
+    eventsSince: () => noEvents,
+    bufferHealth: () => ({ total: 0, dropped: 0 }),
+    blindSpots: () => ({}),
+    health: () => ({ lastSeenMs: 0, throttled: false, focused: true }),
+    throttled: () => false,
+    getState: () => SessionState.ACTIVE,
+    drainInbox: () => [],
+    inboxSize: () => 0,
+    onEvent: () => () => undefined,
+    ambientCounts: () => ({}),
+  };
+  return stub as Session;
+}
+
+function fakeDeps(session: Session): ToolDeps {
+  const sessions: Partial<SessionManager> = { resolve: () => session };
+  return {
+    sessions: sessions as SessionManager,
+    baselines: new BaselineStore(),
+    recordings: new RecordingStore(),
+    flows: new FlowStore(createNodeFileSystem(), '/tmp/reticle-test/.reticle', { now: () => 0 }),
+    project: new ProjectStore(createNodeFileSystem(), '/tmp/reticle-test/.reticle', {
+      now: () => 0,
+    }),
+    annotations: new AnnotationStore(),
+    fs: createNodeFileSystem(),
+    reticleRoot: '/tmp/reticle-test/.reticle',
+    now: () => 0,
+  };
+}
+
+/** An act that dispatched, settled, and moved nothing — the shape that earns the accusation. */
+function actAt(cursor: number): LastAct {
+  const a = new LastAct();
+  a.markActed(cursor, 'click', 0);
+  return a;
+}
+
+async function observe(deps: ToolDeps, since: number): Promise<{ contradictions?: unknown[] }> {
+  return (await TOOLS.find((t) => t.name === ReticleTool.OBSERVE)?.handler(deps, {
+    since,
+  })) as { contradictions?: unknown[] };
+}
+
+describe('observe judges only an act inside the window', () => {
+  it('does not blame a control for an act that happened BEFORE this window', async () => {
+    // Act at cursor 5; the caller is asking about everything since 100. The act is not in here.
+    const r = await observe(fakeDeps(fakeSession(actAt(5))), 100);
+    expect(
+      r.contradictions ?? [],
+      'an act outside the window must not be judged by it',
+    ).toHaveLength(0);
+  });
+
+  it('DOES judge an act inside the window — the guard must not silence the real case', async () => {
+    // The control. A guard that never judged anything would pass the test above and destroy the
+    // feature, which is the more expensive direction to get wrong.
+    const r = await observe(fakeDeps(fakeSession(actAt(150))), 100);
+    expect(r.contradictions ?? []).not.toHaveLength(0);
+  });
+
+  it('judges an act exactly ON the boundary — `>= since`, not `>`', async () => {
+    // An act at the cursor the caller passed IS in the window; observe is called with the cursor the
+    // act returned, so off-by-one here silences the single commonest sequence there is.
+    const r = await observe(fakeDeps(fakeSession(actAt(100))), 100);
+    expect(r.contradictions ?? []).not.toHaveLength(0);
+  });
+});


### PR DESCRIPTION
The guard is:

```ts
const judgingTheAct = actCursor !== undefined && actCursor >= since;
```

Found by mutation: dropping the **`actCursor >= since`** half failed **zero tests**, while dropping the whole guard fails one. The half that decides *which window the act belongs to* was completely undefended.

## What that half prevents

Without it, an act from an earlier window has its effect fed to the contradiction engine on a later, unrelated `observe` — producing `action-had-no-effect`:

> "the click was dispatched and the page settled … the target does not react to this action"

A confident accusation about a control that is fine, derived from an action the window never contained.

**Not hypothetical.** `refused-act-leaves-nothing.test.ts` exists because that same contradiction was reported from the field for the adjacent reason — act state surviving a *refused* act. This is the other route to it: act state surviving into a later *window*.

## Three tests

| scenario | expected |
|---|---|
| act **before** the window | not judged |
| act **inside** the window | judged |
| act exactly **on** the boundary | judged — `>= since`, not `>` |

The second is a control: a guard that never judged anything would pass the first and quietly destroy the feature.

The third is not an edge case. `observe` is normally called with the cursor the act returned, so an off-by-one there silences **the commonest sequence there is**, not a corner.

## Mutation-verified

| mutation | fails |
|---|---|
| `actCursor !== undefined` (drop window half) | 1 |
| `false` (never judge) | 2 |
| `actCursor > since` (off-by-one) | boundary test |

## One correction worth stating

My first measurement of the boundary mutation reported **"0 of 3 fail"** — wrong. Bash escaping corrupted the file, vitest produced no parseable output, and my grep defaulted to zero.

A probe that silently reports *no coverage* is the same failure class I have been using it to find. I re-ran it cleanly rather than publishing the number, and the test does catch it.

**No production code changed.**

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)