### PR TITLE
fix(e2e): a bind clash crashed the stress spec instead of failing it

### DIFF
--- a/apps/e2e/specs/mcp-stress-test.mjs
+++ b/apps/e2e/specs/mcp-stress-test.mjs
@@ -51,6 +51,55 @@ function daemonPid(port = PORT) {
   }
 }
 
+/**
+ * `listen()` with the bind error surfaced as a REJECTION, not an unhandled 'error' event.
+ *
+ * `await new Promise((r) => server.listen(port, host, r))` can never report a bind failure: the
+ * callback is the `listening` handler, and EADDRINUSE arrives as an `error` EVENT on the server. With
+ * no listener for it, Node throws it as an unhandled 'error' and the whole spec dies with a raw
+ * stack — which is exactly how this battery failed on main:
+ *
+ *   Error: listen EADDRINUSE: address already in use 127.0.0.1:4731
+ *       at Server.setupListenHandle …
+ *   [e2e] ✗ mcp-stress-test FAILED (exit 1)
+ *
+ * A try/catch around that promise does not help either, which is why it looked safe.
+ */
+function listenOn(server, port, host = '127.0.0.1') {
+  return new Promise((resolve, reject) => {
+    const onError = (err) => {
+      server.removeListener('listening', onListening);
+      reject(err);
+    };
+    const onListening = () => {
+      server.removeListener('error', onError);
+      resolve();
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(Number(port), host);
+  });
+}
+
+/**
+ * Bind as soon as the port frees. A SIGKILLed daemon does not release its socket instantly, and the
+ * old code waited a flat 200 ms and hoped — a timing assumption about the machine, which is the one
+ * thing this repo's own rules forbid. It also let a daemon leaked by attempt 1 fail attempt 2 on
+ * EADDRINUSE, so the retry could never succeed.
+ */
+async function listenWhenFree(server, port, host = '127.0.0.1', budgetMs = 15_000) {
+  const deadline = Date.now() + budgetMs;
+  for (;;) {
+    try {
+      await listenOn(server, port, host);
+      return;
+    } catch (err) {
+      if (err?.code !== 'EADDRINUSE' || Date.now() >= deadline) throw err;
+      await sleep(100);
+    }
+  }
+}
+
 function killDaemon(port = PORT) {
   const pid = daemonPid(port);
   if (pid === null) return false;
@@ -147,7 +196,7 @@ chk('  and answered every call in between', 10 === answered, `${answered}/10 ans
   killDaemon();
   await sleep(200);
   const squatter = net.createServer((s) => s.destroy());
-  await new Promise((r) => squatter.listen(Number(PORT), '127.0.0.1', r));
+  await listenWhenFree(squatter, PORT);
   const r = await settled(client.request('tools/call', { name: 'reticle_sessions', arguments: {} }, 30_000));
   chk('a squatter on the port does not hang the client', r.answered, r.how);
   chk('  server still alive with the port stolen', alive(client));
@@ -223,7 +272,7 @@ killDaemon();
     });
   });
   fake.on('clientError', () => undefined);
-  await new Promise((r) => fake.listen(Number(RESET_PORT), '127.0.0.1', r));
+  await listenOn(fake, RESET_PORT);
 
   const resetClient = new McpStdioClient(
     'node',
@@ -257,7 +306,7 @@ killDaemon();
     res.end(); // headers, then gone
   });
   flapper.on('clientError', () => undefined);
-  await new Promise((r) => flapper.listen(Number(FLAP_PORT), '127.0.0.1', r));
+  await listenOn(flapper, FLAP_PORT);
 
   const flapClient = new McpStdioClient(
     'node',


### PR DESCRIPTION
**`main`'s e2e battery is RED at `ba3848b8`** — the only red on the release candidate — and this is why:

```
Error: listen EADDRINUSE: address already in use 127.0.0.1:4731
    at Server.setupListenHandle …
[e2e] ✗ mcp-stress-test FAILED (exit 1)
```

## The bug is how it binds, not that it binds

The spec puts a "squatter" on the bridge port **on purpose** — simulating a foreign process stealing 4400 is the case under test. The problem:

```js
await new Promise((r) => server.listen(Number(PORT), '127.0.0.1', r))
```

That can **never** report a bind failure. The callback is the `listening` handler; `EADDRINUSE` arrives as an `error` **event** on the server, and with no listener Node throws it as unhandled and kills the process. **A `try/catch` around it does not help either** — which is exactly why it looked safe. I reproduced that standalone before changing anything.

So a port that was merely still-closing turned a check into a crash with a raw stack — in the one spec whose entire subject is surviving a hostile port.

## Two changes

- **`listenOn()`** surfaces the bind error as a rejection. Used for the two servers on dedicated ports, so a clash there fails legibly instead of taking the battery down.
- **`listenWhenFree()`** retries until the port frees, bounded. The squatter binds the port of a daemon it `SIGKILL`ed one line earlier, and the old code waited a flat `200ms` and hoped — a timing assumption about the machine, which this repo's own rules forbid.

That second one is also **why CI's retry could not save it**: a daemon leaked by attempt 1 held the port, so attempt 2 failed on the same `EADDRINUSE`. The workflow even has a comment anticipating exactly this. Two attempts, one cause.

## Verified

All three behaviours, standalone, with the process surviving each:

```
1. rejects legibly: EADDRINUSE
2. bound after 612ms once the port freed
3. gives up in budget: EADDRINUSE
process survived all three
```

`node --check` clean, `pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages. The battery itself runs in CI here.

## Why this matters beyond the red

I had been reporting "main green" for several passes. I was reading **workflow-level** status (`API docs`, `CodeQL`, `Package quality` — all success) and never opened the CI workflow's **job** list, where `e2e` was failing. That is the same silent-zero mistake I have documented three times tonight, made by me, about the release candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)