### PR TITLE
Put the DCO where contributors look, not only where they fail

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,7 @@ Closes #
 
 ## Checklist
 
+- [ ] **Every commit is signed off** (`git commit -s`) — CI's DCO check fails the PR without it. Already pushed? `git rebase --signoff origin/main && git push --force-with-lease`
 - [ ] Tests added/updated (RED → GREEN); the change is covered by a test that would fail without it
 - [ ] No `any`, no free strings (wire strings live in `@reticlehq/core`), no non-null `!`
 - [ ] No `console.log` or internal tracking codes left in the diff

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -5,8 +5,9 @@ name: DCO
 # the project's license (https://developercertificate.org). Sign off with `git commit -s`.
 #
 # On failure it prints the exact remedy for both shapes (one commit vs several) rather than a link:
-# three of three external contributors have been blocked here, and CONTRIBUTING.md does not mention
-# sign-off, so the old "see CONTRIBUTING.md" pointed at a document that could not answer it.
+# three of three external contributors were blocked here while CONTRIBUTING.md did not mention sign-off,
+# so the old "see CONTRIBUTING.md" pointed at a document that could not answer it. Both now say it:
+# CONTRIBUTING.md step 3 of the PR flow, and the first line of the PR template checklist.
 #
 # This runs and reports on every PR; it only BLOCKS merges once a maintainer adds "DCO" to the required
 # status checks in branch protection. Self-contained (no third-party action) to keep the supply chain small.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,10 +166,26 @@ From there, point your MCP-capable agent at Reticle and ask it to verify the app
 
 1. **Branch off `main`.** Use a short, descriptive branch name.
 2. **Write tests first** for the behavior you're adding or fixing.
-3. **Use [Conventional Commits](https://www.conventionalcommits.org/)** for commit messages, e.g. `feat(server): add reticle_viewport tool`, `fix(browser): restore patched fetch on teardown`, `docs: clarify install steps`. Common scopes mirror the packages: `protocol`, `browser`, `server`, `react`, plus `docs` / `chore`.
-4. **Keep the gates green:** `pnpm lint && pnpm typecheck && pnpm test:unit`.
-5. **Update docs and `CHANGELOG.md`** when the change is user-facing. New entries go under the `[Unreleased]` section, following [Keep a Changelog](https://keepachangelog.com/).
-6. **Open a PR against `main`** and **link the issue** it resolves (e.g. `Closes #123`). Fill out the PR template checklist.
+3. **Sign off every commit — `git commit -s`.** This is the one thing that will fail your PR before a human reads it. CI runs a [Developer Certificate of Origin](https://developercertificate.org) check, and every commit needs a `Signed-off-by:` trailer matching its author. `-s` adds it for you.
+
+   Forgot? Nothing is lost — fix it in place:
+
+   ```bash
+   git commit --amend --no-edit -s          # one commit
+   git rebase --signoff origin/main         # several
+   git push --force-with-lease
+   ```
+
+   `git config format.signOff true` does **not** cover `git commit`, so setting it is not enough. If you want this to be automatic, alias the commit itself:
+
+   ```bash
+   git config --local alias.ci 'commit -s'
+   ```
+
+4. **Use [Conventional Commits](https://www.conventionalcommits.org/)** for commit messages, e.g. `feat(server): add reticle_viewport tool`, `fix(browser): restore patched fetch on teardown`, `docs: clarify install steps`. Common scopes mirror the packages: `protocol`, `browser`, `server`, `react`, plus `docs` / `chore`.
+5. **Keep the gates green:** `pnpm lint && pnpm typecheck && pnpm test:unit`.
+6. **Update docs and `CHANGELOG.md`** when the change is user-facing. New entries go under the `[Unreleased]` section, following [Keep a Changelog](https://keepachangelog.com/).
+7. **Open a PR against `main`** and **link the issue** it resolves (e.g. `Closes #123`). Fill out the PR template checklist.
 
 For anything non-trivial, **open an issue first** so we can agree on the approach before you invest time in a PR.
 


### PR DESCRIPTION
CI requires a `Signed-off-by:` trailer on every commit. **CONTRIBUTING.md mentioned sign-off zero times, and so did the PR template** — the two documents a contributor reads *before* pushing. The only place it was explained was the error message they get after failing.

`dco.yml` already records the cost in its own docblock:

> three of three external contributors have been blocked here, and CONTRIBUTING.md does not mention sign-off

That was mitigated by improving the failure text — which helps only *after* someone has hit a red check on their first contribution, the single worst moment to discover an unwritten rule. PR #182 in the current queue is failing DCO right now.

## What changed

**CONTRIBUTING.md** — step 3 of the PR flow, ahead of the commit-message convention, because it fails a PR before a human reads it. Names the recovery for both shapes (`--amend` for one commit, `rebase --signoff` for several) so a forgotten sign-off costs a minute rather than a re-push.

It also says what does **not** work: `git config format.signOff true` does not apply to `git commit`. That is not theoretical — I set it in this repo today, kept producing unsigned commits, and had to rebase anyway. The `alias.ci` line is what actually automates it.

**PR template** — first checklist item, recovery inline, visible in the box the contributor is already typing into.

**dco.yml** — its docblock still claimed CONTRIBUTING.md does not mention sign-off. That stops being true with this commit, so it is corrected rather than left to rot.

Docs only. No code, no gate behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)