### PR TITLE
fix(desktop): write captures to a private directory, not shared /tmp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ### Security
 
-- **`@reticlehq/electron` / `reticle-tauri` — desktop captures are written into a private per-process directory (mode `0700`) instead of straight into the shared OS temp directory.** The old filename was guessable by construction — a public constant prefix, a readable pid, and a counter starting at 0 — so on a multi-user machine a screenshot of your app window (customer records, a token on screen, an authenticated session) was readable by any other local user until the sweep removed it, and a symlink pre-placed at that name would be followed by the write. Fixes the CodeQL `js/insecure-temporary-file` alert on `packages/electron/main.cjs`, and the same pattern in the Tauri crate, which CodeQL does not scan. Both writes now also use `O_CREAT|O_EXCL`, which refuses an existing path rather than writing through it. `@reticlehq/server` accepts the new layout **and** the old flat one, so an app on an older shell package keeps getting screenshots against a newer daemon.
+- **`@reticlehq/electron` / `reticle-tauri` — desktop captures are written into a private per-process directory (mode `0700`) instead of straight into the shared OS temp directory.** The old filename was guessable by construction — a public constant prefix, a readable pid, and a counter starting at 0 — so on a multi-user machine a screenshot of your app window (customer records, a token on screen, an authenticated session) was readable by any other local user until the sweep removed it, and a symlink pre-placed at that name would be followed by the write. Fixes the CodeQL `js/insecure-temporary-file` alert on `packages/electron/main.cjs`, and the same pattern in the Tauri crate, which CodeQL does not scan. Both writes now also use `O_CREAT|O_EXCL`, which refuses an existing path rather than writing through it. `@reticlehq/server` accepts the new layout **and** the old flat one, so an app on an older shell package keeps getting screenshots against a newer daemon, and removes consumed private capture directories during shutdown so they do not accumulate in the OS temp directory.
 
 ## [2.6.0] — 2026-08-12
 
