### PR TITLE
feat(server): persist learned routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
-_Nothing yet._
+### Learned app knowledge survives
+
+- **`@reticlehq/server` — learned routes now accumulate during crawls and normal navigation.** Runtime route discoveries are persisted in `.reticle/project.json` as a deterministic union, so later sessions can reuse the app map without re-exploring previously visited routes.
 
 ## [2.8.0] — 2026-08-15
 

--- a/apps/e2e/specs/crawl-test.mjs
+++ b/apps/e2e/specs/crawl-test.mjs
@@ -13,7 +13,10 @@ const chk = (l, o, d = '') => {
 };
 
 const server = await start({ port: 4400, mcp: false });
-const deps = { sessions: server.bridge.sessions };
+const deps = {
+  sessions: server.bridge.sessions,
+  project: { recordRoutes: async () => {} },
+};
 const T = (n, a = {}) => TOOLS.find((t) => t.name === n).handler(deps, { sessionId: 'next-smoke', ...a });
 const b = await chromium.launch({ headless: true });
 const p = await b.newPage();

--- a/packages/core/src/flow-constants.ts
+++ b/packages/core/src/flow-constants.ts
@@ -50,6 +50,9 @@ export const PROJECT_RUN_CAP = {
   TOTAL: 200,
 } as const;
 
+/** Maximum distinct route identities retained in project.json. */
+export const PROJECT_ROUTE_CAP = 200;
+
 /** Schema version stamped onto on-disk flow files (.reticle/flows/<name>.json). */
 export const FLOW_FILE_VERSION = 1;
 

--- a/packages/server/src/crawl/crawl-tools.test.ts
+++ b/packages/server/src/crawl/crawl-tools.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   CrawlAnomalyKind,
+  EventType,
   ReticleCommand,
   type CommandResult,
   type ReticleEvent,
@@ -44,13 +45,62 @@ describe('reticle_crawl tool', () => {
   it('drives the resolved session and returns a structured anomaly report', async () => {
     const session = deadButtonSession();
     const sessions: Partial<SessionManager> = { resolve: () => session };
-    const deps = { sessions: sessions as SessionManager } as ToolDeps;
+    const deps = {
+      sessions: sessions as SessionManager,
+      project: { recordRoutes: () => Promise.resolve() },
+    } as unknown as ToolDeps;
 
     const r = (await tool(ReticleTool.CRAWL).handler(deps, { settleMs: 0 })) as CrawlReport;
     expect(r.interactiveFound).toBe(1);
     expect(r.stepsRun).toBe(1);
     expect(r.counts.deadControls).toBe(1);
     expect(r.anomalies[0]?.kind).toBe(CrawlAnomalyKind.DEAD_CONTROL);
+  });
+
+  it('persists actual routes discovered during the crawl, not clicked-control labels', async () => {
+    let clock = 0;
+    const buffer: ReticleEvent[] = [];
+    const ok = (result: unknown): Promise<CommandResult> =>
+      Promise.resolve({ kind: 'command_result', id: 'c', ok: true, result });
+    const session = {
+      id: 'demo',
+      url: 'https://example.test/',
+      elapsed: () => clock,
+      eventsSince: (since: number) => buffer.filter((event) => event.t > since),
+      command: (name: string) => {
+        if (name === ReticleCommand.SNAPSHOT) return ok({ tree: 'link "Deployments" (ref=e1)' });
+        if (name === ReticleCommand.ACT) {
+          clock += 1;
+          buffer.push({
+            t: clock,
+            type: EventType.ROUTE_CHANGE,
+            sessionId: 'demo',
+            data: {
+              from: 'https://example.test/',
+              to: 'https://example.test/deployments',
+              pathname: '/deployments',
+              search: '',
+              hash: '',
+            },
+          });
+          return ok({ dispatched: true });
+        }
+        return ok({});
+      },
+    } as Session;
+    const sessions: Partial<SessionManager> = { resolve: () => session };
+    const recordRoutes = vi.fn<(routes: readonly string[]) => Promise<void>>(() =>
+      Promise.resolve(),
+    );
+    const deps = {
+      sessions: sessions as SessionManager,
+      project: { recordRoutes },
+    } as unknown as ToolDeps;
+
+    const report = (await tool(ReticleTool.CRAWL).handler(deps, { settleMs: 0 })) as CrawlReport;
+
+    expect(report.visited).toEqual(['link "Deployments"']);
+    expect(recordRoutes).toHaveBeenCalledWith(['/', '/deployments']);
   });
 });
 

