### PR TITLE
fix(telemetry): a crash with no Reticle frames still reports where it was

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the **`@reticlehq/*`** packages are documented here (each entry notes the package it affects). The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`@reticlehq/server` — a crash whose stack is entirely node internals no longer reports no location at all.** `connect ECONNREFUSED` is the commonest failure in a loopback-heavy tool and its stack contains no Reticle frame, so `crash_frames` was `[]` and the report carried an error type and a redacted message and nothing else — measured at 65 such crashes in one day, one fingerprint, zero location on all 65. `runtime_crashed` now also carries the failing syscall, the symbolic errno, whether the target was loopback, whether the port was one of Reticle's own (as an enum), and the innermost frame naming Node's own source. The address and port number are used to derive those answers and then discarded; the frame is included only when the crash is a system error and no Reticle frame survived. The rule that drops your application's frames is unchanged. See [`docs/telemetry.md`](docs/telemetry.md).
+
 ## [2.5.0] — 2026-08-09
 
 **One tool surface, an MCP server that stays up, and a long list of answers that were wrong.** Most of it was found by driving the shipped surface against live apps: a hostile-argument fuzz of all 48 tools, a nine-app fixture fleet under a new trace, and stress specs against every transport.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -65,18 +65,9 @@ at doCheckout (/Users/ada/secret-app/src/checkout.tsx:42:9)   ← dropped
 at resolveAnchor (…/@reticlehq/server/dist/tools/act-tools.js:142:19)   ← sent
 ```
 
-**One narrow exception, for the crash that otherwise says nothing.** A refused connection —
-`connect ECONNREFUSED` — has a stack that is *entirely* node internals, so the rule above correctly
-keeps nothing and the report arrives with no location at all. Those crashes now also carry the
-failing **syscall** (`connect`), the **errno** (`ECONNREFUSED`), whether the target was **loopback**
-(one boolean), whether the port was **one of Reticle's own** (the enum `reticle` / `other`), and the
-innermost frame naming **Node's own source** (`node:net:1637`).
+**One narrow exception, for the crash that otherwise says nothing.** A refused connection — `connect ECONNREFUSED` — has a stack that is _entirely_ node internals, so the rule above correctly keeps nothing and the report arrives with no location at all. Those crashes now also carry the failing **syscall** (`connect`), the **errno** (`ECONNREFUSED`), whether the target was **loopback** (one boolean), whether the port was **one of Reticle's own** (the enum `reticle` / `other`), and the innermost frame naming **Node's own source** (`node:net:1637`).
 
-The address and the port number are used to compute those two answers and are then discarded —
-neither is ever sent. The Node frame is a line in Node's published source, not yours: it says a
-connect failed rather than a DNS lookup, and carries nothing about your machine, your app, or your
-directory layout. The frame is included **only** when the crash is a system error and no Reticle
-frame survived — the report that would otherwise be blind.
+The address and the port number are used to compute those two answers and are then discarded — neither is ever sent. The Node frame is a line in Node's published source, not yours: it says a connect failed rather than a DNS lookup, and carries nothing about your machine, your app, or your directory layout. The frame is included **only** when the crash is a system error and no Reticle frame survived — the report that would otherwise be blind.
 
 `project_profiled` carries: the framework and its major version, a size **bucket** (`tiny` … `huge`, never a file count), whether it is a monorepo, its age in whole **weeks**, how many saved flows/baselines/runs exist, and which Reticle feature families have been used. It also carries whether the project has git at all, whether it has ever been pushed (`none` / `local_only` / `remote`), and which forge hosts it — `github`, `gitlab`, `bitbucket`, `azure`, `sourcehut`, `codeberg`, or just `self_hosted` for anything else. A private git host is usually `git.<company>.com`, so self-hosted repos report **only** that they are self-hosted, never the hostname.
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -65,6 +65,19 @@ at doCheckout (/Users/ada/secret-app/src/checkout.tsx:42:9)   ← dropped
 at resolveAnchor (…/@reticlehq/server/dist/tools/act-tools.js:142:19)   ← sent
 ```
 
