### PR TITLE
fix(mcp): prevent duplicate responses after SSE stream drop

### DIFF
--- a/packages/server/src/mcp/mcp-proxy.ts
+++ b/packages/server/src/mcp/mcp-proxy.ts
@@ -554,6 +554,7 @@ export function startMcpProxy(
         for (const line of replay.replayLines()) forward(url, line);
         clearQueueTimer();
         for (const queued of stdinQueue.splice(0)) forward(url, queued);
+        handshakeAnswered = true;
         return;
       }
       if ('message' === event && !replay.shouldSuppressInbound(data)) {
@@ -627,8 +628,10 @@ export function startMcpProxy(
         const drop = (reason: string, detail?: string): void => {
           if (settled) return;
           settled = true;
-          // Answer anything the dead session owed BEFORE reconnecting. The new session cannot know
-          // about it, so silence here is permanent.
+          // Drain the queue BEFORE answering pending: a request can be in both (queued but tracked),
+          // and leaving it in the queue means the reconnect will forward it, the daemon will answer,
+          // and the client sees two responses for one id — a protocol violation.
+          stdinQueue.splice(0);
           const lost = streamLossReplies(pending, reason);
           for (const reply of lost) emit(reply);
           // How many calls this drop actually killed. Zero means the agent could not feel it.


### PR DESCRIPTION
## Summary

- Drain `stdinQueue` in the SSE drop handler before emitting stream-loss replies, so a queued request cannot be both error-replied AND re-forwarded on reconnect
- Set `handshakeAnswered = true` when the endpoint arrives and the queue flushes, preventing the local handshake timer from firing a duplicate initialize response after the daemon already answered

Both paths lead to two JSON-RPC responses for one request ID — a protocol violation the existing code explicitly warns about in comments but did not fully close.

## Test plan

- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] All 116 MCP tests pass (stream-loss-replies, proxy handshake, pending-requests, tool-catalog-cache, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)