--- a/packages/server/src/crawl/crawl-tools.ts
+++ b/packages/server/src/crawl/crawl-tools.ts
@@ -3,6 +3,7 @@ import { ReticleTool } from '../tools/tool-names.js';
 import { asNumber, asString } from '../tools/tools-helpers.js';
 import { crawl, type CrawlOptions } from './crawl.js';
 import type { ToolDef, ToolDeps } from '../tools/tools.js';
+import { routeFromUrl, routesFromEvents } from '../project/learned-routes.js';
 
 const nodeSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -70,8 +71,10 @@ export const CRAWL_TOOLS: ToolDef[] = [
         ),
       truncated: z.boolean(),
     },
-    handler: (deps: ToolDeps, args) => {
+    handler: async (deps: ToolDeps, args) => {
       const session = deps.sessions.resolve(asString(args['sessionId']));
+      const since = session.elapsed();
+      const initialRoute = routeFromUrl(session.url);
       const maxSteps = asNumber(args['maxSteps']);
       const settleMs = asNumber(args['settleMs']);
       const scope = asString(args['scope']);
@@ -81,7 +84,13 @@ export const CRAWL_TOOLS: ToolDef[] = [
         ...(scope !== undefined ? { scope } : {}),
         ...(true === args['confirmDangerous'] ? { confirmDangerous: true } : {}),
       };
-      return crawl(session, opts, nodeSleep);
+      const report = await crawl(session, opts, nodeSleep);
+      const routes = [
+        ...(initialRoute === undefined ? [] : [initialRoute]),
+        ...routesFromEvents(session.eventsSince(since)),
+      ];
+      if (routes.length > 0) await deps.project.recordRoutes(routes);
+      return report;
     },
   },
 ];

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -26,6 +26,7 @@ import { RecordingStore } from './flows/recordings.js';
 import { FlowStore } from './flows/flows.js';
 import { buildFlowChips } from './flows/flow-scope.js';
 import { ProjectStore } from './project/project-store.js';
+import { attachRouteLearning } from './project/learned-routes.js';
 import { AnnotationStore } from './flows/annotation-store.js';
 import { createNodeFileSystem, type FileSystemPort } from './project/fs-port.js';
 import { cleanupCaptureDirectories } from './visual/capture-cleanup.js';
@@ -415,6 +416,7 @@ export async function start(options: StartOptions = {}): Promise<RunningServer> 
     attachJournal(bridge, { fs, reticleRoot, enabled: journalEnabled });
     const flows = new FlowStore(fs, reticleRoot, { now });
     const project = new ProjectStore(fs, reticleRoot, { now });
+    attachRouteLearning(bridge, project);
     const annotations = new AnnotationStore();
     pool = createBrowserPool(options.headless ?? true);
     leaseReaper = new LeaseReaper(pool);
@@ -526,6 +528,7 @@ export async function startDaemon(options: StartOptions = {}): Promise<RunningSe
   attachJournal(bridge, { fs, reticleRoot, enabled: journalEnabled });
   const flows = new FlowStore(fs, reticleRoot, { now });
   const project = new ProjectStore(fs, reticleRoot, { now });
+  attachRouteLearning(bridge, project);
   const annotations = new AnnotationStore();
   const pool = createBrowserPool(options.headless ?? true);
   const leaseReaper = new LeaseReaper(pool);

