### PR TITLE
Temp-dir teardown must not manufacture a Windows failure

### DIFF
--- a/packages/server/src/capsule/capsule-store.test.ts
+++ b/packages/server/src/capsule/capsule-store.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ActionType, AnchorKind, type FlowStep } from '@reticlehq/core';
@@ -38,7 +39,7 @@ describe('CapsuleStore (fail-to-pass bug capsules)', () => {
     root = join(dir, '.reticle');
   });
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('saves a capsule and reads it back', async () => {

--- a/packages/server/src/cli/cli-port.test.ts
+++ b/packages/server/src/cli/cli-port.test.ts
@@ -1,3 +1,4 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -18,7 +19,7 @@ describe('readJournalEnabled', () => {
     dir = await mkdtemp(join(tmpdir(), 'reticle-journal-cfg-'));
   });
   afterEach(async () => {
-    await rm(dir, { recursive: true, force: true });
+    await removeTempDir(dir);
   });
 
   it('defaults to on when no config and no env', () => {
@@ -46,7 +47,7 @@ describe('readProjectPort', () => {
     dir = await mkdtemp(join(tmpdir(), 'reticle-port-'));
   });
   afterEach(async () => {
-    await rm(dir, { recursive: true, force: true });
+    await removeTempDir(dir);
   });
 
   async function writeConfig(content: string): Promise<void> {
@@ -164,7 +165,7 @@ describe('readProjectId', () => {
     dir = await mkdtemp(join(tmpdir(), 'reticle-projid-'));
   });
   afterEach(async () => {
-    await rm(dir, { recursive: true, force: true });
+    await removeTempDir(dir);
   });
 
   async function writeConfig(content: string): Promise<void> {

--- a/packages/server/src/cloud/cloud-config.test.ts
+++ b/packages/server/src/cloud/cloud-config.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { resolveProjectCloud, CLOUD_LINK_FILE, CREDENTIALS_FILE } from './cloud-config.js';
@@ -20,7 +21,7 @@ describe('resolveProjectCloud — per-project cloud binding + sync policy', () =
     fs = createNodeFileSystem();
   });
   afterEach(async () => {
-    await rm(dir, { recursive: true, force: true });
+    await removeTempDir(dir);
   });
 
   const writeLink = (obj: unknown): Promise<void> =>

--- a/packages/server/src/flows/annotate-tools.test.ts
+++ b/packages/server/src/flows/annotate-tools.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -85,7 +86,7 @@ describe('reticle_annotate handler — temp dir, never touches the repo', () => 
   });
 
   afterEach(async () => {
-    await rm(dir, { recursive: true, force: true });
+    await removeTempDir(dir);
   });
 
   it('annotate during an active recording sets the last step expect + returns compiled text', async () => {

--- a/packages/server/src/flows/assertion-tiers-store.test.ts
+++ b/packages/server/src/flows/assertion-tiers-store.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createNodeFileSystem } from '../project/fs-port.js';
@@ -15,7 +16,7 @@ describe('AssertionTiersStore (anti-downgrade baseline)', () => {
     root = join(dir, '.reticle');
   });
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('records a passing flow’s assertion shape and reads it back', async () => {

--- a/packages/server/src/flows/flake-store.test.ts
+++ b/packages/server/src/flows/flake-store.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createNodeFileSystem, type FileSystemPort } from '../project/fs-port.js';
@@ -15,7 +16,7 @@ describe('FlakeStore', () => {
     fs = createNodeFileSystem();
   });
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('accrues outcomes and quarantines a flow once it is intermittently failing', async () => {

--- a/packages/server/src/flows/flow-verify.flaky.test.ts
+++ b/packages/server/src/flows/flow-verify.flaky.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ReplayStatus } from '@reticlehq/core';
@@ -27,7 +28,7 @@ describe('flow_verify feeds and reads the flake ledger', () => {
     root = join(await mkdtemp(join(tmpdir(), 'reticle-verify-flake-')), '.reticle');
   });
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   /**

--- a/packages/server/src/flows/flows.heal.test.ts
+++ b/packages/server/src/flows/flows.heal.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -178,7 +179,7 @@ describe('FlowStore.heal + reticle_flow_heal', () => {
   });
 
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('heal apply:true rewrites a renamed testid and a subsequent replay is green', async () => {
@@ -439,7 +440,7 @@ describe('FlowStore.heal — writer', () => {
   });
 
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('rewrites only the named step anchors, leaving every other step byte-identical', async () => {

--- a/packages/server/src/flows/flows.recorded.test.ts
+++ b/packages/server/src/flows/flows.recorded.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -57,7 +58,7 @@ describe('FlowStore.saveFlow — temp-dir fs', () => {
   });
 
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('saveFlow writes a valid FlowFile and round-trips via load', async () => {
@@ -129,7 +130,7 @@ describe('reticle_flow_save_recorded handler', () => {
   });
 
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('reads the LAST FLOW_RECORDED event and persists it', async () => {

--- a/packages/server/src/flows/flows.scope.test.ts
+++ b/packages/server/src/flows/flows.scope.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { asFlowName, AnchorKind, FLOW_FILE_VERSION, type FlowFile } from '@reticlehq/core';
@@ -30,7 +31,7 @@ describe('FlowStore — per-project storage (shared-daemon isolation)', () => {
   });
 
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('nests a saved flow under its projectId and stamps the file', async () => {

--- a/packages/server/src/flows/flows.test.ts
+++ b/packages/server/src/flows/flows.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, readFile, rm, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -37,7 +38,7 @@ describe('FlowStore — temp-dir fs, never touches the repo', () => {
   });
 
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   // ---- VALID ----

--- a/packages/server/src/flows/suite-flakes.test.ts
+++ b/packages/server/src/flows/suite-flakes.test.ts
@@ -1,3 +1,4 @@
+import { removeTempDir } from '../temp-dir.js';
 /**
  * The flake-ledger step of `flow_verify`, tested against the shipped function rather than a copy.
  *
@@ -9,7 +10,7 @@
  * extracted now: the part worth pinning is separable from the part that needs a browser.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ReplayStatus } from '@reticlehq/core';
@@ -26,7 +27,7 @@ beforeEach(async () => {
   root = join(await mkdtemp(join(tmpdir(), 'reticle-suite-flakes-')), '.reticle');
 });
 afterEach(async () => {
-  await rm(join(root, '..'), { recursive: true, force: true });
+  await removeTempDir(join(root, '..'));
 });
 
 /** One suite run, as the handler passes it: a list of `{ replay }` wrappers. */

--- a/packages/server/src/flows/tools.flow-replay.test.ts
+++ b/packages/server/src/flows/tools.flow-replay.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -121,7 +122,7 @@ describe('reticle_flow_replay handler — temp dir, never touches the repo', () 
   });
 
   afterEach(async () => {
-    await rm(dir, { recursive: true, force: true });
+    await removeTempDir(dir);
   });
 
   async function saveFlow(name: string, steps: RecordedStep[]): Promise<void> {

--- a/packages/server/src/index.daemon.test.ts
+++ b/packages/server/src/index.daemon.test.ts
@@ -1,6 +1,7 @@
+import { removeTempDir } from './temp-dir.js';
 import { afterEach, describe, expect, it } from 'vitest';
 import * as http from 'node:http';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ReticleEnv, LOOPBACK_HOST } from '@reticlehq/core';
@@ -54,7 +55,7 @@ describe('startDaemon port collision', () => {
     server = undefined;
     if (blocker !== undefined) await new Promise<void>((r) => blocker?.close(() => r()));
     blocker = undefined;
-    if (root !== undefined) await rm(join(root, '..'), { recursive: true, force: true });
+    if (root !== undefined) await removeTempDir(join(root, '..'));
     root = undefined;
   });
 

--- a/packages/server/src/journal/ambient-store.test.ts
+++ b/packages/server/src/journal/ambient-store.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createNodeFileSystem, type FileSystemPort } from '../project/fs-port.js';
@@ -15,7 +16,7 @@ describe('AmbientStore', () => {
     fs = createNodeFileSystem();
   });
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('returns an empty map when nothing is persisted', async () => {

--- a/packages/server/src/journal/attach-journal.test.ts
+++ b/packages/server/src/journal/attach-journal.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { EventType, type ReticleEvent } from '@reticlehq/core';
@@ -30,7 +31,7 @@ describe('makeJournalAttach', () => {
   });
 
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('attaches a recorder that journals events to disk for a valid session', async () => {

--- a/packages/server/src/journal/bridge-journal.integration.test.ts
+++ b/packages/server/src/journal/bridge-journal.integration.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { EventType, type JournalAction, type ReticleEvent } from '@reticlehq/core';
@@ -39,7 +40,7 @@ describe('durable journal over a live bridge session', () => {
   afterAll(async () => {
     browser.close();
     await bridge.close();
-    await rm(dir, { recursive: true, force: true });
+    await removeTempDir(dir);
   });
 
   it('journals streamed events and a minted act to disk', async () => {

--- a/packages/server/src/journal/deviation-service.test.ts
+++ b/packages/server/src/journal/deviation-service.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createNodeFileSystem, type FileSystemPort } from '../project/fs-port.js';
@@ -32,7 +33,7 @@ describe('reportAndAccumulate — the push-default loop', () => {
     store = new EnvelopeStore(fs, root);
   });
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('is silent on early runs, then catches a regression once the envelope matures', async () => {

--- a/packages/server/src/journal/envelope-store.test.ts
+++ b/packages/server/src/journal/envelope-store.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createNodeFileSystem, type FileSystemPort } from '../project/fs-port.js';
@@ -30,7 +31,7 @@ describe('EnvelopeStore', () => {
     fs = createNodeFileSystem();
   });
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('returns an empty map when nothing is persisted (never throws)', async () => {

--- a/packages/server/src/journal/retention.test.ts
+++ b/packages/server/src/journal/retention.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm, mkdir, writeFile, readdir } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createNodeFileSystem, type FileSystemPort } from '../project/fs-port.js';
@@ -31,7 +32,7 @@ describe('pruneSessions', () => {
     fs = createNodeFileSystem();
   });
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('keeps only the retention-most-recent session dirs on disk', async () => {

--- a/packages/server/src/journal/session-end.test.ts
+++ b/packages/server/src/journal/session-end.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createNodeFileSystem } from '../project/fs-port.js';
@@ -34,7 +35,7 @@ describe('makeSessionEnd (teardown: flush journal + persist ambient)', () => {
     root = join(dir, '.reticle');
   });
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('flushes the journal so the tail of a session is never lost from disk', async () => {
@@ -88,7 +89,7 @@ describe('journal retention is bounded on a long-running daemon', () => {
     root = join(dir, '.reticle');
   });
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('prunes at session END, not only at daemon start', async () => {

--- a/packages/server/src/journal/session-journal.test.ts
+++ b/packages/server/src/journal/session-journal.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -45,7 +46,7 @@ describe('SessionJournal — durable JSONL over a temp dir', () => {
   });
 
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('appends events in batches and reads them back in order', async () => {

--- a/packages/server/src/orphan-modules.test.ts
+++ b/packages/server/src/orphan-modules.test.ts
@@ -26,6 +26,11 @@ const DECLARED_UNWIRED: Record<string, string> = {
     'Mermaid confidence report. No caller can produce it today — needs a CLI or tool surface first.',
   'phenomena/phenomena.ts':
     'Phenomenon classification over journal actions. Staged for the deviation reporter; not yet called.',
+  'temp-dir.ts':
+    'Test-only teardown helper: removing a temp directory tolerantly of Windows’ delayed handle ' +
+    'release. Production code never deletes a temp tree, so a production importer would be the ' +
+    'surprise here — it is imported by ~30 test files and belongs to src only because that is where ' +
+    'the tsconfig can see it.',
   'ee/audit-log.ts':
     'Enterprise audit hook, a self-admitted pass-through stub. Nothing calls it; the license gate that ' +
     'would is real, but this consumer is not implemented.',

--- a/packages/server/src/project/contract-governance.test.ts
+++ b/packages/server/src/project/contract-governance.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { RiskSurface, type CapabilitiesContract } from '@reticlehq/core';
@@ -32,7 +33,7 @@ describe('contract persistence preserves declared governance', () => {
   });
 
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('round-trips governance through write + read', async () => {

--- a/packages/server/src/project/project-store.test.ts
+++ b/packages/server/src/project/project-store.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -36,7 +37,7 @@ describe('ProjectStore — temp-dir filesystem, never touches the repo', () => {
   });
 
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   // ---- VALID ----

--- a/packages/server/src/project/project-tools.test.ts
+++ b/packages/server/src/project/project-tools.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ProjectReadError, RunKind, RunStatus } from '@reticlehq/core';
@@ -62,7 +63,7 @@ describe('project tools — temp dir, never touches the repo', () => {
   });
 
   afterEach(async () => {
-    await rm(dir, { recursive: true, force: true });
+    await removeTempDir(dir);
   });
 
   it('1: reticle_run_record appends a run, defaulting kind to manual', async () => {

--- a/packages/server/src/project/reticle-dir.test.ts
+++ b/packages/server/src/project/reticle-dir.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { asFlowName, ContractReadError, type CapabilitiesContract } from '@reticlehq/core';
@@ -38,7 +39,7 @@ describe('reticle-dir — temp-dir filesystem, never touches the repo', () => {
   });
 
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   // ---- VALID ----
@@ -83,8 +84,8 @@ describe('reticle-dir — temp-dir filesystem, never touches the repo', () => {
     expect(textA).toBe(textB);
     expect(textA).toContain('"testids": [\n      "a",\n      "b"\n    ]');
     expect(textA.indexOf('"name": "a"')).toBeLessThan(textA.indexOf('"name": "z"'));
-    await rm(dirA, { recursive: true, force: true });
-    await rm(dirB, { recursive: true, force: true });
+    await removeTempDir(dirA);
+    await removeTempDir(dirB);
   });
 
   it('4: writeContract stamps version + generatedAt from injected clock', async () => {

--- a/packages/server/src/runs/run-store.test.ts
+++ b/packages/server/src/runs/run-store.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, readdir, rm } from 'node:fs/promises';
+import { mkdtemp, readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { asRunId, RunReadError, type ReticleVerificationRun } from '@reticlehq/core';
@@ -38,7 +39,7 @@ describe('RunStore — temp-dir filesystem, never touches the repo', () => {
   });
 
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('writes then reads a run round-trip', async () => {

--- a/packages/server/src/runs/run-tools.test.ts
+++ b/packages/server/src/runs/run-tools.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -71,7 +72,7 @@ describe('reticle_run_export (MCP persona)', () => {
   });
 
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('is registered', () => {

--- a/packages/server/src/runs/verification-sync.test.ts
+++ b/packages/server/src/runs/verification-sync.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ReplayStatus, type FlowReplayResult } from '@reticlehq/core';
@@ -49,7 +50,7 @@ describe('persistAndSyncVerificationRun — MCP verification → Runs-tab artifa
     globalThis.fetch = origFetch;
     delete process.env[URL_ENV];
     delete process.env[KEY_ENV];
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('writes the run artifact to disk even when not logged in (no phone-home)', async () => {

--- a/packages/server/src/runs/verify-daemon.test.ts
+++ b/packages/server/src/runs/verify-daemon.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtemp, readdir, rm } from 'node:fs/promises';
+import { mkdtemp, readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { startDaemon, type RunningServer } from '../index.js';
@@ -17,7 +18,7 @@ describe('reticle serve --http (daemon wiring)', () => {
   afterEach(async () => {
     await server?.close();
     server = undefined;
-    if (root !== undefined) await rm(join(root, '..'), { recursive: true, force: true });
+    if (root !== undefined) await removeTempDir(join(root, '..'));
     root = undefined;
   });
 

--- a/packages/server/src/temp-dir.ts
+++ b/packages/server/src/temp-dir.ts
@@ -1,0 +1,48 @@
+/**
+ * Removing a temp directory on Windows, without inventing a product failure.
+ *
+ * `rm(dir, { recursive: true, force: true })` is the obvious teardown and it is not enough on
+ * Windows. Deletion there is not immediate: a handle the OS, the indexer or a virus scanner still
+ * holds keeps the entry alive for a moment after the last close, so the directory is observed
+ * non-empty at the instant `rmdir` runs and Node throws `ENOTEMPTY`. `force` does not cover it —
+ * that suppresses "missing", not "busy".
+ *
+ * The failure lands in `afterEach`, so it is reported against the test that just PASSED, and the
+ * leftover directory then bleeds state into what runs next. On CI this presented as five failures in
+ * one file, four of them consequential and one of them the wonderfully misleading "expected length 1
+ * but got 2" — a fake production bug manufactured entirely by teardown. This repo already has that
+ * exact story written up in `project-store.test.ts` about a timed-out test's stray writes; this is the
+ * same failure arriving through the filesystem instead of through the clock.
+ *
+ * `maxRetries`/`retryDelay` exist in Node for precisely this, and are documented as Windows-oriented.
+ * They are a no-op on POSIX, where the first attempt already succeeds.
+ */
+
+import { rm } from 'node:fs/promises';
+
+/**
+ * Retries and backoff. Small and bounded: this is covering a millisecond-scale handle release, so if
+ * it has not gone in half a second the cause is not a race and a slower retry would only hide it.
+ */
+const MAX_RETRIES = 10;
+const RETRY_DELAY_MS = 50;
+
+/**
+ * Delete a temp directory tree, tolerating Windows' delayed handle release.
+ *
+ * Never throws: a temp directory that outlives the test is the operating system's problem, not a
+ * reason to fail a run or to report a defect the product does not have. What must not happen is the
+ * opposite — a red that says nothing about the code under test.
+ */
+export async function removeTempDir(dir: string): Promise<void> {
+  try {
+    await rm(dir, {
+      recursive: true,
+      force: true,
+      maxRetries: MAX_RETRIES,
+      retryDelay: RETRY_DELAY_MS,
+    });
+  } catch {
+    // Deliberately swallowed — see above. The OS reclaims the temp directory regardless.
+  }
+}

--- a/packages/server/src/visual/visual-store.test.ts
+++ b/packages/server/src/visual/visual-store.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { VisualStore } from './visual-store.js';
@@ -20,7 +21,7 @@ describe('VisualStore — temp dir, never touches the repo', () => {
   });
 
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   it('1: saveBaseline → readBaseline round-trips the exact bytes', async () => {

--- a/packages/server/src/visual/visual-tools.test.ts
+++ b/packages/server/src/visual/visual-tools.test.ts
@@ -1,5 +1,6 @@
+import { removeTempDir } from '../temp-dir.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { mkdtemp, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PNG } from 'pngjs';
@@ -59,7 +60,7 @@ describe('visual tools — temp dir, never touches the repo', () => {
   });
 
   afterEach(async () => {
-    await rm(join(root, '..'), { recursive: true, force: true });
+    await removeTempDir(join(root, '..'));
   });
 
   function deps(provider?: RealInputProvider): ToolDeps {


### PR DESCRIPTION
Five tests failed on the Windows runner for a reason that is not in the code under test.

```
ENOTEMPTY: directory not empty, rmdir 'C:\...\Temp\reticle-proj-CjOVBG'
AssertionError: expected [...] to have a length of 1 but got 2
```

Deletion on Windows is not immediate. A handle held by the OS, the indexer or a virus scanner keeps the entry alive for a moment after the last close, so the directory is observed non-empty at the instant `rmdir` runs. `force` does not cover it — that suppresses *missing*, not *busy*.

The failure lands in `afterEach`, so **it is reported against the test that just passed**, and the leftover tree bleeds into what runs next. That is where `expected length 1 but got 2` comes from — a fake production bug manufactured entirely by teardown.

This repo already has that exact story written up in `project-store.test.ts`, about a timed-out test's stray writes landing in the next test's store. Same failure, arriving through the filesystem instead of through the clock.

## Fixed at the root, not where it went red

`maxRetries`/`retryDelay` exist in Node for precisely this case and are documented as Windows-oriented. They are a no-op on POSIX.

All **32** test files used the same `rm(dir, { recursive: true, force: true })`, so every one carries the hazard and only timing decides which reports it. Patching the one file that failed would have left 31 loaded guns. They now share `removeTempDir`, which also swallows the error: a temp directory outliving a test is the OS's problem, and must never produce a red that says nothing about the code.

`temp-dir.ts` is declared in the orphan-module list with its reason — production code never deletes a temp tree, so a production importer would be the surprise.

## Gates

format ✓ · lint ✓ · typecheck ✓ · unit 15/15 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)