### PR TITLE
A baseline must come from the commit it claims to describe

### DIFF
--- a/bench/harness/analyze.mjs
+++ b/bench/harness/analyze.mjs
@@ -2,6 +2,28 @@
 // (avg/median tokens, p95 latency, detection accuracy, FN/FP rates) and per-scenario
 // winners. Pure arithmetic over measured rows — no synthetic data.
 import { readFileSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+/**
+ * Which commit produced these numbers.
+ *
+ * analysis.json carried no provenance, so `record.mjs` would happily write a baseline row from
+ * WHATEVER file happened to be on disk — including one left by a run weeks earlier. That is not
+ * hypothetical: the recorded 2.7.0 baseline claims `broken-form-validation` was measured, and at that
+ * commit the injector's anchor did not match the fixture, so it could not have been injected at all.
+ * Every later gate then compared an honest run against a baseline describing a different one, and
+ * reported a regression that was an artefact of the comparison.
+ *
+ * A number without provenance cannot be a baseline. Stamped here, at the moment the numbers are
+ * computed, and checked by record.mjs before it will write a row.
+ */
+function headSha() {
+  try {
+    return execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+  } catch {
+    return 'nogit';
+  }
+}
 
 const rows = JSON.parse(readFileSync('bench/raw/observation-results.json', 'utf8'));
 const TOOLS = ['playwright', 'devtools', 'reticle', 'agentbrowser', 'playwrightcli'];
@@ -86,6 +108,8 @@ for (const s of scenarios) {
 
 const out = {
   generated_from: 'bench/raw/observation-results.json',
+  git_sha: headSha(),
+  generated_at: new Date().toISOString(),
   layer: 'A (observation cost)',
   total_cells: rows.length,
   measured_cells: measured.length,

--- a/bench/harness/record.mjs
+++ b/bench/harness/record.mjs
@@ -8,6 +8,45 @@ const version = process.argv[2] ?? 'unlabeled';
 const note = process.argv[3] ?? '';
 const a = JSON.parse(readFileSync('bench/raw/analysis.json', 'utf8'));
 
+/**
+ * A baseline must come from the commit it claims to describe.
+ *
+ * This script used to record from whatever analysis.json was on disk. The 2.7.0 baseline is the proof
+ * that this matters: it reports `broken-form-validation` as measured, and at that commit the
+ * injector's anchor did not match the fixture, so the scenario could not have been injected. Every
+ * later run was then compared against a baseline describing a DIFFERENT run — and the most expensive
+ * scenario in the suite (2,736 tokens against a ~806 median) being present on one side and absent on
+ * the other reads as a 3.9% efficiency regression that never happened.
+ *
+ * The gate is only as honest as its memory. Refuse rather than record a row that cannot be trusted:
+ * a wrong baseline is worse than no baseline, because it produces confident false verdicts for
+ * months.
+ */
+function assertFreshAnalysis() {
+  let head = 'nogit';
+  try {
+    head = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+  } catch {
+    return; // no git: nothing to check against, and the sha is already recorded as 'nogit'
+  }
+  if (a.git_sha === undefined) {
+    console.error(
+      'refusing to record: bench/raw/analysis.json carries no git_sha, so it predates provenance ' +
+        'stamping and cannot be shown to come from this commit. Re-run `pnpm bench:full`.',
+    );
+    process.exit(1);
+  }
+  if (a.git_sha !== head) {
+    console.error(
+      `refusing to record: analysis.json was generated at ${a.git_sha} but HEAD is ${head}. ` +
+        'That file is from a different run — recording it would create a baseline that describes ' +
+        'code nobody is testing. Re-run `pnpm bench:full`.',
+    );
+    process.exit(1);
+  }
+}
+assertFreshAnalysis();
+
 /** Read an optional raw JSON file (Layer C may not have been run this pass). */
 function readRaw(path) {
   return existsSync(path) ? JSON.parse(readFileSync(path, 'utf8')) : null;


### PR DESCRIPTION
The 3.9% efficiency "regression" the gate has been reporting is an artefact of its own baseline.

## The proof

The recorded 2.7.0 baseline reports `broken-form-validation` as measured. At that commit:

- the injector's anchor was `'    if (service.trim().length === 0) return;\n'`
- the fixture already read `if (0 === service.trim().length) return;`

They do not match, so `replaceOnce` would have thrown and the scenario recorded `NOT MEASURED`. **It could not have been injected at that commit**, so the baseline did not come from a run there.

`record.mjs` reads whatever `analysis.json` is on disk, and `analysis.json` carried no provenance — no commit, no timestamp. Nothing could distinguish a fresh run from one left over weeks earlier.

## Why it produced a confident false verdict

`broken-form-validation` is the most expensive cell in the suite — **2,736 tokens against a ~806 median**. Present on one side of the comparison and absent on the other, it moves the average by ~4% on its own.

| | cells | avg tokens | VE |
| --- | ---: | ---: | ---: |
| baseline (as recorded) | 11 | 1058 | 9.45 |
| today, all scenarios | 11 | 1101 | 9.08 ✗ |
| **today, like-for-like** | **10** | **937.6** | **9.60** |

Like-for-like the run is **~1.6% better** than the baseline it was failing against.

I want to be plain that this took me three attempts. I guessed the denominator first, talked myself out of it by comparing fields *inside the untrustworthy row*, blamed ref width and shipped #281 for it — a real fix, but invisible to this benchmark because it opens a fresh session per scenario — and only settled it by checking what the injector could physically do at that commit. Checking the source rather than the artefact is what ended it.

## The fix

`analyze.mjs` stamps `git_sha` and `generated_at` when the numbers are computed. `record.mjs` refuses to write a row unless that sha matches HEAD, naming both shas — "re-run the benchmark" is only actionable if you know why.

**Refusing is the point.** A wrong baseline is worse than no baseline: it produces confident false verdicts for months, and the obvious way to make a red gate green is to overwrite the baseline with the number under suspicion.

## Verified both directions

Both refusals exit 1 and leave `history.jsonl` untouched:

- an `analysis.json` with no sha (every existing one)
- one stamped with a foreign sha → *"generated at deadbee but HEAD is b527aa0e"*

## This does not re-baseline anything

The 2.7.0 row stays where it is — wrong, and now demonstrably so — until a fresh run replaces it deliberately. Related: #283, #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)