### PR TITLE
A benchmark that cannot inject its bugs must fail loudly, not flatteringly

### DIFF
--- a/bench/harness/bench-all.mjs
+++ b/bench/harness/bench-all.mjs
@@ -19,6 +19,7 @@ import { randomBytes } from 'node:crypto';
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 import * as PORTS from './ports.mjs';
+import { verifyAnchors } from './inject.mjs';
 
 const FULL = process.argv.includes('--full');
 const NO_BOOT = process.argv.includes('--no-boot');
@@ -282,6 +283,26 @@ const scripts = [...(FULL ? OBSERVATION_PASS : []), ...REPLAY_PASS];
 console.log(
   `bench-all: ${FULL ? 'observation-cost + replay passes' : 'replay pass only (pass --full for observation-cost)'}`,
 );
+
+// A benchmark that cannot inject its bugs is not measuring anything — and it fails FLATTERINGLY.
+// The injector throws, the observation harness records NOT MEASURED, the scenario leaves the
+// comparison, and the catch-rate is averaged over the survivors, so the headline stays perfect while
+// coverage shrinks. `broken-form-validation` disappeared exactly that way: the repo's own `yoda` lint
+// rule rewrote the fixture and the anchors were not updated with it. Checked BEFORE the pass, because
+// a drifted anchor found afterwards has already produced a number somebody may have quoted.
+if (FULL) {
+  const drifted = verifyAnchors();
+  if (drifted.length > 0) {
+    for (const d of drifted) console.error(`✗ DRIFTED ${d.id}: ${d.error.split('\n')[0]}`);
+    console.error(
+      `\n✗ ${String(drifted.length)} regression(s) no longer apply to the fixture. Those scenarios would ` +
+        `be silently dropped and every rate below would be computed over what survived. Fix the ` +
+        `anchors (\`node bench/harness/inject.mjs --verify-anchors\`) before trusting a number.`,
+    );
+    process.exit(1);
+  }
+  console.log('✓ all regression anchors still apply');
+}
 
 if (!NO_BOOT) await bootFixtures();
 

