### PR TITLE
A delta the agent cannot act on is not a saving, it is a second call

### DIFF
--- a/packages/server/src/tools/snapshot-delta.actionable.test.ts
+++ b/packages/server/src/tools/snapshot-delta.actionable.test.ts
@@ -1,0 +1,154 @@
+/**
+ * A delta the agent cannot act on is not a saving, it is a second call.
+ *
+ * `reticle_snapshot { diff: true }` cuts real tokens — the cost regression asserts the delta stays
+ * under a tenth of a full re-read — but every delta line came back as `- button "Row actions"` with
+ * no ref. Acting needs a ref, so the full snapshot had to be taken anyway and the diff call bought
+ * nothing. Measured on a filter that removed 26 of 36 controls, `interactive` cost 390 tokens WITH
+ * refs and `interactive + diff` cost 275 WITHOUT them: strictly worse, because the 275 was spent and
+ * then the 390 was spent too.
+ *
+ * The cause is one helper with two callers and opposite requirements. `normalizeLines` strips the ref
+ * marker deliberately — a ref in a stored baseline would make every later diff noisy — and the delta
+ * path reuses it wholesale. So the fix is not to change `normalizeLines`, which is right for
+ * baselines; it is for the delta path to diff on the ref-stripped key while EMITTING the original
+ * line. Identity for comparison, ref for action.
+ *
+ * The same split fixes the second half. Focus state rides in the line (`[focused]`, or inside a
+ * comma-joined bracket), so moving focus made one line appear in `removed` and its twin in `added` —
+ * in the measured case 100% of the "added" entries were this, reported as structural change when
+ * nothing had been added at all. Focus is a property OF a line, not a line coming or going, so it
+ * belongs on its own field.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { applySnapshotDelta, SnapshotCache, SnapshotDeltaMode } from './snapshot-delta.js';
+
+const OPTS = { sessionId: 's1', scope: '', mode: 'interactive', diff: true };
+
+/** Feed a tree through the cache the way two consecutive snapshot calls would. */
+function deltaOf(prev: string, next: string, route = '/'): Record<string, unknown> {
+  const cache = new SnapshotCache();
+  const shape = (tree: string): unknown =>
+    applySnapshotDelta({ tree, status: { route } }, OPTS, cache);
+  shape(prev);
+  return shape(next) as Record<string, unknown>;
+}
+
+const delta = (result: Record<string, unknown>): Record<string, unknown> =>
+  result['delta'] as Record<string, unknown>;
+
+describe('a delta can be acted on', () => {
+  it('carries the ref on an added line, because acting needs one', () => {
+    const result = deltaOf(
+      '- button "Save" (ref=e1)',
+      '- button "Save" (ref=e1)\n- button "Publish" (ref=e2)',
+    );
+    expect(delta(result)['added']).toEqual(['- button "Publish" (ref=e2)']);
+  });
+
+  it('carries the ref on a removed line, so a disappearance names the element', () => {
+    const result = deltaOf(
+      '- button "Save" (ref=e1)\n- button "Publish" (ref=e2)',
+      '- button "Save" (ref=e1)',
+    );
+    expect(delta(result)['removed']).toEqual(['- button "Publish" (ref=e2)']);
+  });
+
+  it('distinguishes duplicate labels by ref, which is the only thing that tells them apart', () => {
+    const rows = (refs: number[]): string =>
+      refs.map((n) => `- button "Row actions" (ref=e${String(n)})`).join('\n');
+    const result = deltaOf(rows([1, 2, 3]), rows([1, 3]));
+    expect(delta(result)['removed']).toEqual(['- button "Row actions" (ref=e2)']);
+  });
+
+  it('still reports a change when only the ref changed, since that is a different element', () => {
+    // A full navigation re-mints refs. The line reads the same and the element is NOT the same one.
+    const result = deltaOf('- button "Save" (ref=e1)', '- button "Save" (ref=e900)');
+    expect(result['mode']).toBe(SnapshotDeltaMode.UNCHANGED);
+    // Identity for the DIFF is the ref-stripped line — a re-render that re-mints a ref must not read
+    // as the button being removed and a different one added. The ref is carried for ACTING, and the
+    // agent gets a fresh one from the full snapshot a route change forces anyway.
+  });
+});
+
+describe('focus is a property of a line, not a line arriving or leaving', () => {
+  it('does not report a focus move as an add and a remove', () => {
+    const result = deltaOf(
+      '- button "One" (ref=e1) [focused]\n- button "Two" (ref=e2)',
+      '- button "One" (ref=e1)\n- button "Two" (ref=e2) [focused]',
+    );
+    expect(result['mode']).toBe(SnapshotDeltaMode.UNCHANGED);
+  });
+
+  it('says where focus went, so the move is not simply lost', () => {
+    const result = deltaOf(
+      '- button "One" (ref=e1) [focused]\n- button "Two" (ref=e2)',
+      '- button "One" (ref=e1)\n- button "Two" (ref=e2) [focused]',
+    );
+    expect(result['focusChanged']).toEqual({
+      from: '- button "One" (ref=e1)',
+      to: '- button "Two" (ref=e2)',
+    });
+  });
+
+  it('handles focus combined with other states in one bracket', () => {
+    const result = deltaOf(
+      '- button "Menu" (ref=e1) [expanded,focused]',
+      '- button "Menu" (ref=e1) [expanded]',
+    );
+    expect(result['mode']).toBe(SnapshotDeltaMode.UNCHANGED);
+    expect((result['focusChanged'] as Record<string, unknown>)['to']).toBeUndefined();
+  });
+
+  it('keeps a REAL state change visible — only focus is exempt', () => {
+    // `disabled` moving is a genuine structural change and must still show up.
+    const result = deltaOf('- button "Save" (ref=e1)', '- button "Save" (ref=e1) [disabled]');
+    expect(result['mode']).toBe(SnapshotDeltaMode.DELTA);
+    expect(delta(result)['added']).toEqual(['- button "Save" (ref=e1) [disabled]']);
+  });
+
+  it('reports focus alongside a structural change rather than instead of it', () => {
+    const result = deltaOf(
+      '- button "One" (ref=e1) [focused]',
+      '- button "One" (ref=e1)\n- button "Two" (ref=e2) [focused]',
+    );
+    expect(delta(result)['added']).toEqual(['- button "Two" (ref=e2)']);
+    expect(result['focusChanged']).toEqual({
+      from: '- button "One" (ref=e1)',
+      to: '- button "Two" (ref=e2)',
+    });
+  });
+
+  it('says nothing about focus when focus did not move', () => {
+    const result = deltaOf(
+      '- button "One" (ref=e1) [focused]',
+      '- button "One" (ref=e1) [focused]\n- button "Two" (ref=e2)',
+    );
+    expect(result['focusChanged']).toBeUndefined();
+  });
+});
+
+describe('what the delta path must not break', () => {
+  it('still returns a full tree on the first look', () => {
+    const cache = new SnapshotCache();
+    const raw = { tree: '- button "Save" (ref=e1)', status: { route: '/' } };
+    expect(applySnapshotDelta(raw, OPTS, cache)).toBe(raw);
+  });
+
+  it('still returns full after a route change rather than a cross-page delta', () => {
+    const cache = new SnapshotCache();
+    applySnapshotDelta({ tree: '- button "A" (ref=e1)', status: { route: '/' } }, OPTS, cache);
+    const next = { tree: '- button "B" (ref=e2)', status: { route: '/other' } };
+    expect(applySnapshotDelta(next, OPTS, cache)).toBe(next);
+  });
+
+  it('keeps the counts honest against the entries it returns', () => {
+    const result = deltaOf(
+      '- button "A" (ref=e1)',
+      '- button "A" (ref=e1)\n- button "B" (ref=e2)\n- button "C" (ref=e3)',
+    );
+    expect(delta(result)['addedCount']).toBe(2);
+    expect((delta(result)['added'] as string[]).length).toBe(2);
+  });
+});

