### PR TITLE
fix(ci): the e2e retry waits for its ports instead of assuming kill -9 freed them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,23 @@ jobs:
             # See apps/e2e/harness-rules.md.
             for port in 8787 4310 3100; do lsof -ti "tcp:$port" | xargs -r kill -9 || true; done
             lsof -ti "tcp:4400" -sTCP:LISTEN | xargs -r kill -9 || true
-            sleep 3
+            # WAIT for the sockets, do not assume. `kill -9` signals a process; it does not free its
+            # port synchronously. This was a flat `sleep 3`, and attempt 2 still failed six seconds
+            # after cleanup began with `EADDRINUSE :::3100` — so the retry that exists to absorb a
+            # transient flake could not succeed, which turns one red into two and hides the first
+            # cause behind a second, different error. Same defect as the one fixed inside
+            # mcp-stress-test.mjs: a sleep standing in for "the port is free".
+            waited=0
+            while [ "$waited" -lt 30 ]; do
+              busy=""
+              for port in 8787 4310 3100 4400; do
+                if lsof -ti "tcp:$port" >/dev/null 2>&1; then busy="$busy $port"; fi
+              done
+              [ -z "$busy" ] && break
+              echo "waiting for ports to close:$busy"
+              sleep 1; waited=$((waited + 1))
+            done
+            [ "$waited" -ge 30 ] && echo "::warning::ports still held after 30s:$busy — retrying anyway"
           done
           echo "e2e battery failed after 2 attempts"; exit 1
       - name: Upload server logs on failure

--- a/packages/server/src/tools/e2e-retry-waits-for-ports.test.ts
+++ b/packages/server/src/tools/e2e-retry-waits-for-ports.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The e2e retry must WAIT for the ports it just killed, not assume they are free.
+ *
+ * Observed on main (run 31480427989): attempt 1 crashed, cleanup ran, and attempt 2 failed six
+ * seconds later with
+ *
+ *   Error: listen EADDRINUSE: address already in use :::3100
+ *
+ * The cleanup is not missing 3100 — it kills it explicitly. The problem is that `kill -9` does not
+ * wait: the process is signalled, the socket is still closing, and the next attempt binds into it.
+ * So the retry, which exists so a transient flake does not red CI, could not succeed — the same
+ * failure it was added to absorb.
+ *
+ * This is the identical defect fixed one layer down in `mcp-stress-test.mjs` (#238): a flat sleep or
+ * a bare kill standing in for "the port is free". A retry that cannot succeed is worse than no
+ * retry, because it turns one red into two and hides the cause behind a second, different error.
+ *
+ * Asserted on the workflow text because CI is the one place where a rule left to prose is never
+ * re-read until it is already costing someone a build.
+ */
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CI = readFileSync(
+  join(HERE, '..', '..', '..', '..', '.github', 'workflows', 'ci.yml'),
+  'utf8',
+);
+
+/**
+ * The e2e job's retry block, bounded at BOTH ends.
+ *
+ * My first version sliced to end-of-file and passed immediately — it was matching `while`/`until`
+ * from later jobs. A guard that reads past its subject is not guarding it.
+ */
+const RETRY_BLOCK = CI.slice(
+  CI.indexOf('for attempt in 1 2; do'),
+  CI.indexOf('e2e battery failed after 2 attempts'),
+);
+
+describe('the e2e retry frees its ports before retrying', () => {
+  it('still kills the app servers it started', () => {
+    // Guards the guard: if the cleanup disappears, the wait below is meaningless.
+    for (const port of ['8787', '4310', '3100']) expect(RETRY_BLOCK).toContain(port);
+  });
+
+  it('waits for the ports to actually close, rather than assuming kill -9 is synchronous', () => {
+    expect(RETRY_BLOCK, 'a flat `sleep N` is a guess about how fast a socket closes').not.toMatch(
+      /^\s*sleep \d+\s*$/m,
+    );
+    expect(RETRY_BLOCK, 'it must poll for the ports to be free').toMatch(/until|while/);
+    expect(RETRY_BLOCK, 'the wait must be bounded, or a stuck port hangs the job').toMatch(
+      /-lt|-le|-gt|-ge/,
+    );
+  });
+});


### PR DESCRIPTION
The other half of main's e2e failure. **#238 fixed why attempt 1 crashed; this is why attempt 2 could not save it.**

## Evidence

From run `31480427989` — cleanup ran at `10:15:43`, and attempt 2 failed **six seconds later**:

```
Error: listen EADDRINUSE: address already in use :::3100
```

The cleanup is **not** missing 3100 — it kills it explicitly. It then slept a flat **3 seconds**.

`kill -9` signals a process; it does not free its port synchronously. Three seconds was a guess about how fast a socket closes on a loaded runner.

## Why it matters more than one red build

The retry exists so a transient flake does not red CI. Because the cleanup could leave a port held, **the retry could not succeed** — which is worse than having no retry: it turns one red into two, and hides the first cause behind a second, different error.

That is precisely what happened here. The real defect (an unhandled `EADDRINUSE` in `mcp-stress-test`) took a log read to find, because the visible failure was a *different* port on a *different* attempt.

Same defect as the one fixed inside the spec by #238, one layer up: **a sleep standing in for "the port is free."**

## After

```sh
waited=0
while [ "$waited" -lt 30 ]; do
  busy=""
  for port in 8787 4310 3100 4400; do
    if lsof -ti "tcp:$port" >/dev/null 2>&1; then busy="$busy $port"; fi
  done
  [ -z "$busy" ] && break
  echo "waiting for ports to close:$busy"
  sleep 1; waited=$((waited + 1))
done
[ "$waited" -ge 30 ] && echo "::warning::ports still held after 30s:$busy — retrying anyway"
```

Bounded, and it names which ports are holding. A genuinely stuck port warns and proceeds rather than hanging the job — a wait that can hang is its own outage.

## Verified

- YAML parses; the full 37-line `run` block passes `bash -n`
- The `[ ... ] && echo` form was **tested under `bash -e`** to confirm a false condition does not fail the step (it does not — the script continues and exits 0)

## On the guard

Asserted by a test, because a CI rule left to prose is not re-read until it is already costing someone a build.

My first version sliced the workflow to end-of-file and **passed immediately** — it was matching `while` from later jobs. A guard that reads past its subject is not guarding it. It is now bounded at both ends, and it also forbids the flat `sleep N` returning.

`pnpm lint && pnpm typecheck && pnpm test:unit` — 15/15 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)