### PR TITLE
feat(browser): expose scroll metrics in reticle_inspect

### DIFF
--- a/packages/browser/src/commands/commands.test.ts
+++ b/packages/browser/src/commands/commands.test.ts
@@ -74,6 +74,22 @@ describe('command registry (driven by the bridge)', () => {
     expect(result.tag).toBe('a');
   });
 
+  it('INSPECT returns scroll metrics for a ref', () => {
+    document.body.innerHTML = '<div style="overflow-y: auto; height: 100px;">content</div>';
+    const div = document.querySelector('div') as HTMLDivElement;
+    Object.defineProperty(div, 'scrollTop', { value: 50, configurable: true });
+    Object.defineProperty(div, 'scrollHeight', { value: 300, configurable: true });
+    Object.defineProperty(div, 'clientHeight', { value: 100, configurable: true });
+    const ref = refs.refFor(div);
+    const result = run(ReticleCommand.INSPECT, { ref }) as {
+      scroll: { scrollTop: number; scrollHeight: number; clientHeight: number; overflowY: string };
+    };
+    expect(result.scroll.scrollTop).toBe(50);
+    expect(result.scroll.scrollHeight).toBe(300);
+    expect(result.scroll.clientHeight).toBe(100);
+    expect(result.scroll.overflowY).toBe('auto');
+  });
+
   it('STATE_READ returns a registered store and its name', () => {
     registerStore('state_ws', () => ({ count: 7 }));
     const result = run(ReticleCommand.STATE_READ, { store: 'state_ws' }) as StateResult;

--- a/packages/browser/src/commands/commands.ts
+++ b/packages/browser/src/commands/commands.ts
@@ -116,6 +116,12 @@ function inspect(ref: string): unknown {
   // stamped host. `act` already did this; inspect did not, so the two tools disagreed about the same
   // ref and inspect — the tool you reach for to ask where something lives — was the one saying null.
   const source = formatSource(sourceFor(el, component?.source));
+  const scroll = {
+    scrollTop: el.scrollTop,
+    scrollHeight: el.scrollHeight,
+    clientHeight: el.clientHeight,
+    overflowY: cs?.overflowY ?? 'visible',
+  };
   return {
     ...describe(el),
     ...(source !== undefined ? { source } : {}),
@@ -129,6 +135,7 @@ function inspect(ref: string): unknown {
     // not this control (a z-index/overlay bug the DOM tree cannot show).
     occluded: isOccluded(el, rect),
     styles,
+    scroll,
     // Theme compliance vs the app's design tokens (off-theme colors a DOM tool can't judge).
     theme: cs !== null ? themeReport(cs) : null,
     component,

--- a/packages/server/src/tools/tools.ts
+++ b/packages/server/src/tools/tools.ts
@@ -432,6 +432,14 @@ const RAW_TOOLS: ToolDef[] = [
         })
         .partial()
         .optional(),
+      scroll: z
+        .object({
+          scrollTop: z.number(),
+          scrollHeight: z.number(),
+          clientHeight: z.number(),
+          overflowY: z.string(),
+        })
+        .optional(),
       // Theme compliance vs the app's design tokens: { colorToken, colorTokens, backgroundToken,
       // backgroundTokens, offTheme, tokenCount, themeScope }. The plural fields carry EVERY token
       // matching the resolved colour; the singular ones abstain (null) when several tokens share it,


### PR DESCRIPTION
## Summary

- Add `scroll` property to `reticle_inspect` output: `scrollTop`, `scrollHeight`, `clientHeight`, `overflowY`
- Lets an agent assert "this element is the scroll container" directly instead of reverse-engineering it from SCSS
- Add corresponding `scroll` field to the server-side output schema so agents see the shape in tool discovery

Closes #254

## Test plan

- [x] `pnpm format:check` — clean
- [x] `pnpm lint` (browser + server) — clean  
- [x] `pnpm typecheck` (browser + server) — clean
- [x] New test: INSPECT returns scroll metrics for a ref (scrollTop=50, scrollHeight=300, clientHeight=100, overflowY=auto)
- [x] Existing INSPECT test still passes (descriptor + box)

🤖 Generated with [Claude Code](https://claude.com/claude-code)