--- a/packages/server/src/project/learned-routes.test.ts
+++ b/packages/server/src/project/learned-routes.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EventType, type ReticleEvent } from '@reticlehq/core';
+import { attachRouteLearning, routeFromEvent, routeFromUrl } from './learned-routes.js';
+
+function routeEvent(pathname: string, search = '', hash = ''): ReticleEvent {
+  return {
+    t: 1,
+    type: EventType.ROUTE_CHANGE,
+    sessionId: 's1',
+    data: { from: '', to: '', pathname, search, hash },
+  };
+}
+
+describe('learned routes', () => {
+  it('normalizes route events and session URLs without persisting origins', () => {
+    expect(routeFromEvent(routeEvent('/search', '?q=reticle', '#results'))).toBe(
+      '/search?q=reticle#results',
+    );
+    expect(routeFromUrl('https://example.test/deployments?region=us#latest')).toBe(
+      '/deployments?region=us#latest',
+    );
+  });
+
+  it('ignores non-route events and invalid URLs', () => {
+    expect(
+      routeFromEvent({
+        t: 1,
+        type: EventType.DOM_ADDED,
+        sessionId: 's1',
+        data: {},
+      }),
+    ).toBeUndefined();
+    expect(routeFromUrl('not a URL')).toBeUndefined();
+  });
+
+  it('records the initial route and every ordinary route change', async () => {
+    let ready: ((session: TestSession) => void) | undefined;
+    let listener: ((event: ReticleEvent) => void) | undefined;
+    const recordRoutes = vi.fn<(routes: readonly string[]) => Promise<void>>(() =>
+      Promise.resolve(),
+    );
+    const session: TestSession = {
+      url: 'https://example.test/',
+      onEvent: (handler) => {
+        listener = handler;
+        return () => undefined;
+      },
+    };
+    const bridge = {
+      sessions: { all: () => [] as TestSession[] },
+      attachSessionReady: (handler: (connected: TestSession) => void) => {
+        ready = handler;
+      },
+    };
+
+    attachRouteLearning(bridge, { recordRoutes });
+    ready?.(session);
+    listener?.(routeEvent('/compose'));
+    await vi.waitFor(() => expect(recordRoutes).toHaveBeenCalledTimes(2));
+
+    expect(recordRoutes.mock.calls).toEqual([[['/']], [['/compose']]]);
+  });
+});
+
+interface TestSession {
+  url: string;
+  onEvent(handler: (event: ReticleEvent) => void): () => void;
+}

