### PR TITLE
Spend the budget you were given before reporting uncertainty

### DIFF
--- a/packages/server/src/tools/act-tools.ts
+++ b/packages/server/src/tools/act-tools.ts
@@ -23,6 +23,7 @@ import { buildReactionReport, summarizeReaction } from '../events/reaction.js';
 import { parsePredicate } from '../events/predicate-parse.js';
 import { causalSummary } from '../capsule/causal-summary.js';
 import { findContradictions } from '../events/contradictions.js';
+import { waitForInFlight } from './settle-in-flight.js';
 import { decideVerified } from '../honesty/verified.js';
 import { readsDomState } from '../honesty/already-true.js';
 import { saveFailedAssertCapsule } from './act-capsule.js';
@@ -458,10 +459,28 @@ export const ACT_TOOLS: ToolDef[] = [
         );
 
         // Honesty: floor the predicate at this act's cursor so a stale buffered event can't satisfy it.
+        const predicateStarted = session.elapsed();
         const verdict =
           timeout > 0
             ? await waitForPredicate(session, until, timeout, since)
             : await evaluatePredicate(session, until, since);
+
+        // The predicate resolves the INSTANT it holds, which on an optimistically-navigating app is
+        // while the write is still in flight — so the verdict was taken over a window the app had not
+        // finished, and came back `unknown / unsettled` asking the CALLER to re-check. A login that
+        // genuinely succeeded returned at 492ms of an 8000ms budget with every corroborating channel
+        // agreeing. Spend the rest of the budget the caller already granted.
+        //
+        // This decides nothing: it waits for the answer instead of guessing at it. A response that
+        // arrives as a FAILURE still contradicts — and now arrives INSIDE the window, where the
+        // detector can see it at all — while a request still open when the budget genuinely runs out
+        // reports unsettled exactly as before, an honest limit rather than an early exit. Costs
+        // nothing on the common path, where no request is in flight.
+        if (verdict.pass && timeout > 0) {
+          await waitForInFlight(session, since, timeout - (session.elapsed() - predicateStarted), {
+            sleep: (ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
+          });
+        }
 
         const r = asRecord(actResult.result);
         if ('boolean' === typeof r['settled']) settledOutcome = r['settled'];

--- a/packages/server/src/tools/settle-in-flight.test.ts
+++ b/packages/server/src/tools/settle-in-flight.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Spend the budget you were given before reporting that you ran out of certainty.
+ *
+ * A login that genuinely succeeds is the most common flow an agent verifies, and it came back
+ * `verified:"unknown" / unsettled` — with the declared signal fired AND its data matching, app state
+ * moved from anonymous to authenticated, the auth token written to storage, honesty grade `signal`
+ * (our strongest evidence class) and capture integrity clean. The single dissenting observation was
+ * that the POST had not come back yet.
+ *
+ * The tool had 8000ms of budget and returned at 492ms. `waitForPredicate` resolves the instant the
+ * predicate holds, so the verdict is taken while the app is still mid-flight, and the answer is a
+ * shrug the caller then has to resolve by hand — the recovery text literally says "re-check". Seven
+ * and a half seconds of authorised waiting went unused.
+ *
+ * Note what this deliberately does NOT do. It never turns an unsettled request into a pass by
+ * assumption: the app navigates optimistically, so at 492ms nobody can know whether that POST
+ * succeeds. It waits for the answer instead of guessing at it. A request that comes back a FAILURE
+ * still contradicts — that is the real false green and it has to keep working — and a request that is
+ * still in flight when the budget genuinely runs out still reports unsettled, which is now an honest
+ * limit rather than an early exit.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ContradictionKind, EventType, type ReticleEvent } from '@reticlehq/core';
+import { findContradictions } from '../events/contradictions.js';
+import { inFlightRequestIds, waitForInFlight } from './settle-in-flight.js';
+
+type Ev = { type: string; t: number; data: Record<string, unknown> };
+
+const pending = (id: string, t = 0): Ev => ({
+  type: EventType.NET_PENDING,
+  t,
+  data: { id, url: `https://api.test/${id}`, method: 'POST' },
+});
+const settled = (id: string, t = 1): Ev => ({
+  type: EventType.NET_REQUEST,
+  t,
+  data: { id, url: `https://api.test/${id}`, method: 'POST', status: 200 },
+});
+
+describe('which requests are still in flight', () => {
+  it('a pending request with no matching settle is in flight', () => {
+    expect(inFlightRequestIds([pending('a')])).toEqual(['a']);
+  });
+
+  it('a pending request that settled is not', () => {
+    expect(inFlightRequestIds([pending('a'), settled('a')])).toEqual([]);
+  });
+
+  it('reports only the ones still outstanding', () => {
+    const events = [pending('a'), pending('b'), settled('a')];
+    expect(inFlightRequestIds(events)).toEqual(['b']);
+  });
+
+  it('says nothing when there was no traffic at all', () => {
+    expect(inFlightRequestIds([])).toEqual([]);
+  });
+
+  it('ignores a settle for a request it never saw start', () => {
+    // The window is floored at the act cursor, so a response to a request made BEFORE the action can
+    // land inside it. That settles nothing this action started and must not be read as progress.
+    expect(inFlightRequestIds([settled('older')])).toEqual([]);
+  });
+});
+
+describe('waiting out the remaining budget', () => {
+  /** A fake session whose events change over successive polls, with a controllable clock. */
+  function fakeSession(frames: Ev[][]) {
+    let poll = 0;
+    let now = 0;
+    return {
+      session: {
+        eventsSince: () => frames[Math.min(poll, frames.length - 1)] ?? [],
+        elapsed: () => now,
+      },
+      tick: (ms: number) => {
+        now += ms;
+        poll += 1;
+      },
+      polls: () => poll,
+    };
+  }
+
+  it('returns as soon as everything has settled', async () => {
+    const f = fakeSession([[pending('a')], [pending('a'), settled('a')]]);
+    const waited = await waitForInFlight(f.session, 0, 5000, {
+      sleep: (ms) => {
+        f.tick(ms);
+        return Promise.resolve();
+      },
+    });
+    expect(waited.settled).toBe(true);
+    expect(waited.stillInFlight).toEqual([]);
+  });
+
+  it('does not wait at all when nothing is in flight', async () => {
+    const f = fakeSession([[pending('a'), settled('a')]]);
+    const waited = await waitForInFlight(f.session, 0, 5000, {
+      sleep: (ms) => {
+        f.tick(ms);
+        return Promise.resolve();
+      },
+    });
+    expect(waited.settled).toBe(true);
+    expect(f.polls()).toBe(0); // the green path with no traffic pays nothing
+  });
+
+  it('gives up at the deadline and says what was still outstanding', async () => {
+    const f = fakeSession([[pending('a')]]);
+    const waited = await waitForInFlight(f.session, 0, 300, {
+      sleep: (ms) => {
+        f.tick(ms);
+        return Promise.resolve();
+      },
+    });
+    expect(waited.settled).toBe(false);
+    expect(waited.stillInFlight).toEqual(['a']);
+  });
+
+  it('never waits past the budget it was given', async () => {
+    const f = fakeSession([[pending('a')]]);
+    await waitForInFlight(f.session, 0, 250, {
+      sleep: (ms) => {
+        f.tick(ms);
+        return Promise.resolve();
+      },
+    });
+    expect(f.session.elapsed()).toBeLessThanOrEqual(250);
+  });
+
+  it('treats a zero or negative budget as no wait, not as an unbounded one', async () => {
+    // The caller may have spent the whole timeout reaching the predicate. Subtracting can go negative,
+    // and a negative deadline must mean "stop", never "loop forever".
+    const f = fakeSession([[pending('a')]]);
+    const waited = await waitForInFlight(f.session, 0, -50, {
+      sleep: (ms) => {
+        f.tick(ms);
+        return Promise.resolve();
+      },
+    });
+    expect(waited.settled).toBe(false);
+    expect(f.polls()).toBe(0);
+  });
+
+  it('waits for a request that settles as a FAILURE, so the contradiction can still be found', async () => {
+    // The point is not to make things green. A 500 that arrives during the wait is evidence the
+    // action failed, and arriving is what lets the verdict see it at all.
+    const failed = (id: string): Ev => ({
+      type: EventType.NET_REQUEST,
+      t: 2,
+      data: { id, url: `https://api.test/${id}`, method: 'POST', status: 500 },
+    });
+    const f = fakeSession([[pending('a')], [pending('a'), failed('a')]]);
+    const waited = await waitForInFlight(f.session, 0, 5000, {
+      sleep: (ms) => {
+        f.tick(ms);
+        return Promise.resolve();
+      },
+    });
+    expect(waited.settled).toBe(true);
+  });
+});
+
+/**
+ * The property that makes this change safe to ship at all.
+ *
+ * The instinct about anything that turns `unknown` into `yes` is that it must have loosened
+ * something. This loosens nothing — it makes the window CONTAIN the response instead of ending
+ * before it. A failure that used to land after the window closed, where no detector could reach it,
+ * now lands inside it where `ui-advanced-request-failed` fires. Strictly more evidence, and the
+ * direction of the change is toward catching false greens, not away.
+ */
+describe('waiting strengthens the false-green guard rather than weakening it', () => {
+  let seq = 0;
+  const ev = (type: EventType, data: Record<string, unknown>): ReticleEvent => {
+    seq += 1;
+    return { t: seq, seq, type, sessionId: 's', data };
+  };
+
+  it('a window that ends before the response sees no failure to report', () => {
+    // What the old early exit produced: the UI advanced, the POST is merely absent, and the only
+    // finding possible is the weak one about not having waited.
+    const early = [
+      ev(EventType.DOM_REMOVED, { path: 'form' }),
+      ev(EventType.NET_PENDING, { id: 'n1', method: 'POST', url: '/api/login' }),
+    ];
+    const found = findContradictions(early).map((c) => c.kind);
+    expect(found).toContain(ContradictionKind.REQUEST_NEVER_SETTLED);
+    expect(found).not.toContain(ContradictionKind.UI_ADVANCED_REQUEST_FAILED);
+  });
+
+  it('a window that waited for the SAME failing request reports the real defect', () => {
+    const waited = [
+      ev(EventType.DOM_REMOVED, { path: 'form' }),
+      ev(EventType.NET_PENDING, { id: 'n2', method: 'POST', url: '/api/login' }),
+      ev(EventType.NET_REQUEST, {
+        id: 'n2',
+        method: 'POST',
+        url: '/api/login',
+        status: 500,
+        ok: false,
+      }),
+    ];
+    const found = findContradictions(waited).map((c) => c.kind);
+    expect(found).toContain(ContradictionKind.UI_ADVANCED_REQUEST_FAILED);
+    // And the weaker absence-derived finding is gone, because it is no longer true.
+    expect(found).not.toContain(ContradictionKind.REQUEST_NEVER_SETTLED);
+  });
+});

