### PR TITLE
fix(tests): heavy DOM tests no longer rely on the default timeout

### DIFF
--- a/packages/browser/src/dom/refs.test.ts
+++ b/packages/browser/src/dom/refs.test.ts
@@ -37,55 +37,81 @@ describe('RefRegistry', () => {
    * transitions and list churn it grew without limit. The elements were collectable — the bookkeeping
    * about them was not.
    */
+  /**
+   * Generous per-test budget for the churn tests below.
+   *
+   * They build thousands of DOM nodes, and vitest's default 5 000 ms is a statement about the runner,
+   * not about the code — observed timing out at 7 410 ms on a Windows CI box while the assertion it
+   * was making held fine. CLAUDE.md prescribes exactly this remedy: a generous explicit timeout, never
+   * a number that turns load into a red build.
+   *
+   * A bigger number cannot make a broken test pass — the bound is still asserted.
+   */
+  const HEAVY_DOM_TIMEOUT_MS = 60_000;
+
   describe('bounded memory', () => {
-    it('does not grow without limit as refs are minted', () => {
-      const registry = new RefRegistry();
-      for (let i = 0; i < MAX_TRACKED_REFS * 2; i += 1) {
-        // Deliberately NOT appended and not retained: these are the transient elements a busy app
-        // mints refs for and then discards.
-        registry.refFor(document.createElement('div'));
-      }
-      expect(registry.size).toBeLessThanOrEqual(MAX_TRACKED_REFS);
-    });
-
-    it('keeps resolving an element that is still on the page after heavy churn', () => {
-      const registry = new RefRegistry();
-      const kept = document.createElement('button');
-      document.body.appendChild(kept);
-      const ref = registry.refFor(kept);
-
-      for (let i = 0; i < MAX_TRACKED_REFS * 2; i += 1) {
-        registry.refFor(document.createElement('div'));
-      }
-
-      // The live element is re-observed the way any snapshot/query would re-observe it. Eviction must
-      // not turn a still-present element into "not found" — a wrong answer is worse than a big Map.
-      expect(registry.refFor(kept)).toBe(ref);
-      expect(registry.resolve(ref)).toBe(kept);
-    });
-
-    it('a ref the agent just RESOLVED survives a following mint storm (LRU-protected)', () => {
-      // The false negative: resolve e7 (about to act on it), a mint storm evicts e7 (FIFO oldest-drop),
-      // then act(e7) -> resolve returns null for a LIVE element. Resolving must touch it to the recent
-      // end so the next wave of oldest-drops can't reclaim it out from under the agent.
-      const registry = new RefRegistry();
-      const kept = document.createElement('button');
-      document.body.appendChild(kept);
-      const ref = registry.refFor(kept);
-      // Churn CONNECTED elements (so the dead-entry sweep can't be what saves `kept` — isolate LRU).
-      const fill = (n: number): void => {
-        for (let i = 0; i < n; i += 1) {
-          const d = document.createElement('div');
-          document.body.appendChild(d);
-          registry.refFor(d);
+    it(
+      'does not grow without limit as refs are minted',
+      () => {
+        const registry = new RefRegistry();
+        for (let i = 0; i < MAX_TRACKED_REFS * 2; i += 1) {
+          // Deliberately NOT appended and not retained: these are the transient elements a busy app
+          // mints refs for and then discards.
+          registry.refFor(document.createElement('div'));
         }
-      };
-      fill(MAX_TRACKED_REFS - 1); // `kept` is now the oldest entry, at the eviction front
-      expect(registry.resolve(ref)).toBe(kept); // agent resolves it — LRU touch to the recent end
-      fill(MAX_TRACKED_REFS - 1); // a second storm evicts the OLD front, but not the just-touched `kept`
-      // Still resolves WITHOUT re-observing via refFor — protected purely by the resolve-time touch.
-      expect(registry.resolve(ref)).toBe(kept);
-    });
+        expect(registry.size).toBeLessThanOrEqual(MAX_TRACKED_REFS);
+      },
+      HEAVY_DOM_TIMEOUT_MS,
+    );
+
+    it(
+      'keeps resolving an element that is still on the page after heavy churn',
+      () => {
+        const registry = new RefRegistry();
+        const kept = document.createElement('button');
+        document.body.appendChild(kept);
+        const ref = registry.refFor(kept);
+
+        for (let i = 0; i < MAX_TRACKED_REFS * 2; i += 1) {
+          registry.refFor(document.createElement('div'));
+        }
+
+        // The live element is re-observed the way any snapshot/query would re-observe it. Eviction must
+        // not turn a still-present element into "not found" — a wrong answer is worse than a big Map.
+        expect(registry.refFor(kept)).toBe(ref);
+        expect(registry.resolve(ref)).toBe(kept);
+      },
+      HEAVY_DOM_TIMEOUT_MS,
+    );
+
+    it(
+      'a ref the agent just RESOLVED survives a following mint storm (LRU-protected)',
+      () => {
+        // The false negative: resolve e7 (about to act on it), a mint storm evicts e7 (FIFO oldest-drop),
+        // then act(e7) -> resolve returns null for a LIVE element. Resolving must touch it to the recent
+        // end so the next wave of oldest-drops can't reclaim it out from under the agent.
+        const registry = new RefRegistry();
+        const kept = document.createElement('button');
+        document.body.appendChild(kept);
+        const ref = registry.refFor(kept);
+        // Churn CONNECTED elements (so the dead-entry sweep can't be what saves `kept` — isolate LRU).
+        const fill = (n: number): void => {
+          for (let i = 0; i < n; i += 1) {
+            const d = document.createElement('div');
+            document.body.appendChild(d);
+            registry.refFor(d);
+          }
+        };
+        fill(MAX_TRACKED_REFS - 1); // `kept` is now the oldest entry, at the eviction front
+        expect(registry.resolve(ref)).toBe(kept); // agent resolves it — LRU touch to the recent end
+        fill(MAX_TRACKED_REFS - 1); // a second storm evicts the OLD front, but not the just-touched `kept`
+        // Still resolves WITHOUT re-observing via refFor — protected purely by the resolve-time touch.
+        expect(registry.resolve(ref)).toBe(kept);
+        // Heaviest of the three: this one APPENDS ~20k elements to the document rather than just
+        // minting refs for detached ones, so it is the most exposed to a loaded runner.
+      },
+      HEAVY_DOM_TIMEOUT_MS,
+    );
   });
 });
 

--- a/packages/browser/src/dom/shadow-registry.test.ts
+++ b/packages/browser/src/dom/shadow-registry.test.ts
@@ -127,6 +127,18 @@ describe('HMR: connect() runs again before the old instance is torn down', () =>
   });
 });
 
