### PR TITLE
ci(security): watch the Rust dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,33 @@ updates:
         update-types:
           - minor
           - patch
+  # Rust. `reticle-tauri` is PUBLISHED to crates.io, so its dependency tree reaches users directly
+  # and was the only shipped surface nothing watched: the npm ecosystem above cannot see a Cargo
+  # manifest, and CodeQL does not scan Rust at all. Its Cargo.lock is committed, so Dependabot
+  # resolves against the exact versions a consumer builds.
+  - package-ecosystem: cargo
+    directory: /packages/tauri
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # The Tauri smoke app. Not published, but it is compiled and RUN by the desktop battery, so a
+  # vulnerable dependency here still executes on a runner. Its Cargo.lock is gitignored, so
+  # Dependabot works from the manifest.
+  - package-ecosystem: cargo
+    directory: /apps/tauri-smoke/src-tauri
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+# Pinned here so the cache key and the install agree on one value.
+env:
+  CARGO_AUDIT_VERSION: 0.22.2
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -196,6 +200,62 @@ jobs:
       - name: Lint (macOS capture path, natively)
         working-directory: packages/tauri
         run: cargo clippy --all-targets -- -D warnings
+
+  # Advisory scan for the Rust tree. Nothing watched it: the npm ecosystem in dependabot.yml cannot
+  # read a Cargo manifest, CodeQL does not scan Rust at all, and the `rust` jobs above only ask
+  # whether the code compiles and lints — never whether anything it depends on is known-vulnerable.
+  # `reticle-tauri` is PUBLISHED, so that gap reached users.
+  #
+  # Its own job rather than a step on `rust`: that one installs WebKitGTK and cross-checks Windows,
+  # none of which an advisory scan needs, and a vulnerable dependency is a different answer from a
+  # broken build — worth reading off a separate line.
+  rust-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Set up Rust
+        run: |
+          rustup update stable --no-self-update
+          rustup default stable
+          rustc --version && cargo --version
+      # Cache the built binary, not just the registry — `cargo install` COMPILES cargo-audit, which
+      # is minutes on a cold runner and seconds on a warm one. Keyed on the pinned version so a bump
+      # below actually rebuilds instead of silently reusing the old binary.
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: |
+            ~/.cargo/bin/cargo-audit
+            ~/.cargo/registry
+          key: cargo-audit-${{ env.CARGO_AUDIT_VERSION }}
+      # Pinned and `--locked`: a tool installed to check the supply chain must not itself resolve a
+      # floating dependency tree on every run.
+      - name: Install cargo-audit
+        run: |
+          if ! command -v cargo-audit >/dev/null 2>&1; then
+            cargo install cargo-audit --locked --version "$CARGO_AUDIT_VERSION"
+          fi
+          cargo audit --version
+      # Default severity ON PURPOSE — a real VULNERABILITY fails this job, an informational
+      # advisory does not. `--deny warnings` was measured before being rejected: it fails today with
+      # 17 findings (16 `unmaintained`, 1 `unsound`), every one of them transitive through
+      # tauri/gtk/glib and none of them fixable here. A gate that is red on the day it merges, for a
+      # reason the person reading it cannot act on, gets muted — and then it is not a gate. Real
+      # vulnerabilities today: 0.
+      #
+      # The published crate is scanned against the COMMITTED lockfile, which is the exact set of
+      # versions a consumer of the crate builds.
+      - name: Audit reticle-tauri
+        working-directory: packages/tauri
+        run: cargo audit
+      # The smoke app is not published, but the desktop battery compiles and RUNS it, so a
+      # vulnerable dependency here still executes on a runner. Its lockfile is gitignored, so one is
+      # resolved for the scan and thrown away with the runner.
+      - name: Audit the Tauri smoke app
+        working-directory: apps/tauri-smoke/src-tauri
+        run: |
+          cargo generate-lockfile
+          cargo audit
 
   # Tier 2: ask reticle-fixtures to install this commit into real third-party apps.
   #
@@ -505,7 +565,18 @@ jobs:
     # red Rust build merged clean. Adding a job to the workflow is half the work; this line is the
     # other half.
     needs:
