### PR TITLE
docs: use the safe port-4400 kill recipe in SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -892,7 +892,13 @@ Then restart Claude Code so the new version is picked up on next connection. `/m
 
 2. **Check for the Stop hook:** `cat ~/.claude/settings.json | grep reticle` If present, delete that hook entry, then repeat step 1.
 
-3. **If -32000 persists**, the daemon may be crashing on startup. Check the log: `cat ~/.reticle/daemon-4400.log | tail -30` Look for `reticle_daemon_start_failed` or `reticle_mcp_daemon_unavailable`. If the port is taken by another process: `lsof -i :4400` to identify it, then kill it and retry.
+3. **If -32000 persists**, the daemon may be crashing on startup. Check the log: `cat ~/.reticle/daemon-4400.log | tail -30` Look for `reticle_daemon_start_failed` or `reticle_mcp_daemon_unavailable`. If the port is taken by another process, stop only the listener — never kill everything `lsof` lists on the port:
+
+   ```bash
+   lsof -nP -iTCP:4400 -sTCP:LISTEN -t | xargs kill -9
+   ```
+
+   The short form `lsof -ti tcp:4400 | xargs kill -9` also SIGKILLs the `reticle mcp` proxy — it holds a *client* socket on the bridge port, so the unfiltered command lists it right beside the daemon and takes down the very transport you are trying to fix.
 
 4. **Confirm the MCP config is user-level** (not project-level) and has no pinned version:
 


### PR DESCRIPTION
## What

Fixes #110. The troubleshooting step in `SKILL.md` told a stuck user to identify what holds port 4400 with `lsof -i :4400` and kill it:

```
lsof -ti tcp:4400 | xargs kill -9
```

That command **also SIGKILLs the `reticle mcp` proxy** — it holds a *client* socket on the bridge port, so the unfiltered form lists it right beside the daemon (verified in #110: `lsof -ti tcp:4400` returned both the daemon listener pid and the proxy pid). Users trying to fix a broken bridge end up destroying their agent's own transport instead.

## Change

`SKILL.md` now uses the listener-only form already established in `README.md`, `docs/gates.md`, and `apps/e2e/harness-rules.md`:

```bash
lsof -nP -iTCP:4400 -sTCP:LISTEN -t | xargs kill -9
```

…and explains *why* the short form is wrong, so it doesn't get re-invented.

## Scope

This was the last remaining dangerous recipe in user-facing docs — the other files were already on the safe form. (A first-class `reticle kill` command is tracked separately in #114.)