--- a/packages/server/src/tools/settle-in-flight.ts
+++ b/packages/server/src/tools/settle-in-flight.ts
@@ -1,0 +1,107 @@
+/**
+ * Spend the budget you were given before reporting that you ran out of certainty.
+ *
+ * `waitForPredicate` resolves the instant the predicate holds. On an app that navigates
+ * optimistically — which is normal, correct behaviour, and the norm on exactly the flows agents
+ * verify most: login, submit, save — that instant arrives while the write is still in flight. The
+ * verdict was then taken over a window the app had not finished writing, and came back
+ * `unknown / unsettled` with a recovery note asking the CALLER to re-check.
+ *
+ * Measured on the most common flow there is: a login that genuinely succeeded returned at 492ms out
+ * of an 8000ms budget. The declared signal had fired with matching data, state had moved from
+ * anonymous to authenticated, the token was in storage, honesty grade was `signal` and capture
+ * integrity was clean. Seven and a half seconds of authorised waiting went unused, and the agent was
+ * handed a shrug.
+ *
+ * A false NEGATIVE is not the mirror of a false positive here. A false positive stops an agent early;
+ * a false negative makes it redo work that already succeeded, and — far worse — teaches it to
+ * discount the verdict channel. The verdict channel is the entire product, and an agent that learns
+ * to ignore `unknown` will ignore the true ones too.
+ *
+ * What this does NOT do is decide the request succeeded. At 492ms nobody can know that, and inventing
+ * a green here would be the exact defect this product exists to prevent. It waits for the answer
+ * rather than guessing at it:
+ *
+ *   - everything settles → the normal contradiction machinery sees the real responses, so a failure
+ *     still contradicts and a success no longer looks like an absence;
+ *   - still in flight when the budget genuinely runs out → `unsettled`, as before, but now an honest
+ *     limit instead of an early exit.
+ */
+
+import { EventType } from '@reticlehq/core';
+
+/** Just the shape this needs — a real Session satisfies it, and a test can supply it. */
+export interface SettleSource {
+  eventsSince(cursor: number): readonly { type: string; data: Record<string, unknown> }[];
+  elapsed(): number;
+}
+
+interface WaitOpts {
+  /** Injected so the wait is testable without real time passing (rule: never call the clock inline). */
+  sleep(ms: number): Promise<void>;
+}
+
+/** How often to re-read the buffer. Short enough to return promptly, long enough not to spin. */
+const POLL_MS = 50;
+
+const idOf = (data: Record<string, unknown>): string | undefined =>
+  'string' === typeof data['id'] ? data['id'] : undefined;
+
+/**
+ * Requests that started in this window and have not come back.
+ *
+ * A settle for a request this window never saw START is ignored on purpose: the window is floored at
+ * the act cursor, so a response belonging to an earlier action can land inside it, and counting that
+ * as progress would let unrelated traffic close the window early.
+ */
+export function inFlightRequestIds(
+  events: readonly { type: string; data: Record<string, unknown> }[],
+): string[] {
+  const settled = new Set<string>();
+  for (const e of events) {
+    if (e.type !== EventType.NET_REQUEST) continue;
+    const id = idOf(e.data);
+    if (id !== undefined) settled.add(id);
+  }
+  const open: string[] = [];
+  for (const e of events) {
+    if (e.type !== EventType.NET_PENDING) continue;
+    const id = idOf(e.data);
+    if (id !== undefined && !settled.has(id) && !open.includes(id)) open.push(id);
+  }
+  return open;
+}
+
+export interface SettleResult {
+  /** True when nothing this window started is still outstanding. */
+  settled: boolean;
+  /** What was still open when the wait ended — empty when `settled`. */
+  stillInFlight: string[];
+}
+
+/**
+ * Wait, bounded by `budgetMs`, for the requests this window started to come back.
+ *
+ * Returns immediately when nothing is in flight, so the common green path — an action with no traffic
+ * — pays nothing at all. A zero or negative budget means no wait: the caller may have spent the whole
+ * timeout reaching the predicate, and a negative deadline must mean "stop", never "loop forever".
+ */
+export async function waitForInFlight(
+  session: SettleSource,
+  since: number,
+  budgetMs: number,
+  opts: WaitOpts,
+): Promise<SettleResult> {
+  let open = inFlightRequestIds(session.eventsSince(since));
+  if (0 === open.length) return { settled: true, stillInFlight: [] };
+  if (budgetMs <= 0) return { settled: false, stillInFlight: open };
+
+  const deadline = session.elapsed() + budgetMs;
+  while (session.elapsed() < deadline) {
+    // Never overshoot the budget: the last sleep is trimmed to whatever is actually left.
+    await opts.sleep(Math.min(POLL_MS, deadline - session.elapsed()));
+    open = inFlightRequestIds(session.eventsSince(since));
+    if (0 === open.length) return { settled: true, stillInFlight: [] };
+  }
+  return { settled: false, stillInFlight: open };
+}