--- a/packages/server/src/project/learned-routes.test.ts
+++ b/packages/server/src/project/learned-routes.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { EventType, type ReticleEvent } from '@reticlehq/core';
-import { attachRouteLearning, routeFromEvent, routeFromUrl } from './learned-routes.js';
+import {
+  attachRouteLearning,
+  ROUTE_PERSIST_DEBOUNCE_MS,
+  routeFromEvent,
+  routeFromUrl,
+} from './learned-routes.js';
 
 function routeEvent(pathname: string, search = '', hash = ''): ReticleEvent {
   return {
@@ -12,13 +17,13 @@ function routeEvent(pathname: string, search = '', hash = ''): ReticleEvent {
 }
 
 describe('learned routes', () => {
-  it('normalizes route events and session URLs without persisting origins', () => {
-    expect(routeFromEvent(routeEvent('/search', '?q=reticle', '#results'))).toBe(
-      '/search?q=reticle#results',
-    );
-    expect(routeFromUrl('https://example.test/deployments?region=us#latest')).toBe(
-      '/deployments?region=us#latest',
-    );
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses pathname route identities without persisting origins, searches, or hashes', () => {
+    expect(routeFromEvent(routeEvent('/search', '?q=reticle', '#results'))).toBe('/search');
+    expect(routeFromUrl('https://example.test/deployments?region=us#latest')).toBe('/deployments');
   });
 
   it('ignores non-route events and invalid URLs', () => {
@@ -33,7 +38,8 @@ describe('learned routes', () => {
     expect(routeFromUrl('not a URL')).toBeUndefined();
   });
 
-  it('records the initial route and every ordinary route change', async () => {
+  it('batches the initial route and rapid ordinary route changes into one store update', async () => {
+    vi.useFakeTimers();
     let ready: ((session: TestSession) => void) | undefined;
     let listener: ((event: ReticleEvent) => void) | undefined;
     const recordRoutes = vi.fn<(routes: readonly string[]) => Promise<void>>(() =>
@@ -56,9 +62,14 @@ describe('learned routes', () => {
     attachRouteLearning(bridge, { recordRoutes });
     ready?.(session);
     listener?.(routeEvent('/compose'));
-    await vi.waitFor(() => expect(recordRoutes).toHaveBeenCalledTimes(2));
+    listener?.(routeEvent('/deployments'));
+    listener?.(routeEvent('/compose', '?draft=2'));
 
-    expect(recordRoutes.mock.calls).toEqual([[['/']], [['/compose']]]);
+    expect(recordRoutes).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(ROUTE_PERSIST_DEBOUNCE_MS);
+
+    expect(recordRoutes).toHaveBeenCalledTimes(1);
+    expect(recordRoutes).toHaveBeenCalledWith(['/', '/compose', '/deployments']);
   });
 });
 

--- a/packages/server/src/project/learned-routes.ts
+++ b/packages/server/src/project/learned-routes.ts
@@ -1,0 +1,64 @@
+import { EventType, type ReticleEvent } from '@reticlehq/core';
+
+interface RouteLearningSession {
+  url: string;
+  onEvent(handler: (event: ReticleEvent) => void): () => void;
+}
+
+interface RouteLearningBridge {
+  sessions: { all(): RouteLearningSession[] };
+  attachSessionReady(handler: (session: RouteLearningSession) => void): void;
+}
+
+interface RouteLearningStore {
+  recordRoutes(routes: readonly string[]): Promise<void>;
+}
+
+/** Convert a validated route-change payload into the route users see, without persisting its origin. */
+export function routeFromEvent(event: ReticleEvent): string | undefined {
+  if (event.type !== EventType.ROUTE_CHANGE) return undefined;
+  const pathname = event.data['pathname'];
+  if ('string' !== typeof pathname || 0 === pathname.length) return undefined;
+  const search = 'string' === typeof event.data['search'] ? event.data['search'] : '';
+  const hash = 'string' === typeof event.data['hash'] ? event.data['hash'] : '';
+  return `${pathname}${search}${hash}`;
+}
+
+/** Read the same route shape from a session's absolute URL. */
+export function routeFromUrl(value: string): string | undefined {
+  try {
+    const url = new URL(value);
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return undefined;
+  }
+}
+
+export function routesFromEvents(events: readonly ReticleEvent[]): string[] {
+  return events.flatMap((event) => {
+    const route = routeFromEvent(event);
+    return route === undefined ? [] : [route];
+  });
+}
+
+/** Persist initial and subsequent routes for existing and future browser sessions. */
+export function attachRouteLearning(
+  bridge: RouteLearningBridge,
+  project: RouteLearningStore,
+): void {
+  const attached = new WeakSet<RouteLearningSession>();
+  const attach = (session: RouteLearningSession): void => {
+    if (attached.has(session)) return;
+    attached.add(session);
+
+    const initial = routeFromUrl(session.url);
+    if (initial !== undefined) void project.recordRoutes([initial]).catch(() => undefined);
+    session.onEvent((event) => {
+      const route = routeFromEvent(event);
+      if (route !== undefined) void project.recordRoutes([route]).catch(() => undefined);
+    });
+  };
+
+  for (const session of bridge.sessions.all()) attach(session);
+  bridge.attachSessionReady(attach);
+}

--- a/packages/server/src/project/learned-routes.ts
+++ b/packages/server/src/project/learned-routes.ts
@@ -14,21 +14,22 @@ interface RouteLearningStore {
   recordRoutes(routes: readonly string[]): Promise<void>;
 }
 
-/** Convert a validated route-change payload into the route users see, without persisting its origin. */
+/** Coalesce navigation bursts so one crawl does not lock and rewrite project.json per event. */
+export const ROUTE_PERSIST_DEBOUNCE_MS = 50;
+
+/** Convert a validated route-change payload into a bounded route identity. */
 export function routeFromEvent(event: ReticleEvent): string | undefined {
   if (event.type !== EventType.ROUTE_CHANGE) return undefined;
   const pathname = event.data['pathname'];
   if ('string' !== typeof pathname || 0 === pathname.length) return undefined;
-  const search = 'string' === typeof event.data['search'] ? event.data['search'] : '';
-  const hash = 'string' === typeof event.data['hash'] ? event.data['hash'] : '';
-  return `${pathname}${search}${hash}`;
+  return pathname;
 }
 
 /** Read the same route shape from a session's absolute URL. */
 export function routeFromUrl(value: string): string | undefined {
   try {
     const url = new URL(value);
-    return `${url.pathname}${url.search}${url.hash}`;
+    return url.pathname;
   } catch {
     return undefined;
   }
@@ -47,15 +48,31 @@ export function attachRouteLearning(
   project: RouteLearningStore,
 ): void {
   const attached = new WeakSet<RouteLearningSession>();
+  const pending = new Set<string>();
+  let flushTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const flush = (): void => {
+    flushTimer = undefined;
+    const routes = [...pending];
+    pending.clear();
+    if (routes.length > 0) void project.recordRoutes(routes).catch(() => undefined);
+  };
+
+  const queue = (route: string): void => {
+    pending.add(route);
+    if (flushTimer !== undefined) clearTimeout(flushTimer);
+    flushTimer = setTimeout(flush, ROUTE_PERSIST_DEBOUNCE_MS);
+  };
+
   const attach = (session: RouteLearningSession): void => {
     if (attached.has(session)) return;
     attached.add(session);
 
     const initial = routeFromUrl(session.url);
-    if (initial !== undefined) void project.recordRoutes([initial]).catch(() => undefined);
+    if (initial !== undefined) queue(initial);
     session.onEvent((event) => {
       const route = routeFromEvent(event);
-      if (route !== undefined) void project.recordRoutes([route]).catch(() => undefined);
+      if (route !== undefined) queue(route);
     });
   };
 

--- a/packages/server/src/project/project-store.test.ts
+++ b/packages/server/src/project/project-store.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  PROJECT_FILE_VERSION,
   PROJECT_RUN_CAP,
   ProjectReadError,
   RunKind,
@@ -184,5 +185,49 @@ describe('ProjectStore — temp-dir filesystem, never touches the repo', () => {
     if (!r.ok) throw new Error('expected ok');
     expect(r.file.runs).toHaveLength(N);
     expect(new Set(r.file.runs.map((x) => x.name)).size).toBe(N); // every distinct run survived
+  });
+
+  it('13: recordRoutes unions and sorts routes while preserving learned flows and runs', async () => {
+    await fs.mkdir(root);
+    await writeFile(
+      reticleDirPaths(root).project,
+      JSON.stringify({
+        version: PROJECT_FILE_VERSION,
+        learned: { flows: ['checkout'], routes: ['/settings'] },
+        runs: [{ ...RUN, at: FROZEN }],
+      }),
+      'utf8',
+    );
+
+    await store.recordRoutes(['/deployments', '/', '/settings']);
+
+    const r = await store.read();
+    if (!r.ok) throw new Error('expected ok');
+    expect(r.file.learned).toEqual({
+      flows: ['checkout'],
+      routes: ['/', '/deployments', '/settings'],
+    });
+    expect(r.file.runs).toEqual([{ ...RUN, at: FROZEN }]);
+  });
+
+  it('14: recording no routes keeps learned absent rather than writing routes: []', async () => {
+    await store.recordRun(RUN);
+    await store.recordRoutes([]);
+
+    const r = await store.read();
+    if (!r.ok) throw new Error('expected ok');
+    expect(r.file.learned).toBeUndefined();
+    expect(await readFile(reticleDirPaths(root).project, 'utf8')).not.toContain('"routes"');
+  });
+
+  it('15: concurrent recordRoutes calls union without losing either session', async () => {
+    await Promise.all([
+      store.recordRoutes(['/compose', '/deployments']),
+      store.recordRoutes(['/diagnostics', '/deployments']),
+    ]);
+
+    const r = await store.read();
+    if (!r.ok) throw new Error('expected ok');
+    expect(r.file.learned?.routes).toEqual(['/compose', '/deployments', '/diagnostics']);
   });
 });

--- a/packages/server/src/project/project-store.test.ts
+++ b/packages/server/src/project/project-store.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   PROJECT_FILE_VERSION,
+  PROJECT_ROUTE_CAP,
   PROJECT_RUN_CAP,
   ProjectReadError,
   RunKind,
@@ -229,5 +230,20 @@ describe('ProjectStore — temp-dir filesystem, never touches the repo', () => {
     const r = await store.read();
     if (!r.ok) throw new Error('expected ok');
     expect(r.file.learned?.routes).toEqual(['/compose', '/deployments', '/diagnostics']);
+  });
+
+  it('16: caps learned routes while preserving the routes learned first', async () => {
+    const routes = Array.from(
+      { length: PROJECT_ROUTE_CAP + 25 },
+      (_value, index) => `/route-${String(index).padStart(3, '0')}`,
+    );
+
+    await store.recordRoutes(routes);
+
+    const r = await store.read();
+    if (!r.ok) throw new Error('expected ok');
+    expect(r.file.learned?.routes).toHaveLength(PROJECT_ROUTE_CAP);
+    expect(r.file.learned?.routes).toContain('/route-000');
+    expect(r.file.learned?.routes).not.toContain(`/route-${String(PROJECT_ROUTE_CAP)}`);
   });
 });

--- a/packages/server/src/project/project-store.ts
+++ b/packages/server/src/project/project-store.ts
@@ -1,5 +1,6 @@
 import {
   PROJECT_FILE_VERSION,
+  PROJECT_ROUTE_CAP,
   PROJECT_RUN_CAP,
   ProjectFileSchema,
   ProjectReadError,
@@ -113,9 +114,13 @@ export class ProjectStore {
       const existing = await this.read();
       const base: ProjectFile = existing.ok ? existing.file : EMPTY_PROJECT;
       const current = base.learned?.routes ?? [];
-      const merged = new Set([...current, ...additions]);
-      if (merged.size === new Set(current).size) return;
-      const learned: ProjectLearned = { ...base.learned, routes: [...merged] };
+      const merged = [...new Set([...current, ...additions])].slice(0, PROJECT_ROUTE_CAP);
+      if (
+        merged.length === current.length &&
+        merged.every((route, index) => route === current[index])
+      )
+        return;
+      const learned: ProjectLearned = { ...base.learned, routes: merged };
       const next: ProjectFile = { ...base, learned };
       await this.#fs.mkdir(reticleDirPaths(this.#root).root);
       await this.#fs.writeFile(path, this.#serialize(next));

--- a/packages/server/src/project/project-store.ts
+++ b/packages/server/src/project/project-store.ts
@@ -99,6 +99,29 @@ export class ProjectStore {
     });
   }
 
+  /**
+   * Add discovered routes to the learned app map. Empty input is a no-op so "nothing observed"
+   * does not materialize as `learned.routes: []`; non-empty updates are serialized per file so
+   * concurrent browser sessions accumulate rather than overwriting one another.
+   */
+  async recordRoutes(routes: readonly string[]): Promise<void> {
+    const additions = routes.filter((route) => route.length > 0);
+    if (0 === additions.length) return;
+
+    const path = reticleDirPaths(this.#root).project;
+    await withFileLock(path, async () => {
+      const existing = await this.read();
+      const base: ProjectFile = existing.ok ? existing.file : EMPTY_PROJECT;
+      const current = base.learned?.routes ?? [];
+      const merged = new Set([...current, ...additions]);
+      if (merged.size === new Set(current).size) return;
+      const learned: ProjectLearned = { ...base.learned, routes: [...merged] };
+      const next: ProjectFile = { ...base, learned };
+      await this.#fs.mkdir(reticleDirPaths(this.#root).root);
+      await this.#fs.writeFile(path, this.#serialize(next));
+    });
+  }
+
   /** The most-recent run for `name` (undefined on missing/malformed/none). Powers diff-vs-last. */
   async lastRun(name: string): Promise<RunRecord | undefined> {
     const read = await this.read();


### PR DESCRIPTION
## What & why

Persist routes learned from both `reticle_crawl` and ordinary browser navigation in `.reticle/project.json`.

The project schema and serializer already supported `learned.routes`, but no runtime path populated it. This change adds an atomic union operation to `ProjectStore`, records initial and subsequent session routes, and has the crawl handler persist actual route values rather than its clicked-control descriptions. Existing learned flows and run history are preserved, duplicate routes are removed, and empty observations remain absent instead of becoming `routes: []`.

Closes #259

## How it was verified

- Added store tests for deterministic unioning, preservation of flows/runs, absent-vs-empty semantics, and concurrent session updates.
- Added route-learning tests for URL normalization, ordinary navigation, and initial routes.
- Added a crawl-tool test proving `/` and `/deployments` are persisted while `link "Deployments"` remains only in the `visited` report.
- Ran the focused suite: 23 tests passed.
- Ran the full monorepo lint, typecheck, and unit gates successfully.
- Attempted the E2E gate through Git Bash because the default Windows `bash` command points to an unavailable WSL installation. The process produced no test output and reached the 10-minute environment timeout, so E2E is not claimed as passing locally.

## Gates run

- [x] `pnpm lint && pnpm typecheck && pnpm test:unit` (~2 min — **always**)
- [ ] `pnpm test:e2e` (~8 min) — _attempted; local Windows runner timed out without test output_
- [ ] `pnpm gate:install` (~15 min) — _not applicable_
- [ ] `pnpm test:e2e:desktop` (~3 min) — _not applicable_
- [ ] None of the above tiers apply to this change

## Checklist

- [x] Tests added/updated (RED → GREEN); the change is covered by a test that would fail without it
- [x] No `any`, no free strings (wire strings live in `@reticlehq/core`), no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 1000-line cap
- [x] Docs and `CHANGELOG.md` updated if this is user-facing (entry under `[Unreleased]`)
- [x] Not security-affecting; route origins are deliberately not persisted
