### PR TITLE
fix(errors): do not blame Reticle for an upstream validation sentence

### DIFF
--- a/packages/server/src/tools/error-recovery.test.ts
+++ b/packages/server/src/tools/error-recovery.test.ts
@@ -585,3 +585,44 @@ describe('a serialized zod array is rendered as a sentence', () => {
     expect(buildErrorPayload(notIssues).error).toBe(notIssues);
   });
 });
+
+/**
+ * A validation sentence produced UPSTREAM must not be read as an unrecognized Reticle failure.
+ *
+ * `ARGUMENT_REJECTION` keys on the shapes our validators produce, and it has now been widened twice
+ * for the same reason: every time a layer replaces a raw zod dump with prose, the codes this pattern
+ * matched (`invalid_type`, `unrecognized_keys`) disappear with it, and the rejection falls through
+ * to "may be a defect in Reticle" — which asks a contributor for a bug report about the agent's own
+ * malformed call.
+ *
+ * Third time. The trigger here is PR #182, which formats the MCP SDK's validation error at the arg
+ * boundary into "Missing required parameter for reticle_session: action (one of: …). Nothing ran."
+ * That is strictly better prose than the field-level sentence produced downstream — it names the
+ * TOOL and the allowed VALUES — and it was authored before the downstream formatter existed. It
+ * should not be punished for arriving first.
+ */
+describe('an upstream validation sentence is still the caller to fix', () => {
+  const MISSING =
+    'Missing required parameter for reticle_session: action ' +
+    '(one of: tune, yield, end, resume, messages, review, narrate). Nothing ran.';
+  const INVALID = 'Invalid parameter for reticle_act: action (Invalid enum value). Nothing ran.';
+
+  it('a missing-parameter sentence gets the schema recovery, not a bug-report ask', () => {
+    const payload = buildErrorPayload(MISSING);
+    expect(String(payload.recovery)).toContain("did not match the tool's schema");
+    expect(JSON.stringify(payload)).not.toMatch(/defect in Reticle|report this/i);
+  });
+
+  it('an invalid-parameter sentence is treated the same way', () => {
+    const payload = buildErrorPayload(INVALID);
+    expect(String(payload.recovery)).toContain("did not match the tool's schema");
+    expect(JSON.stringify(payload)).not.toMatch(/defect in Reticle/i);
+  });
+
+  it('still asks for a report on an error it genuinely does not recognize', () => {
+    // The control. Widening the pattern until everything looks like the caller's fault would
+    // silence the feedback channel this project depends on.
+    const payload = buildErrorPayload('the presenter pool exploded');
+    expect(JSON.stringify(payload)).toMatch(/defect in Reticle/i);
+  });
+});

--- a/packages/server/src/tools/error-recovery.ts
+++ b/packages/server/src/tools/error-recovery.ts
@@ -309,9 +309,14 @@ export function zodArrayAsSentence(message: string): string {
  * through to the generic branch and came back as "may be a defect in Reticle" — worse than the dump
  * it replaced, because it also asks for a bug report about the agent's own malformed call. This repo
  * has now made that mistake twice; the second time a test caught it before CI did.
+ *
+ * Widened a THIRD time for PR #182, which formats the MCP SDK's validation error at the argument
+ * boundary — "Missing required parameter for reticle_session: action (one of: …)". That is better
+ * prose than the field-level sentence below (it names the TOOL and the allowed VALUES) and it was
+ * authored before this formatter existed, so it must not be punished for arriving first.
  */
 const ARGUMENT_REJECTION =
-  /Unrecognized key|unrecognized_keys|invalid_type|did not parse|unknown field|: Required\b|Invalid arguments for tool|Unknown parameters? for|^Required |Expected \w+, received/i;
+  /Unrecognized key|unrecognized_keys|invalid_type|did not parse|unknown field|: Required\b|Missing required parameter|Invalid parameter for|Invalid arguments for tool|Unknown parameters? for|^Required |Expected \w+, received/i;
 
 /**
  * What to say instead of asking for a bug report. The schema already stated the problem precisely;


### PR DESCRIPTION
**Unblocks #182 (thanks @EvanGruhlkey), which my #213 broke by landing after it.**

## What happened

#182 formats the MCP SDK's validation error at the **argument boundary**:

```
Missing required parameter for reticle_session: action
(one of: tune, yield, end, resume, messages, review, narrate). Nothing ran.
```

That is **better prose than what #213 produces downstream** — it names the tool *and* the allowed values, which is precisely what #109 asked for. It was also authored six hours earlier.

`ARGUMENT_REJECTION` keys on the shapes *our* validators emit, and none of its patterns match that wording. So on current `main`, that message falls through to the generic branch:

```
recovery: (none)
feedback: "This error is not one Reticle recognizes, which means it may be a defect in Reticle…"
```

Verified against the built server, not assumed. A contributor's improvement would have shipped as a request for a bug report about the caller's own malformed call.

## Third widening, same cause

Every time a layer replaces a raw zod dump with prose, the codes this pattern matched vanish with the dump. It happened when `parsePredicate` landed, again when `zodArrayAsSentence` landed, and now here. The docblock says so, so the next person expects it rather than rediscovering it.

## Control

A genuinely unrecognised error must still ask for a report — widening until everything looks like the caller's fault would silence the feedback channel this project runs on. Pinned by a test.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)