### PR TITLE
feat(cli): reticle doctor warns on daemon/project port mismatch

### DIFF
--- a/packages/server/src/cli/cli-doctor.ts
+++ b/packages/server/src/cli/cli-doctor.ts
@@ -12,6 +12,7 @@ import { spawnSync } from 'node:child_process';
 import { SERVER_VERSION } from '../version/server-version.js';
 import { CONTRACT_FINGERPRINT } from '@reticlehq/core';
 import { diagnoseDesktop, isDesktopProject } from '../init/desktop-doctor.js';
+import { diagnosePortMismatch, readProjectPort } from './cli-port.js';
 
 /**
  * `reticle doctor` — collapse the ~6 independent first-run failure modes into one command. Checks the
@@ -94,6 +95,9 @@ export async function handleDoctor(port: number): Promise<void> {
     );
   }
   line(`  bridge port  ${port}  (your app must dial THIS port — not your dev-server port)`);
+  const projectPort = readProjectPort(process.cwd());
+  const mismatch = diagnosePortMismatch(port, projectPort);
+  if (mismatch !== undefined) line(`  port check   ✗ ${mismatch}`);
   // Where to LOOK when something is wrong. The daemon has always written a structured log here and
   // nothing ever said so, so the first move in every investigation was reading source instead of
   // reading the log. `RETICLE_TRACE=1` turns the same stream into a per-stage trace — see

--- a/packages/server/src/cli/cli-port.test.ts
+++ b/packages/server/src/cli/cli-port.test.ts
@@ -10,6 +10,7 @@ import {
   resolvePort,
   isLikelyDevServerPort,
   devServerPortWarning,
+  diagnosePortMismatch,
 } from './cli-port.js';
 import { RETICLE_DEFAULT_PORT } from '@reticlehq/core';
 
@@ -362,5 +363,31 @@ describe('isLikelyDevServerPort', () => {
     expect(w).toContain('3000');
     expect(w).toContain('.reticle.json');
     expect(w).toContain('4400');
+  });
+});
+
+// ─── diagnosePortMismatch ───────────────────────────────────────────────────
+
+describe('diagnosePortMismatch', () => {
+  it('returns undefined when no project port is configured', () => {
+    expect(diagnosePortMismatch(4400, undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when the daemon port matches .reticle.json', () => {
+    expect(diagnosePortMismatch(4460, 4460)).toBeUndefined();
+  });
+
+  it('returns a diagnostic when the daemon port differs from .reticle.json', () => {
+    const msg = diagnosePortMismatch(4400, 4460);
+    expect(msg).toBeDefined();
+    expect(msg).toContain('4460');
+    expect(msg).toContain('4400');
+    expect(msg).toContain('.reticle.json');
+  });
+
+  it('names both the fix options: start with --port or update .reticle.json', () => {
+    const msg = diagnosePortMismatch(4400, 4460);
+    expect(msg).toContain('--port 4460');
+    expect(msg).toContain('update .reticle.json');
   });
 });

--- a/packages/server/src/cli/cli-port.ts
+++ b/packages/server/src/cli/cli-port.ts
@@ -125,3 +125,23 @@ export function resolvePort(
 ): number {
   return portFlag ?? envPort ?? projectPort ?? defaultPort;
 }
+
+/**
+ * Detect a port mismatch between the daemon and the project's SDK configuration.
+ *
+ * Returns a diagnostic string when the daemon port differs from what `.reticle.json` declares.
+ * The SDK reads `.reticle.json` at build/connect time, so a mismatch means the app will dial a
+ * port nothing is listening on — the silent no-connect that #261 documents.
+ */
+export function diagnosePortMismatch(
+  daemonPort: number,
+  projectPort: number | undefined,
+): string | undefined {
+  if (projectPort === undefined) return undefined;
+  if (projectPort === daemonPort) return undefined;
+  return (
+    `.reticle.json says "port": ${String(projectPort)} but this daemon is on :${String(daemonPort)}` +
+    ` — the SDK will dial :${String(projectPort)} and never connect. ` +
+    `Either start the daemon with --port ${String(projectPort)}, or update .reticle.json to match.`
+  );
+}


### PR DESCRIPTION
## Summary

- Add `diagnosePortMismatch()` to `cli-port.ts` — pure function comparing daemon port against `.reticle.json`
- Wire it into `reticle doctor` output between `bridge port` and `daemon log`
- When the daemon is on `:4400` but `.reticle.json` says `port: 4460`, doctor now prints the mismatch and names both fixes

Addresses #261 (item 3: "doctor does not compare the port in .reticle.json against the port the daemon actually bound")

## Test plan

- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] 4 new tests: no project port → undefined, matching → undefined, mismatch → diagnostic with both ports, diagnostic names fix options
- [x] All 45 existing cli-port tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)