### PR TITLE
The money false green could not fire on act_and_wait

### DIFF
--- a/packages/server/src/tools/act-tools.ts
+++ b/packages/server/src/tools/act-tools.ts
@@ -542,8 +542,20 @@ export const ACT_TOOLS: ToolDef[] = [
         // Pass the action: an EMPTY window then reads as "the target does not react" rather than as a
         // clean run — `settled` is satisfied by a page that did nothing, i.e. by a click that missed.
         const acted = asString(args['action']);
+        // `prior` matters here for the same reason it matters on the assert path: a SCALE error
+        // disagrees with a value the API stated EARLIER in the session, which an action-scoped
+        // window can never contain. Without it `unit-mismatch` — the money false green, where a
+        // total renders 100x off — is structurally unreachable from `act_and_wait`, which is the
+        // tool the product tells agents to reach for first. Our best detector could not fire on our
+        // flagship path, and nothing said so: the finding was simply never produced.
+        //
+        // Learning material only. Attribution is unchanged — findings still come exclusively from
+        // `windowEvents`, exactly as on the assert path.
+        const prior =
+          since > 0 ? (await session.queryEvents({ since: 0 })).filter((e) => e.t < since) : [];
         const contradictions = findContradictions(windowEvents, {
           action: acted,
+          prior,
           ...session.lastAct.effect(),
         });
         // The single field an agent reads. Everything below it is the evidence it was derived from;

--- a/packages/server/src/tools/act-verdict-parity.test.ts
+++ b/packages/server/src/tools/act-verdict-parity.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Both verdict paths must look at the same evidence for the same question.
+ *
+ * `reticle_act_and_wait` is the tool the product tells agents to reach for first — it is named in
+ * the MCP handshake, in SKILL.md, and in the cheatsheet. `reticle_assert` is the other one. They
+ * answer the same question and they were not reading the same inputs: `assert` passed `prior` to
+ * the contradiction engine and `act_and_wait` did not.
+ *
+ * `prior` is what makes `unit-mismatch` possible — the money false green, where a total renders 100x
+ * off because a value in minor units is displayed as major. A scale error disagrees with a value the
+ * API stated EARLIER in the session, so an action-scoped window can never contain both halves. No
+ * `prior`, no comparison, no finding.
+ *
+ * So the flagship detector could not fire on the flagship path, and nothing anywhere said so: the
+ * finding was not suppressed or downgraded, it was simply never produced. That is the same shape as
+ * the three wiring defects already fixed this release — a capability that exists, is tested, and
+ * never reaches the caller.
+ *
+ * This pins the property rather than the plumbing: whatever the two paths pass, they must agree on
+ * the inputs that decide which contradiction kinds are REACHABLE.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const src = (file: string): string => readFileSync(join(import.meta.dirname, file), 'utf8');
+
+describe('act_and_wait and assert see the same evidence', () => {
+  const act = src('act-tools.ts');
+  const assert = src('assert-verdict.ts');
+
+  it('both paths pass `prior` to the contradiction engine', () => {
+    // Without this on the act path, `unit-mismatch` cannot fire there at all.
+    expect(act).toMatch(/findContradictions\([\s\S]{0,200}prior/);
+    expect(assert).toMatch(/findContradictions\([\s\S]{0,120}prior/);
+  });
+
+  it('both compute `prior` as everything strictly before the window', () => {
+    // Same definition on both sides — a `prior` that overlapped the window would let an event be
+    // both the claim and the counter-evidence.
+    const shape = /queryEvents\(\{ since: 0 \}\)\)\.filter\(\(e\) => e\.t < since\)/;
+    expect(act).toMatch(shape);
+    expect(assert).toMatch(shape);
+  });
+
+  it('act_and_wait still passes the action and its effect — prior is added, not swapped', () => {
+    expect(act).toMatch(/findContradictions\([\s\S]{0,260}action: acted/);
+    expect(act).toMatch(/findContradictions\([\s\S]{0,260}session\.lastAct\.effect\(\)/);
+  });
+
+  it('prior is documented as learning material, so nobody later attributes findings to it', () => {
+    // Attribution must stay window-scoped on both paths: `prior` explains a value, it never sources
+    // a finding. Stated in both files because the next person will read only one of them.
+    expect(act).toMatch(/[Ll]earning material/);
+    expect(assert).toMatch(/LEARNING material/);
+  });
+});


### PR DESCRIPTION
A capability loss, found by mining the verifier analysis rather than by a failing test — because nothing failed.

`unit-mismatch` — a total rendered 100x off because minor units are displayed as major — is the flagship detection in this product. It was **structurally unreachable from `reticle_act_and_wait`**, the tool the MCP handshake, SKILL.md and the cheatsheet all tell agents to reach for first.

`assert-verdict.ts` passes `prior` (everything before the window) to the contradiction engine. `act-tools.ts` passed `action` and the act effect, and nothing else. A scale error disagrees with a value the API stated **earlier in the session**, so an action-scoped window can never hold both halves of the comparison. No `prior`, no comparison, no finding — and no error, no downgrade, no signal of any kind. The finding was simply never produced.

That is the **fourth** instance this release of the same shape: a capability that exists, is tested, and does not reach the caller.

| | where it broke |
| --- | --- |
| telemetry `instrumentation` block | reached the wire through none of its four lists |
| `self` on `reticle_query` | in the tool schema and server forward, missing from the browser parser |
| the no-session diagnosis | computed in the daemon, never left it |
| `unit-mismatch` on `act_and_wait` | detector present, its required input never passed |

All four now have guards. This one pins the *property* — the two verdict paths must agree on the inputs that decide which contradiction kinds are reachable — and is verified to fail when `prior` is removed.

## Verification

format ✓ · lint ✓ · typecheck ✓ · unit 15/15 ✓

Benchmark: detection **3/3**, consequence **2/2**, state **1/1**, network-cardinality / forbidden-call / console-clean / state-blast-radius **all caught**, **0% flake** over 8 runs. `gate.mjs` passes against the 2.7.0 baseline with no regression.

Note the direction: the earlier verdict change made Reticle assert failure *less* often; this one makes it *detect* more. Together the verifier is both less wrong and more capable, and the benchmark says neither cost the other anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)