### PR TITLE
Never accuse an app before it has had a chance to react

### DIFF
--- a/packages/server/src/tools/act-tools.ts
+++ b/packages/server/src/tools/act-tools.ts
@@ -24,6 +24,7 @@ import { parsePredicate } from '../events/predicate-parse.js';
 import { causalSummary } from '../capsule/causal-summary.js';
 import { findContradictions } from '../events/contradictions.js';
 import { waitForInFlight } from './settle-in-flight.js';
+import { waitForReaction } from './react-grace.js';
 import { decideVerified } from '../honesty/verified.js';
 import { readsDomState } from '../honesty/already-true.js';
 import { saveFailedAssertCapsule } from './act-capsule.js';
@@ -477,9 +478,22 @@ export const ACT_TOOLS: ToolDef[] = [
         // reports unsettled exactly as before, an honest limit rather than an early exit. Costs
         // nothing on the common path, where no request is in flight.
         if (verdict.pass && timeout > 0) {
-          await waitForInFlight(session, since, timeout - (session.elapsed() - predicateStarted), {
-            sleep: (ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
-          });
+          const sleep = {
+            sleep: (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
+          };
+          const spent = (): number => timeout - (session.elapsed() - predicateStarted);
+          await waitForInFlight(session, since, spent(), sleep);
+          // Waiting for the response moved the hazard rather than removing it: the response now lands
+          // inside the window BY DESIGN, and the app's re-render happens a task or two later. Close
+          // the window in that gap and every channel agrees the app took a successful write and did
+          // nothing — `response-ignored`, i.e. `verified:"no"` on a correct app, produced entirely by
+          // where we stopped looking. A false accusation is the more damaging direction of error for
+          // a verification tool: it sends someone to fix code that is not broken.
+          //
+          // So the response is not the end of the window; the app's REACTION to it is. Paid only in
+          // the shape that would otherwise be accused — a successful mutating write with nothing
+          // moved after it — and short enough that a genuinely dropped response is still reported.
+          await waitForReaction(session, since, spent(), sleep);
         }
 
         const r = asRecord(actResult.result);

--- a/packages/server/src/tools/react-grace.test.ts
+++ b/packages/server/src/tools/react-grace.test.ts
@@ -1,0 +1,159 @@
+/**
+ * "The app ignored this response" is only sayable once the app has had a chance to read it.
+ *
+ * `response-ignored` fires when a write succeeded on the server and nothing on the client moved. It
+ * is a genuine and valuable finding — a lost write, a response parsed into the void, a render that
+ * never happened. It is also an ACCUSATION, and it is decided by a window boundary.
+ *
+ * Waiting for in-flight requests before taking the verdict made that boundary dangerous in a way it
+ * was not before. Previously the write was still pending when the window closed, so it never reached
+ * the `settled` list and this rule could not fire at all. Now the response lands inside the window by
+ * design — and the app's re-render happens in a later task, a few milliseconds after. Close the
+ * window in that gap and every channel agrees the app took a successful write and did nothing.
+ *
+ * The verdict would be `verified: "no"` on a completely correct application, produced entirely by
+ * where we chose to stop looking. That is a false green's evil twin and the more damaging one for a
+ * verification tool: it accuses.
+ *
+ * So the response is not the end of the window — the app's REACTION to it is. When a successful write
+ * settles and nothing has moved yet, wait briefly for the reaction, bounded by the caller's remaining
+ * budget. Only after that grace has passed with nothing at all is "ignored" an honest word.
+ *
+ * The grace is paid only in the exact case that would otherwise be accused: a successful mutating
+ * write with no movement after it. An action that already moved the UI returns immediately.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ContradictionKind, EventType, type ReticleEvent } from '@reticlehq/core';
+import { findContradictions } from '../events/contradictions.js';
+import { awaitsReaction, waitForReaction } from './react-grace.js';
+
+type Ev = { type: string; t: number; data: Record<string, unknown> };
+
+const okWrite = (t = 1): Ev => ({
+  type: EventType.NET_REQUEST,
+  t,
+  data: { id: 'n1', method: 'POST', url: '/api/save', status: 200, ok: true },
+});
+const okRead = (t = 1): Ev => ({
+  type: EventType.NET_REQUEST,
+  t,
+  data: { id: 'n2', method: 'GET', url: '/api/list', status: 200, ok: true },
+});
+const failedWrite = (t = 1): Ev => ({
+  type: EventType.NET_REQUEST,
+  t,
+  data: { id: 'n3', method: 'POST', url: '/api/save', status: 500, ok: false },
+});
+const domMoved = (t = 2): Ev => ({ type: EventType.DOM_TEXT, t, data: { path: 'div' } });
+const stateMoved = (t = 2): Ev => ({ type: EventType.STATE_CHANGE, t, data: { store: 'app' } });
+
+describe('is this window one that could be wrongly accused?', () => {
+  it('yes: a successful write with nothing moved after it', () => {
+    expect(awaitsReaction([okWrite()])).toBe(true);
+  });
+
+  it('no: the app already moved, so there is nothing to wait for', () => {
+    expect(awaitsReaction([okWrite(), domMoved()])).toBe(false);
+    expect(awaitsReaction([okWrite(), stateMoved()])).toBe(false);
+  });
+
+  it('no: a READ that changed nothing is a prefetch, never an accusation', () => {
+    // response-ignored is writes-only, so a GET must not buy a grace period nobody needs.
+    expect(awaitsReaction([okRead()])).toBe(false);
+  });
+
+  it('no: a FAILED write is a different finding, and waiting cannot change it', () => {
+    expect(awaitsReaction([failedWrite()])).toBe(false);
+  });
+
+  it('no: no traffic at all — the overwhelmingly common action pays nothing', () => {
+    expect(awaitsReaction([])).toBe(false);
+    expect(awaitsReaction([domMoved()])).toBe(false);
+  });
+});
+
+describe('waiting for the reaction', () => {
+  function fakeSession(frames: Ev[][]) {
+    let poll = 0;
+    let now = 0;
+    return {
+      session: {
+        eventsSince: () => frames[Math.min(poll, frames.length - 1)] ?? [],
+        elapsed: () => now,
+      },
+      tick: (ms: number) => {
+        now += ms;
+        poll += 1;
+      },
+      polls: () => poll,
+    };
+  }
+  const sleeper = (f: { tick: (ms: number) => void }) => ({
+    sleep: (ms: number) => {
+      f.tick(ms);
+      return Promise.resolve();
+    },
+  });
+
+  it('returns the moment the app reacts', async () => {
+    const f = fakeSession([[okWrite()], [okWrite(), domMoved()]]);
+    expect(await waitForReaction(f.session, 0, 5000, sleeper(f))).toBe(true);
+  });
+
+  it('does not wait when the app had already reacted', async () => {
+    const f = fakeSession([[okWrite(), stateMoved()]]);
+    expect(await waitForReaction(f.session, 0, 5000, sleeper(f))).toBe(true);
+    expect(f.polls()).toBe(0);
+  });
+
+  it('gives up after the grace, so a genuinely ignored write is still reported', async () => {
+    // The finding must survive. An app that really does drop the response gets accused, as it should.
+    const f = fakeSession([[okWrite()]]);
+    expect(await waitForReaction(f.session, 0, 5000, sleeper(f))).toBe(false);
+  });
+
+  it('never waits longer than the grace, however much budget is left', async () => {
+    const f = fakeSession([[okWrite()]]);
+    await waitForReaction(f.session, 0, 60_000, sleeper(f));
+    expect(f.session.elapsed()).toBeLessThanOrEqual(300);
+  });
+
+  it('never waits past the remaining budget when that is the smaller of the two', async () => {
+    const f = fakeSession([[okWrite()]]);
+    await waitForReaction(f.session, 0, 80, sleeper(f));
+    expect(f.session.elapsed()).toBeLessThanOrEqual(80);
+  });
+
+  it('treats a spent budget as no wait', async () => {
+    const f = fakeSession([[okWrite()]]);
+    expect(await waitForReaction(f.session, 0, 0, sleeper(f))).toBe(false);
+    expect(f.polls()).toBe(0);
+  });
+});
+
+/** The behaviour this exists to protect, stated against the real detector. */
+describe('the accusation itself', () => {
+  let seq = 0;
+  const ev = (type: EventType, data: Record<string, unknown>): ReticleEvent => {
+    seq += 1;
+    return { t: seq, seq, type, sessionId: 's', data };
+  };
+  const write = (): ReticleEvent =>
+    ev(EventType.NET_REQUEST, { id: 'w', method: 'POST', url: '/api/save', status: 200, ok: true });
+
+  it('a window cut between the response and the render accuses a correct app', () => {
+    // Exactly what the grace prevents — kept as the statement of the hazard.
+    const cut = [write()];
+    expect(findContradictions(cut).map((c) => c.kind)).toContain(
+      ContradictionKind.RESPONSE_IGNORED,
+    );
+  });
+
+  it('the same window including the render does not', () => {
+    const whole = [write(), ev(EventType.DOM_TEXT, { path: 'div' })];
+    expect(findContradictions(whole).map((c) => c.kind)).not.toContain(
+      ContradictionKind.RESPONSE_IGNORED,
+    );
+  });
+});

--- a/packages/server/src/tools/react-grace.ts
+++ b/packages/server/src/tools/react-grace.ts
@@ -1,0 +1,99 @@
+/**
+ * "The app ignored this response" is only sayable once the app has had a chance to read it.
+ *
+ * `response-ignored` fires when a write succeeded on the server and nothing on the client moved. It
+ * is a real and valuable finding — a lost write, a response parsed into the void, a render that never
+ * happened. It is also an ACCUSATION, and it is decided by where a window happens to end.
+ *
+ * Waiting for in-flight requests before taking the verdict made that boundary dangerous in a way it
+ * was not before. Previously the write was still pending when the window closed, so it never reached
+ * the settled list and this rule could not fire at all. Now the response lands inside the window BY
+ * DESIGN — and the app's re-render happens in a later task, a few milliseconds after it. Close the
+ * window in that gap and every channel agrees that the app took a successful write and did nothing.
+ *
+ * The verdict is then `verified:"no"` on a completely correct application, produced entirely by where
+ * we chose to stop looking. For a verification tool that is the more damaging direction of error: a
+ * false green is a missed catch, but a false accusation sends someone to fix code that is not broken,
+ * and it is how the instrument stops being believed.
+ *
+ * So the response is not the end of the window — the app's REACTION to it is. The grace is paid only
+ * in the exact case that would otherwise be accused: a successful mutating write with nothing moved
+ * after it. Every other action returns without a single poll.
+ *
+ * Deliberately short. This covers a task-boundary re-render, not a slow app: if nothing has moved
+ * within the grace, "ignored" has become an honest description and the finding should stand.
+ */
+
+import { EventType } from '@reticlehq/core';
+import type { SettleSource } from './settle-in-flight.js';
+
+/**
+ * How long to let the app react. A React commit after a resolved fetch is one or two task hops; this
+ * is generous against that and still far too short to paper over an app that genuinely dropped the
+ * response.
+ */
+const REACTION_GRACE_MS = 300;
+
+/** Poll cadence — the same as the settle wait, for the same reason. */
+const POLL_MS = 50;
+
+const MUTATING = ['POST', 'PUT', 'PATCH', 'DELETE'];
+
+/** Movement that would clear `response-ignored`; mirrors `uiAdvanced` in the detector. */
+const MOVEMENT = new Set<string>([
+  EventType.DOM_ADDED,
+  EventType.DOM_REMOVED,
+  EventType.DOM_ATTR,
+  EventType.DOM_TEXT,
+  EventType.STATE_CHANGE,
+  EventType.ROUTE_CHANGE,
+]);
+
+function moved(events: readonly { type: string }[]): boolean {
+  return events.some((e) => MOVEMENT.has(e.type));
+}
+
+/**
+ * Is this a window that would be wrongly accused if it ended right now?
+ *
+ * True only for the accusable shape: a SUCCESSFUL MUTATING request settled, and nothing has moved. A
+ * read that changed nothing is a prefetch, a failed write is a different finding entirely, and an
+ * action that already moved the UI has nothing to wait for — none of them buy a grace period.
+ */
+export function awaitsReaction(
+  events: readonly { type: string; data: Record<string, unknown> }[],
+): boolean {
+  if (moved(events)) return false;
+  return events.some((e) => {
+    if (e.type !== EventType.NET_REQUEST) return false;
+    const method = 'string' === typeof e.data['method'] ? e.data['method'].toUpperCase() : '';
+    const ok = e.data['ok'];
+    return MUTATING.includes(method) && true === ok;
+  });
+}
+
+/**
+ * Wait, bounded by BOTH the grace and the caller's remaining budget, for the app to react to a write
+ * it has just been told succeeded.
+ *
+ * Returns whether the app moved. A `false` is not a verdict — it hands the question back to the
+ * contradiction engine, which will raise `response-ignored` exactly as it does today. The point is
+ * only that by then the app has been given its chance, so the finding means what it says.
+ */
+export async function waitForReaction(
+  session: SettleSource,
+  since: number,
+  budgetMs: number,
+  opts: { sleep(ms: number): Promise<void> },
+): Promise<boolean> {
+  if (!awaitsReaction(session.eventsSince(since))) return true;
+  const window = Math.min(REACTION_GRACE_MS, budgetMs);
+  if (window <= 0) return false;
+
+  const deadline = session.elapsed() + window;
+  while (session.elapsed() < deadline) {
+    await opts.sleep(Math.min(POLL_MS, deadline - session.elapsed()));
+    if (moved(session.eventsSince(since))) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
The other half of #275.

## The defect

`response-ignored` fires when a write succeeded on the server and nothing on the client moved. It is a real and valuable finding — a lost write, a response parsed into the void, a render that never happened. It is also an **accusation**, and it is decided by where a window happens to end.

The app’s re-render runs a task or two *after* the response resolves. Close the window in that gap and every channel agrees the app took a successful write and did nothing:

```
verified: "no"   response-ignored
  claim:   1 write(s) succeeded on the server
  counter: nothing on the client changed — no DOM, store or route movement
```

On a completely correct application. Produced entirely by where we chose to stop looking.

For a verification tool this is the more damaging direction of error. A false green is a missed catch; a **false accusation sends someone to fix code that is not broken**, and it is how the instrument stops being believed.

## Honest about provenance

This race already existed for a predicate that waits on the response itself (`{ kind: "net" }`), where the window has always been able to contain the settled write. #275 widened it considerably, because the response now lands inside the window **by design** rather than by luck. So this is the other half of that change, not an unrelated find.

## The fix

The response is not the end of the window — the app’s **reaction** to it is. When a successful mutating write has settled and nothing has moved yet, wait briefly for the movement, bounded by both a short grace and the caller’s remaining budget.

Scoped to the shape that would otherwise be accused, so nothing else pays for it:

| window | waits? |
| --- | --- |
| successful write, nothing moved | **yes** |
| write, UI already moved | no |
| successful GET that changed nothing (a prefetch) | no |
| failed write (a different finding entirely) | no |
| no traffic at all — almost every action | no |

The grace is deliberately short. It covers a task-boundary re-render, not a slow app: if nothing has moved within it, "ignored" has become an honest description and the finding stands. A test pins that a genuinely dropped response is **still reported** — the point is not to make things green.

## Verification

format ✓ · lint ✓ · typecheck ✓ · unit 15/15 ✓ (13 new)

**I could not reproduce this live, and would rather say so than imply otherwise.** The bench fixture’s only real write is login, which moves state inside the same window and therefore never enters the accusable shape; its deploy flow is entirely client-side (`net.total: 0`). The hazard is pinned deterministically instead — one test asserts the detector *does* accuse on a window cut between response and render, and another that the same window including the render does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)