### PR TITLE
fix(diagnosis): an aged-out lease is not a human closing a tab

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -496,7 +496,14 @@ export async function startDaemon(options: StartOptions = {}): Promise<RunningSe
   // never picked when the agent omits a sessionId. Explicit per-call scope/sessionId still overrides.
   // Scope + the no-session diagnosis: "no browser session connected" is the error that ends most
   // sessions, and the agent is told to check two things it cannot see. See no-session-diagnosis.ts.
-  wireSessionScope(bridge.sessions, readProjectId(process.cwd()), port);
+  // The pool reader is passed lazily: `pool` is assigned above but may be undefined when this
+  // daemon runs without one, and the diagnosis must degrade to the tab message rather than lie.
+  wireSessionScope(
+    bridge.sessions,
+    readProjectId(process.cwd()),
+    port,
+    () => pool?.reapedLeaseCount() ?? 0,
+  );
 
   const { realInput, owned } = await resolveRealInput(
     options,

--- a/packages/server/src/pool/browser-pool.ts
+++ b/packages/server/src/pool/browser-pool.ts
@@ -85,6 +85,8 @@ export class BrowserPool {
   #browser: PooledBrowser | undefined;
   #launching: Promise<PooledBrowser> | undefined;
   #closed = false;
+  /** Leases reclaimed for going stale — see reapedLeaseCount(). */
+  #reapedLeases = 0;
   readonly #active = new Map<string, ActiveLease>();
   /**
    * Slots claimed-or-active — the real concurrency gate. Incremented SYNCHRONOUSLY the instant an
@@ -148,7 +150,20 @@ export class BrowserPool {
       .filter(([, lease]) => now - lease.touchedAt > this.#ttl)
       .map(([sessionId]) => sessionId);
     for (const sessionId of expired) await this.#release(sessionId);
+    this.#reapedLeases += expired.length;
     return expired;
+  }
+
+  /**
+   * How many leases this pool has reclaimed for going stale.
+   *
+   * Read by the no-session diagnosis: an aged-out lease used to be reported as "the tab was closed
+   * … ask the human to reopen the app", which is wrong on every clause and sent one reporter looking
+   * for a port mismatch (#157). A count is enough — the message says "likeliest", not "certainly",
+   * because nothing here knows WHICH session the caller just lost.
+   */
+  reapedLeaseCount(): number {
+    return this.#reapedLeases;
   }
 
   /**

--- a/packages/server/src/session/no-session-diagnosis.test.ts
+++ b/packages/server/src/session/no-session-diagnosis.test.ts
@@ -197,3 +197,56 @@ describe('the no-listener branch does not overclaim what an eleven-port scan pro
     expect(scanned).toMatch(/dev server|npm run dev/i);
   });
 });
+
+/**
+ * A lease that aged out must not be reported as a human closing a tab.
+ *
+ * Reported from the field (#157): when a pooled lease expires, the agent gets the `everConnected`
+ * message — "The tab was closed, navigated away, or hard-reloaded. Ask the human to reopen the app"
+ * — and none of it is true. There is no human tab; the lease simply aged out, and the fix is a
+ * re-acquire the agent can do itself. The reporter said it "sent me looking for a port mismatch".
+ *
+ * That is the same defect as the eleven-port scan: a message asserting one specific cause and one
+ * specific fix, both wrong, to an audience that will act on it. Here it is worse than a dead end,
+ * because the recovery it names (ask a human) is unavailable to the caller and the one that would
+ * work (`reticle_lease { action: "acquire" }`) is not mentioned.
+ *
+ * `leaseExpired` is "this daemon has reaped at least one expired lease", NOT "the session that just
+ * vanished was that lease" — nothing knows that. So the message leads with the lease because a reap
+ * is a fact, and still admits the tab case rather than swapping one false certainty for another.
+ */
+describe('a reaped lease is not reported as a closed tab', () => {
+  const afterReap = diagnoseNoSession({
+    everConnected: true,
+    initialized: true,
+    listening: [5173],
+    port: 4400,
+    leaseExpired: true,
+  });
+
+  it('does not assert that a human closed the tab', () => {
+    expect(afterReap).not.toMatch(/tab was closed, navigated away, or hard-reloaded/i);
+  });
+
+  it('names the lease AGEING OUT as the likely cause', () => {
+    // Deliberately not just /lease/: the existing message already mentions `reticle_lease` in its
+    // self-serve hint, so a looser assertion here would pass without the fix and prove nothing.
+    expect(afterReap).toMatch(/expired|aged out/i);
+  });
+
+  it('tells the agent to re-acquire rather than to fetch a human', () => {
+    expect(afterReap).toMatch(/acquire/i);
+    expect(afterReap).not.toMatch(/Ask the human to reopen/i);
+  });
+
+  it('still keeps the old message when no lease was ever reaped', () => {
+    // The control. Most sessions are human tabs, and that message is right for them.
+    const plain = diagnoseNoSession({
+      everConnected: true,
+      initialized: true,
+      listening: [5173],
+      port: 4400,
+    });
+    expect(plain).toMatch(/tab was closed, navigated away, or hard-reloaded/i);
+  });
+});

--- a/packages/server/src/session/no-session-diagnosis.ts
+++ b/packages/server/src/session/no-session-diagnosis.ts
@@ -30,6 +30,13 @@ interface NoSessionFacts {
   listening: readonly number[];
   /** The port this daemon is on — half of the mismatch the old message asked about. */
   port: number;
+  /**
+   * This daemon has reaped at least one EXPIRED pooled lease.
+   *
+   * Deliberately not "the session that just vanished was that lease" — nothing knows that. It is
+   * evidence, not proof, and the message below is worded accordingly.
+   */
+  leaseExpired?: boolean;
 }
 
 /**
@@ -74,6 +81,22 @@ export function diagnoseNoSession(facts: NoSessionFacts): string {
   const ports = listening.join(', ');
 
   if (everConnected) {
+    // A reaped lease first, because it is the one cause we have POSITIVE evidence for. Reported
+    // from the field (#157): an aged-out lease produced "the tab was closed … ask the human to
+    // reopen the app", which is wrong on every clause — there is no human tab, and the recovery it
+    // names is unavailable to the caller while the one that works goes unmentioned. The reporter
+    // went looking for a port mismatch. Hedged rather than swapped: a human tab may ALSO have
+    // closed, and this does not know which session went.
+    if (true === facts.leaseExpired) {
+      return (
+        'no browser session connected — but one WAS connected to this daemon earlier, so the wiring ' +
+        'is correct. This daemon has expired at least one pooled lease, so the likeliest cause is ' +
+        'that a lease you were using aged out; a lease is a headless context, not a human tab, and ' +
+        'it takes its cookies with it (so an authenticated app needs signing in again). Re-acquire ' +
+        'with reticle_lease {action:"acquire", url} and carry on. If you were driving a human tab ' +
+        `instead, it went away — reopen it or run \`reticle open\`. ${RETRY}`
+      );
+    }
     return (
       'no browser session connected — but one WAS connected to this daemon earlier, so the wiring ' +
       'is correct. The tab was closed, navigated away, or hard-reloaded. Ask the human to reopen ' +

--- a/packages/server/src/session/no-session-watch.ts
+++ b/packages/server/src/session/no-session-watch.ts
@@ -23,6 +23,12 @@ interface NoSessionWatchOptions {
   /** Whether this project has been through `reticle init` (a projectId is stamped in .reticle.json). */
   initialized: boolean;
   probe?: () => Promise<number[]>;
+  /**
+   * How many pooled leases have aged out, if a pool exists. Injected as a reader rather than the
+   * pool itself: the diagnosis needs one number, and taking the whole pool would tie the session
+   * layer to the browser layer for it.
+   */
+  reapedLeases?: () => number;
 }
 
 /** Start the watch. Returns a stop function; the timer is unref'd so it never holds the daemon up. */
@@ -57,6 +63,7 @@ function startNoSessionWatch(options: NoSessionWatchOptions): () => void {
       initialized: options.initialized,
       listening,
       port: options.port,
+      leaseExpired: (options.reapedLeases?.() ?? 0) > 0,
     }),
   );
 
