### PR TITLE
Correction

### DIFF
--- a/packages/server/src/tools/e2e-surface-drift.test.ts
+++ b/packages/server/src/tools/e2e-surface-drift.test.ts
@@ -15,7 +15,8 @@ import { ReticleTool } from './tool-names.js';
  * taking flow record/replay, self-heal, run history and live control with them, across bench-app AND
  * next-smoke. That is a whole framework's worth of coverage, dark for an unknown number of commits.
  *
- * It went unnoticed because the e2e battery needs three servers and ~20 minutes, so it is not in
+ * It went unnoticed because the e2e battery needs three servers and ~8 minutes (measured; it was
+ * documented as "~20 min" for months, and briefly as "~70s" — both wrong), so it is not in
  * `test:unit` — which is what actually runs. The battery cannot move into the unit gate, but the
  * failure mode that killed it is a name lookup, and a name lookup is checkable in milliseconds.
  *


### PR DESCRIPTION
<!-- Thanks for contributing to Reticle! Please fill this out so review is fast. -->

## What & why

Just a description change 

 * It went unnoticed because the e2e battery needs three servers and ~8 minutes (measured; it was
 * documented as "~20 min" for months, and briefly as "~70s" — both wrong), so it is not in 

Checklist

Closes #

Fixes 1/4 of https://github.com/reticlehq/reticle/issues/133

## How it was verified

```
@reticlehq/browser:test:unit:  Test Files  92 passed (92)
@reticlehq/browser:test:unit:       Tests  862 passed (862)
```

## Checklist

- [ ] Tests added/updated (RED → GREEN); the change is covered by a test that would fail without it
- [ ] `pnpm lint && pnpm typecheck && pnpm test:unit` all pass locally
- [ ] No `any`, no free strings (wire strings live in `@reticlehq/core`), no non-null `!`
- [ ] No `console.log` or internal tracking codes left in the diff
- [ ] Each changed file is under the 1000-line cap
- [ ] Docs and `CHANGELOG.md` updated if this is user-facing (entry under `[Unreleased]`)
- [ ] Security-affecting? Auth/redaction/trust-boundary changes keep the localhost-only, no-app-data-leaves-the-machine, no-arbitrary-JS posture (usage telemetry stays anonymous + opt-out per `docs/telemetry.md`) and are covered by a test
