### PR TITLE
init names the command that confirms the install

### DIFF
--- a/packages/server/src/init/run.test.ts
+++ b/packages/server/src/init/run.test.ts
@@ -803,15 +803,30 @@ describe('the closing hint names the MCP reload before it tells you to ask the a
     expect(out, 'the reason, or it reads as superstition').toMatch(/tool list|only appear/i);
   });
 
-  it('puts the reload BEFORE "ask your agent" — the instruction that depends on it', () => {
+  it('puts the reload BEFORE the instruction that depends on it', () => {
     const io = memoryIo(VITE_FILES);
     runInit(OPTS, io);
     const out = io.lines.join('\n');
     const reload = out.search(/\/mcp|reload the window/i);
-    const ask = out.indexOf('List Reticle sessions');
+    // The dependent instruction is now "ask your agent to drive a flow" — asking the agent for
+    // ANYTHING requires the reload, because it read its tool list before Reticle existed. The
+    // closing line used to end on "ask your agent: List Reticle sessions", a question whose failure
+    // is a dead end; it now ends on `reticle status`, which ANSWERS it and needs no reload at all.
+    const dependent = out.search(/ask your agent to drive/i);
     expect(reload).toBeGreaterThan(-1);
-    expect(ask).toBeGreaterThan(-1);
-    expect(reload, 'reload must come first').toBeLessThan(ask);
+    expect(dependent, 'the closing line must still hand off to the agent').toBeGreaterThan(-1);
+    expect(reload, 'reload must come first').toBeLessThan(dependent);
+  });
+
+  it('names a command that CONFIRMS the install, not one that merely asks', () => {
+    // `init` writes files and stops. The install is not finished until an app carrying the SDK has
+    // dialled the daemon, and this is the last instruction most people read — so it has to point at
+    // the thing that can answer, which since 2.7.0 also says WHY when the answer is no.
+    const io = memoryIo(VITE_FILES);
+    runInit(OPTS, io);
+    const out = io.lines.join('\n');
+    expect(out).toMatch(/status/);
+    expect(out, 'and say what it proves').toMatch(/confirms the app connected|why it has not/i);
   });
 
   it('says nothing about MCP when this run did not register it', () => {

--- a/packages/server/src/init/run.ts
+++ b/packages/server/src/init/run.ts
@@ -504,13 +504,27 @@ function devServerRestart(framework: Framework): string {
  */
 function restartHint(framework: Framework, mcpRegistered: boolean): string {
   const dev = `${devServerRestart(framework)}.`;
-  if (!mcpRegistered) return `${dev} Then ask your agent: "List Reticle sessions".`;
+  // NAME THE COMMAND THAT PROVES IT, not one that merely asks.
+  //
+  // `init` writes files and stops; the install is not finished until an app carrying the SDK has
+  // actually dialled the daemon, and nothing here confirmed that. The field shape is unambiguous:
+  // people complete the agent half, never complete the app half, and keep a daemon running for
+  // weeks with nothing to drive — so this is the last instruction most of them read.
+  //
+  // "Ask your agent: List Reticle sessions" asks a question whose failure is a dead end. `reticle
+  // status` ANSWERS it: as of 2.7.0 it reports the session, or says why there is none — no app
+  // running, an app running that never dialled us, a tab that closed — with the fix for each.
+  const prove =
+    'Then run `npx @reticlehq/server status` — it confirms the app connected, or says exactly why ' +
+    'it has not.';
+  if (!mcpRegistered) return `${dev} ${prove}`;
   return (
     `${dev}\n` +
     "Then reload your agent's MCP tools — `/mcp` in Claude Code, or reload the window in " +
     'Cursor/VS Code.\n' +
     'The tools only appear after that: your agent read its tool list before Reticle existed.\n' +
-    'Then ask it: "List Reticle sessions".'
+    `${prove}\n` +
+    'Once it shows a session, ask your agent to drive a flow — that is the install finished.'
   );
 }
 


### PR DESCRIPTION
The last instruction most people read, pointed at something that can answer.

`reticle init` writes files and stops. The install is not finished until an app carrying the SDK has dialled the daemon, and nothing confirmed that. The field shape is unambiguous — people finish the agent half, never finish the app half, and leave a daemon running for weeks with nothing to drive.

It ended on:

> Then ask your agent: "List Reticle sessions"

That asks a question whose failure is a dead end. The agent answers "no sessions" and neither side knows why. It now ends on `npx @reticlehq/server status`, which **answers** it — since 2.7.0 that command reports the session or says why there is none, with the fix for each — followed by the handoff: once it shows a session, ask the agent to drive a flow.

The ordering guard is re-pointed rather than dropped. The MCP reload must still precede the instruction that depends on it, which is now the agent handoff. `status` needs no reload at all, which is part of why it is the better thing to name: it runs in the terminal the user is already in.

## Gates

format ✓ · lint ✓ · typecheck ✓ · unit 15/15 ✓ · **install gate 4/4 scaffolds, a real session in each**

The install gate is the one that matters here — it is the only thing in the repo that can see the install, and it exercises this exact path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)