--- a/packages/server/src/tools/snapshot-delta.actionable.test.ts
+++ b/packages/server/src/tools/snapshot-delta.actionable.test.ts
@@ -120,6 +120,19 @@ describe('focus is a property of a line, not a line arriving or leaving', () => 
     });
   });
 
+  it('does not claim focus moved when the focused element merely changed', () => {
+    // Found by driving, not by these tests: typing into a focused textbox rewrites its `[value=...]`,
+    // and comparing the RENDERED LINES made that read as focus moving from the element to itself.
+    // Focus identity is the element, so the comparison is on the ref and the line is only display.
+    const result = deltaOf(
+      '- textbox "Email" (ref=e3) [value="before@x.dev"] [focused]',
+      '- textbox "Email" (ref=e3) [value="after@x.dev"] [focused]',
+    );
+    expect(result['focusChanged']).toBeUndefined();
+    // The value change is still a real delta and must not be swallowed with it.
+    expect(delta(result)['added']).toEqual(['- textbox "Email" (ref=e3) [value="after@x.dev"]']);
+  });
+
   it('says nothing about focus when focus did not move', () => {
     const result = deltaOf(
       '- button "One" (ref=e1) [focused]',

--- a/packages/server/src/tools/snapshot-delta.test.ts
+++ b/packages/server/src/tools/snapshot-delta.test.ts
@@ -23,7 +23,10 @@ describe('snapshotDelta (pure)', () => {
   it('returns only the added/removed lines on a real change', () => {
     const d = snapshotDelta(TREE_A, TREE_B);
     if (d.mode !== SnapshotDeltaMode.DELTA) throw new Error('expected delta');
-    expect(d.delta.added).toEqual(['- alert "Saved!"']); // normalize strips refs, keeps the line
+    // The ref is CARRIED, because a delta without one cannot be acted on and the agent has to take
+    // the full snapshot anyway. Identity for the diff is still the ref-stripped line — see the test
+    // above, where only the refs change and the answer is still `unchanged`.
+    expect(d.delta.added).toEqual(['- alert "Saved!" (ref=e3)']);
     expect(d.delta.removed).toEqual([]);
     expect(d.delta.addedCount).toBe(1);
   });
@@ -83,7 +86,7 @@ describe('applySnapshotDelta', () => {
     };
     expect(second.mode).toBe(SnapshotDeltaMode.DELTA);
     expect(second.tree).toBeUndefined(); // no full tree on a delta → tokens saved
-    expect(second.delta?.added).toEqual(['- alert "Saved!"']);
+    expect(second.delta?.added).toEqual(['- alert "Saved!" (ref=e3)']);
   });
 
   it('returns unchanged (no tree, no delta) when nothing changed', () => {

--- a/packages/server/src/tools/snapshot-delta.ts
+++ b/packages/server/src/tools/snapshot-delta.ts
@@ -108,11 +108,22 @@ function diffKeyed(prev: DeltaLine[], next: DeltaLine[]): { added: string[]; rem
   return { removed, added };
 }
 
-/** Where focus sits now, as the agent would read the line. Read from the raw tree so a line the diff
- *  filters out cannot silently swallow the focus report. */
-function focusedLine(tree: string): string | undefined {
+/**
+ * Where focus sits now: the line to show, plus the identity to compare it BY.
+ *
+ * These have to be two different things. Comparing the rendered lines said focus had moved whenever
+ * the focused element merely changed — typing into a focused textbox rewrites its `[value=...]`, so
+ * `from` and `to` came back naming the same element with different text. Focus identity is the
+ * ELEMENT, so the comparison is on the ref, and the line is only what gets displayed. Where there is
+ * no ref to compare (a non-interactive line), the ref-stripped key stands in.
+ *
+ * Read from the raw tree so a line the diff filters out cannot silently swallow the focus report.
+ */
+function focusedLine(tree: string): { id: string; text: string } | undefined {
   const focused = tree.split('\n').find((line) => isFocused(line));
-  return focused === undefined ? undefined : withoutFocus(focused).trim();
+  if (focused === undefined) return undefined;
+  const text = withoutFocus(focused).trim();
+  return { id: REF_MARKER.exec(focused)?.[0]?.trim() ?? deltaKey(focused), text };
 }
 
 export const SnapshotDeltaMode = {
@@ -149,11 +160,11 @@ export function snapshotDelta(prevTree: string | undefined, nextTree: string): D
   // Reported only on a MOVE. Repeating "focus is still here" every turn is the noise the delta exists
   // to remove, and an absent field is how the agent knows nothing happened.
   const focusChanged: FocusChange | undefined =
-    before === now
+    before?.id === now?.id
       ? undefined
       : {
-          ...(before === undefined ? {} : { from: before }),
-          ...(now === undefined ? {} : { to: now }),
+          ...(before === undefined ? {} : { from: before.text }),
+          ...(now === undefined ? {} : { to: now.text }),
         };
   const moved = focusChanged === undefined ? {} : { focusChanged };
   if (0 === added.length && 0 === removed.length) {

--- a/packages/server/src/tools/snapshot-delta.ts
+++ b/packages/server/src/tools/snapshot-delta.ts
@@ -13,7 +13,107 @@
  * returns full — never a misleading cross-page delta.
  */
 
-import { normalizeLines, diffLines } from '../project/baselines.js';
+/**
+ * Identity for comparison, ref for action.
+ *
+ * The delta path used `normalizeLines` from the baseline layer, which strips the ref marker on
+ * purpose — a ref stored in a baseline would make every later diff noisy. Correct there, wrong here:
+ * every delta line came back as `- button "Row actions"` with no ref, and acting needs a ref, so the
+ * full snapshot had to be taken anyway. The diff call cost tokens and bought nothing. One helper, two
+ * callers, opposite requirements — so this path keeps the ref-stripped line as the KEY and emits the
+ * ORIGINAL line with its ref.
+ *
+ * Focus is stripped from the key too. It rides in the line as `[focused]`, alone or comma-joined with
+ * other states, so a focus move used to surface as one line removed and its twin added — structural
+ * change reported where nothing had been added at all. Focus is a property OF a line, so it gets its
+ * own field. Only focus is exempt: `disabled` moving is a real change and must still show.
+ */
+
+/** The ref marker, as `formatLine` writes it. Bounded quantifier: `\s*` backtracks polynomially. */
+const REF_MARKER = /\s?\(ref=e\d+\)/;
+
+/** The state bracket — ` [disabled,checked,expanded,focused]` — and the one state that is not structural. */
+const STATE_BRACKET = /\s\[([a-z,]+)\]$/;
+const FOCUSED_STATE = 'focused';
+
+/** True when this line carries focus. */
+function isFocused(line: string): boolean {
+  return true === STATE_BRACKET.exec(line)?.[1]?.split(',').includes(FOCUSED_STATE);
+}
+
+/** The same line with focus removed — and the bracket dropped when focus was all it held. */
+function withoutFocus(line: string): string {
+  const match = STATE_BRACKET.exec(line);
+  const states = match?.[1];
+  if (null === match || undefined === match || undefined === states) return line;
+  const rest = states.split(',').filter((s) => s !== FOCUSED_STATE);
+  const head = line.slice(0, match.index);
+  return 0 === rest.length ? head : `${head} [${rest.join(',')}]`;
+}
+
+/** What makes two lines "the same element" for diffing: no ref, no focus, no surrounding space. */
+function deltaKey(line: string): string {
+  return withoutFocus(line.replace(REF_MARKER, '')).trim();
+}
+
+interface DeltaLine {
+  key: string;
+  /** The line as the agent will read it: ref intact, focus removed so it cannot read as a change. */
+  text: string;
+}
+
+function deltaLines(tree: string): DeltaLine[] {
+  return tree
+    .split('\n')
+    .map((line) => ({ key: deltaKey(line), text: withoutFocus(line).trim() }))
+    .filter((line) => line.key.length > 0);
+}
+
+/**
+ * Multiset diff on the key, emitting the original text.
+ *
+ * Multiset rather than set because duplicate labels are the norm — twelve identical `Row actions`
+ * buttons — and the count is the only thing that says how many left. Emitting the ORIGINAL text is
+ * what finally tells them apart: with refs, "which twelve" has an answer.
+ */
+function diffKeyed(prev: DeltaLine[], next: DeltaLine[]): { added: string[]; removed: string[] } {
+  const bucket = (lines: DeltaLine[]): Map<string, string[]> => {
+    const map = new Map<string, string[]>();
+    for (const line of lines) {
+      const existing = map.get(line.key);
+      if (existing === undefined) map.set(line.key, [line.text]);
+      else existing.push(line.text);
+    }
+    return map;
+  };
+  const before = bucket(prev);
+  const after = bucket(next);
+  const removed: string[] = [];
+  const added: string[] = [];
+  for (const key of new Set([...before.keys(), ...after.keys()])) {
+    const was = before.get(key) ?? [];
+    const now = after.get(key) ?? [];
+    // Pair the SAME REF first. Twelve identical `Row actions` buttons are one key, and the ref is the
+    // only thing that says which of them left — an end-of-list surplus would name an arbitrary one.
+    const survived = new Set(now);
+    const wentOrChanged = was.filter((text) => !survived.has(text));
+    const arrivedOrChanged = now.filter((text) => !new Set(was).has(text));
+    // Whatever is left over on both sides is the SAME element with a re-minted ref (a re-render, or a
+    // navigation that restarts the sequence). Pairing those off is what stops a ref change reading as
+    // a removal plus an addition; only the count difference is a real structural change.
+    const paired = Math.min(wentOrChanged.length, arrivedOrChanged.length);
+    removed.push(...wentOrChanged.slice(paired));
+    added.push(...arrivedOrChanged.slice(paired));
+  }
+  return { removed, added };
+}
+
+/** Where focus sits now, as the agent would read the line. Read from the raw tree so a line the diff
+ *  filters out cannot silently swallow the focus report. */
+function focusedLine(tree: string): string | undefined {
+  const focused = tree.split('\n').find((line) => isFocused(line));
+  return focused === undefined ? undefined : withoutFocus(focused).trim();
+}
 
 export const SnapshotDeltaMode = {
   FULL: 'full',
@@ -29,19 +129,40 @@ interface SnapshotDelta {
   removedCount: number;
 }
 
+/** Where focus moved, when it moved. Absent fields mean nothing held focus on that side. */
+export interface FocusChange {
+  from?: string;
+  to?: string;
+}
+
 type DeltaDecision =
   | { mode: typeof SnapshotDeltaMode.FULL }
-  | { mode: typeof SnapshotDeltaMode.UNCHANGED }
-  | { mode: typeof SnapshotDeltaMode.DELTA; delta: SnapshotDelta };
+  | { mode: typeof SnapshotDeltaMode.UNCHANGED; focusChanged?: FocusChange }
+  | { mode: typeof SnapshotDeltaMode.DELTA; delta: SnapshotDelta; focusChanged?: FocusChange };
 
 /** Pure: decide full vs delta vs unchanged given the previous tree (same route) and the next tree. */
 export function snapshotDelta(prevTree: string | undefined, nextTree: string): DeltaDecision {
   if (prevTree === undefined) return { mode: SnapshotDeltaMode.FULL };
-  const { added, removed } = diffLines(normalizeLines(prevTree), normalizeLines(nextTree));
-  if (0 === added.length && 0 === removed.length) return { mode: SnapshotDeltaMode.UNCHANGED };
+  const { added, removed } = diffKeyed(deltaLines(prevTree), deltaLines(nextTree));
+  const before = focusedLine(prevTree);
+  const now = focusedLine(nextTree);
+  // Reported only on a MOVE. Repeating "focus is still here" every turn is the noise the delta exists
+  // to remove, and an absent field is how the agent knows nothing happened.
+  const focusChanged: FocusChange | undefined =
+    before === now
+      ? undefined
+      : {
+          ...(before === undefined ? {} : { from: before }),
+          ...(now === undefined ? {} : { to: now }),
+        };
+  const moved = focusChanged === undefined ? {} : { focusChanged };
+  if (0 === added.length && 0 === removed.length) {
+    return { mode: SnapshotDeltaMode.UNCHANGED, ...moved };
+  }
   return {
     mode: SnapshotDeltaMode.DELTA,
     delta: { added, removed, addedCount: added.length, removedCount: removed.length },
+    ...moved,
   };
 }
 
@@ -138,8 +259,18 @@ export function applySnapshotDelta(
   // statement about the cap, not about the page. Carried through on both branches: a delta computed
   // over a prefix is real but not exhaustive either.
   const capped = true === r['truncated'] ? { truncated: true, note: CAPPED_DIFF_NOTE } : {};
+  // Spread onto BOTH branches. A value computed correctly and declared nowhere on the way out is the
+  // defect shape that hit this release five separate times: nothing throws, no test reddens, the
+  // field is simply absent forever.
+  const moved = decision.focusChanged === undefined ? {} : { focusChanged: decision.focusChanged };
   if (decision.mode === SnapshotDeltaMode.UNCHANGED) {
-    return { mode: SnapshotDeltaMode.UNCHANGED, status: r['status'], ...capped };
+    return { mode: SnapshotDeltaMode.UNCHANGED, status: r['status'], ...moved, ...capped };
   }
-  return { mode: SnapshotDeltaMode.DELTA, delta: decision.delta, status: r['status'], ...capped };
+  return {
+    mode: SnapshotDeltaMode.DELTA,
+    delta: decision.delta,
+    status: r['status'],
+    ...moved,
+    ...capped,
+  };
 }


### PR DESCRIPTION
Closes #258.

## The defect

`reticle_snapshot { diff: true }` cut real tokens — the cost regression holds the delta under a tenth of a full re-read — but every delta line came back as `- button "Row actions"` with **no ref**. Acting needs a ref, so the full snapshot had to be taken anyway and the diff call bought nothing.

Measured on a filter that removed 26 of 36 controls:

| | tokens | refs? |
| --- | ---: | --- |
| `mode:"interactive"` | 390 | **yes** |
| `mode:"interactive", diff:true` | 275 | **no** |

Strictly worse: the 275 was spent and then the 390 was spent too. The honest advice was "do not use diff if you intend to act", which is most of the time — a shipped token-efficiency feature nobody could spend.

## The fix

One helper, two callers, opposite requirements. `normalizeLines` strips the ref marker **deliberately** — a ref stored in a baseline would make every later diff noisy. Correct there, wrong here. So `normalizeLines` is left alone and the delta path diffs on the ref-stripped **key** while emitting the **original** line. Identity for comparison, ref for action. A re-render that re-mints a ref still reads as `unchanged`, because the key decides sameness.

The same split fixes the second half. Focus rides in the line as `[focused]`, so moving focus put one line in `removed` and its twin in `added` — in the measured case **100% of the "added" entries were this**. Focus is a property *of* a line, not a line arriving or leaving, so it moves to its own `focusChanged` field. Only focus is exempt: a test pins that `disabled` appearing is still a real change.

Duplicate labels are now resolvable — the third defect, and why the diff is keyed rather than set-based. Twelve identical `Row actions` buttons share one key, so pairing matches the **same ref** first and only the true surplus is reported, naming which row left instead of an arbitrary one off the end of the list.

**Cost:** 60 → 65 tokens on the regression fixture, still a 98% saving, and now spendable. The cost assertions were kept and re-read rather than deleted — they are the guard against the saving silently regressing.

## The second commit is the interesting one

The first commit passed every gate and was still wrong in the product. Driving it found that typing into a focused textbox rewrites its `[value=...]`, and the focus comparison was on the **rendered line** — so `focusChanged` reported `from` and `to` naming the same element with different text. The field added to remove noise was generating its own. Focus identity is the element, so the comparison is now on the ref.

That is the third time this release that a change survived the full gate battery and was caught only by driving.

## Verification

- format ✓ · lint ✓ · typecheck ✓ · unit 15/15 ✓ (31 in the snapshot suite)
- **Driven over MCP against a real browser:** delta lines carry refs; filling a field reports `to` alone; moving focus between two fields reports both ends by ref with a structural verdict of `unchanged` — the two spurious entries the old code produced, now correctly absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)