--- a/bench/harness/inject.mjs
+++ b/bench/harness/inject.mjs
@@ -75,12 +75,15 @@ const REGRESSIONS = {
       // Empty service no longer blocked: the guard checks the raw (un-trimmed) length so a whitespace
       // or empty-after-trim service slips through, and submit is enabled. Comment-free (an off-by-a-
       // method bug), so source-reading gets no self-labeled giveaway.
+      // Anchors are in YODA form because the repo's own `yoda` lint rule rewrote the fixture that way.
+      // They were not updated with it, so the injector stopped finding them and this scenario silently
+      // left the comparison — see the drift note above replaceOnce.
       replaceOnce(
         F.modal,
-        '    if (service.trim().length === 0) return;\n',
-        '    if (service.length === -1) return;\n',
+        '    if (0 === service.trim().length) return;\n',
+        '    if (-1 === service.length) return;\n',
       );
-      replaceOnce(F.modal, 'disabled={service.trim().length === 0}', 'disabled={false}');
+      replaceOnce(F.modal, 'disabled={0 === service.trim().length}', 'disabled={false}');
     },
   },
   'cross-component-regression': {
@@ -128,7 +131,7 @@ export const INJECTION_SIGNATURES = {
   'signal-contract-violation': ['emit(Sig.FILTER_CHANGED, { view })'],
   'route-transition-break': ["view === 'compose' ? get().view : view"],
   'missing-modal': ['set({ newDeployOpen: false })'],
-  'broken-form-validation': ['if (service.length === -1) return;', 'disabled={false}'],
+  'broken-form-validation': ['if (-1 === service.length) return;', 'disabled={false}'],
   'cross-component-regression': ['set({ filter: get().filter })'],
   'layout-shift': ["gridTemplateColumns: '1fr 1fr 1fr'"],
   'network-timeout': ['fault-timeout'],
@@ -175,6 +178,44 @@ export function revertAll() {
   }
 }
 
+/**
+ * Do all the anchors still resolve?
+ *
+ * Anchor drift is SILENT and it flatters us. The injector throws, the observation harness records
+ * `NOT MEASURED`, the scenario leaves the comparison, and the catch-rate is then computed over
+ * whatever survived — so the headline stays perfect while coverage shrinks. That is exactly how
+ * `broken-form-validation` vanished: the repo's own `yoda` lint rule rewrote the fixture from
+ * `service.trim().length === 0` to `0 === service.trim().length`, these anchors were not updated with
+ * it, and three tools' worth of cells silently went missing with nothing red anywhere.
+ *
+ * Injects each regression and reverts it, reporting the ones that no longer apply. Cheap enough to
+ * run before a measured pass, which is the point: a benchmark that cannot inject its bugs is not
+ * measuring anything, and it must say so LOUDLY rather than average itself over the survivors.
+ */
+export function verifyAnchors() {
+  const broken = [];
+  for (const id of Object.keys(REGRESSIONS)) {
+    try {
+      inject(id);
+    } catch (e) {
+      broken.push({ id, error: e instanceof Error ? e.message : String(e) });
+    } finally {
+      revert(id);
+    }
+  }
+  return broken;
+}
+
+if (process.argv[2] === '--verify-anchors') {
+  const broken = verifyAnchors();
+  for (const b of broken) console.error(`DRIFTED ${b.id}: ${b.error.split('\n')[0]}`);
+  console.log(
+    0 === broken.length
+      ? `anchors ok — all ${String(Object.keys(REGRESSIONS).length)} regressions still apply`
+      : `${String(broken.length)} of ${String(Object.keys(REGRESSIONS).length)} regressions no longer apply`,
+  );
+  process.exit(0 === broken.length ? 0 : 1);
+}
 if (process.argv[2] === '--revert-all') {
   revertAll();
   console.log('reverted all');


### PR DESCRIPTION
One scenario has not been measured for any tool, and nothing anywhere was red.

## What happened

The repo's own `yoda` lint rule rewrote the fixture from `service.trim().length === 0` to `0 === service.trim().length`. The injector's anchors for `broken-form-validation` were never updated with it, so `replaceOnce` threw, the observation harness recorded `NOT MEASURED` for all three tools, and the scenario left the comparison.

The failure mode is the dangerous one — it **flatters us**. The catch-rate is computed over measured rows, so a scenario disappearing from the denominator cannot lower it. The headline stayed perfect while coverage shrank, and the gate compared catch-rate `1` against catch-rate `1` and passed.

This is the third time the harness has produced a confidently wrong number by measuring less than it claimed, after the two port disagreements already written up at the top of `ports.mjs` and the fixture orphan that stopped `bench-all` completing at all.

## The fix

**Anchors corrected** to the yoda form the fixture actually has, restoring the scenario.

**`verifyAnchors()`** injects and reverts every registered regression up front and reports any that no longer apply. Wired into `bench-all --full` **before any pass runs** — a drifted anchor discovered afterwards has already produced a number somebody may have quoted. Also standalone:

```
node bench/harness/inject.mjs --verify-anchors   # exits non-zero on drift
```

## Verified both directions

- On the fixed anchors: `anchors ok — all 8 regressions still apply`, exit 0
- Re-introducing the old non-yoda anchor: `DRIFTED broken-form-validation: …NewDeployModal.tsx`, exit 1

The working tree is left clean either way (each injection is reverted in a `finally`).

## Not a defect, deliberately left alone

`cross-component-regression` is also `NOT MEASURED`, but that one is an **explicit documented skip** in `run-observation.mjs` — deferred to the agent-loop layer to avoid a per-tool counting heuristic that would bias the comparison. An honest abstention is not the same thing as a silent loss, and it should not be "fixed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)