### PR TITLE
A ref minted before a full navigation must never resolve after one

### DIFF
--- a/packages/browser/src/dom/refs.navigation.test.ts
+++ b/packages/browser/src/dom/refs.navigation.test.ts
@@ -1,0 +1,123 @@
+/**
+ * A ref minted before a full navigation must never resolve after one.
+ *
+ * The stale-ref refusal was closed for SPA route changes and open for full navigations, which is the
+ * more dangerous half. Refs are minted per DOCUMENT — a reload or a cross-page link tears the module
+ * down and the next document starts minting from `e1` again — so `e7` from page A is a valid,
+ * resolvable, DIFFERENT element on page B. Nothing refused: the wrong element was clicked and the
+ * result reported `ok`. That is a false green we produce, which is the one category of defect this
+ * product cannot ship.
+ *
+ * The fix does NOT change the wire format. Refs stay `e<n>` and the sequence simply never restarts:
+ * each document reserves a block of numbers in `sessionStorage` before minting, so page B's `e7`
+ * cannot exist. A stale ref then misses the map and the EXISTING refusal fires, already worded for
+ * exactly this ("Reticle refuses here rather than clicking whatever now occupies that slot"). No new
+ * ref grammar, no round-trip concern for the agents that pass refs back verbatim, and no migration
+ * for the refs already sitting in saved flows on disk.
+ *
+ * `sessionStorage` is the right scope for the same reason session continuity uses it: it survives
+ * reloads and same-tab navigations, and is not shared with another tab — where a second tab is a
+ * second session with its own registry anyway.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { RefRegistry, REF_BLOCK } from './refs.js';
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+/** A `sessionStorage` that outlives the document, which is the whole point of it. */
+function fakeStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    clear: () => void map.clear(),
+    key: (i: number) => [...map.keys()][i] ?? null,
+    get length() {
+      return map.size;
+    },
+  };
+}
+
+const button = (): Element => {
+  const el = document.createElement('button');
+  document.body.appendChild(el);
+  return el;
+};
+
+describe('refs across a full navigation', () => {
+  it('never mints a ref the previous document already used', () => {
+    const store = fakeStorage();
+    const before = new RefRegistry(() => store);
+    const minted = [button(), button(), button()].map((el) => before.refFor(el));
+
+    // The document is torn down and rebuilt: a NEW registry, the SAME tab storage.
+    document.body.innerHTML = '';
+    const after = new RefRegistry(() => store);
+    const fresh = [button(), button(), button()].map((el) => after.refFor(el));
+
+    expect(fresh.filter((ref) => minted.includes(ref))).toEqual([]);
+  });
+
+  it('refuses a ref carried across the navigation instead of resolving it to another element', () => {
+    const store = fakeStorage();
+    const before = new RefRegistry(() => store);
+    const stale = before.refFor(button());
+
+    document.body.innerHTML = '';
+    const after = new RefRegistry(() => store);
+    // Page B mints plenty of its own elements — under the old scheme one of them WAS `stale`.
+    for (let i = 0; i < 20; i += 1) after.refFor(button());
+
+    expect(after.resolve(stale)).toBeNull();
+  });
+
+  it('keeps the plain `e<n>` wire format, so refs still round-trip verbatim', () => {
+    const store = fakeStorage();
+    new RefRegistry(() => store).refFor(button());
+    const after = new RefRegistry(() => store);
+    expect(after.refFor(button())).toMatch(/^e[1-9][0-9]*$/);
+  });
+
+  it('starts at e1 on the first document, so the common case stays short', () => {
+    const registry = new RefRegistry(() => fakeStorage());
+    expect(registry.refFor(button())).toBe('e1');
+  });
+
+  it('reserves before minting, so a document killed mid-flight still cannot be re-used', () => {
+    // The reservation is written on the FIRST mint, not at unload — a page that crashes, is killed,
+    // or navigates away with no unload event still leaves its block claimed.
+    const store = fakeStorage();
+    new RefRegistry(() => store).refFor(button());
+    expect(Number(store.getItem('__reticle_ref_base'))).toBeGreaterThanOrEqual(REF_BLOCK);
+  });
+
+  it('claims another block rather than colliding when a page outmints its first one', () => {
+    const store = fakeStorage();
+    const busy = new RefRegistry(() => store);
+    for (let i = 0; i < REF_BLOCK + 2; i += 1) busy.refFor(button());
+    const next = new RefRegistry(() => store).refFor(button());
+    expect(next).not.toBe('e1');
+    expect(Number(next.slice(1))).toBeGreaterThan(REF_BLOCK);
+  });
+
+  it('still works when storage is unavailable, because a sandboxed iframe throws on access', () => {
+    const hostile = (): Storage => {
+      throw new Error('SecurityError');
+    };
+    const registry = new RefRegistry(hostile);
+    const ref = registry.refFor(button());
+    // No cross-document guarantee is possible without storage — but a session must still start, and
+    // the SPA-side refusal (WeakRef liveness + isConnected) is unaffected.
+    expect(registry.resolve(ref)).not.toBeNull();
+  });
+
+  it('ignores a corrupted reservation rather than minting NaN refs', () => {
+    const store = fakeStorage();
+    store.setItem('__reticle_ref_base', 'not-a-number');
+    expect(new RefRegistry(() => store).refFor(button())).toMatch(/^e[1-9][0-9]*$/);
+  });
+});