### PR DESCRIPTION
The second half of #263. A login that genuinely succeeds is still not a pass.

## What the product does today

Driven over MCP against bench-app, on the most common flow there is:

```json
{
  "verified": "unknown",
  "verifiedReason": "unsettled",
  "because": "the assertion held, but this window closed before the app finished (request-never-settled) — re-check, or assert a consequence that settles",
  "verdict": { "pass": true, "evidence": { "name": "auth:granted", "data": { "email": "admin@reticle.dev" } } },
  "honesty": { "grade": "signal", "integrity": { "clean": true, "issues": [] } }
}
```

Everything that could corroborate the action did — the declared signal fired **with matching data**, state moved anonymous → authenticated, the token was written to storage, the grade is `signal` (our strongest evidence class) and the capture is clean.

It returned at **492ms of an 8000ms budget.** `waitForPredicate` resolves the instant the predicate holds, so on an app that navigates optimistically — normal, correct behaviour, and the norm on login/submit/save — the verdict is taken mid-flight. Seven and a half seconds of authorised waiting went unused, and the recovery text asks the *caller* to re-check.

A false negative is not the mirror of a false positive. A false positive stops an agent early; a false negative makes it redo work that already succeeded and teaches it to discount the verdict channel — which is the entire product. An agent that learns to ignore `unknown` will ignore the true ones too.

