### PR TITLE
feat(server): lease acquire returns expiresInMs so agents can schedule around TTL

### DIFF
--- a/packages/server/src/pool/browser-pool.ts
+++ b/packages/server/src/pool/browser-pool.ts
@@ -109,7 +109,11 @@ export class BrowserPool {
     this.#navTimeout = opts.navTimeoutMs ?? DEFAULT_NAV_TIMEOUT_MS;
   }
 
-  /** Currently leased contexts. */
+  /** The TTL configured for leases — how long an untouched lease lives before the reaper reclaims it. */
+  leaseTtlMs(): number {
+    return this.#ttl;
+  }
+
   /** Max simultaneous leases — the ceiling the parallel suite sizes its concurrency to. */
   capacity(): number {
     return this.#max;

--- a/packages/server/src/tools/lease-tools.test.ts
+++ b/packages/server/src/tools/lease-tools.test.ts
@@ -44,6 +44,7 @@ function fakePool(): {
     activeCount: () => active,
     queuedCount: () => 0,
     leasedSessionIds: () => [],
+    leaseTtlMs: () => 300_000,
   } as unknown as BrowserPool;
   return { pool, acquired };
 }
@@ -145,6 +146,15 @@ describe('reticle_lease_acquire', () => {
     expect(navUrl.searchParams.get(RETICLE_URL_PARAM.SESSION)).toBe(result.sessionId);
     expect(navUrl.searchParams.get(RETICLE_URL_PARAM.PROJECT)).toBe('acme');
     expect(acquired[0]?.sessionId).toBe(result.sessionId);
+  });
+
+  it('returns expiresInMs so the agent knows when the lease will die', async () => {
+    const { pool } = fakePool();
+    const result = (await tool(ReticleTool.LEASE_ACQUIRE)(
+      { ...baseDeps, pool },
+      { url: 'http://localhost:3000/' },
+    )) as { expiresInMs: number };
+    expect(result.expiresInMs).toBe(300_000);
   });
 
   it('throws a clear error when no pool is available', async () => {

--- a/packages/server/src/tools/lease-tools.ts
+++ b/packages/server/src/tools/lease-tools.ts
@@ -140,6 +140,11 @@ export const LEASE_TOOLS: ToolDef[] = [
         .describe(
           'Whether the leased tab connected — false ⇒ the app may not embed @reticlehq/core.',
         ),
+      expiresInMs: z
+        .number()
+        .describe(
+          'Milliseconds until this lease expires if untouched. Each tool call that targets this session resets the clock. Plan your work to finish or re-acquire before this runs out.',
+        ),
       leased: z.number().describe('How many contexts are currently leased from the pool.'),
       queued: z.number().describe('How many acquires are waiting for a free slot.'),
       hint: z.string().optional(),
@@ -171,6 +176,7 @@ export const LEASE_TOOLS: ToolDef[] = [
         sessionId: lease.sessionId,
         url,
         ready,
+        expiresInMs: pool.leaseTtlMs(),
         leased: pool.activeCount(),
         queued: pool.queuedCount(),
         ...(ready


### PR DESCRIPTION
## Summary

- Adds `expiresInMs` to the `reticle_lease_acquire` response — the pool's configured lease TTL (default 5 minutes), reset on every tool call targeting the session.
- Exposes `BrowserPool.leaseTtlMs()` accessor (pure, no side effects).
- An agent can now plan its verification pass to finish before expiry, or proactively re-acquire — instead of losing measurements mid-assertion to a silent timeout.

Addresses the "cheapest fix on the list" from #157: "No expiry is ever stated. No tool result carries expiresInMs."

## Test plan

- [x] New test: `returns expiresInMs so the agent knows when the lease will die`
- [x] All 15 lease-tools tests pass
- [x] Full server suite: 3461 tests pass, 0 regressions
- [x] `pnpm format:check && pnpm lint && pnpm typecheck` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: Dev Chiniwala <dev.chiniwala@gmail.com>