### PR TITLE
fix(diagnosis): a project with no server AND no init is told both at once

### DIFF
--- a/packages/server/src/session/no-session-diagnosis.test.ts
+++ b/packages/server/src/session/no-session-diagnosis.test.ts
@@ -197,3 +197,53 @@ describe('the no-listener branch does not overclaim what an eleven-port scan pro
     expect(scanned).toMatch(/dev server|npm run dev/i);
   });
 });
+
+/**
+ * Nothing listening AND never instrumented is a TWO-step problem, and saying only one step is a
+ * dead end that costs the reader a whole round trip.
+ *
+ * This is the largest cohort in the funnel (#171): 77 users attached an agent and never
+ * instrumented an app. They registered the MCP server — so a daemon is up and the agent can call
+ * tools — but `reticle init` never ran, so no app carries the SDK.
+ *
+ * The no-listener branch runs BEFORE the `initialized` check and only ever said "start your dev
+ * server". Someone in that cohort follows it, starts the server, calls again — and lands in the
+ * `!initialized` branch to be told, only now, that the project was never wired. Two round trips to
+ * learn two facts the daemon knew at the first call.
+ *
+ * The instrumented case must NOT gain the extra sentence: for a project that HAS been through
+ * `init`, "run reticle init" is noise at best and a wrong instruction at worst.
+ */
+describe('an uninstrumented project with no server is told BOTH things at once', () => {
+  const uninstrumented = diagnoseNoSession({
+    everConnected: false,
+    initialized: false,
+    listening: [],
+    port: 4400,
+  });
+
+  it('still leads with the dev server, which is the first thing to do', () => {
+    expect(uninstrumented).toMatch(/dev server|npm run dev/i);
+  });
+
+  it('also names `reticle init`, so the second step is not a second round trip', () => {
+    expect(uninstrumented).toContain('reticle init');
+  });
+
+  it('says the app carries no SDK — the reason starting a server alone will not help', () => {
+    expect(uninstrumented).toMatch(/SDK|instrument/i);
+  });
+
+  it('does NOT tell an already-initialised project to run init', () => {
+    // The control. This branch fires for both, and "run reticle init" on a wired project sends the
+    // reader to re-run a step that already succeeded.
+    const wired = diagnoseNoSession({
+      everConnected: false,
+      initialized: true,
+      listening: [],
+      port: 4400,
+    });
+    expect(wired).not.toContain('reticle init');
+    expect(wired).toMatch(/dev server|npm run dev/i);
+  });
+});

--- a/packages/server/src/session/no-session-diagnosis.ts
+++ b/packages/server/src/session/no-session-diagnosis.ts
@@ -67,6 +67,18 @@ const SELF_SERVE =
  * check, or omits ones it does, is a new version of the same defect — a confident claim about
  * evidence that was never gathered.
  */
+/**
+ * The second half of the answer for a project that never went through `init`.
+ *
+ * Held separately because it must appear ONLY when the project is uninstrumented — telling a wired
+ * project to re-run `init` sends the reader back to a step that already succeeded, which is its own
+ * kind of wrong answer.
+ */
+const UNINSTRUMENTED =
+  'Separately: this project has not been through `reticle init`, which is what installs the SDK ' +
+  'and wires it into the build — so even once the dev server is up, the app will carry no SDK and ' +
+  "no session will appear. Run `reticle init` in the app's directory too.";
+
 const SCANNED_PORTS = [...DEV_SERVER_PORTS].join(', ');
 
 export function diagnoseNoSession(facts: NoSessionFacts): string {
@@ -95,7 +107,14 @@ export function diagnoseNoSession(facts: NoSessionFacts): string {
       // Deliberately NOT offering reticle_lease here, and a test pins that: a lease opens a URL, and
       // if nothing is listening there is nothing at any URL to open. Asking for the real one is the
       // only move that can recover the :7699 case.
-      `the app IS running, ask the human for its URL rather than assuming it is down. ${RETRY}`
+      'the app IS running, ask the human for its URL rather than assuming it is down. ' +
+      // BOTH facts at once when the project was never wired. This branch fires before the
+      // `!initialized` one, so an uninstrumented project used to be told only "start your dev
+      // server" — the reader starts it, calls again, and is told ONLY THEN that no app carries the
+      // SDK. Two round trips to learn two things the daemon knew on the first call, and this is the
+      // largest cohort in the funnel (#171): 77 users attached an agent and never instrumented an
+      // app. They have a daemon (they registered the MCP server) and no SDK anywhere.
+      `${initialized ? '' : UNINSTRUMENTED} ${RETRY}`
     );
   }
 


### PR DESCRIPTION
Part of #171 — the largest cohort in the funnel.

## The cohort

**Many users attached an agent and never instrumented an app.** They registered the MCP server, so a daemon is up and tools are callable — but `reticle init` never ran, so no app carries the SDK.

## The dead end

The no-listener branch fires **before** the `!initialized` check, and only ever said *"start your dev server"*.

So someone in that cohort follows it, starts the server, calls again — and is told **only then** that the project was never wired. Two round trips to learn two facts the daemon had on the first call, and each round trip is a place to give up. For the cohort defined by giving up, that matters.

## After

The same message now adds, when and only when the project is uninstrumented:

> Separately: this project has not been through `reticle init`, which is what installs the SDK and wires it into the build — so even once the dev server is up, the app will carry no SDK and no session will appear. Run `reticle init` in the app's directory too.

It still **leads with the dev server**, because that is genuinely the first step and this branch also serves people who simply have not started one. Pinned by a test, so a later edit cannot bury the common case under the caveat.

## The control

A wired project must **not** gain the sentence — telling someone to re-run `init` on a project that already has it sends them back to a step that succeeded, which is its own wrong answer. `expect(wired).not.toContain('reticle init')`.

## What this does not do

It does not decide whether the daemon should *offer to run* `init` — that is the open product question in #171 and it is not mine to answer. This only stops the daemon withholding half of what it already knows.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages. Verified against the built server, both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)