@@ -78,6 +78,7 @@ The measured problem: **137 of the 140 sessions that produced no verdict never c
 ### Thanks
 
 **[Dev Chiniwala](https://github.com/DevChiniwala)** — five fixes, all in the resource-leak and shutdown paths that decide whether the daemon survives a long session. **[Vijay Misal](https://github.com/vjymisal0)** — the lossy-transform guard missed export lists, default and wildcard exports, and type-only exports; the guard's own self-test never tried them. **[BabuBahir](https://github.com/BabuBahir)** ([#236](https://github.com/reticlehq/reticle/pull/236)) — corrected a test-duration figure this repo had been quoting wrongly for months.
+
 ## [2.5.0] — 2026-08-09
 
 **One tool surface, an MCP server that stays up, and a long list of answers that were wrong.** Most of it was found by driving the shipped surface against live apps: a hostile-argument fuzz of all 48 tools, a nine-app fixture fleet under a new trace, and stress specs against every transport.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the **`@reticlehq/*`** packages are documented here (each entry notes the package it affects). The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- **`@reticlehq/electron` / `reticle-tauri` — desktop captures are written into a private per-process directory (mode `0700`) instead of straight into the shared OS temp directory.** The old filename was guessable by construction — a public constant prefix, a readable pid, and a counter starting at 0 — so on a multi-user machine a screenshot of your app window (customer records, a token on screen, an authenticated session) was readable by any other local user until the sweep removed it, and a symlink pre-placed at that name would be followed by the write. Fixes the CodeQL `js/insecure-temporary-file` alert on `packages/electron/main.cjs`, and the same pattern in the Tauri crate, which CodeQL does not scan. Both writes now also use `O_CREAT|O_EXCL`, which refuses an existing path rather than writing through it. `@reticlehq/server` accepts the new layout **and** the old flat one, so an app on an older shell package keeps getting screenshots against a newer daemon.
+
 ## [2.6.0] — 2026-08-12
 
 **Stop breaking, stop lying, and be able to prove it.** 140+ commits, driven by what the telemetry and the field reports actually said rather than what the backlog assumed. No breaking changes.
@@ -72,7 +78,6 @@ The measured problem: **137 of the 140 sessions that produced no verdict never c
 ### Thanks
 
 **[Dev Chiniwala](https://github.com/DevChiniwala)** — five fixes, all in the resource-leak and shutdown paths that decide whether the daemon survives a long session. **[Vijay Misal](https://github.com/vjymisal0)** — the lossy-transform guard missed export lists, default and wildcard exports, and type-only exports; the guard's own self-test never tried them. **[BabuBahir](https://github.com/BabuBahir)** ([#236](https://github.com/reticlehq/reticle/pull/236)) — corrected a test-duration figure this repo had been quoting wrongly for months.
-
 ## [2.5.0] — 2026-08-09
 
 **One tool surface, an MCP server that stays up, and a long list of answers that were wrong.** Most of it was found by driving the shipped surface against live apps: a hostile-argument fuzz of all 48 tools, a nine-app fixture fleet under a new trace, and stress specs against every transport.

--- a/apps/e2e/specs/electron-desktop-test.mjs
+++ b/apps/e2e/specs/electron-desktop-test.mjs
@@ -184,10 +184,14 @@ try {
     concurrent.every((s) => s.saved === true),
     JSON.stringify(concurrent.map((s) => s.reason ?? s.saved)),
   );
-  chk('no capture is left behind in the temp dir', tempCaptures().length === 0, tempCaptures().join(','));
 } finally {
   await session?.shutdown();
 }
+chk(
+  'shutdown removes the private capture directory from the temp dir',
+  tempCaptures().length === 0,
+  tempCaptures().join(','),
+);
 
 // ── the same app with the ONE line an integrator forgets ──────────────────────────────────────────
 // Without the preload shim every IPC call is invisible. The failure mode this pins is not the

--- a/apps/e2e/specs/tauri-desktop-test.mjs
+++ b/apps/e2e/specs/tauri-desktop-test.mjs
@@ -159,7 +159,6 @@ try {
     concurrent.every((s) => s.saved === true),
     JSON.stringify(concurrent.map((s) => s.reason ?? s.saved)),
   );
-  chk('no capture is left behind in the temp dir', tempCaptures().length === 0, tempCaptures().join(','));
 
   /**
    * The webview must still be there a few seconds later.
@@ -202,6 +201,11 @@ try {
 } finally {
   await session?.shutdown();
 }
+chk(
+  'shutdown removes the private capture directory from the temp dir',
+  tempCaptures().length === 0,
+  tempCaptures().join(','),
+);
 
 console.log(
   `\n${state.fail === 0 ? '✅ TAURI DESKTOP VERIFIED' : '❌ FAILED'} (${String(state.pass)} passed, ${String(state.fail)} failed)`,

--- a/packages/electron/main.cjs
+++ b/packages/electron/main.cjs
@@ -17,7 +17,7 @@
  * Dev-only, like the rest of Reticle. Gate the require behind your dev check so it never ships.
  */
 const { ipcMain } = require('electron');
-const { writeFile, readdir, stat, unlink } = require('node:fs/promises');
+const { writeFile, readdir, stat, unlink, mkdtemp } = require('node:fs/promises');
 const { tmpdir } = require('node:os');
 const { join } = require('node:path');
 // Generated from @reticlehq/core's TypeScript source, so the main process, the preload and the
@@ -67,14 +67,37 @@ function usableContents(sender) {
  */
 const STALE_CAPTURE_MS = 60_000;
 
+/**
+ * This process's own capture directory, created 0700 — made once, on the first capture.
+ *
+ * A screenshot of your app window can hold customer records, a token on screen, an authenticated
+ * session. Written straight into the SHARED temp dir under a guessable name — a constant prefix, a
+ * readable pid and a counter from 0 — it is readable by any other local user for as long as it
+ * sits there, and a symlink pre-placed at that name would have `writeFile` follow it and write
+ * through with this app's privileges.
+ *
+ * `mkdtemp` closes both at once, and it is the DIRECTORY that does it rather than a less guessable
+ * filename: the OS creates it 0700 with a random suffix, so another user cannot enter it to read a
+ * capture, and cannot pre-create anything inside a directory that did not exist until this process
+ * made it. Guessing is not the property that matters; the shared parent was.
+ *
+ * Memoised as the PROMISE, not the resolved path, so two captures racing on the first screenshot
+ * await one `mkdtemp` instead of creating two directories and leaking one.
+ */
+let capturesDirPromise;
+
+function capturesDir() {
+  capturesDirPromise ??= mkdtemp(join(tmpdir(), RETICLE_CAPTURE_FILE_PREFIX));
+  return capturesDirPromise;
+}
+
 async function sweepOldCaptures(dir, keepFile) {
-  const mine = `${RETICLE_CAPTURE_FILE_PREFIX}${String(process.pid)}-`;
   const cutoff = Date.now() - STALE_CAPTURE_MS;
   try {
     const entries = await readdir(dir);
     await Promise.all(
       entries
-        .filter((name) => name.startsWith(mine) && join(dir, name) !== keepFile)
+        .filter((name) => join(dir, name) !== keepFile)
         .map(async (name) => {
           const file = join(dir, name);
           const info = await stat(file).catch(() => undefined);
@@ -83,7 +106,7 @@ async function sweepOldCaptures(dir, keepFile) {
         }),
     );
   } catch {
-    /* the temp dir is unreadable; a capture is still worth attempting */
+    /* the capture directory is unreadable; a capture is still worth attempting */
   }
 }
 
@@ -116,12 +139,19 @@ function installReticleCapture(win) {
         // always on the same machine here (the bridge is loopback), so a path is the honest channel:
         // no size cap, no chunking, and nothing large on the event wire.
         captureSeq += 1;
-        const file = join(
-          tmpdir(),
-          `${RETICLE_CAPTURE_FILE_PREFIX}${String(process.pid)}-${String(captureSeq)}.png`,
-        );
-        await writeFile(file, image.toPNG());
-        await sweepOldCaptures(tmpdir(), file);
+        // Inside this process's own 0700 directory. A failure to create it throws to the catch
+        // below and answers no-image; it deliberately does NOT fall back to the shared temp dir,
+        // because that fallback is the very exposure this directory exists to remove.
+        const dir = await capturesDir();
+        const file = join(dir, `${RETICLE_CAPTURE_FILE_PREFIX}${String(captureSeq)}.png`);
+        // `wx` is O_CREAT|O_EXCL: it REFUSES an existing path instead of writing through it, and
+        // O_EXCL does not follow a final symlink. The 0700 directory already stops an attacker
+        // getting a symlink here, so this is the second lock on the same door — and the one that
+        // still holds if a later change moves this write back out into the shared temp dir. The
+        // sequence only ever climbs within a fresh per-process directory, so it never collides
+        // with a capture of our own.
+        await writeFile(file, image.toPNG(), { flag: 'wx' });
+        await sweepOldCaptures(dir, file);
         return file;
       } catch {
         return null;

--- a/packages/electron/main.cjs
+++ b/packages/electron/main.cjs
@@ -57,8 +57,9 @@ function usableContents(sender) {
  *
  * The daemon unlinks a capture after reading it, but only if it ever reads: a session that died, a
  * command that timed out, or a path the daemon rejected all leave a ~300KB PNG in the temp directory
- * forever. Sweeping our own prefix on each capture bounds that to one file at a time, with no timer
- * to leak and no cleanup handler to forget. Best-effort — a failed sweep must never fail a capture.
+ * forever. Sweeping our own prefix on each capture bounds that to one file at a time, and the daemon
+ * removes this empty private directory in its existing shutdown path. Best-effort — a failed sweep
+ * must never fail a capture.
  *
  * Only files older than STALE_CAPTURE_MS are swept. Deleting every sibling unconditionally raced
  * with CONCURRENT captures: with two screenshots in flight, the second one's sweep unlinked the

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -26,6 +26,7 @@ import { buildFlowChips } from './flows/flow-scope.js';
 import { ProjectStore } from './project/project-store.js';
 import { AnnotationStore } from './flows/annotation-store.js';
 import { createNodeFileSystem, type FileSystemPort } from './project/fs-port.js';
+import { cleanupCaptureDirectories } from './visual/capture-cleanup.js';
 import { ReticleRunner } from './runs/reticle-runner.js';
 import { createRunnerPort } from './runs/runner-port.js';
 import { RunStore } from './runs/run-store.js';
@@ -453,6 +454,7 @@ export async function start(options: StartOptions = {}): Promise<RunningServer> 
     ...(security.token !== undefined ? { token: security.token } : {}),
     close: async () => {
       reaper.stop();
+      await cleanupCaptureDirectories();
       leaseReaper?.stop();
       await pool?.shutdown();
       await owned?.dispose();
@@ -617,6 +619,7 @@ export async function startDaemon(options: StartOptions = {}): Promise<RunningSe
     agentAttached: () => agentConnected,
     close: async () => {
       reaper.stop();
+      await cleanupCaptureDirectories();
       const vh = verifyHttp;
       if (vh !== undefined) await new Promise<void>((resolve) => vh.server.close(() => resolve()));
       leaseReaper.stop();

--- a/packages/server/src/visual/capture-cleanup.test.ts
+++ b/packages/server/src/visual/capture-cleanup.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { access, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RETICLE_CAPTURE_FILE_PREFIX } from '@reticlehq/core';
+import { start } from '../index.js';
+import { cleanupCaptureDirectories, trackCaptureDirectory } from './capture-cleanup.js';
+
+const made = new Set<string>();
+
+async function privateCaptureDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), RETICLE_CAPTURE_FILE_PREFIX));
+  made.add(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all([...made].map((dir) => rm(dir, { recursive: true, force: true })));
+  made.clear();
+  await cleanupCaptureDirectories();
+});
+
+describe('private capture directory shutdown cleanup', () => {
+  it('removes the empty directory after its consumed capture has been unlinked', async () => {
+    const dir = await privateCaptureDir();
+    const capture = join(dir, `${RETICLE_CAPTURE_FILE_PREFIX}1.png`);
+    await writeFile(capture, 'png');
+    trackCaptureDirectory(capture);
+    await rm(capture);
+
+    await cleanupCaptureDirectories();
+
+    await expect(access(dir)).rejects.toMatchObject({ code: 'ENOENT' });
+    made.delete(dir);
+  });
+
+  it('refuses to recursively remove a directory with an unexpected file', async () => {
+    const dir = await privateCaptureDir();
+    const capture = join(dir, `${RETICLE_CAPTURE_FILE_PREFIX}1.png`);
+    await writeFile(join(dir, 'unexpected.txt'), 'keep');
+    trackCaptureDirectory(capture);
+
+    await cleanupCaptureDirectories();
+
+    await expect(access(join(dir, 'unexpected.txt'))).resolves.toBeUndefined();
+  });
+
+  it('runs from the server close path used by the desktop harness', async () => {
+    const dir = await privateCaptureDir();
+    const capture = join(dir, `${RETICLE_CAPTURE_FILE_PREFIX}1.png`);
+    trackCaptureDirectory(capture);
+    const server = await start({ port: 0, mcp: false });
+
+    await server.close();
+
+    await expect(access(dir)).rejects.toMatchObject({ code: 'ENOENT' });
+    made.delete(dir);
+  });
+});

--- a/packages/server/src/visual/capture-cleanup.ts
+++ b/packages/server/src/visual/capture-cleanup.ts
@@ -1,0 +1,42 @@
+import { rmdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, dirname } from 'node:path';
+import { RETICLE_CAPTURE_FILE_PREFIX } from '@reticlehq/core';
+
+/** Private shell directories whose captures this daemon has successfully consumed. */
+const captureDirectories = new Set<string>();
+
+/**
+ * Remember the private parent of a capture after the daemon has read it.
+ *
+ * Legacy captures live directly in `tmpdir()` and therefore have no directory to reclaim. The
+ * caller has already applied the capture-path trust-boundary check; this second exact parent check
+ * keeps the cleanup set limited to the one-level private layout.
+ */
+export function trackCaptureDirectory(path: string): void {
+  const parent = dirname(path);
+  if (dirname(parent) === tmpdir() && basename(parent).startsWith(RETICLE_CAPTURE_FILE_PREFIX)) {
+    captureDirectories.add(parent);
+  }
+}
+
+/**
+ * Remove empty private capture directories during the daemon's existing awaited shutdown path.
+ *
+ * Deliberately `rmdir`, never recursive removal: captures are unlinked after reading, so a genuine
+ * directory is empty by shutdown. If anything unexpected remains, refusing to remove the directory
+ * is safer than widening a renderer-supplied path into a recursive delete.
+ */
+export async function cleanupCaptureDirectories(): Promise<void> {
+  await Promise.all(
+    [...captureDirectories].map(async (dir) => {
+      try {
+        await rmdir(dir);
+      } catch {
+        // Best-effort shutdown housekeeping. A non-empty or already-removed directory is harmless.
+      } finally {
+        captureDirectories.delete(dir);
+      }
+    }),
+  );
+}

--- a/packages/server/src/visual/capture-path.test.ts
+++ b/packages/server/src/visual/capture-path.test.ts
@@ -22,9 +22,9 @@ describe('isCapturePath — what the daemon agrees to read', () => {
   });
 
   it('refuses a private directory whose name is not ours', () => {
-    expect(isCapturePath(join(tmpdir(), 'someone-else', `${RETICLE_CAPTURE_FILE_PREFIX}1.png`))).toBe(
-      false,
-    );
+    expect(
+      isCapturePath(join(tmpdir(), 'someone-else', `${RETICLE_CAPTURE_FILE_PREFIX}1.png`)),
+    ).toBe(false);
   });
 
   it('refuses a file that does not carry the prefix, even inside our directory', () => {
@@ -32,15 +32,15 @@ describe('isCapturePath — what the daemon agrees to read', () => {
   });
 
   it('refuses a traversal that climbs out of the temp dir', () => {
-    expect(
-      isCapturePath(`${PRIVATE_DIR}/../../etc/${RETICLE_CAPTURE_FILE_PREFIX}passwd.png`),
-    ).toBe(false);
+    expect(isCapturePath(`${PRIVATE_DIR}/../../etc/${RETICLE_CAPTURE_FILE_PREFIX}passwd.png`)).toBe(
+      false,
+    );
   });
 
   it('refuses a nesting deeper than one private directory', () => {
-    expect(
-      isCapturePath(join(PRIVATE_DIR, 'deeper', `${RETICLE_CAPTURE_FILE_PREFIX}1.png`)),
-    ).toBe(false);
+    expect(isCapturePath(join(PRIVATE_DIR, 'deeper', `${RETICLE_CAPTURE_FILE_PREFIX}1.png`))).toBe(
+      false,
+    );
   });
 
   it('refuses a path outside the temp dir entirely', () => {

--- a/packages/server/src/visual/capture-path.test.ts
+++ b/packages/server/src/visual/capture-path.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RETICLE_CAPTURE_FILE_PREFIX } from '@reticlehq/core';
+import { isCapturePath } from './visual-tools.js';
+
+/**
+ * The daemon reads a path that arrived from the PAGE, so this predicate is a trust boundary: it
+ * decides whether `reticle_screenshot` will open a file a compromised renderer named. Both halves
+ * matter and are tested separately — what it must accept (or desktop capture silently returns no
+ * image), and what it must refuse (or the daemon becomes a file-read oracle).
+ */
+const PRIVATE_DIR = join(tmpdir(), `${RETICLE_CAPTURE_FILE_PREFIX}a1b2c3`);
+
+describe('isCapturePath — what the daemon agrees to read', () => {
+  it('accepts a capture inside the shell private capture directory', () => {
+    expect(isCapturePath(join(PRIVATE_DIR, `${RETICLE_CAPTURE_FILE_PREFIX}1.png`))).toBe(true);
+  });
+
+  it('accepts the legacy flat layout, so an older SDK keeps working against a newer daemon', () => {
+    expect(isCapturePath(join(tmpdir(), `${RETICLE_CAPTURE_FILE_PREFIX}90502-0.png`))).toBe(true);
+  });
+
+  it('refuses a private directory whose name is not ours', () => {
+    expect(isCapturePath(join(tmpdir(), 'someone-else', `${RETICLE_CAPTURE_FILE_PREFIX}1.png`))).toBe(
+      false,
+    );
+  });
+
+  it('refuses a file that does not carry the prefix, even inside our directory', () => {
+    expect(isCapturePath(join(PRIVATE_DIR, 'id_rsa'))).toBe(false);
+  });
+
+  it('refuses a traversal that climbs out of the temp dir', () => {
+    expect(
+      isCapturePath(`${PRIVATE_DIR}/../../etc/${RETICLE_CAPTURE_FILE_PREFIX}passwd.png`),
+    ).toBe(false);
+  });
+
+  it('refuses a nesting deeper than one private directory', () => {
+    expect(
+      isCapturePath(join(PRIVATE_DIR, 'deeper', `${RETICLE_CAPTURE_FILE_PREFIX}1.png`)),
+    ).toBe(false);
+  });
+
+  it('refuses a path outside the temp dir entirely', () => {
+    expect(isCapturePath(`/etc/${RETICLE_CAPTURE_FILE_PREFIX}shadow.png`)).toBe(false);
+  });
+});

--- a/packages/server/src/visual/visual-tools.ts
+++ b/packages/server/src/visual/visual-tools.ts
@@ -113,12 +113,27 @@ async function desktopCapture(
 }
 
 /**
- * Only read a capture the shell wrote: inside the OS temp dir, with Reticle's own filename prefix.
- * The path arrives from the PAGE, and the daemon must not become a file-read oracle for whatever a
- * compromised renderer names.
+ * Only read a capture the shell wrote. The path arrives from the PAGE, and the daemon must not
+ * become a file-read oracle for whatever a compromised renderer names.
+ *
+ * Two layouts are accepted, and the pair is the whole subtlety:
+ *
+ * - `<tmp>/<prefix><dir>/<prefix><n>.png` — the shell's own PRIVATE capture directory, created 0700
+ *   so no other local user can read the screenshot or pre-place a symlink at the path we write.
+ * - `<tmp>/<prefix><pid>-<n>.png` — the legacy flat layout. Kept because the shell ships as a
+ *   SEPARATE package on the user's own upgrade schedule: an app still on the older
+ *   `@reticlehq/electron` talking to a newer daemon must keep getting screenshots, not silently
+ *   start returning no image. It grants the daemon nothing it did not already have.
+ *
+ * Every comparison is an exact match against an UNRESOLVED path, which is what refuses traversal:
+ * `<tmp>/<prefix>x/../../etc/<prefix>passwd.png` has a grandparent of `<tmp>/<prefix>x/..`, not
+ * `<tmp>`. Exactly one directory level is allowed, so a deeper nesting is refused too.
  */
-function isCapturePath(path: string): boolean {
-  return dirname(path) === tmpdir() && basename(path).startsWith(RETICLE_CAPTURE_FILE_PREFIX);
+export function isCapturePath(path: string): boolean {
+  if (!basename(path).startsWith(RETICLE_CAPTURE_FILE_PREFIX)) return false;
+  const parent = dirname(path);
+  if (parent === tmpdir()) return true;
+  return dirname(parent) === tmpdir() && basename(parent).startsWith(RETICLE_CAPTURE_FILE_PREFIX);
 }
 
 /**

--- a/packages/server/src/visual/visual-tools.ts
+++ b/packages/server/src/visual/visual-tools.ts
@@ -10,6 +10,7 @@ import { sessionIdShape } from '../tools/tool-kit.js';
 import { asNumber, asRecord, asString } from '../tools/tools-helpers.js';
 import { diffPng, type VisualRect } from './visual-diff.js';
 import { VisualStore } from './visual-store.js';
+import { trackCaptureDirectory } from './capture-cleanup.js';
 import { readFile, unlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, dirname } from 'node:path';
@@ -106,6 +107,7 @@ async function desktopCapture(
   try {
     const bytes = await readFile(path);
     await unlink(path).catch(() => undefined);
+    trackCaptureDirectory(path);
     return isCompletePng(bytes) ? { png: new Uint8Array(bytes) } : {};
   } catch {
     return {};

--- a/packages/tauri/src/capture.rs
+++ b/packages/tauri/src/capture.rs
@@ -52,20 +52,78 @@ fn capture_to_temp_file(
     full_page: Option<bool>,
 ) -> Result<String, String> {
     let png = snapshot_png(window, full_page == Some(true))?;
-    let dir = std::env::temp_dir();
-    let path = dir.join(format!("{}{}.png", capture_prefix(), nanos()));
-    std::fs::write(&path, png).map_err(|error| error.to_string())?;
-    sweep_stale_captures(&dir, &path);
+    let dir = captures_dir()?;
+    let path = dir.join(format!("{}{}.png", CAPTURE_FILE_PREFIX, nanos()));
+    write_new_file(&path, &png).map_err(|error| error.to_string())?;
+    sweep_stale_captures(dir, &path);
     Ok(path.to_string_lossy().into_owned())
 }
 
-/// This process's own capture filenames, so a sweep can never touch another app's pending capture.
+/// This process's own capture directory, created 0700 on the first capture and reused after.
 ///
-/// The pid is in the name for the same reason Electron's helper puts it there: two instrumented
-/// desktop apps can be running at once, and "delete everything with Reticle's prefix" would have one
-/// of them unlink the other's screenshot out from under the daemon.
-fn capture_prefix() -> String {
-    format!("{CAPTURE_FILE_PREFIX}{}-", std::process::id())
+/// A screenshot of the app window can hold customer records, a token on screen, an authenticated
+/// session. Written straight into the SHARED temp directory it is readable by any other local user
+/// until the sweep removes it, and a symlink pre-placed at the name we are about to use would be
+/// followed by the write.
+///
+/// A less guessable filename does not fix that — `nanos()` was already hard to guess. The property
+/// that was missing is a private PARENT: another user cannot enter a 0700 directory to read a
+/// capture, and cannot pre-create anything inside one that did not exist until this process made
+/// it. `DirBuilder::create` is `mkdir(2)`, which fails rather than reusing an existing path, and
+/// the mode is applied AS it is created so there is no window where it sits world-readable.
+fn captures_dir() -> Result<&'static std::path::Path, String> {
+    static CAPTURES_DIR: std::sync::OnceLock<Option<std::path::PathBuf>> =
+        std::sync::OnceLock::new();
+    CAPTURES_DIR
+        .get_or_init(|| create_private_dir(&std::env::temp_dir()).ok())
+        .as_deref()
+        // Deliberately an error rather than a fall back to the shared temp directory: that fallback
+        // is the exposure this directory exists to remove, and a capture that cannot be written
+        // privately is one the caller should hear about.
+        .ok_or_else(|| "reticle-tauri could not create a private capture directory".to_string())
+}
+
+/// Create `<base>/<prefix><pid>-<nanos>` with mode 0700, retrying only a name collision.
+fn create_private_dir(base: &std::path::Path) -> std::io::Result<std::path::PathBuf> {
+    let mut last = std::io::Error::new(std::io::ErrorKind::AlreadyExists, "no attempt made");
+    for _ in 0..MAX_DIR_NAME_ATTEMPTS {
+        let candidate = base.join(format!(
+            "{CAPTURE_FILE_PREFIX}{}-{}",
+            std::process::id(),
+            nanos()
+        ));
+        let mut builder = std::fs::DirBuilder::new();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            builder.mode(0o700);
+        }
+        match builder.create(&candidate) {
+            Ok(()) => return Ok(candidate),
+            // Two captures on the same nanosecond tick, or a name an attacker guessed and squatted.
+            // Both are answered by trying a new name rather than by adopting the existing one.
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => last = error,
+            Err(error) => return Err(error),
+        }
+    }
+    Err(last)
+}
+
+/// How many times to re-roll a colliding directory name before giving up.
+const MAX_DIR_NAME_ATTEMPTS: u8 = 8;
+
+/// Write, refusing an existing path instead of writing through it.
+///
+/// `create_new` is `O_CREAT|O_EXCL`, which does not follow a final symlink. The 0700 directory
+/// already stops an attacker placing one here; this is the second lock on the same door, and the
+/// one that still holds if a later change moves the write back out into the shared temp directory.
+fn write_new_file(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)?;
+    file.write_all(bytes)
 }
 
 /// How long a capture may sit in the temp dir before this process treats it as abandoned.
@@ -82,17 +140,15 @@ const STALE_CAPTURE_SECS: u64 = 60;
 /// unlink the older one before the daemon had read it, turning a working screenshot into a
 /// no-provider error. Best-effort throughout — a failed sweep must never fail a capture.
 fn sweep_stale_captures(dir: &std::path::Path, keep: &std::path::Path) {
-    let prefix = capture_prefix();
     let Ok(entries) = std::fs::read_dir(dir) else {
-        return; // the temp dir is unreadable; the capture itself already succeeded
+        return; // the capture directory is unreadable; the capture itself already succeeded
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        if path == keep
-            || !path
-                .file_name()
-                .is_some_and(|n| n.to_string_lossy().starts_with(&prefix))
-        {
+        // Everything in here is this process's own, so the pid no longer has to be spelled into
+        // each filename to keep one app from unlinking another's pending capture — the directory
+        // carries that guarantee now.
+        if path == keep {
             continue;
         }
         // A clock that went backwards yields Err here; that reads as "not old enough", which errs
@@ -144,4 +200,86 @@ use platform::snapshot_png;
 )))]
 fn snapshot_png(_window: &tauri::WebviewWindow, _full_page: bool) -> Result<Vec<u8>, String> {
     Err("reticle-tauri cannot capture a webview on this platform".into())
+}
+
+/// The capture directory and the write are a trust boundary, not a tidiness detail: a screenshot of
+/// the app window is exactly the kind of thing another local user should not be able to read, and
+/// the path we write is one they should not be able to redirect. These cover both without a webview.
+#[cfg(test)]
+mod tests {
+    use super::{create_private_dir, write_new_file, CAPTURE_FILE_PREFIX};
+
+    fn scratch(name: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("reticle-tauri-test-{}-{}", name, super::nanos()));
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        dir
+    }
+
+    #[test]
+    fn private_dir_is_a_named_child_of_the_base() {
+        let base = scratch("child");
+        let dir = create_private_dir(&base).expect("create");
+        assert_eq!(dir.parent(), Some(base.as_path()));
+        assert!(dir
+            .file_name()
+            .expect("name")
+            .to_string_lossy()
+            .starts_with(CAPTURE_FILE_PREFIX));
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_dir_is_created_0700_so_no_other_user_can_enter_it() {
+        use std::os::unix::fs::PermissionsExt;
+        let base = scratch("mode");
+        let dir = create_private_dir(&base).expect("create");
+        let mode = std::fs::metadata(&dir)
+            .expect("metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o700,
+            "capture directory must not be readable by other local users"
+        );
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn two_calls_never_share_a_directory() {
+        let base = scratch("unique");
+        let first = create_private_dir(&base).expect("first");
+        let second = create_private_dir(&base).expect("second");
+        assert_ne!(first, second);
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn write_refuses_an_existing_path_instead_of_overwriting_it() {
+        let base = scratch("exists");
+        let path = base.join("taken.png");
+        std::fs::write(&path, b"ORIGINAL").expect("seed");
+        assert!(write_new_file(&path, b"REPLACED").is_err());
+        assert_eq!(std::fs::read(&path).expect("read"), b"ORIGINAL");
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    /// The half that catches a regression a permissions assertion alone would not: if the write is
+    /// ever moved back out into the shared temp directory, a pre-placed symlink must still not be
+    /// written through.
+    #[cfg(unix)]
+    #[test]
+    fn write_does_not_follow_a_pre_placed_symlink() {
+        let base = scratch("symlink");
+        let victim = base.join("victim.txt");
+        std::fs::write(&victim, b"ORIGINAL").expect("seed");
+        let link = base.join("capture.png");
+        std::os::unix::fs::symlink(&victim, &link).expect("symlink");
+
+        assert!(write_new_file(&link, b"ATTACKER").is_err());
+        assert_eq!(std::fs::read(&victim).expect("read"), b"ORIGINAL");
+        std::fs::remove_dir_all(&base).ok();
+    }
 }

--- a/packages/tauri/src/capture.rs
+++ b/packages/tauri/src/capture.rs
@@ -134,7 +134,7 @@ const STALE_CAPTURE_SECS: u64 = 60;
 /// The daemon unlinks a capture once it has read it — but only if it ever reads. A session that
 /// died, a command that timed out, or a path the daemon rejected each leave a ~500KB PNG in the temp
 /// directory forever, and nothing else ever collects them. Sweeping on the next capture needs no
-/// timer and no shutdown hook.
+/// timer; the daemon removes this empty private directory in its existing shutdown path.
 ///
 /// Age-gated, not "delete every sibling": two captures in flight and an unconditional sweep would
 /// unlink the older one before the daemon had read it, turning a working screenshot into a


### PR DESCRIPTION
## What & why

Closes #135

A desktop screenshot was written straight into the **shared** OS temp directory under a name anyone could work out — a public constant prefix, a readable pid, and a counter starting at `0`.

The code treated the **filename** as the thing to make safe. The shared **parent** was the actual exposure, and no filename fixes that. Tauri's `nanos()` is harder to guess than a counter, which is exactly why it reads as safe and is not.

CodeQL flags the JS half (`js/insecure-temporary-file`, high, `main.cjs:123`). **It does not scan Rust**, so fixing only the alert would have fixed half the problem.

## The fix

One private per-process directory, and the captures go inside it.

- **Node** — `mkdtemp(join(tmpdir(), RETICLE_CAPTURE_FILE_PREFIX))`. The OS creates it `0700`, so another local user cannot enter it to read a capture, and cannot pre-create anything inside a directory that did not exist until this process made it.
- **Rust** — `DirBuilder` with `.mode(0o700)` and a **non-recursive** create, which is `mkdir(2)`: it fails rather than adopting an existing path, and applies the mode *as* the directory is created, so there is no window where it sits world-readable. **No new dependency** — this crate is published, so `tempfile` was not worth the cost.

Both writes also use `O_CREAT|O_EXCL` (`wx` / `create_new`), which refuses an existing path instead of writing through it and does not follow a final symlink. The directory already stops an attacker placing one — this is the lock that still holds **if a later change moves the write back out to the shared root**, which is the regression a permissions assertion alone would not catch.

Neither path falls back to the shared temp dir on failure. That fallback is the exposure being removed, so a capture that cannot be written privately answers no-image instead.

The sweep keeps its pid-scoping guarantee for free: everything in the directory is this process's own, so one instrumented app can no longer unlink another's pending capture even in principle.

## The coupling the issue does not mention

The daemon gates reads with `dirname(path) === tmpdir()` — an **exact** match (`visual-tools.ts:121`). A capture one directory deeper would have been refused and **every desktop screenshot would have silently returned no image**. So this had to move too.

`isCapturePath` now accepts the private layout **and** the legacy flat one. The shell ships as a separate package on the user's own upgrade schedule, so an app still on the older `@reticlehq/electron` has to keep working against a newer daemon. It grants the daemon nothing it did not already have. Every comparison stays an exact match on an **unresolved** path — that is what refuses traversal (`<tmp>/<prefix>x/../../etc/...` has a grandparent of `<tmp>/<prefix>x/..`, not `<tmp>`), and exactly one directory level is allowed.

## How it was verified

**`isCapturePath` — RED proven against real behaviour, not a missing import.** The predicate was exported *unchanged* first and the suite run: **1 failure (the private layout) with 6 negative controls passing**, which both reproduces the bug and pins every refusal that must survive. 7/7 green after.

**Rust — 5 unit tests**, no webview needed: `0700` mode, direct child of the base, unique per call, an existing path refused, and a pre-placed symlink not written through.

```
test capture::tests::private_dir_is_created_0700_so_no_other_user_can_enter_it ... ok
test capture::tests::private_dir_is_a_named_child_of_the_base ... ok
test capture::tests::write_refuses_an_existing_path_instead_of_overwriting_it ... ok
test capture::tests::two_calls_never_share_a_directory ... ok
test capture::tests::write_does_not_follow_a_pre_placed_symlink ... ok
test result: ok. 5 passed; 0 failed
```

**Electron — driven end to end** through a stubbed `ipcMain` against a real capture:

```
capture 1 : /var/folders/.../T/reticle-capture-gXbAd2/reticle-capture-1.png
capture 2 : /var/folders/.../T/reticle-capture-gXbAd2/reticle-capture-2.png
dir mode  : 700 OK (0700)
dir parent is tmpdir : true
both captures share one dir : true
bytes written OK : true
capture 3 (symlink pre-placed) : null      <- refused, target untouched
```

That symlink line is worth calling out: with the `0700` directory alone the write **still followed** a symlink placed inside it. Not reachable by an attacker, but it is the case the issue asks to guard, and `O_EXCL` is what actually closes it.

**Gates:** `pnpm lint`, `pnpm typecheck`, `cargo fmt --check`, `cargo clippy --all-targets -D warnings` all clean. `@reticlehq/server` 3137/3137.

> **Pre-existing failure, not from this change:** `@reticlehq/browser` has 14 failing `readStorage`/`installStorage` tests on a clean `main` with this branch stashed — verified before and after. Looks like the jsdom bump in #156 territory. Untouched here.

## Checklist

- [x] Tests added/updated (RED → GREEN); the change is covered by a test that would fail without it
- [x] `pnpm lint && pnpm typecheck && pnpm test:unit` all pass locally *(browser failures pre-existing on `main`, see above)*
- [x] No `any`, no free strings (wire strings live in `@reticlehq/core`), no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 1000-line cap
- [x] Docs and `CHANGELOG.md` updated if this is user-facing (entry under `[Unreleased]`)
- [x] Security-affecting? Yes — and it strictly narrows exposure. No wire-contract change: the path stays a plain absolute path, nothing leaves the machine, and the read predicate grants the daemon nothing it did not already have.