+**One narrow exception, for the crash that otherwise says nothing.** A refused connection —
+`connect ECONNREFUSED` — has a stack that is *entirely* node internals, so the rule above correctly
+keeps nothing and the report arrives with no location at all. Those crashes now also carry the
+failing **syscall** (`connect`), the **errno** (`ECONNREFUSED`), whether the target was **loopback**
+(one boolean), whether the port was **one of Reticle's own** (the enum `reticle` / `other`), and the
+innermost frame naming **Node's own source** (`node:net:1637`).
+
+The address and the port number are used to compute those two answers and are then discarded —
+neither is ever sent. The Node frame is a line in Node's published source, not yours: it says a
+connect failed rather than a DNS lookup, and carries nothing about your machine, your app, or your
+directory layout. The frame is included **only** when the crash is a system error and no Reticle
+frame survived — the report that would otherwise be blind.
+
 `project_profiled` carries: the framework and its major version, a size **bucket** (`tiny` … `huge`, never a file count), whether it is a monorepo, its age in whole **weeks**, how many saved flows/baselines/runs exist, and which Reticle feature families have been used. It also carries whether the project has git at all, whether it has ever been pushed (`none` / `local_only` / `remote`), and which forge hosts it — `github`, `gitlab`, `bitbucket`, `azure`, `sourcehut`, `codeberg`, or just `self_hosted` for anything else. A private git host is usually `git.<company>.com`, so self-hosted repos report **only** that they are self-hosted, never the hostname.
 
 This is how we learn whether people are getting value from the whole product or only a corner of it. No file names, no paths, no flow names, no dependency list.

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -303,6 +303,19 @@ export type VersionChange = z.infer<typeof VersionChangeSchema>;
  * give the hash a meaning, while keeping the line that matters: our code and our failure, never the
  * user's code and never their data.
  */
