### PR TITLE
fix(ci): the DCO failure now carries the fix instead of a dead pointer

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -4,6 +4,10 @@ name: DCO
 # matching its author — the contributor's affirmation that they wrote the change and can submit it under
 # the project's license (https://developercertificate.org). Sign off with `git commit -s`.
 #
+# On failure it prints the exact remedy for both shapes (one commit vs several) rather than a link:
+# three of three external contributors have been blocked here, and CONTRIBUTING.md does not mention
+# sign-off, so the old "see CONTRIBUTING.md" pointed at a document that could not answer it.
+#
 # This runs and reports on every PR; it only BLOCKS merges once a maintainer adds "DCO" to the required
 # status checks in branch protection. Self-contained (no third-party action) to keep the supply chain small.
 
@@ -35,7 +39,23 @@ jobs:
             fi
           done
           if [ "$fail" -ne 0 ]; then
-            echo "One or more commits are not signed off. See https://developercertificate.org and CONTRIBUTING.md."
+            # The fix, in the failure itself. This check is the single most common thing standing
+            # between a first-time contributor and a merged PR here, and the message used to point at
+            # CONTRIBUTING.md, which does not mention signing off at all. The two remedies are
+            # different commands and the multi-commit one is the case people are usually in, so both
+            # are spelled out — a contributor who has just been blocked should not have to go and
+            # find this.
+            echo ""
+            echo "How to fix — sign off certifies you wrote the change and may submit it"
+            echo "under the project's license (https://developercertificate.org)."
+            echo ""
+            echo "  one commit:      git commit --amend --no-edit -s"
+            echo "  several:         git rebase --signoff origin/main"
+            echo ""
+            echo "  then:            git push --force-with-lease"
+            echo ""
+            echo "Signing rewrites the commits, so the push has to be forced. Nothing else changes."
+            echo "For future work: git commit -s, or 'git config format.signOff true' in this repo."
             exit 1
           fi
           echo "All commits are signed off."

--- a/packages/server/src/tools/dco-failure-is-actionable.test.ts
+++ b/packages/server/src/tools/dco-failure-is-actionable.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The DCO failure must carry the fix, not a pointer to a document that lacks it.
+ *
+ * Three of three external contributors have now been blocked by this check (#180, #181, #182). It is
+ * the single most common thing standing between a first-time contributor and a merged PR here, and
+ * the message they got said:
+ *
+ *   See https://developercertificate.org and CONTRIBUTING.md.
+ *
+ * `CONTRIBUTING.md` says nothing about signing off — the word does not appear in it, nor in the PR
+ * template. So the error pointed at a document that could not answer it, which is the same defect
+ * this codebase keeps fixing elsewhere: a message that sends the reader somewhere useless.
+ *
+ * The remedy differs by shape and both are needed, which is exactly why prose failed:
+ *   - one commit  -> `git commit --amend --no-edit -s`
+ *   - several     -> `git rebase --signoff <base>`
+ *
+ * Pinned here rather than trusted, because a CI message is the one piece of documentation nobody
+ * re-reads until it is already failing someone.
+ */
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, '..', '..', '..', '..');
+const DCO = readFileSync(join(REPO, '.github', 'workflows', 'dco.yml'), 'utf8');
+
+/**
+ * Only what the contributor actually SEES — the echoed lines.
+ *
+ * Grepping the whole file conflates the message with the comments explaining it, and a comment that
+ * mentions CONTRIBUTING.md in order to say why we stopped linking to it would fail the last check
+ * below. The rule is about the output, so the assertion has to be too.
+ */
+const EMITTED = DCO.split('\n')
+  .filter((line) => /^\s*echo /.test(line))
+  .join('\n');
+
+describe('the DCO failure tells a contributor how to fix it', () => {
+  it('names the single-commit remedy', () => {
+    expect(EMITTED).toContain('--amend');
+    expect(EMITTED).toMatch(/--amend[^\n]*-s|commit -s/);
+  });
+
+  it('names the multi-commit remedy, which is not the same command', () => {
+    // The case every one of the three blocked PRs was actually in: more than one commit, so
+    // `--amend` alone signs only the last.
+    expect(EMITTED).toContain('--signoff');
+    expect(EMITTED).toContain('rebase');
+  });
+
+  it('says the push must be forced, since signing rewrites history', () => {
+    // Omitting this leaves the contributor with a rejected push and no idea why.
+    expect(EMITTED).toContain('force-with-lease');
+  });
+
+  it('does not send the reader to a document that does not cover sign-off', () => {
+    // If CONTRIBUTING.md ever documents it, this may reference it again — but only then.
+    const contributing = readFileSync(join(REPO, 'CONTRIBUTING.md'), 'utf8');
+    const documented = /sign[- ]?off|signed-off-by|commit -s/i.test(contributing);
+    if (!documented) expect(EMITTED).not.toContain('CONTRIBUTING.md');
+  });
+});


### PR DESCRIPTION
**Three of three external contributors have been blocked by this check** (#180, #181, #182). It is the single most common thing standing between a first-time contributor and a merged PR here.

What they got:

```
See https://developercertificate.org and CONTRIBUTING.md.
```

**`CONTRIBUTING.md` does not mention signing off.** The word does not appear in it, nor in the PR template. So the error pointed at a document that could not answer it — the same defect this codebase keeps fixing elsewhere: a message that sends the reader somewhere useless.

## What a blocked contributor now sees

```
How to fix — sign off certifies you wrote the change and may submit it
under the project's license (https://developercertificate.org).

  one commit:      git commit --amend --no-edit -s
  several:         git rebase --signoff origin/main

  then:            git push --force-with-lease

Signing rewrites the commits, so the push has to be forced. Nothing else changes.
For future work: git commit -s, or 'git config format.signOff true' in this repo.
```

Both remedies, because they are **different commands** and the multi-commit one is the case people are actually in — `--amend` alone signs only the last commit, which is how someone "fixes" it and stays red.

The forced push is spelled out because signing rewrites history; omitting it leaves a contributor with a rejected push and no idea why, which is a second dead end after the first.

## Pinned by a test

A CI message is the one piece of documentation nobody re-reads until it is already failing someone.

The test asserts on the **echoed lines only**, not the file — my first version grepped the whole thing and failed, because a comment explaining *why we stopped linking to CONTRIBUTING.md* contains the string. The rule is about the output, so the assertion had to be too.

The last assertion is conditional: if `CONTRIBUTING.md` ever documents sign-off, linking to it becomes correct again and the test permits it. It only forbids pointing at a doc that cannot answer.

## Deliberately not changed

This check verifies a `Signed-off-by` trailer **exists**, while its own docblock says *"matching its author"*. That gap is real, but tightening it now would newly fail PRs already in flight — including the three above. Worth doing separately, on purpose, not as a side effect.

## Still open, and not mine to fix

`CONTRIBUTING.md` and the PR template genuinely should mention this, and neither does. Both files are being edited by someone else right now (uncommitted in my tree), so I have not touched them. Suggested text is in the plan; whoever holds them should add a sign-off line.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages. Workflow YAML parses and the shell block passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)