@@ -76,7 +83,14 @@ export function wireSessionScope(
   sessions: SessionManager,
   activeProjectId: string | undefined,
   port: number,
+  /** Reader for the pool's aged-out-lease count; omitted when this daemon runs no pool. */
+  reapedLeases?: () => number,
 ): () => void {
   if (activeProjectId !== undefined) sessions.setDefaultScope({ projectId: activeProjectId });
-  return startNoSessionWatch({ sessions, port, initialized: activeProjectId !== undefined });
+  return startNoSessionWatch({
+    sessions,
+    port,
+    initialized: activeProjectId !== undefined,
+    ...(reapedLeases === undefined ? {} : { reapedLeases }),
+  });
 }


### PR DESCRIPTION
Part of #157 — the half that needs no product decision.

## The lie

When a pooled lease expires, the agent gets:

> "The tab was closed, navigated away, or hard-reloaded. **Ask the human to reopen the app**"

None of it is true. There is no human tab; the lease aged out. From the report:

> the error message on a dropped lease is also misleading … **That sent me looking for a port mismatch.**

Worse than a dead end: the recovery it names is unavailable to the caller (there may be no human at all), and the one that works — `reticle_lease {action:"acquire"}` — goes unmentioned. Same defect as the eleven-port scan: one specific cause and one specific fix, both wrong, delivered to an audience that will act on it.

## After

```
no browser session connected — but one WAS connected to this daemon earlier, so the wiring is
correct. This daemon has expired at least one pooled lease, so the likeliest cause is that a
lease you were using aged out; a lease is a headless context, not a human tab, and it takes its
cookies with it (so an authenticated app needs signing in again). Re-acquire with
reticle_lease {action:"acquire", url} and carry on. If you were driving a human tab instead,
it went away — reopen it or run `reticle open`.
```

The cookie sentence is there because losing auth state on re-acquire is the surprise that cost the reporter **a third of their tool calls**.

## Hedged, not swapped

`leaseExpired` means *"this daemon has reaped a lease"*, **not** *"the session you just lost was that lease"* — nothing knows that. So the message says "likeliest" and still admits the human-tab case. A daemon running no pool degrades to the old message unchanged, and a test pins that.

The pool exposes a **count**, not itself: the diagnosis needs one number, and taking the whole pool would tie the session layer to the browser layer for it.

## Not fixed here, deliberately

The TTL length, a renew/heartbeat, and persisting storage across re-acquires are all real product decisions with trade-offs. This only stops the layer lying about what happened.

## On the tests

Two of my first three assertions **passed without the fix** — the old message already mentions `reticle_lease` in its self-serve hint, so `/lease/i` proved nothing. Tightened to `/expired|aged out/` and `/acquire/`, which made them fail properly first. Recording it because a control that passes trivially is the thing I have spent this whole session finding elsewhere.

Verified end to end against the built server, not just the pure function — `reapedLeaseCount()` is wired from `sweepExpired` through `wireSessionScope`, so this fires in production rather than being a well-tested function nothing calls.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)