-      [verify, e2e, install-gate, matrix-records, windows, macos, rust, rust-macos, desktop-e2e]
+      [
+        verify,
+        e2e,
+        install-gate,
+        matrix-records,
+        windows,
+        macos,
+        rust,
+        rust-audit,
+        rust-macos,
+        desktop-e2e,
+      ]
     if: always()
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## What & why

Closes #137

`reticle-tauri` is **published to crates.io**, so its dependency tree reaches users directly — and nothing in this repo was watching it.

Every mechanism guarding the JS side is structurally blind to Rust:

| mechanism | covers Rust? |
|---|---|
| `dependabot.yml` (`npm`, `github-actions`) | no — cannot read a Cargo manifest |
| CodeQL | no — does not scan Rust |
| `rust` / `rust-macos` jobs | no — they ask "does it compile and lint", never "is a dependency vulnerable" |

Three mechanisms, one uncovered language, and it happens to be the one that ships a published artifact.

## What this does

**1. Dependabot gains a `cargo` ecosystem** for `/packages/tauri` and `/apps/tauri-smoke/src-tauri` — grouped minor+patch, same weekly Monday cadence as npm, so a routine week stays one PR. The published crate has a committed `Cargo.lock` so Dependabot resolves the exact versions a consumer builds; the smoke app's is gitignored, so it works from the manifest.

**2. A `rust-audit` job runs `cargo audit`** against both crates. Its own job rather than a step on `rust`: that one installs WebKitGTK and cross-checks the Windows target, none of which an advisory scan needs — and "a dependency is vulnerable" is a different answer from "the build is broken", worth reading off a separate line.

## Two decisions, both measured rather than assumed

**Default severity, not `--deny warnings`.** I tried `--deny warnings` first. It fails on this tree **today**:

```
error: 17 denied warnings found!     # 16 unmaintained, 1 unsound
```

Every one is transitive through `tauri` / `gtk` / `glib` — `proc-macro-error`, `unic-*`, `glib::VariantStrIter` unsoundness — and none is fixable here. A gate that is red the day it merges, for a reason the reader cannot act on, gets muted; a muted gate is not a gate. (#144 is the same lesson from the other direction.) Default severity fails on a real vulnerability and reports the rest.

**Real vulnerabilities today: 0.** So this merges green and only ever goes red for something actionable.

**`rust-audit` is listed in `gate`'s `needs`.** That file already says it better than I can:

> Adding a job to the workflow is half the work; this line is the other half.

A job missing from that list runs, reports, and is structurally incapable of stopping a merge.

**cargo-audit is pinned** (`0.22.2`, shared by the cache key and the install so a bump actually rebuilds instead of silently reusing the old binary) and installed with `--locked` — a tool that checks the supply chain should not resolve a floating dependency tree on every run. The built *binary* is cached, not just the registry, because `cargo install` compiles it (minutes cold, seconds warm).

## How it was verified

Run locally with cargo-audit 0.22.2:

```
packages/tauri            Scanning Cargo.lock for vulnerabilities (422 crate dependencies)
                          vulnerabilities: 0    warnings: {unmaintained: 16, unsound: 1}    exit 0

apps/tauri-smoke/src-tauri   cargo generate-lockfile && cargo audit
                          Scanning Cargo.lock for vulnerabilities (433 crate dependencies)
                          vulnerabilities: 0                                              exit 0

--deny warnings           error: 17 denied warnings found!                        exit non-zero
                          ^ the measurement behind the decision above
```

Both YAML files parse, and `gate.needs` now carries `rust-audit`:

```
jobs: [verify, windows, rust, rust-macos, rust-audit, fixtures-dispatch, changes,
       matrix-records, install-gate, e2e, desktop-e2e, gate]
gate needs: [verify, e2e, install-gate, matrix-records, windows, rust, rust-audit,
             rust-macos, desktop-e2e]
```

## Checklist

- [x] Tests added/updated — n/a for CI config; the verification above is the evidence, including the negative result that drove the severity choice
- [x] `pnpm lint && pnpm typecheck && pnpm test:unit` unaffected — this touches no package
- [x] No `any`, no free strings, no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 1000-line cap
- [x] Docs and `CHANGELOG.md` — not updated on purpose: CI-only, nothing user-facing ships
- [x] Security-affecting? It adds coverage and changes no runtime behaviour. Both new workflow steps run on the default read-only `permissions:` block; no secrets are read and no third-party action is introduced.