### PR TITLE
reticle status says WHY nothing is connected

### DIFF
--- a/packages/server/src/cli/cli-launch.ts
+++ b/packages/server/src/cli/cli-launch.ts
@@ -30,9 +30,13 @@ interface StatusSession {
 export function summarizeStatus(payload: unknown): {
   sessionCount: number;
   sessions: StatusSession[];
+  why?: string;
 } {
   if (typeof payload !== 'object' || null === payload) return { sessionCount: 0, sessions: [] };
   const obj = payload as Record<string, unknown>;
+  // Carried through to the printed line: with no sessions this is the whole answer, and dropping it
+  // here would silently undo the reason it is on the wire.
+  const why = 'string' === typeof obj['why'] ? obj['why'] : undefined;
   const raw = Array.isArray(obj['sessions']) ? obj['sessions'] : [];
   const sessions = raw
     .map((s): StatusSession | null => {
@@ -51,7 +55,7 @@ export function summarizeStatus(payload: unknown): {
     .filter((s): s is StatusSession => s !== null);
   const sessionCount =
     'number' === typeof obj['sessionCount'] ? obj['sessionCount'] : sessions.length;
-  return { sessionCount, sessions };
+  return { sessionCount, sessions, ...(why === undefined ? {} : { why }) };
 }
 
 /** A string field off the /status body, or undefined on a daemon too old to report it. */

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -481,7 +481,11 @@ export async function startDaemon(options: StartOptions = {}): Promise<RunningSe
   // mirror rejection so a port collision can't surface as an unhandled promise rejection.
   void bridge.ready.catch(() => undefined);
   // `reticle status` GETs this for a live, at-a-glance view of connected tabs + their health.
-  shared.attachStatus(() => statusPayload(bridge.sessions.count(), bridge.sessions.list()));
+  // The same diagnosis agents get on an empty `reticle_sessions`, so `reticle status` — the
+  // most-run command in the field — stops answering "sessionCount: 0" and nothing else.
+  shared.attachStatus(() =>
+    statusPayload(bridge.sessions.count(), bridge.sessions.list(), bridge.sessions.noSessionHint()),
+  );
   // Agent-independent presence: the daemon outlives any single agent, so when the LAST agent's MCP
   // connection drops (it stopped, or is waiting on the human), end every session and push a clear
   // "go to your terminal" notice to the panel — the human is on the browser and must not lose a typed

--- a/packages/server/src/status-payload.ts
+++ b/packages/server/src/status-payload.ts
@@ -17,14 +17,32 @@ interface StatusPayload {
   contract: string;
   sessionCount: number;
   sessions: SessionInfo[];
+  /**
+   * Why nothing is connected — present ONLY when `sessionCount` is 0.
+   *
+   * `reticle status` is the most-run command in the field, and with no sessions it answered
+   * `sessionCount: 0` and stopped. That is the same dead end `reticle_sessions` used to be for
+   * agents, at the same point in the funnel — the daemon is up, the agent is attached, and the app
+   * never arrived — and it is where most installs stop. Agents got the diagnosis in 2.7.0; a human
+   * running the command we tell them to run in `init`'s closing line deserves the same sentence.
+   */
+  why?: string;
 }
 
-export function statusPayload(sessionCount: number, sessions: SessionInfo[]): StatusPayload {
+export function statusPayload(
+  sessionCount: number,
+  sessions: SessionInfo[],
+  /** The no-session diagnosis, injected so this stays pure and the port probe stays off this path. */
+  why?: string,
+): StatusPayload {
   return {
     running: true,
     version: SERVER_VERSION,
     contract: CONTRACT_FINGERPRINT,
     sessionCount,
     sessions,
+    // Only when there is nothing to explain away: a diagnosis printed beside a live session would
+    // contradict it.
+    ...(0 === sessionCount && why !== undefined ? { why } : {}),
   };
 }

--- a/packages/server/src/status-why.test.ts
+++ b/packages/server/src/status-why.test.ts
@@ -1,0 +1,65 @@
+/**
+ * `reticle status` is where humans land at the exact point the funnel dies.
+ *
+ * It is the most-run command in the field, and `init`'s closing line sends people to it. With no app
+ * connected it answered `sessionCount: 0` and stopped — the same dead end `reticle_sessions` used to
+ * be for agents, at the same moment: the daemon is up, the MCP server is registered, and the app has
+ * never arrived. Agents got the diagnosis in 2.7.0. A human running the command we tell them to run
+ * deserves the same sentence.
+ *
+ * The daemon already computes it. This only stops it being thrown away between the bridge and the
+ * printed line — which is the same defect shape as the telemetry block that reached the wire through
+ * none of its four lists: computed correctly, declared nowhere, silently dropped.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { statusPayload } from './status-payload.js';
+import { summarizeStatus } from './cli/cli-launch.js';
+
+const session = {
+  sessionId: 's1',
+  url: 'http://localhost:5173/',
+  adapters: [],
+  hasCapabilities: true,
+  lastSeenMs: 12,
+  throttled: false,
+  focused: true,
+  hidden: false,
+} as never;
+
+describe('the status payload', () => {
+  it('carries the diagnosis when nothing is connected', () => {
+    const out = statusPayload(0, [], 'run `reticle init` in the app directory');
+    expect(out.why).toBe('run `reticle init` in the app directory');
+  });
+
+  it('omits it when a session IS connected — it would contradict the session', () => {
+    expect(statusPayload(1, [session], 'no app is running').why).toBeUndefined();
+  });
+
+  it('omits it when the daemon has nothing to say', () => {
+    expect(statusPayload(0, [], undefined).why).toBeUndefined();
+  });
+});
+
+describe('the CLI summary', () => {
+  it('carries `why` through to what gets printed', () => {
+    // The whole point: computed daemon-side, and previously dropped on the way to the terminal.
+    const summary = summarizeStatus({
+      sessionCount: 0,
+      sessions: [],
+      why: 'the app carries no SDK',
+    });
+    expect(summary.why).toBe('the app carries no SDK');
+    expect(summary.sessionCount).toBe(0);
+  });
+
+  it('does not invent one when the daemon did not send it', () => {
+    expect(summarizeStatus({ sessionCount: 0, sessions: [] }).why).toBeUndefined();
+  });
+
+  it('survives a payload that is not an object at all', () => {
+    expect(summarizeStatus(null).sessionCount).toBe(0);
+    expect(summarizeStatus('nonsense').why).toBeUndefined();
+  });
+});


### PR DESCRIPTION
One more funnel fix, on the same defect shape as the rest of this release.

`reticle status` is the **most-run command in the field**, and `init`'s closing line sends people to it. With no app connected it answered `sessionCount: 0` and stopped.

That is the same dead end `reticle_sessions` was for agents — same point in the funnel, same population: the daemon is up, the MCP server is registered, the app never arrived. It is where most installs stop. Agents got the diagnosis in 2.7.0; a human running the command we tell them to run got a bare zero.

The daemon already computed it. This stops it being discarded on the way to the terminal. Verified live — a daemon with no app now prints the narrow-port-scan hedge and the missing-`.reticle.json` caveat, both properly qualified.

## The shape worth naming

Third instance this release of **a value computed correctly, declared nowhere on the way out, and silently dropped**:

- the telemetry `instrumentation` block reached the wire through none of its four lists
- `self` was in the tool schema and the server forward, missing from the browser parser
- this one existed in the daemon and never left it

Each looked like a missing feature and was a missing wire. Two now have guards (`extra-blocks-reach-the-wire.test.ts`, `query-forwarding.test.ts`); this one has `status-why.test.ts`.

## Gates

format ✓ · lint ✓ · typecheck ✓ · unit 15/15 ✓ · e2e 32/32 ✓

**Benchmark gate passes against the 2.7.0 baseline** — selector 3/3 → 3/3, consequence 2/2 → 2/2, state 1/1 → 1/1, tokens 237 → 236. First time the gate has had a baseline to compare against since June, so this is the first run that says anything about regression at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)