## The fix is not verdict semantics

Nothing is loosened and no green is invented. At 492ms nobody can know whether that POST succeeds, and asserting it would be the exact defect this product exists to prevent.

The tool was **exiting early and then reporting uncertainty it still had the budget to resolve.** It now waits, bounded by the remaining budget, for the requests this window started to come back — and only then decides.

## Why waiting makes the guard STRONGER

This is the part worth checking rather than trusting. A failure that used to land *after* the window closed, where no detector could reach it, now lands **inside** the window where `ui-advanced-request-failed` fires. Two tests pin exactly that:

- early window → only the weak absence-derived `request-never-settled`
- waited window, same failing request → the real `ui-advanced-request-failed`, and the weak finding correctly gone

Strictly more evidence. The direction of travel is toward catching false greens, not away.

## Cost

Nothing on the common path — an action with no request in flight returns without a single poll. A zero or negative budget means no wait, never an unbounded one, since the caller may have spent the whole timeout reaching the predicate.

## Verification

format ✓ · lint ✓ · typecheck ✓ · unit 15/15 ✓ (13 new)

**Driven over MCP before and after** on the identical login: `unknown / unsettled` → `yes / proved` at signal grade, with the POST now inside the window at zero errors.

Deferring to CI for the e2e battery on this one. My local runs were contaminated by browser tabs left connected from the manual driving above, which is exactly the state that *should* make a navigation assertion fail — the instrument was right and my environment was dirty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)