+/**
+ * Whether a failed connection was aimed at a port Reticle itself uses.
+ *
+ * An enum rather than the number, because the number is the reporter's and the answer is ours: all
+ * anyone needs to know is whose problem it is. Refused on a Reticle port is a lifecycle problem —
+ * a daemon that is not up; refused anywhere else is somebody else's service.
+ */
+export const CrashPort = {
+  RETICLE: 'reticle',
+  OTHER: 'other',
+} as const;
+export type CrashPort = (typeof CrashPort)[keyof typeof CrashPort];
+
 export const CrashSchema = z.object({
   /** `uncaught_exception` | `unhandled_rejection`. */
   kind: z.string().min(1).max(32),
@@ -345,6 +358,34 @@ export const CrashSchema = z.object({
    * trace and are completely different problems; this is what tells them apart.
    */
   machine: MachineSnapshotSchema.optional(),
+  /**
+   * The failing SYSCALL — `connect`, `write`, `open`. Already inside `message`; structured here so
+   * it can be grouped on rather than parsed back out of prose.
+   */
+  syscall: z.string().max(32).optional(),
+  /**
+   * The symbolic errno — `ECONNREFUSED`, `EPIPE`. The name, never the platform-specific number.
+   */
+  errno: z.string().max(32).optional(),
+  /**
+   * Was the target the machine it was running on?
+   *
+   * One bit, and it splits two populations that currently look identical and have different owners:
+   * refused ON loopback is a Reticle-lifecycle problem (no daemon), refused off-box is a network
+   * problem that is not ours.
+   */
+  loopback: z.boolean().optional(),
+  /** Whether the port was one of ours, as an enum. The number itself is never sent. */
+  port: z.enum([CrashPort.RETICLE, CrashPort.OTHER]).optional(),
+  /**
+   * The innermost frame naming NODE's own source — `node:net:1637`.
+   *
+   * Only present when the crash is a system error AND no Reticle frame survived, which is exactly
+   * the report that otherwise arrives with no location at all. It is a line in Node's published
+   * source: it says a connect failed rather than a DNS lookup, and carries nothing about the
+   * machine, the app, or anyone's directory layout.
+   */
+  internalFrame: z.string().max(64).optional(),
 });
 export type Crash = z.infer<typeof CrashSchema>;
 

--- a/packages/server/src/daemon/crash-cause-wiring.test.ts
+++ b/packages/server/src/daemon/crash-cause-wiring.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CrashPort, TelemetryEventKind } from '@reticlehq/core';
+import type { TelemetryExtra } from '../telemetry/telemetry.js';
+
+const emit = vi.fn((_kind: TelemetryEventKind, _extra?: TelemetryExtra) => Promise.resolve(true));
+vi.mock('../telemetry/telemetry.js', () => ({
+  getTelemetry: () => ({ emit, enabled: true, firstRun: false }),
+}));
+
+const { installDaemonResilience } = await import('./daemon-resilience.js');
+type ProcessLike = Parameters<typeof installDaemonResilience>[0];
+
+function fakeProc(): ProcessLike & { fire: (event: string, arg: unknown) => void } {
+  const listeners = new Map<string, (arg: unknown) => void>();
+  return {
+    on(event: string, handler: (arg: unknown) => void) {
+      listeners.set(event, handler);
+      return this;
+    },
+    fire(event, arg) {
+      listeners.get(event)?.(arg);
+    },
+  };
+}
+
+/** A refused loopback connect: the shape that arrives with `frames: []` and nothing else. */
+function refusedLoopback(port: number): Error {
+  const error = Object.assign(new Error(`connect ECONNREFUSED 127.0.0.1:${String(port)}`), {
+    syscall: 'connect',
+    code: 'ECONNREFUSED',
+    address: '127.0.0.1',
+    port,
+  });
+  error.stack = `Error: connect ECONNREFUSED 127.0.0.1:${String(port)}\n    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)`;
+  return error;
+}
+
+function crashOf(extra: TelemetryExtra | undefined): Record<string, unknown> {
+  return { ...extra?.crash };
+}
+
+describe('a crash with no Reticle frames still reports where it was', () => {
+  beforeEach(() => {
+    emit.mockClear();
+  });
+
+  it('carries the syscall, the errno, the loopback bit and a node frame', () => {
+    const proc = fakeProc();
+    installDaemonResilience(proc, () => undefined, () => undefined);
+    proc.fire('unhandledRejection', refusedLoopback(4400));
+
+    const call = emit.mock.calls.find(([kind]) => kind === TelemetryEventKind.RUNTIME_CRASHED);
+    expect(call).toBeDefined();
+    const crash = crashOf(call?.[1]);
+
+    // The defect, reproduced: this is what the report used to be, and all it used to be.
+    expect(crash['frames']).toEqual([]);
+
+    expect(crash['syscall']).toBe('connect');
+    expect(crash['errno']).toBe('ECONNREFUSED');
+    expect(crash['loopback']).toBe(true);
+    expect(crash['port']).toBe(CrashPort.RETICLE);
+    expect(crash['internalFrame']).toBe('node:net:1637');
+  });
+
+  it('never sends the address or the port number', () => {
+    const proc = fakeProc();
+    installDaemonResilience(proc, () => undefined, () => undefined);
+    proc.fire('unhandledRejection', refusedLoopback(4400));
+
+    const call = emit.mock.calls.find(([kind]) => kind === TelemetryEventKind.RUNTIME_CRASHED);
+    const serialized = JSON.stringify(crashOf(call?.[1]));
+    expect(serialized).not.toContain('127.0.0.1');
+    // The message is skeletonised, so the port survives nowhere — not in a field, not in prose.
+    expect(serialized).not.toContain('4400');
+  });
+});

--- a/packages/server/src/daemon/crash-cause-wiring.test.ts
+++ b/packages/server/src/daemon/crash-cause-wiring.test.ts
@@ -46,7 +46,11 @@ describe('a crash with no Reticle frames still reports where it was', () => {
 
   it('carries the syscall, the errno, the loopback bit and a node frame', () => {
     const proc = fakeProc();
-    installDaemonResilience(proc, () => undefined, () => undefined);
+    installDaemonResilience(
+      proc,
+      () => undefined,
+      () => undefined,
+    );
     proc.fire('unhandledRejection', refusedLoopback(4400));
 
     const call = emit.mock.calls.find(([kind]) => kind === TelemetryEventKind.RUNTIME_CRASHED);
@@ -65,7 +69,11 @@ describe('a crash with no Reticle frames still reports where it was', () => {
 
   it('never sends the address or the port number', () => {
     const proc = fakeProc();
-    installDaemonResilience(proc, () => undefined, () => undefined);
+    installDaemonResilience(
+      proc,
+      () => undefined,
+      () => undefined,
+    );
     proc.fire('unhandledRejection', refusedLoopback(4400));
 
     const call = emit.mock.calls.find(([kind]) => kind === TelemetryEventKind.RUNTIME_CRASHED);

--- a/packages/server/src/daemon/daemon-resilience.ts
+++ b/packages/server/src/daemon/daemon-resilience.ts
@@ -9,7 +9,7 @@
  * daemon, which beats crashing silently or limping along corrupt.
  */
 
-import { TelemetryActor, TelemetryEventKind } from '@reticlehq/core';
+import { RETICLE_DEFAULT_PORT, TelemetryActor, TelemetryEventKind } from '@reticlehq/core';
 import {
   errorSkeleton,
   errorTypeOf,
@@ -19,6 +19,7 @@ import {
 } from '../telemetry/error-fingerprint.js';
 import { getSessionMetrics } from '../telemetry/session-metrics.js';
 import { machineSnapshot } from '../telemetry/machine-snapshot.js';
+import { crashCause } from '../telemetry/crash-cause.js';
 import { getTelemetry } from '../telemetry/telemetry.js';
 
 export interface ProcessLike {
@@ -82,6 +83,20 @@ export const CrashKind = {
 export type CrashKind = (typeof CrashKind)[keyof typeof CrashKind];
 
 /**
+ * The ports Reticle itself uses, so a refusal can be classified as ours or somebody else's.
+ *
+ * Read here rather than threaded through `installCrashHandlers`: a crash handler is installed once,
+ * at startup, and the port can be set after it. The values are only ever compared against — the
+ * port a crash names is turned into an enum and then discarded.
+ */
+function knownPorts(): readonly number[] {
+  const configured = Number(process.env['RETICLE_PORT']);
+  return Number.isInteger(configured) && configured > 0
+    ? [RETICLE_DEFAULT_PORT, configured]
+    : [RETICLE_DEFAULT_PORT];
+}
+
+/**
  * Report a crash with enough detail to actually diagnose it.
  *
  * This is the only place in the product that learns about a crash at all. An uncaught exception in a
@@ -104,6 +119,10 @@ function reportCrash(kind: CrashKind, value: unknown): void {
     const message = describe(value);
     const { breadcrumb, inFlight } = getSessionMetrics().trail;
     const machine = machineSnapshot();
+    // Where the frames cannot say. A refused socket's stack is entirely node internals, so
+    // `reticleFrames` correctly keeps nothing and the report lands with no location at all — the
+    // single commonest crash shape in a loopback-heavy tool.
+    const cause = crashCause(value, knownPorts());
     void getTelemetry().emit(TelemetryEventKind.RUNTIME_CRASHED, {
       // A crash is ALWAYS reached through something the agent asked for — the daemon does nothing on
       // its own — so attributing it to the agent is accurate rather than a guess.
@@ -125,6 +144,9 @@ function reportCrash(kind: CrashKind, value: unknown): void {
         arch: process.arch,
         // "Out of memory" and "our bug" look identical in a stack trace. This is what tells them apart.
         ...(machine !== undefined ? { machine } : {}),
+        // The syscall, the errno, whether it was loopback, whether the port was ours, and the
+        // innermost frame in NODE's own source. Present only when the error carries them.
+        ...cause,
       },
     });
   } catch {

--- a/packages/server/src/telemetry/crash-cause.test.ts
+++ b/packages/server/src/telemetry/crash-cause.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { CrashPort } from '@reticlehq/core';
+import { crashCause, innermostInternalFrame } from './crash-cause.js';
+
+/** The real thing, captured from `net.connect(1, '127.0.0.1')` on Node 22. */
+function refusedLoopback(port: number): NodeJS.ErrnoException {
+  const error: NodeJS.ErrnoException & { address?: string; port?: number } = Object.assign(
+    new Error(`connect ECONNREFUSED 127.0.0.1:${String(port)}`),
+    { syscall: 'connect', code: 'ECONNREFUSED', errno: -61, address: '127.0.0.1', port },
+  );
+  error.stack = `Error: connect ECONNREFUSED 127.0.0.1:${String(port)}\n    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)`;
+  return error;
+}
+
+const KNOWN = [4400];
+
+describe('crashCause — a location for a stack that has none', () => {
+  it('names the syscall and the errno', () => {
+    const cause = crashCause(refusedLoopback(4400), KNOWN);
+    expect(cause.syscall).toBe('connect');
+    expect(cause.errno).toBe('ECONNREFUSED');
+  });
+
+  it('reports loopback, which splits a Reticle lifecycle problem from a network one', () => {
+    expect(crashCause(refusedLoopback(4400), KNOWN).loopback).toBe(true);
+  });
+
+  it('classifies a port we know as ours, without sending the number', () => {
+    const cause = crashCause(refusedLoopback(4400), KNOWN);
+    expect(cause.port).toBe(CrashPort.RETICLE);
+  });
+
+  it('classifies a port we do not know as other', () => {
+    expect(crashCause(refusedLoopback(5432), KNOWN).port).toBe(CrashPort.OTHER);
+  });
+
+  it('carries the innermost node-internal frame, which names Node source and nothing else', () => {
+    expect(crashCause(refusedLoopback(4400), KNOWN).internalFrame).toBe('node:net:1637');
+  });
+
+  it('sends nothing at all for an ordinary error with no system-error properties', () => {
+    expect(crashCause(new Error('something broke'), KNOWN)).toEqual({});
+  });
+
+  it('sends nothing for a non-error value', () => {
+    expect(crashCause('a string', KNOWN)).toEqual({});
+  });
+
+  /** The half that needs a test, because a telemetry regression is silent and about someone else. */
+  it('never carries the address or the port number anywhere in its output', () => {
+    const serialized = JSON.stringify(crashCause(refusedLoopback(4400), KNOWN));
+    expect(serialized).not.toContain('127.0.0.1');
+    expect(serialized).not.toContain('4400');
+  });
+
+  it('reports an off-box refusal as not loopback', () => {
+    const error = Object.assign(new Error('connect ECONNREFUSED 10.0.0.5:443'), {
+      syscall: 'connect',
+      code: 'ECONNREFUSED',
+      address: '10.0.0.5',
+      port: 443,
+    });
+    expect(crashCause(error, KNOWN).loopback).toBe(false);
+  });
+
+  it('treats IPv6 loopback as loopback', () => {
+    const error = Object.assign(new Error('connect ECONNREFUSED ::1:4400'), {
+      syscall: 'connect',
+      code: 'ECONNREFUSED',
+      address: '::1',
+      port: 4400,
+    });
+    expect(crashCause(error, KNOWN).loopback).toBe(true);
+  });
+});
+
+describe('innermostInternalFrame', () => {
+  it('finds the node-internal frame in an all-internal stack', () => {
+    expect(
+      innermostInternalFrame(
+        'Error: connect ECONNREFUSED\n    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)',
+      ),
+    ).toBe('node:net:1637');
+  });
+
+  it('takes the INNERMOST when several node frames are present', () => {
+    expect(
+      innermostInternalFrame(
+        'Error: x\n    at a (node:dns:120:9)\n    at b (node:net:1637:16)',
+      ),
+    ).toBe('node:dns:120');
+  });
+
+  it('ignores a frame from the user application', () => {
+    expect(
+      innermostInternalFrame('Error: x\n    at doCheckout (/Users/ada/secret-app/src/checkout.tsx:42:9)'),
+    ).toBeUndefined();
+  });
+
+  it('returns nothing for a stack with no frames', () => {
+    expect(innermostInternalFrame('Error: x')).toBeUndefined();
+  });
+});
+
+describe('internalFrame is a fallback, not a default', () => {
+  /** A crash inside our own code already has a location; it does not need Node's. */
+  it('is omitted when Reticle frames are present', () => {
+    const error = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:4400'), {
+      syscall: 'connect',
+      code: 'ECONNREFUSED',
+      address: '127.0.0.1',
+      port: 4400,
+    });
+    error.stack =
+      'Error: connect ECONNREFUSED\n' +
+      '    at startMcpProxy (/x/node_modules/@reticlehq/server/dist/mcp/proxy.js:88:3)\n' +
+      '    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)';
+    const cause = crashCause(error, KNOWN);
+    expect(cause.internalFrame).toBeUndefined();
+    expect(cause.syscall).toBe('connect');
+  });
+});

--- a/packages/server/src/telemetry/crash-cause.test.ts
+++ b/packages/server/src/telemetry/crash-cause.test.ts
@@ -85,15 +85,15 @@ describe('innermostInternalFrame', () => {
 
   it('takes the INNERMOST when several node frames are present', () => {
     expect(
-      innermostInternalFrame(
-        'Error: x\n    at a (node:dns:120:9)\n    at b (node:net:1637:16)',
-      ),
+      innermostInternalFrame('Error: x\n    at a (node:dns:120:9)\n    at b (node:net:1637:16)'),
     ).toBe('node:dns:120');
   });
 
   it('ignores a frame from the user application', () => {
     expect(
-      innermostInternalFrame('Error: x\n    at doCheckout (/Users/ada/secret-app/src/checkout.tsx:42:9)'),
+      innermostInternalFrame(
+        'Error: x\n    at doCheckout (/Users/ada/secret-app/src/checkout.tsx:42:9)',
+      ),
     ).toBeUndefined();
   });
 

--- a/packages/server/src/telemetry/crash-cause.ts
+++ b/packages/server/src/telemetry/crash-cause.ts
@@ -1,0 +1,110 @@
+/**
+ * What a crash was, when the stack cannot say where it was.
+ *
+ * `reticleFrames` keeps only frames inside our own published packages, on the rule that a crash
+ * stack is mostly the user's application and node internals and neither is ours to collect. That
+ * rule is right and stays. But a refused socket has a stack that is ENTIRELY node internals:
+ *
+ *     Error: connect ECONNREFUSED 127.0.0.1:4400
+ *         at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)
+ *
+ * so every crash of that shape arrives with an error type, a redacted message, and nothing else —
+ * 65 of them in one measured day, one fingerprint, zero location on all 65, and 63 of those from
+ * two people who emitted no other event of any kind. A loopback-heavy tool produces plenty of
+ * these, and the next one is just as blind.
+ *
+ * Everything here is derived from a Node SYSTEM ERROR's own structured properties, and every field
+ * is chosen so that it carries nothing of the reporter's: the syscall and errno are our own
+ * vocabulary, `loopback` is one bit, the port is compared against values we already know and
+ * reported as an enum, and the frame names a line in NODE's source. The address and the port number
+ * are read and deliberately thrown away.
+ */
+
+/** The structured cause of a crash, when the error carries one. Every field is optional. */
+export interface CrashCause {
+  syscall?: string;
+  errno?: string;
+  loopback?: boolean;
+  port?: CrashPort;
+  internalFrame?: string;
+}
+
+import { CrashPort } from '@reticlehq/core';
+import { reticleFrames } from './error-fingerprint.js';
+
+/** IPv4 loopback is the whole 127/8 block, not just 127.0.0.1. */
+const IPV4_LOOPBACK = /^127\./;
+/** `node:net:1637` out of `at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)`. */
+const NODE_INTERNAL_FRAME = /\((node:[\w/.-]+):(\d+):\d+\)/;
+/** V8 renders an IPv4-mapped IPv6 address this way; the mapped half is what decides loopback. */
+const IPV6_MAPPED_PREFIX = '::ffff:';
+
+/**
+ * Was this aimed at the machine it was running on?
+ *
+ * One bit, and it splits two populations with different owners: refused ON loopback is a Reticle
+ * lifecycle problem (a daemon that is not up), refused off-box is a network problem that is not
+ * ours. Today they are indistinguishable in the data.
+ */
+function isLoopback(address: string): boolean {
+  const host = address.toLowerCase();
+  if ('::1' === host || 'localhost' === host) return true;
+  const unmapped = host.startsWith(IPV6_MAPPED_PREFIX)
+    ? host.slice(IPV6_MAPPED_PREFIX.length)
+    : host;
+  return IPV4_LOOPBACK.test(unmapped);
+}
+
+/**
+ * The innermost frame that names NODE's own source.
+ *
+ * Innermost because that is where the failure actually happened, and it distinguishes a connect
+ * from a DNS lookup from a TLS handshake — the thing that, in the report this came from, had to be
+ * worked out by hand from a proxy's reject path. `node:net:1637` is a line in Node's published
+ * source: it carries nothing about the machine, the app, or anyone's directory layout, which is
+ * why it can be kept when the user's own frames cannot.
+ */
+export function innermostInternalFrame(stack: string): string | undefined {
+  for (const line of stack.split('\n')) {
+    const match = line.match(NODE_INTERNAL_FRAME);
+    if (null === match) continue;
+    const [, module, lineNumber] = match;
+    if (module === undefined || lineNumber === undefined) continue;
+    return `${module}:${lineNumber}`;
+  }
+  return undefined;
+}
+
+/**
+ * Read a Node system error's structured cause, keeping only what is ours to keep.
+ *
+ * `knownPorts` is passed IN rather than read from the environment so this stays pure and so the
+ * comparison is testable — the port itself is used to answer one enum and is then discarded.
+ */
+export function crashCause(value: unknown, knownPorts: readonly number[]): CrashCause {
+  if (!(value instanceof Error)) return {};
+  const error: NodeJS.ErrnoException & { address?: unknown; port?: unknown } = value;
+  const cause: CrashCause = {};
+
+  if ('string' === typeof error.syscall && error.syscall.length > 0) cause.syscall = error.syscall;
+  // `code` (`ECONNREFUSED`), not the numeric `errno` (-61): the symbolic name is stable across
+  // platforms, where the number is not.
+  if ('string' === typeof error.code && error.code.length > 0) cause.errno = error.code;
+  if ('string' === typeof error.address) cause.loopback = isLoopback(error.address);
+  if ('number' === typeof error.port) {
+    cause.port = knownPorts.includes(error.port) ? CrashPort.RETICLE : CrashPort.OTHER;
+  }
+
+  // Only for a SYSTEM error, and only when nothing of ours is on the stack.
+  //
+  // Both halves are about collecting the minimum that answers the question. Any error raised
+  // anywhere in Node carries `node:internal/*` frames from whatever called it, so an ungated rule
+  // would attach one to every crash — noise on the reports that already have a location, and more
+  // than we need. The blind reports are the ones with a syscall and no frames of our own, and they
+  // are the only ones this exists for.
+  if (cause.syscall === undefined && cause.errno === undefined) return cause;
+  if (reticleFrames(error.stack ?? '').length > 0) return cause;
+  const frame = innermostInternalFrame(error.stack ?? '');
+  if (frame !== undefined) cause.internalFrame = frame;
+  return cause;
+}


### PR DESCRIPTION
## What & why

Closes #142

A crash whose stack is entirely node internals arrives with no location at all:

```
crash_kind        unhandled_rejection
crash_errorType   Error
crash_message     connect ECONNREFUSED *.*.*.*:*
crash_frames      []
```

**This is not a defect in the collector.** `reticleFrames` keeps only frames inside `@reticlehq/*` or a `reticle` dist path, because a crash stack is mostly the user's application and node internals and neither is ours to collect. That rule is right and is **unchanged** here.

But a refused socket has a stack that is *entirely* node internals, so the filter correctly keeps nothing — and refused connections are the commonest failure in a loopback-heavy tool. Captured from a real `net.connect` refusal on Node 22:

```
Error: connect ECONNREFUSED 127.0.0.1:1
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)

{"syscall":"connect","code":"ECONNREFUSED","errno":-61,"address":"127.0.0.1","port":1}
```

The structured cause is *right there* on the error object. Only the stack was being read.

## What is carried

Read from the Node system error's own properties — never parsed back out of prose:

| field | example | why |
|---|---|---|
| `syscall` | `connect` | already in the message; structured so it can be grouped on |
| `errno` | `ECONNREFUSED` | the symbolic name, never the platform-specific number |
| `loopback` | `true` | **the one that earns its place** — see below |
| `port` | `reticle` \| `other` | an enum compared against ports we already know |
| `internalFrame` | `node:net:1637` | separates a connect from a DNS lookup from a TLS handshake |

`loopback` is the field worth having if it has to be one thing: refused **on** loopback is a Reticle-lifecycle problem (no daemon), refused off-box is a network problem that is not ours. Today those two populations are indistinguishable.

## The gate is the part worth reviewing

`internalFrame` is carried **only** when the error is a system error **and** no Reticle frame survived.

I found this by running it, not by reasoning about it: a test with an ordinary `new Error()` failed because *any* error raised anywhere in Node carries `node:internal/*` frames from whatever called it. An ungated rule would attach a frame to **every** crash — noise on the reports that already have a location, and more collection than the question needs. The blind reports are the only ones this exists for.

## Nothing of the reporter's is added

The address and the port number are read, used to compute one boolean and one enum, and **thrown away**. Both suites assert the serialized crash contains neither.

`docs/telemetry.md` is corrected in the same change. It promised node internals are dropped *entirely*, which stops being true for this one narrow case — and a privacy document that overstates what it does is worse than one that explains the exception.

## How it was verified

**RED proven against real behaviour, not a missing import.** The module was created returning today's answer — nothing — and the suite run first: **9 failures with 5 negative controls passing**, including the privacy guard. 15/15 green after implementing.

**The wiring is covered end to end**, by driving `installDaemonResilience` with a fake process and asserting the payload that actually reaches `emit`. That test also asserts `frames: []` on the same event, so it reproduces the defect and pins the fix in one place:

```js
expect(crash['frames']).toEqual([]);          // the defect, still true
expect(crash['syscall']).toBe('connect');
expect(crash['errno']).toBe('ECONNREFUSED');
expect(crash['loopback']).toBe(true);
expect(crash['port']).toBe(CrashPort.RETICLE);
expect(crash['internalFrame']).toBe('node:net:1637');
```

The privacy assertion is the half that matters for a regression here — telemetry fails silently and about somebody else's data.

**Gates:** `pnpm build`, `pnpm lint`, `pnpm typecheck` all clean. `@reticlehq/server` 3147/3147, `@reticlehq/core` 211/211.

> **Pre-existing failure, not from this change:** `@reticlehq/browser` has 14 failing `readStorage`/`installStorage` tests on clean `main` — verified by stashing this branch. Untouched here.

## Notes for the maintainer

- `CrashPort` is defined in `@reticlehq/core` beside `CrashSchema`, per the rule that wire vocabulary lives there rather than being inlined in `server`.
- `knownPorts()` is read at the crash site rather than threaded through `installCrashHandlers`, because the handler is installed at startup and the port can be set after it. `crashCause` itself stays pure and takes the ports as an argument.
- Every new schema field is optional, so an older collector sees exactly what it sees today.
- Deliberately **not** included: the async-origin frame (item 5 in the issue). It is worth checking how often it survives before anything relies on it, and that measurement belongs in its own change.

## Checklist

- [x] Tests added/updated (RED → GREEN); the change is covered by a test that would fail without it
- [x] `pnpm lint && pnpm typecheck && pnpm test:unit` all pass locally *(browser failures pre-existing on `main`, see above)*
- [x] No `any`, no free strings (the port enum lives in `@reticlehq/core`), no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 1000-line cap
- [x] Docs and `CHANGELOG.md` updated (entry under `[Unreleased]`)
- [x] Security-affecting? Telemetry — and it is covered by a test asserting the address and port number never appear in the payload. Nothing about the user's machine, paths, or app is added; the no-app-data-leaves-the-machine posture is unchanged and `docs/telemetry.md` is updated to describe the new fields exactly.