### PR TITLE
fix(server): record-stop omits the raw events array that blew context windows

### DIFF
--- a/packages/server/src/tools/read-tools.ts
+++ b/packages/server/src/tools/read-tools.ts
@@ -12,7 +12,7 @@ import { replayProgram } from '../flows/replay.js';
 import { diffLines } from '../project/baselines.js';
 import { selectPath, capDepth, projectComponentState } from '../session/state-select.js';
 import { costHint } from '../session/output-budget.js';
-import { buildReactionReport } from '../events/reaction.js';
+import { buildReactionReport, summarizeReaction } from '../events/reaction.js';
 import { asString, asNumber, parseInteractive } from './tools-helpers.js';
 import { type ToolDef, sessionIdShape, commandOrThrow, snapshotTree } from './tool-kit.js';
 import { bufferEnvelope } from '../session/session-health.js';
@@ -198,7 +198,8 @@ export const READ_TOOLS: ToolDef[] = [
       const report = buildReactionReport(events, session.elapsed() - rec.cursor);
       // Self-generating oracles: propose ranked mustHold from what the recorded window actually did.
       const proposedConsequences = proposeConsequences(events);
-      return Promise.resolve({
+      const digest = summarizeReaction(report);
+      const body = {
         recordingName: name,
         program,
         ...(unstable > 0
@@ -207,8 +208,11 @@ export const READ_TOOLS: ToolDef[] = [
             }
           : {}),
         ...(proposedConsequences.length > 0 ? { proposedConsequences } : {}),
-        ...report,
-        cost: costHint(report, events.length),
+        ...digest,
+      };
+      return Promise.resolve({
+        ...body,
+        cost: costHint(body, events.length),
       });
     },
   },

--- a/packages/server/src/tools/record-stop-budget.test.ts
+++ b/packages/server/src/tools/record-stop-budget.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { EventType, REPLAY_PROGRAM_VERSION } from '@reticlehq/core';
+import { READ_TOOLS } from './read-tools.js';
+import { ReticleTool } from './tool-names.js';
+import type { ToolDeps } from './tools.js';
+import type { Session, SessionManager } from '../session/session.js';
+import { RecordingStore, type CompiledProgram } from '../flows/recordings.js';
+
+function recordStopTool() {
+  const t = READ_TOOLS.find((x) => x.name === ReticleTool.RECORD_STOP);
+  if (t === undefined) throw new Error('no reticle_record_stop tool');
+  return t;
+}
+
+function buildDeps(eventCount: number): ToolDeps {
+  const recordings = new RecordingStore();
+  recordings.start('test-rec', 0);
+  const events = Array.from({ length: eventCount }, (_, i) => ({
+    t: i,
+    type: EventType.DOM_ADDED,
+    sessionId: 's1',
+    data: { html: `<div class="item-${String(i)}">content ${String(i)}</div>` },
+  }));
+  const session = {
+    elapsed: () => eventCount,
+    eventsSince: () => events,
+  } as unknown as Session;
+  const sessions = { resolve: () => session } as unknown as SessionManager;
+  return { sessions, recordings } as unknown as ToolDeps;
+}
+
+describe('reticle_record_stop output budget', () => {
+  it('never returns a raw events array — the timeline is omitted by default', async () => {
+    const deps = buildDeps(440);
+    const result = (await recordStopTool().handler(deps, { recordingName: 'test-rec' })) as Record<
+      string,
+      unknown
+    >;
+    expect(result['events']).toBeUndefined();
+  });
+
+  it('returns summary counts so the agent knows what happened without the raw timeline', async () => {
+    const deps = buildDeps(10);
+    const result = (await recordStopTool().handler(deps, { recordingName: 'test-rec' })) as {
+      summary?: { total: number; domAdded: number };
+    };
+    expect(result.summary).toBeDefined();
+    expect(result.summary?.total).toBe(10);
+    expect(result.summary?.domAdded).toBe(10);
+  });
+
+  it('keeps program, proposedConsequences, and cost in the response', async () => {
+    const deps = buildDeps(5);
+    const result = (await recordStopTool().handler(deps, { recordingName: 'test-rec' })) as {
+      program?: CompiledProgram;
+      cost?: { events: number };
+      recordingName?: string;
+    };
+    expect(result.recordingName).toBe('test-rec');
+    expect(result.program).toBeDefined();
+    expect(result.program?.version).toBe(REPLAY_PROGRAM_VERSION);
+    expect(result.cost).toBeDefined();
+    expect(result.cost?.events).toBe(5);
+  });
+
+  it('stays under 4KB for a 440-event recording (was ~63KB before the fix)', async () => {
+    const deps = buildDeps(440);
+    const result = await recordStopTool().handler(deps, { recordingName: 'test-rec' });
+    const size = JSON.stringify(result).length;
+    expect(size).toBeLessThan(4000);
+  });
+
+  it('reports window_ms from the reaction without the heavy events payload', async () => {
+    const deps = buildDeps(20);
+    const result = (await recordStopTool().handler(deps, { recordingName: 'test-rec' })) as {
+      window_ms?: number;
+    };
+    expect(result.window_ms).toBeDefined();
+    expect(result.window_ms).toBe(20);
+  });
+});


### PR DESCRIPTION
## Summary

- `reticle_record { action: "stop" }` returned ~63k chars (440 events for a single click). The actionable content (`program`, `proposedConsequences`, `summary`) totals ~1 KB.
- Uses the existing `summarizeReaction()` to strip the heavy per-event timeline, keeping only `window_ms` + `summary` counts.
- `costHint` now measures the body the agent actually receives (not the pre-strip payload), while still reporting the full event count so the agent knows how large the recording window was.
- The raw timeline remains accessible via `reticle_observe { since }` when needed.

Closes #305

## Test plan

- [x] New test file `record-stop-budget.test.ts` with 5 assertions:
  - Raw events array is never returned
  - Summary counts are present (the agent knows what happened)
  - Program, proposedConsequences, and cost are preserved
  - A 440-event recording stays under 4 KB (was ~63 KB)
  - `window_ms` is reported without the heavy payload
- [x] Test goes RED when the fix is reverted (spreading `...report` instead of `...summarizeReaction(report)`)
- [x] Full server suite: 3465 tests pass, 0 regressions
- [x] `pnpm format:check && pnpm lint && pnpm typecheck` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: Dev Chiniwala <dev.chiniwala@gmail.com>