--- a/packages/browser/src/dom/refs.ts
+++ b/packages/browser/src/dom/refs.ts
@@ -48,11 +48,86 @@ export function echoRef(ref: string): string {
  */
 const SWEEP_EVERY_MINTS = 1000;
 
+/**
+ * Where a document records the ref numbers it has claimed, so the next one starts past them.
+ *
+ * Refs are per-DOCUMENT: a reload or a cross-page link tears this module down and the next document
+ * used to start minting from `e1` again. So `e7` from page A was a valid, resolvable, DIFFERENT
+ * element on page B — nothing refused, the wrong element was acted on, and the result came back `ok`.
+ * The SPA case was always safe (WeakRef liveness + isConnected); this was the other half, and the
+ * more dangerous one, because it produced a false green instead of an error.
+ *
+ * Deliberately NOT a change to the ref grammar. Stamping refs `e7@3` would have worked too, but every
+ * agent passes refs back verbatim and every saved flow on disk already holds bare ones, so it buys a
+ * wire-format migration for a property the sequence itself can carry. A number that never restarts
+ * means a stale ref simply misses the map, and the refusal that already exists — already worded for
+ * exactly this case — fires unchanged.
+ *
+ * Namespaced like the session key it sits beside; `sessionStorage` is the right scope for the same
+ * reason session continuity uses it (survives reloads and same-tab navigations, not shared with
+ * another tab, which is a different session with its own registry anyway).
+ */
+const REF_BASE_KEY = '__reticle_ref_base';
+
+/**
+ * How many numbers a document claims at once.
+ *
+ * The reservation is a synchronous storage write, so it cannot happen per mint — mints are frequent
+ * (every meaningful DOM addition, every transitionend, every scroll reveal). One write per this many
+ * mints is free. Sized to keep refs SHORT: refs are echoed in every snapshot and every error, so the
+ * digits are a token cost paid on every turn, and a page would have to navigate a hundred times
+ * before they reach seven of them.
+ */
+export const REF_BLOCK = 10000;
+
+/** The reserved-block high-water mark, or 0 when storage is unavailable or its value is junk. */
+function readBase(store: Storage | undefined): number {
+  try {
+    const raw = store?.getItem(REF_BASE_KEY);
+    const value = null === raw || undefined === raw ? Number.NaN : Number(raw);
+    return Number.isSafeInteger(value) && value > 0 ? value : 0;
+  } catch {
+    return 0; // a sandboxed iframe throws on access; a session must still start
+  }
+}
+
 export class RefRegistry {
   readonly #toRef = new WeakMap<Element, Ref>();
   readonly #fromRef = new Map<string, WeakRef<Element>>();
+  readonly #storage: () => Storage | undefined;
   #seq = 0;
+  /** The end of the block currently reserved. Minting past it claims the next one. */
+  #reserved = 0;
   #mintsSinceSweep = 0;
+
+  /**
+   * Storage is injected rather than read from the global for the same reason the clock is: it is an
+   * ambient dependency that decides behaviour, and the cross-document property is untestable if the
+   * only way to get a second document is to actually navigate.
+   */
+  constructor(storage: () => Storage | undefined = () => globalThis.sessionStorage) {
+    this.#storage = storage;
+  }
+
+  /** Read the tab's high-water mark and claim the next block, BEFORE any of it is handed out. */
+  #reserve(): void {
+    let store: Storage | undefined;
+    try {
+      store = this.#storage();
+    } catch {
+      store = undefined; // hostile storage: no cross-document guarantee, but the session still starts
+    }
+    const base = Math.max(readBase(store), this.#seq);
+    this.#reserved = base + REF_BLOCK;
+    try {
+      store?.setItem(REF_BASE_KEY, String(this.#reserved));
+    } catch {
+      /* same: never block a mint on storage */
+    }
+    // Claimed on the FIRST mint, not at unload — a page that crashes, is killed, or navigates away
+    // without firing unload has still permanently spent its numbers.
+    this.#seq = base;
+  }
 
   /** How many reverse entries are currently retained. Exposed so the bound can be asserted. */
   get size(): number {
@@ -90,6 +165,7 @@ export class RefRegistry {
       this.#fromRef.set(existing, weak ?? new WeakRef(el));
       return existing;
     }
+    if (this.#seq >= this.#reserved) this.#reserve();
     this.#seq += 1;
     const ref = asRef(`e${String(this.#seq)}`);
     this.#toRef.set(el, ref);


### PR DESCRIPTION
Closes #260 — the last known path by which Reticle acts on the wrong element and reports `ok`.

## The defect

Refs are minted per **document**. The SPA case was always safe (WeakRef liveness + `isConnected`), but a reload or a cross-page link tears the module down and the next document started minting from `e1` again. So `e7` from page A was a valid, resolvable, **different** element on page B. Nothing refused: the wrong element was acted on and the result came back `ok`.

That is a false green we produce, which is the one category of defect this product cannot ship.

## The fix, and the option not taken

The issue suggested stamping refs `e7@3` and refusing on mismatch. That works, but it buys a wire-format migration: agents pass refs back verbatim, and saved flows on disk already hold bare ones.

The sequence can carry the property by itself. Each document reserves a block of numbers in `sessionStorage` **before** minting, so page B's `e7` cannot exist — a stale ref misses the map and the **existing** refusal fires, already worded for exactly this case:

> That ref is stale… Reticle refuses here rather than clicking whatever now occupies that slot.

No new ref grammar, no round-trip concern, no migration.

`sessionStorage` is the right scope for the same reason `session-continuity.ts` uses it: it survives reloads and same-tab navigations and is not shared with another tab, which is a different session with its own registry anyway. Where it is unavailable — a sandboxed iframe throws on access — the cross-document guarantee is simply absent and nothing else changes.

Two details that are deliberate: the block is claimed on the **first mint** rather than at unload, so a page that crashes or is killed has still spent its numbers; and it is sized to keep refs short, since they are echoed in every snapshot and every error.

## Verification

Each of the four behavioural tests was confirmed to go **RED** with the reservation removed. The other four are invariants that must hold either way — wire format, first-document `e1`, hostile storage, corrupt stored value — and correctly stay green.

- format ✓ · lint ✓ · typecheck ✓ · unit 15/15 ✓ (browser: 916)
- **e2e battery 32/32**, including `a stale ref is refused by name, not silently mis-clicked`

**Driven against a real browser, not only jsdom.** Hard-reloaded the bench app; the pre-navigation ref was refused by name, the new document minted past the old block, and a fresh ref still drove to `verified:"yes"` on a clean capture with a source pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)