+/**
+ * Generous per-test budget for the churn tests below.
+ *
+ * They build thousands of DOM nodes, and vitest's default 5 000 ms is a statement about the runner,
+ * not about the code — observed timing out at 7 410 ms on a Windows CI box while the assertion it
+ * was making held fine. CLAUDE.md prescribes exactly this remedy: a generous explicit timeout, never
+ * a number that turns load into a red build.
+ *
+ * A bigger number cannot make a broken test pass — the bound is still asserted.
+ */
+const HEAVY_DOM_TIMEOUT_MS = 60_000;
+
 describe('a long session with churning web components', () => {
   /**
    * The registry held roots in a strong Set that only cleared on teardown. Measured: a virtualized
@@ -135,23 +147,27 @@ describe('a long session with churning web components', () => {
    * components, so the most ordinary data-heavy page was the worst case, in an SDK meant to sit in a
    * dev session all day.
    */
-  it('stays bounded while a list renders and discards thousands of rows', () => {
-    const stop = installShadowRegistry();
-    for (let i = 0; i < 5000; i++) {
-      const host = document.createElement('div');
-      document.body.appendChild(host);
-      host.attachShadow({ mode: 'open' }).innerHTML = `<span>row ${String(i)}</span>`;
-      host.remove();
-    }
-    // The entries are weak, so a real engine collects the roots outright; the cap is the backstop
-    // that bounds the bookkeeping even where nothing has been collected yet.
-    //
-    // The bound is MAX + SWEEP_EVERY, not MAX: the sweep is amortized so the cap is enforced once
-    // per SWEEP_EVERY records rather than on each one. What matters is that it does not grow with
-    // churn — 5,000 rows in, and the ceiling is the same as it would be for 50,000.
-    expect(capturedRoots().length).toBeLessThanOrEqual(MAX_TRACKED_ROOTS + SWEEP_EVERY);
-    stop();
-  });
+  it(
+    'stays bounded while a list renders and discards thousands of rows',
+    () => {
+      const stop = installShadowRegistry();
+      for (let i = 0; i < 5000; i++) {
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+        host.attachShadow({ mode: 'open' }).innerHTML = `<span>row ${String(i)}</span>`;
+        host.remove();
+      }
+      // The entries are weak, so a real engine collects the roots outright; the cap is the backstop
+      // that bounds the bookkeeping even where nothing has been collected yet.
+      //
+      // The bound is MAX + SWEEP_EVERY, not MAX: the sweep is amortized so the cap is enforced once
+      // per SWEEP_EVERY records rather than on each one. What matters is that it does not grow with
+      // churn — 5,000 rows in, and the ceiling is the same as it would be for 50,000.
+      expect(capturedRoots().length).toBeLessThanOrEqual(MAX_TRACKED_ROOTS + SWEEP_EVERY);
+      stop();
+    },
+    HEAVY_DOM_TIMEOUT_MS,
+  );
 
   it('still recognises a root it has already seen, without scanning every root', () => {
     const stop = installShadowRegistry();

--- a/packages/server/src/tools/heavy-browser-tests-declare-a-timeout.test.ts
+++ b/packages/server/src/tools/heavy-browser-tests-declare-a-timeout.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * A test that builds thousands of DOM nodes must declare its own timeout.
+ *
+ * Vitest's default is 5 000 ms, and a default timeout is the same statement CLAUDE.md already
+ * forbids in assertions — "a statement about the machine … fails only under parallel load, i.e.
+ * only in CI". Observed on a Windows runner:
+ *
+ *   × stays bounded while a list renders and discards thousands of rows  7410ms
+ *     → Test timed out in 5000ms.
+ *
+ * The assertion had not failed. The bound held. The runner was slow, and 5 000 rows of
+ * `attachShadow` took longer than a number nobody chose for this test.
+ *
+ * `refs.test.ts` is the same shape — two tests at 20 000 iterations — and it flaked three separate
+ * times tonight under full-monorepo load. I first guessed that one was GC-dependent; it is not, and
+ * this is what it actually was.
+ *
+ * A generous timeout cannot make a broken test pass: the bound is still asserted, and a registry
+ * that grew without limit would still fail. It only stops the suite reporting the runner.
+ *
+ * Coarse by design, in two ways worth stating rather than discovering later:
+ *
+ *  1. It checks that a file with a heavy loop declares SOME explicit timeout, not that the right
+ *     `it()` carries it. A precise version would need to parse the file, and the failure this
+ *     guards against is someone deleting the timeout wholesale, not moving it.
+ *  2. The loop pattern only sees a literal or `CONST * n` bound. `refs.test.ts` hides its heaviest
+ *     loop behind a `fill(n)` helper — ~20 000 elements APPENDED to the document — and this rule
+ *     would not have found it. I found it by reading, and gave it a timeout too. A guard that
+ *     cannot see indirection should say so instead of implying coverage it does not have.
+ */
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, '..', '..', '..', '..');
+/**
+ * Scanned from the SERVER package, not the browser one, because `@reticlehq/browser` may not import
+ * Node builtins — it runs in the DOM, and the lint rule that says so is a real architectural
+ * boundary rather than a nuisance. Every other source-scanning guard in this repo lives here for
+ * the same reason (see e2e-surface-drift.test.ts).
+ */
+const SRC = join(REPO, 'packages', 'browser', 'src');
+
+/** A loop big enough that the default timeout is a coin flip on a loaded runner. */
+const HEAVY_LOOP = /for \([^)]*<\s*(?:\d{4,}|[A-Z_]+ \* \d)/;
+/**
+ * `}, 60_000);` or `}, HEAVY_DOM_TIMEOUT_MS);` — an explicit per-test timeout.
+ *
+ * A NAMED constant counts, and must: this repo's convention is that a magic number gets a name, so a
+ * rule that only accepted a literal would push the fix toward worse style. My first version did
+ * exactly that and failed against its own remedy.
+ *
+ * Whitespace-tolerant because prettier splits the call once it grows:
+ *
+ *     },
+ *     HEAVY_DOM_TIMEOUT_MS,
+ *   );
+ *
+ * A single-line pattern matched neither of the two files it was written for. A guard has to match
+ * what the formatter actually emits, not what the author typed.
+ */
+const EXPLICIT_TIMEOUT = /\},\s*(?:\d[\d_]{3,}|[A-Z][A-Z0-9_]*_MS)\s*,?\s*\)/;
+
+function testFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...testFiles(full));
+    else if (entry.name.endsWith('.test.ts')) out.push(full);
+  }
+  return out;
+}
+
+describe('heavy DOM tests do not rely on the default timeout', () => {
+  const heavy = testFiles(SRC)
+    .map((file) => ({ file, text: readFileSync(file, 'utf8') }))
+    .filter(({ text }) => HEAVY_LOOP.test(text));
+
+  it('finds the heavy files at all — a vacuous rule is not a rule', () => {
+    // Guards the guard: if the pattern stops matching, everything below passes for free.
+    expect(heavy.length).toBeGreaterThan(0);
+  });
+
+  it('every file that builds thousands of nodes declares an explicit timeout', () => {
+    const missing = heavy
+      .filter(({ text }) => !EXPLICIT_TIMEOUT.test(text))
+      .map(({ file }) => relative(SRC, file));
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
Windows CI, on an unrelated PR (#234, which touches only `packages/server`):

```
× stays bounded while a list renders and discards thousands of rows  7410ms
  → Test timed out in 5000ms.
```

**The assertion had not failed. The bound held.** The runner was slow, and 5,000 `attachShadow` calls took longer than a number nobody chose for this test — vitest's 5s default.

That is the rule CLAUDE.md already states, applied to a timeout instead of an assertion: *"a statement about the machine … fails only under parallel load, i.e. only in CI."* Same diagnosis as #140.

## It also closes a thread I got wrong

`refs.test.ts` flaked **three separate times** tonight and I guessed it was GC-dependent (a WeakRef registry) and therefore unreproducible. **It is not.** It is the same default timeout on two 20,000-iteration loops — and the heaviest of them *appends* ~20k elements to the document rather than minting refs for detached ones.

I left that flagged as an unknown on #210. This is what it actually was.

A generous timeout cannot make a broken test pass: the bounds are still asserted, and a registry that grew without limit still fails.

## The guard needed three corrections of its own

All recorded in its docblock, because each one is a way this rule could have shipped looking like it worked:

1. **It demanded a numeric literal**, so it rejected the named constant this repo's conventions call for — it failed against its own remedy.
2. **It was single-line**, and prettier splits the call once it grows (`},\n    HEAVY_DOM_TIMEOUT_MS,\n  );`), so it matched neither of the two files it was written for.
3. **It cannot see a bound behind a helper** (`fill(n)`) — which is exactly where the heaviest test hides. I found that one by reading, and the docblock says so rather than implying coverage the pattern does not have.

Mutation-verified: removing a timeout makes it fail.

## Placement

In `packages/server`, because `@reticlehq/browser` may not import Node builtins — that boundary is real, not a nuisance, and every other source-scanning guard here lives in the same place. I moved the file rather than disabling the rule.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages, 178/178 in `browser/src/dom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)