### PR TITLE
fix(vite-plugin): bind integration test servers to 127.0.0.1, not localhost

### DIFF
--- a/packages/vite-plugin/src/build.integration.test.ts
+++ b/packages/vite-plugin/src/build.integration.test.ts
@@ -157,7 +157,7 @@ describe('the connect module picks up a token written after the dev server start
       root,
       logLevel: 'silent',
       configFile: false,
-      server: { port: 0 },
+      server: { port: 0, host: '127.0.0.1' },
       resolve: { alias: { '@reticlehq/react': join(root, 'src/sdk.js') } },
       plugins: [reticle()],
     });

--- a/packages/vite-plugin/src/define-warning.integration.test.ts
+++ b/packages/vite-plugin/src/define-warning.integration.test.ts
@@ -124,7 +124,7 @@ describe('vite 8 dev boot with the plugin produces no define warnings (#165)', (
     const server = await createServer({
       root,
       configFile: false,
-      server: { port: 0 },
+      server: { port: 0, host: '127.0.0.1' },
       // Force the optimizer to run — without this, a warm .vite cache skips Rolldown entirely
       // and the warning never fires even when the options are wrong.
       optimizeDeps: { force: true },


### PR DESCRIPTION
## Summary

- Pin `host: '127.0.0.1'` in both `build.integration.test.ts` and `define-warning.integration.test.ts` so Vite binds to IPv4 loopback explicitly
- Prevents Windows CI from resolving `localhost` to `::1` and timing out against a server listening only on IPv4
- Same class of defect Reticle already fixed for users in 2.7.0 — our own test suite still had it

Closes #292

## Test plan

- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 106 passed (both integration tests ran and passed on IPv4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)