### PR TITLE
Guard tests that do real IO inside a loop, not just big loops

### DIFF
--- a/packages/server/src/flows/flake-store.test.ts
+++ b/packages/server/src/flows/flake-store.test.ts
@@ -6,6 +6,14 @@ import { join } from 'node:path';
 import { createNodeFileSystem, type FileSystemPort } from '../project/fs-port.js';
 import { FlakeStore } from './flake-store.js';
 
+/**
+ * A BOUND, not a measurement. Every `store.record()` reads and rewrites `flake.json` on the real
+ * filesystem, so a five-iteration loop is ten syscalls, not five cheap calls — the cost is what is
+ * inside the loop, not the iteration count. Cheap on macOS and Linux, much slower on a Windows
+ * runner, and vitest's 5 s default would then report the runner rather than the ledger.
+ */
+const FLAKE_LEDGER_IO_TIMEOUT_MS = 30_000;
+
 describe('FlakeStore', () => {
   let root: string;
   let fs: FileSystemPort;
@@ -19,17 +27,25 @@ describe('FlakeStore', () => {
     await removeTempDir(join(root, '..'));
   });
 
-  it('accrues outcomes and quarantines a flow once it is intermittently failing', async () => {
-    const store = new FlakeStore(fs, root);
-    for (const passed of [true, false, true, true, false]) await store.record('checkout', passed);
-    expect(await store.flakyFlows()).toEqual(['checkout']);
-  });
+  it(
+    'accrues outcomes and quarantines a flow once it is intermittently failing',
+    async () => {
+      const store = new FlakeStore(fs, root);
+      for (const passed of [true, false, true, true, false]) await store.record('checkout', passed);
+      expect(await store.flakyFlows()).toEqual(['checkout']);
+    },
+    FLAKE_LEDGER_IO_TIMEOUT_MS,
+  );
 
-  it('does not quarantine a consistently passing flow', async () => {
-    const store = new FlakeStore(fs, root);
-    for (let i = 0; i < 5; i += 1) await store.record('login', true);
-    expect(await store.flakyFlows()).toEqual([]);
-  });
+  it(
+    'does not quarantine a consistently passing flow',
+    async () => {
+      const store = new FlakeStore(fs, root);
+      for (let i = 0; i < 5; i += 1) await store.record('login', true);
+      expect(await store.flakyFlows()).toEqual([]);
+    },
+    FLAKE_LEDGER_IO_TIMEOUT_MS,
+  );
 
   it('degrades to an empty ledger on a malformed or wrong-version file', async () => {
     await mkdir(root, { recursive: true });
@@ -45,32 +61,48 @@ describe('FlakeStore', () => {
      * failure was intermittent. A flake and a regression demand opposite responses: one is quarantined,
      * the other is chased. An agent that cannot tell them apart does the wrong one half the time.
      */
-    it('reports a flow that passed and then failed on unchanged code', async () => {
-      // Five runs is the deliberate floor (DEFAULT_MIN_FLAKE_RUNS): calling a flow flaky off two
-      // samples would quarantine real regressions, which is the more expensive mistake.
-      const store = new FlakeStore(fs, root);
-      for (const passed of [true, false, true, true, false]) {
-        await store.record('checkout', passed);
-      }
-      expect(await store.flakyFlows()).toContain('checkout');
-    });
+    it(
+      'reports a flow that passed and then failed on unchanged code',
+      async () => {
+        // Five runs is the deliberate floor (DEFAULT_MIN_FLAKE_RUNS): calling a flow flaky off two
+        // samples would quarantine real regressions, which is the more expensive mistake.
+        const store = new FlakeStore(fs, root);
+        for (const passed of [true, false, true, true, false]) {
+          await store.record('checkout', passed);
+        }
+        expect(await store.flakyFlows()).toContain('checkout');
+      },
+      FLAKE_LEDGER_IO_TIMEOUT_MS,
+    );
 
-    it('needs enough runs before judging — three samples is not evidence', async () => {
-      const store = new FlakeStore(fs, root);
-      for (const passed of [true, false, true]) await store.record('early', passed);
-      expect(await store.flakyFlows()).not.toContain('early');
-    });
+    it(
+      'needs enough runs before judging — three samples is not evidence',
+      async () => {
+        const store = new FlakeStore(fs, root);
+        for (const passed of [true, false, true]) await store.record('early', passed);
+        expect(await store.flakyFlows()).not.toContain('early');
+      },
+      FLAKE_LEDGER_IO_TIMEOUT_MS,
+    );
 
-    it('does NOT report a flow that always fails — that is a regression, not a flake', async () => {
-      const store = new FlakeStore(fs, root);
-      for (let i = 0; i < 5; i += 1) await store.record('broken', false);
-      expect(await store.flakyFlows()).not.toContain('broken');
-    });
+    it(
+      'does NOT report a flow that always fails — that is a regression, not a flake',
+      async () => {
+        const store = new FlakeStore(fs, root);
+        for (let i = 0; i < 5; i += 1) await store.record('broken', false);
+        expect(await store.flakyFlows()).not.toContain('broken');
+      },
+      FLAKE_LEDGER_IO_TIMEOUT_MS,
+    );
 
-    it('does NOT report a flow that always passes', async () => {
-      const store = new FlakeStore(fs, root);
-      for (let i = 0; i < 5; i += 1) await store.record('stable', true);
-      expect(await store.flakyFlows()).not.toContain('stable');
-    });
+    it(
+      'does NOT report a flow that always passes',
+      async () => {
+        const store = new FlakeStore(fs, root);
+        for (let i = 0; i < 5; i += 1) await store.record('stable', true);
+        expect(await store.flakyFlows()).not.toContain('stable');
+      },
+      FLAKE_LEDGER_IO_TIMEOUT_MS,
+    );
   });
 });

--- a/packages/server/src/flows/flow-verify.flaky.test.ts
+++ b/packages/server/src/flows/flow-verify.flaky.test.ts
@@ -20,6 +20,14 @@ import { ReticleTool } from '../tools/tool-names.js';
  * These drive the ledger the way the tool does — record every replay outcome, then ask what is
  * intermittent — so the contract is pinned even though the handler itself needs a live session.
  */
+/**
+ * A BOUND, not a measurement. `verifyRound` records every outcome through `FlakeStore`, which reads
+ * and rewrites the ledger on the real filesystem per call, and the tests below drive it in a loop.
+ * Six rounds is not a big number; twelve syscalls on a Windows runner is, and vitest's 5 s default
+ * would then be reporting the runner rather than the ledger's verdict.
+ */
+const LEDGER_ROUND_TIMEOUT_MS = 30_000;
+
 describe('flow_verify feeds and reads the flake ledger', () => {
   let root: string;
   const fs = createNodeFileSystem();
@@ -43,52 +51,69 @@ describe('flow_verify feeds and reads the flake ledger', () => {
     return store.flakyFlows();
   }
 
-  it('says nothing until the ledger has seen enough runs to be sure', async () => {
-    const store = new FlakeStore(fs, root);
-    // Two runs, one each way — genuinely intermittent, but calling it flaky off two samples is noise.
-    await verifyRound(store, { checkout: ReplayStatus.OK });
-    const early = await verifyRound(store, { checkout: ReplayStatus.ERROR });
-    expect(early, 'a verdict on two runs is a guess, not a measurement').toEqual([]);
-  });
+  it(
+    'says nothing until the ledger has seen enough runs to be sure',
+    async () => {
+      const store = new FlakeStore(fs, root);
+      // Two runs, one each way — genuinely intermittent, but calling it flaky off two samples is noise.
+      await verifyRound(store, { checkout: ReplayStatus.OK });
+      const early = await verifyRound(store, { checkout: ReplayStatus.ERROR });
+      expect(early, 'a verdict on two runs is a guess, not a measurement').toEqual([]);
+    },
+    LEDGER_ROUND_TIMEOUT_MS,
+  );
 
-  it('reports a flow that has both passed and failed on unchanged code', async () => {
-    const store = new FlakeStore(fs, root);
-    const rounds = [
-      ReplayStatus.OK,
-      ReplayStatus.ERROR,
-      ReplayStatus.OK,
-      ReplayStatus.OK,
-      ReplayStatus.ERROR,
-    ];
-    let flaky: string[] = [];
-    for (const status of rounds) flaky = await verifyRound(store, { checkout: status });
-    expect(flaky).toContain('checkout');
-  });
+  it(
+    'reports a flow that has both passed and failed on unchanged code',
+    async () => {
+      const store = new FlakeStore(fs, root);
+      const rounds = [
+        ReplayStatus.OK,
+        ReplayStatus.ERROR,
+        ReplayStatus.OK,
+        ReplayStatus.OK,
+        ReplayStatus.ERROR,
+      ];
+      let flaky: string[] = [];
+      for (const status of rounds) flaky = await verifyRound(store, { checkout: status });
+      expect(flaky).toContain('checkout');
+    },
+    LEDGER_ROUND_TIMEOUT_MS,
+  );
 
-  it('does not confuse a consistently BROKEN flow with a flaky one', async () => {
-    // The distinction the field exists for: a flow that always fails is a regression to fix, not a
-    // ghost to chase. Reporting it as flaky would send the agent looking for nondeterminism.
-    const store = new FlakeStore(fs, root);
-    let flaky: string[] = [];
-    for (let i = 0; i < 6; i += 1) flaky = await verifyRound(store, { broken: ReplayStatus.ERROR });
-    expect(flaky).not.toContain('broken');
-  });
+  it(
+    'does not confuse a consistently BROKEN flow with a flaky one',
+    async () => {
+      // The distinction the field exists for: a flow that always fails is a regression to fix, not a
+      // ghost to chase. Reporting it as flaky would send the agent looking for nondeterminism.
+      const store = new FlakeStore(fs, root);
+      let flaky: string[] = [];
+      for (let i = 0; i < 6; i += 1)
+        flaky = await verifyRound(store, { broken: ReplayStatus.ERROR });
+      expect(flaky).not.toContain('broken');
+    },
+    LEDGER_ROUND_TIMEOUT_MS,
+  );
 
-  it('keeps per-flow ledgers separate within one suite run', async () => {
-    const store = new FlakeStore(fs, root);
-    let flaky: string[] = [];
-    for (const status of [
-      ReplayStatus.OK,
-      ReplayStatus.ERROR,
-      ReplayStatus.OK,
-      ReplayStatus.OK,
-      ReplayStatus.ERROR,
-    ]) {
-      flaky = await verifyRound(store, { wobbly: status, steady: ReplayStatus.OK });
-    }
-    expect(flaky).toContain('wobbly');
-    expect(flaky, 'a stable flow in the same suite must stay clean').not.toContain('steady');
-  });
+  it(
+    'keeps per-flow ledgers separate within one suite run',
+    async () => {
+      const store = new FlakeStore(fs, root);
+      let flaky: string[] = [];
+      for (const status of [
+        ReplayStatus.OK,
+        ReplayStatus.ERROR,
+        ReplayStatus.OK,
+        ReplayStatus.OK,
+        ReplayStatus.ERROR,
+      ]) {
+        flaky = await verifyRound(store, { wobbly: status, steady: ReplayStatus.OK });
+      }
+      expect(flaky).toContain('wobbly');
+      expect(flaky, 'a stable flow in the same suite must stay clean').not.toContain('steady');
+    },
+    LEDGER_ROUND_TIMEOUT_MS,
+  );
 
   it('never lets a ledger failure break the verdict', async () => {
     // The handler wraps both halves in .catch() on purpose: a flake ledger is memory, not a gate.

--- a/packages/server/src/flows/flows.test.ts
+++ b/packages/server/src/flows/flows.test.ts
@@ -25,6 +25,16 @@ function program(name: string, steps: RecordedStep[]): CompiledProgram {
   return { name, version: 1, steps };
 }
 
+/**
+ * A BOUND, not a measurement — and the lightest of the six the IO-in-a-loop guard flags, which is
+ * worth saying rather than leaving for the next reader to wonder about. Test 9's loop runs twice and
+ * both saves are rejected on the name before anything is written, so the LOOP is not what costs
+ * here. What costs is the block around it: every valid test round-trips a flow through a real temp
+ * directory. The bound is cheap, generous, and cannot make a broken test pass; the alternative is a
+ * file that only satisfies the guard by accident the day someone adds a third iteration that writes.
+ */
+const FLOW_ROUND_TRIP_TIMEOUT_MS = 30_000;
+
 describe('FlowStore — temp-dir fs, never touches the repo', () => {
   let root: string;
   let fs: FileSystemPort;
@@ -213,12 +223,16 @@ describe('FlowStore — temp-dir fs, never touches the repo', () => {
     expect(await fs.exists(join(root, '..', 'evil.json'))).toBe(false);
   });
 
-  it('9: save rejects an absolute / slashed name', async () => {
-    for (const name of ['a/b', '/etc/x']) {
-      const saved = await store.save(program(name, []));
-      expect(saved).toEqual({ ok: false, code: FlowErrorCode.INVALID_NAME });
-    }
-  });
+  it(
+    '9: save rejects an absolute / slashed name',
+    async () => {
+      for (const name of ['a/b', '/etc/x']) {
+        const saved = await store.save(program(name, []));
+        expect(saved).toEqual({ ok: false, code: FlowErrorCode.INVALID_NAME });
+      }
+    },
+    FLOW_ROUND_TRIP_TIMEOUT_MS,
+  );
 
   it('10: load of a missing flow returns NOT_FOUND, not a throw', async () => {
     const loaded = await store.load('ghost');

--- a/packages/server/src/flows/suite-flakes.test.ts
+++ b/packages/server/src/flows/suite-flakes.test.ts
@@ -34,42 +34,58 @@ afterEach(async () => {
 const round = (outcomes: Record<string, ReplayStatus>) =>
   Object.entries(outcomes).map(([name, status]) => ({ replay: { name, status } }));
 
-describe('recordSuiteFlakes', () => {
-  it('reports a flow that has both passed and failed on unchanged code', async () => {
-    let flaky: readonly string[] = [];
-    for (const status of [
-      ReplayStatus.OK,
-      ReplayStatus.ERROR,
-      ReplayStatus.OK,
-      ReplayStatus.OK,
-      ReplayStatus.ERROR,
-    ]) {
-      flaky = await recordSuiteFlakes(fs, root, round({ checkout: status }));
-    }
-    expect(flaky).toContain('checkout');
-  });
+/**
+ * A BOUND, not a measurement. Each `recordSuiteFlakes` call rewrites the ledger on the real
+ * filesystem, and a batch round does it once per flow — so a five-round loop over a three-flow suite
+ * is fifteen writes, not five iterations. That is the shape that timed out at vitest's 5 s default
+ * on a Windows runner in `project-tools.test.ts`, and nothing here claims the code is fast.
+ */
+const SUITE_LEDGER_TIMEOUT_MS = 30_000;
 
-  it('records EVERY flow in a batch, not just the first or last', async () => {
-    // The parallel path records a whole round at once. A loop that broke early, or overwrote, would
-    // still look right for a one-flow suite.
-    let flaky: readonly string[] = [];
-    for (const s of [
-      ReplayStatus.OK,
-      ReplayStatus.ERROR,
-      ReplayStatus.OK,
-      ReplayStatus.OK,
-      ReplayStatus.ERROR,
-    ]) {
-      flaky = await recordSuiteFlakes(
-        fs,
-        root,
-        round({ login: s, steady: ReplayStatus.OK, search: s }),
-      );
-    }
-    expect(flaky).toContain('login');
-    expect(flaky).toContain('search');
-    expect(flaky, 'a stable flow in the same batch must stay clean').not.toContain('steady');
-  });
+describe('recordSuiteFlakes', () => {
+  it(
+    'reports a flow that has both passed and failed on unchanged code',
+    async () => {
+      let flaky: readonly string[] = [];
+      for (const status of [
+        ReplayStatus.OK,
+        ReplayStatus.ERROR,
+        ReplayStatus.OK,
+        ReplayStatus.OK,
+        ReplayStatus.ERROR,
+      ]) {
+        flaky = await recordSuiteFlakes(fs, root, round({ checkout: status }));
+      }
+      expect(flaky).toContain('checkout');
+    },
+    SUITE_LEDGER_TIMEOUT_MS,
+  );
+
+  it(
+    'records EVERY flow in a batch, not just the first or last',
+    async () => {
+      // The parallel path records a whole round at once. A loop that broke early, or overwrote, would
+      // still look right for a one-flow suite.
+      let flaky: readonly string[] = [];
+      for (const s of [
+        ReplayStatus.OK,
+        ReplayStatus.ERROR,
+        ReplayStatus.OK,
+        ReplayStatus.OK,
+        ReplayStatus.ERROR,
+      ]) {
+        flaky = await recordSuiteFlakes(
+          fs,
+          root,
+          round({ login: s, steady: ReplayStatus.OK, search: s }),
+        );
+      }
+      expect(flaky).toContain('login');
+      expect(flaky).toContain('search');
+      expect(flaky, 'a stable flow in the same batch must stay clean').not.toContain('steady');
+    },
+    SUITE_LEDGER_TIMEOUT_MS,
+  );
 
   it('says nothing until the ledger has seen enough runs to be sure', async () => {
     await recordSuiteFlakes(fs, root, round({ checkout: ReplayStatus.OK }));
@@ -77,29 +93,37 @@ describe('recordSuiteFlakes', () => {
     expect(early, 'a verdict on two runs is a guess, not a measurement').toEqual([]);
   });
 
-  it('does not confuse a consistently BROKEN flow with a flaky one', async () => {
-    let flaky: readonly string[] = [];
-    for (let i = 0; i < 6; i += 1) {
-      flaky = await recordSuiteFlakes(fs, root, round({ broken: ReplayStatus.ERROR }));
-    }
-    expect(flaky, 'always-failing is a regression to fix, not a ghost to chase').not.toContain(
-      'broken',
-    );
-  });
+  it(
+    'does not confuse a consistently BROKEN flow with a flaky one',
+    async () => {
+      let flaky: readonly string[] = [];
+      for (let i = 0; i < 6; i += 1) {
+        flaky = await recordSuiteFlakes(fs, root, round({ broken: ReplayStatus.ERROR }));
+      }
+      expect(flaky, 'always-failing is a regression to fix, not a ghost to chase').not.toContain(
+        'broken',
+      );
+    },
+    SUITE_LEDGER_TIMEOUT_MS,
+  );
 
-  it('counts DRIFT as a failure, like ERROR', async () => {
-    let flaky: readonly string[] = [];
-    for (const s of [
-      ReplayStatus.OK,
-      ReplayStatus.DRIFT,
-      ReplayStatus.OK,
-      ReplayStatus.OK,
-      ReplayStatus.DRIFT,
-    ]) {
-      flaky = await recordSuiteFlakes(fs, root, round({ wobbly: s }));
-    }
-    expect(flaky).toContain('wobbly');
-  });
+  it(
+    'counts DRIFT as a failure, like ERROR',
+    async () => {
+      let flaky: readonly string[] = [];
+      for (const s of [
+        ReplayStatus.OK,
+        ReplayStatus.DRIFT,
+        ReplayStatus.OK,
+        ReplayStatus.OK,
+        ReplayStatus.DRIFT,
+      ]) {
+        flaky = await recordSuiteFlakes(fs, root, round({ wobbly: s }));
+      }
+      expect(flaky).toContain('wobbly');
+    },
+    SUITE_LEDGER_TIMEOUT_MS,
+  );
 
   it('never lets a ledger failure break the verdict', async () => {
     // A flake ledger is memory, not a gate. A full disk must not turn a working verify into an error.

--- a/packages/server/src/journal/deviation-service.test.ts
+++ b/packages/server/src/journal/deviation-service.test.ts
@@ -21,6 +21,14 @@ function seg(route: string, durationMs: number): SegmentRollup {
   };
 }
 
+/**
+ * A BOUND, not a measurement. Every test below drives the envelope through a loop, and each
+ * iteration reads and rewrites the store on the real filesystem — the cost is per-iteration IO, not
+ * the three or four samples the loop counts. Cheap on macOS and Linux, much slower on a Windows
+ * runner, where vitest's 5 s default would decide the result instead of the assertion.
+ */
+const ENVELOPE_IO_TIMEOUT_MS = 30_000;
+
 describe('reportAndAccumulate — the push-default loop', () => {
   let root: string;
   let fs: FileSystemPort;
@@ -36,36 +44,48 @@ describe('reportAndAccumulate — the push-default loop', () => {
     await removeTempDir(join(root, '..'));
   });
 
-  it('is silent on early runs, then catches a regression once the envelope matures', async () => {
-    // First runs: too few samples — falls back to the causal summary.
-    for (const d of [100, 110, 95]) {
-      const report = await reportAndAccumulate(store, [seg('/checkout', d)]);
-      expect(report.insufficientSamples).toBe(true);
-    }
-    // A now-established route stays nominal on a healthy run…
-    const healthy = await reportAndAccumulate(store, [seg('/checkout', 104)]);
-    expect(healthy.insufficientSamples).toBe(false);
-    expect(healthy.deviations).toEqual([]);
-    expect(healthy.headline).toContain('nominal');
+  it(
+    'is silent on early runs, then catches a regression once the envelope matures',
+    async () => {
+      // First runs: too few samples — falls back to the causal summary.
+      for (const d of [100, 110, 95]) {
+        const report = await reportAndAccumulate(store, [seg('/checkout', d)]);
+        expect(report.insufficientSamples).toBe(true);
+      }
+      // A now-established route stays nominal on a healthy run…
+      const healthy = await reportAndAccumulate(store, [seg('/checkout', 104)]);
+      expect(healthy.insufficientSamples).toBe(false);
+      expect(healthy.deviations).toEqual([]);
+      expect(healthy.headline).toContain('nominal');
 
-    // …and flags a real slowdown, naming the route.
-    const regressed = await reportAndAccumulate(store, [seg('/checkout', 1500)]);
-    expect(regressed.deviations[0]?.route).toBe('/checkout');
-    expect(regressed.headline).toContain('/checkout');
-  });
+      // …and flags a real slowdown, naming the route.
+      const regressed = await reportAndAccumulate(store, [seg('/checkout', 1500)]);
+      expect(regressed.deviations[0]?.route).toBe('/checkout');
+      expect(regressed.headline).toContain('/checkout');
+    },
+    ENVELOPE_IO_TIMEOUT_MS,
+  );
 
-  it('never learns from a truncated segment (its understated counts would poison the baseline)', async () => {
-    for (const d of [100, 110, 95]) await reportAndAccumulate(store, [seg('/a', d)]);
-    // A truncated run (understated counts) must not fold into the envelope.
-    await reportAndAccumulate(store, [{ ...seg('/a', 0), truncated: true }]);
-    const loaded = await store.load();
-    expect(loaded.get('/a')?.samples).toBe(3); // still 3 — the truncated run was not learned
-  });
+  it(
+    'never learns from a truncated segment (its understated counts would poison the baseline)',
+    async () => {
+      for (const d of [100, 110, 95]) await reportAndAccumulate(store, [seg('/a', d)]);
+      // A truncated run (understated counts) must not fold into the envelope.
+      await reportAndAccumulate(store, [{ ...seg('/a', 0), truncated: true }]);
+      const loaded = await store.load();
+      expect(loaded.get('/a')?.samples).toBe(3); // still 3 — the truncated run was not learned
+    },
+    ENVELOPE_IO_TIMEOUT_MS,
+  );
 
-  it('persists the accumulated baseline across separate store instances (run to run)', async () => {
-    for (const d of [100, 110, 95, 105]) await reportAndAccumulate(store, [seg('/a', d)]);
-    const fresh = new EnvelopeStore(fs, root); // a later daemon run
-    const report = await reportAndAccumulate(fresh, [seg('/a', 100)]);
-    expect(report.insufficientSamples).toBe(false);
-  });
+  it(
+    'persists the accumulated baseline across separate store instances (run to run)',
+    async () => {
+      for (const d of [100, 110, 95, 105]) await reportAndAccumulate(store, [seg('/a', d)]);
+      const fresh = new EnvelopeStore(fs, root); // a later daemon run
+      const report = await reportAndAccumulate(fresh, [seg('/a', 100)]);
+      expect(report.insufficientSamples).toBe(false);
+    },
+    ENVELOPE_IO_TIMEOUT_MS,
+  );
 });

--- a/packages/server/src/journal/retention.test.ts
+++ b/packages/server/src/journal/retention.test.ts
@@ -22,6 +22,17 @@ describe('selectPrunable', () => {
   });
 });
 
+/**
+ * A BOUND, not a measurement: nothing below claims the code is fast.
+ *
+ * The test that follows creates directories and writes files sequentially through the real
+ * filesystem inside a loop, and sleeps 5 ms per iteration on purpose to stagger mtimes. That is
+ * milliseconds on macOS and Linux and much slower on a Windows runner, so vitest's 5 s default is a
+ * statement about the machine — the exact shape CLAUDE.md forbids asserting on. A generous ceiling
+ * cannot make a broken test pass; the `['s2', 's3']` assertion still has to hold.
+ */
+const SESSION_PRUNE_TIMEOUT_MS = 30_000;
+
 describe('pruneSessions', () => {
   let root: string;
   let fs: FileSystemPort;
@@ -35,18 +46,22 @@ describe('pruneSessions', () => {
     await removeTempDir(join(root, '..'));
   });
 
-  it('keeps only the retention-most-recent session dirs on disk', async () => {
-    const sessions = join(root, 'sessions');
-    for (const name of ['s1', 's2', 's3']) {
-      await mkdir(join(sessions, name), { recursive: true });
-      await writeFile(join(sessions, name, 'events.jsonl'), '', 'utf8');
-      // stagger mtimes so ordering is deterministic
-      await new Promise((r) => setTimeout(r, 5));
-    }
-    await pruneSessions(fs, root, 2);
-    const remaining = (await readdir(sessions)).sort();
-    expect(remaining).toEqual(['s2', 's3']);
-  });
+  it(
+    'keeps only the retention-most-recent session dirs on disk',
+    async () => {
+      const sessions = join(root, 'sessions');
+      for (const name of ['s1', 's2', 's3']) {
+        await mkdir(join(sessions, name), { recursive: true });
+        await writeFile(join(sessions, name, 'events.jsonl'), '', 'utf8');
+        // stagger mtimes so ordering is deterministic
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      await pruneSessions(fs, root, 2);
+      const remaining = (await readdir(sessions)).sort();
+      expect(remaining).toEqual(['s2', 's3']);
+    },
+    SESSION_PRUNE_TIMEOUT_MS,
+  );
 
   it('never throws when there is no sessions dir', async () => {
     await expect(pruneSessions(fs, root, 2)).resolves.toBeUndefined();

--- a/packages/server/src/journal/session-end.test.ts
+++ b/packages/server/src/journal/session-end.test.ts
@@ -80,6 +80,15 @@ describe('makeSessionEnd (teardown: flush journal + persist ambient)', () => {
   });
 });
 
+/**
+ * A BOUND, not a measurement — and the heaviest IO loop of the set, which is why it is surprising it
+ * was not on the original list. The test below creates `DEFAULT_SESSION_RETENTION + 5` session
+ * directories and writes a file into each, sequentially, through the real filesystem. That is more
+ * per-iteration IO than the 40-record loop in `project-tools.test.ts` that actually timed out at
+ * vitest's 5 s default on Windows CI.
+ */
+const SESSION_RETENTION_TIMEOUT_MS = 30_000;
+
 describe('journal retention is bounded on a long-running daemon', () => {
   let root: string;
   const fs = createNodeFileSystem();
@@ -92,22 +101,26 @@ describe('journal retention is bounded on a long-running daemon', () => {
     await removeTempDir(join(root, '..'));
   });
 
-  it('prunes at session END, not only at daemon start', async () => {
-    // The leak this closes: pruneSessions ran once during wiring, so a daemon that stays up — the
-    // normal case, and the entire point of the pool — accumulated a session directory per tab
-    // forever. Session end is the right moment: it is exactly when a new directory was just created.
-    const end = makeSessionEnd({ fs, reticleRoot: root, enabled: true });
-    const overBound = DEFAULT_SESSION_RETENTION + 5;
-    for (let i = 0; i < overBound; i++) {
-      const dir = sessionDirPath(root, `s${i}`);
-      await fs.mkdir(dir);
-      await fs.writeFile(join(dir, 'events.jsonl'), '{}\n');
-    }
-    expect((await fs.readdir(reticleDirPaths(root).sessions)).length).toBe(overBound);
+  it(
+    'prunes at session END, not only at daemon start',
+    async () => {
+      // The leak this closes: pruneSessions ran once during wiring, so a daemon that stays up — the
+      // normal case, and the entire point of the pool — accumulated a session directory per tab
+      // forever. Session end is the right moment: it is exactly when a new directory was just created.
+      const end = makeSessionEnd({ fs, reticleRoot: root, enabled: true });
+      const overBound = DEFAULT_SESSION_RETENTION + 5;
+      for (let i = 0; i < overBound; i++) {
+        const dir = sessionDirPath(root, `s${i}`);
+        await fs.mkdir(dir);
+        await fs.writeFile(join(dir, 'events.jsonl'), '{}\n');
+      }
+      expect((await fs.readdir(reticleDirPaths(root).sessions)).length).toBe(overBound);
 
-    await end(fakeSession('s-last', { 'chat-log': 1 }));
+      await end(fakeSession('s-last', { 'chat-log': 1 }));
 
-    const remaining = await fs.readdir(reticleDirPaths(root).sessions);
-    expect(remaining.length).toBeLessThanOrEqual(DEFAULT_SESSION_RETENTION);
-  });
+      const remaining = await fs.readdir(reticleDirPaths(root).sessions);
+      expect(remaining.length).toBeLessThanOrEqual(DEFAULT_SESSION_RETENTION);
+    },
+    SESSION_RETENTION_TIMEOUT_MS,
+  );
 });

--- a/packages/server/src/runs/run-store.test.ts
+++ b/packages/server/src/runs/run-store.test.ts
@@ -26,6 +26,13 @@ const baseInput = (runId: string): VerificationRunInput => ({
 const make = (runId: string, at: number): ReticleVerificationRun =>
   buildVerificationRun(baseInput(runId), () => at);
 
+/**
+ * A BOUND, not a measurement. The retention test writes five runs sequentially through the real
+ * filesystem, and each write is an atomic publish — a temp file plus a rename — so the cost is two
+ * syscalls per iteration rather than the five the loop counts.
+ */
+const RUN_WRITE_TIMEOUT_MS = 30_000;
+
 describe('RunStore — temp-dir filesystem, never touches the repo', () => {
   let root: string;
   let fs: FileSystemPort;
@@ -89,12 +96,16 @@ describe('RunStore — temp-dir filesystem, never touches the repo', () => {
     await expect(store.write(evil)).rejects.toThrow(/unsafe runId/);
   });
 
-  it('prunes oldest runs beyond the retention cap, keeping the newest', async () => {
-    const capped = new RunStore(fs, root, { retention: 3, slack: 1 });
-    for (let i = 1; i <= 5; i += 1) await capped.write(make(`run-${i}`, i * 1000));
-    const ids = (await capped.list()).sort();
-    expect(ids).toEqual(['run-3', 'run-4', 'run-5']); // oldest two pruned
-  });
+  it(
+    'prunes oldest runs beyond the retention cap, keeping the newest',
+    async () => {
+      const capped = new RunStore(fs, root, { retention: 3, slack: 1 });
+      for (let i = 1; i <= 5; i += 1) await capped.write(make(`run-${i}`, i * 1000));
+      const ids = (await capped.list()).sort();
+      expect(ids).toEqual(['run-3', 'run-4', 'run-5']); // oldest two pruned
+    },
+    RUN_WRITE_TIMEOUT_MS,
+  );
 
   it('leaves no .tmp file after a write (atomic publish)', async () => {
     await store.write(make('run-x', 1));

--- a/packages/server/src/tools/heavy-browser-tests-declare-a-timeout.test.ts
+++ b/packages/server/src/tools/heavy-browser-tests-declare-a-timeout.test.ts
@@ -57,6 +57,23 @@ const PACKAGES = join(REPO, 'packages');
 /** A loop big enough that the default timeout is a coin flip on a loaded runner. */
 const HEAVY_LOOP = /for \([^)]*<\s*(?:\d{4,}|[A-Z_]+ \* \d)/;
 /**
+ * The second shape: heavy because of what is INSIDE the loop, not because of the iteration count.
+ *
+ * `project-tools.test.ts` timed out at vitest's 5s default on Windows CI and nowhere else. It loops
+ * **40 times**, writing run records sequentially through the real filesystem port. Milliseconds on
+ * macOS and Linux, much slower on a Windows runner — and no count-based rule can see it, because 40
+ * is not a big number. `HEAVY_LOOP` above was written for the browser incident and is blind to this
+ * one by construction.
+ *
+ * Two conditions, ANDed, and the conjunction is the whole point. `await` in a loop is common and
+ * usually cheap; a real temp directory is what turns each iteration into a syscall. Either half
+ * alone is a blanket rule over most of the suite. Together, and with hook bodies excluded, they
+ * matched 11 of 558 test files when this was written — which is why `EXPECTED_IO_LOOP_FILES` below
+ * is pinned rather than left implicit.
+ */
+const REAL_TEMP_DIR = /\bmkdtemp(?:Sync)?\s*\(/;
+const LOOP_HEAD = /\b(?:for|while)\s*\(/g;
+/**
  * `}, 60_000);` or `}, HEAVY_DOM_TIMEOUT_MS);` — an explicit per-test timeout.
  *
  * A NAMED constant counts, and must: this repo's convention is that a magic number gets a name, so a
@@ -74,6 +91,124 @@ const HEAVY_LOOP = /for \([^)]*<\s*(?:\d{4,}|[A-Z_]+ \* \d)/;
  */
 const EXPLICIT_TIMEOUT = /\},\s*(?:\d[\d_]{3,}|[A-Z][A-Z0-9_]*_MS)\s*,?\s*\)/;
 
+/**
+ * Does any `for`/`while` body in this source await?
+ *
+ * Brace-matched from the loop head rather than pattern-matched across the file. The regex form of
+ * this — `/for \([^)]*\)[^]*?await/` — matches a loop with an unrelated `await` 200 lines below it,
+ * which is most files in this repo and none of the shape being guarded against.
+ *
+ * Coarse in the same way the rest of this guard is, and worth stating rather than discovering: the
+ * brace counting does not skip braces inside strings, template literals or comments, so a test file
+ * containing `` `${a}` `` inside a loop could end the body early. That direction is a FALSE
+ * NEGATIVE — the guard under-reports and stays silent — which is the safe way for it to be wrong.
+ * A version that cannot be fooled needs a parser, and the failure mode here is a file drifting into
+ * the shape unnoticed, not someone hiding one deliberately.
+ */
+function hasAwaitInsideLoop(text: string): boolean {
+  const scanned = withoutHookBodies(text);
+  LOOP_HEAD.lastIndex = 0;
+  for (let head = LOOP_HEAD.exec(scanned); head !== null; head = LOOP_HEAD.exec(scanned)) {
+    const body = loopBody(scanned, scanned.indexOf('(', head.index));
+    if (body !== null && /\bawait\b/.test(body)) return true;
+  }
+  return false;
+}
+
+/**
+ * `beforeEach`/`afterEach`/`beforeAll`/`afterAll` bodies, blanked out.
+ *
+ * A per-test timeout is the wrong remedy for a slow hook: vitest bounds hooks with `hookTimeout`,
+ * which `}, TIMEOUT_MS)` on an `it()` does not touch. Flagging a file for a hook loop would demand an
+ * annotation that cannot fix the thing being flagged.
+ *
+ * This is not hypothetical — it is the one false positive the shape produced on this checkout.
+ * `mcp/proxy-reconnect-fanout.test.ts` matches on nothing but `for (const cleanup of
+ * cleanups.splice(0).reverse()) await cleanup();` in its teardown. Excluding hooks drops it and
+ * changes no other file, which is the argument for narrowing here rather than annotating around it.
+ *
+ * Blanked to spaces rather than deleted so every offset in the scanned copy still lines up with the
+ * original — a deletion would silently join a loop head to a body that is not its own.
+ */
+function withoutHookBodies(text: string): string {
+  const HOOK = /\b(?:before|after)(?:Each|All)\s*\(/g;
+  let out = text;
+  for (let hook = HOOK.exec(text); hook !== null; hook = HOOK.exec(text)) {
+    const open = text.indexOf('(', hook.index);
+    let depth = 0;
+    for (let close = open; close < text.length; close += 1) {
+      if ('(' === text[close]) depth += 1;
+      else if (')' === text[close]) {
+        depth -= 1;
+        if (0 === depth) {
+          out = out.slice(0, open) + ' '.repeat(close - open + 1) + out.slice(close + 1);
+          break;
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * The loop's body, brace-matched — or, for a brace-less loop, its single statement.
+ *
+ * The brace-less case is not an edge case here, it is the majority: `for (const d of […]) await
+ * store.record(…)` is how most of these tests are written. A first cut jumped to the next `{` after
+ * the loop head, which for a brace-less loop is some unrelated block further down the file, and it
+ * mis-reported two files on this checkout for exactly that reason. Skipping the loop's own
+ * parentheses first also matters — `for (let i = 0; i < n; i += 1)` contains no braces but the
+ * header can contain anything.
+ */
+function loopBody(text: string, headOpen: number): string | null {
+  if (-1 === headOpen) return null;
+  let parens = 0;
+  let cursor = headOpen;
+  for (; cursor < text.length; cursor += 1) {
+    if ('(' === text[cursor]) parens += 1;
+    else if (')' === text[cursor]) {
+      parens -= 1;
+      if (0 === parens) break;
+    }
+  }
+  const start = text.slice(cursor + 1).search(/\S/);
+  if (-1 === start) return null;
+  const open = cursor + 1 + start;
+  if (text[open] !== '{') {
+    const end = text.indexOf(';', open);
+    return -1 === end ? text.slice(open) : text.slice(open, end);
+  }
+  let depth = 0;
+  for (let close = open; close < text.length; close += 1) {
+    if ('{' === text[close]) depth += 1;
+    else if ('}' === text[close]) {
+      depth -= 1;
+      if (0 === depth) return text.slice(open, close);
+    }
+  }
+  return text.slice(open);
+}
+
+/**
+ * Pinned so the rule cannot silently widen into "every loop in the repo".
+ *
+ * 11 of 558 `.test.ts` files, or 2%. The count is the guard's own blast radius: if a later edit drops
+ * the `mkdtemp` half or the hook exclusion, this number jumps and the change announces itself in
+ * review instead of arriving as a hundred annotated files. Adding a genuinely new IO-in-a-loop test
+ * is expected to bump it — by one, deliberately.
+ *
+ * The issue that asked for this rule measured 6 files needing an annotation. That is an undercount
+ * of the same shape, not a different shape: `journal/session-end.test.ts` and `runs/run-store.test.ts`
+ * need one too, making 8. The remaining 3 of the 11 — `project/project-tools.test.ts`,
+ * `project/project-store.test.ts`, `multi-project.test.ts` — match the shape but already carry a
+ * bound, so a search for files still lacking one could not see them.
+ *
+ * `session-end` is the one worth naming: it creates `DEFAULT_SESSION_RETENTION + 5` directories and
+ * writes a file into each, which is more per-iteration IO than the 40-record loop that actually
+ * broke Windows CI and prompted this issue.
+ */
+const EXPECTED_IO_LOOP_FILES = 11;
+
 function testFiles(dir: string): string[] {
   const out: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -85,9 +220,9 @@ function testFiles(dir: string): string[] {
 }
 
 describe('heavy tests do not rely on the default timeout', () => {
-  const heavy = testFiles(PACKAGES)
-    .map((file) => ({ file, text: readFileSync(file, 'utf8') }))
-    .filter(({ text }) => HEAVY_LOOP.test(text));
+  const sources = testFiles(PACKAGES).map((file) => ({ file, text: readFileSync(file, 'utf8') }));
+  const heavy = sources.filter(({ text }) => HEAVY_LOOP.test(text));
+  const ioLoop = sources.filter(({ text }) => REAL_TEMP_DIR.test(text) && hasAwaitInsideLoop(text));
 
   it('finds the heavy files at all — a vacuous rule is not a rule', () => {
     // Guards the guard: if the pattern stops matching, everything below passes for free.
@@ -99,5 +234,23 @@ describe('heavy tests do not rely on the default timeout', () => {
       .filter(({ text }) => !EXPLICIT_TIMEOUT.test(text))
       .map(({ file }) => relative(PACKAGES, file));
     expect(missing).toEqual([]);
+  });
+
+  it('finds the IO-in-a-loop files, and only those — the rule is narrow on purpose', () => {
+    // The count is the rule's blast radius, not decoration. See EXPECTED_IO_LOOP_FILES.
+    expect(ioLoop.map(({ file }) => relative(PACKAGES, file))).toHaveLength(EXPECTED_IO_LOOP_FILES);
+  });
+
+  it('every file that does real IO inside a loop declares an explicit timeout', () => {
+    const missing = ioLoop
+      .filter(({ text }) => !EXPLICIT_TIMEOUT.test(text))
+      .map(({ file }) => relative(PACKAGES, file));
+    expect(
+      missing,
+      `These tests write to a real temp directory inside a loop. That is milliseconds on macOS and\n` +
+        `Linux and much slower on a Windows runner, so vitest's 5s default decides the result instead\n` +
+        `of the assertion. Give each one a named ${'`'}*_MS${'`'} bound — a generous ceiling, never a duration\n` +
+        `assertion — the way HISTORY_WRITE_TIMEOUT_MS does in project/project-tools.test.ts.`,
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #331.

Took the first branch of your fork — the second heuristic, not only the annotations.

## The rule

A file that creates a real temp directory **and** has a `for`/`while` whose body `await`s. The conjunction is the narrow part: `await` in a loop is common and mostly cheap, a real temp directory is what turns each iteration into a syscall. **11 of 558** test files match, pinned in `EXPECTED_IO_LOOP_FILES` so the rule cannot silently widen into a blanket rule over every loop.

Two implementation notes that were not obvious until they broke:

- **The loop body is brace-matched, not regex-matched.** `/for \([^)]*\)[^]*?await/` matches a loop with an unrelated `await` 200 lines below it. More to the point, the brace-*less* body — `for (const d of [...]) await store.record(...)` — is the majority shape in these files, not an edge case, and a first cut that jumped to the next `{` mis-reported two files for exactly that reason.
- **Hook bodies are excluded.** A per-test timeout cannot bound a `beforeEach`; vitest uses `hookTimeout` for those, which `}, TIMEOUT_MS)` on an `it()` does not touch. `mcp/proxy-reconnect-fanout.test.ts` matched on nothing but `for (const cleanup of cleanups.splice(0).reverse()) await cleanup();` in its teardown — the one false positive the shape produced on this checkout. Excluding hooks drops it and changes no other file, which felt like the honest narrowing rather than annotating around it.

## Your count of six is an undercount

Same shape, not a different one. **Eight** files needed a bound, not six:

- `journal/session-end.test.ts` — creates `DEFAULT_SESSION_RETENTION + 5` directories and writes a file into each. That is more per-iteration IO than the 40-record loop that actually broke Windows CI, and it is the one I would have expected on the list first.
- `runs/run-store.test.ts` — five runs, each an atomic publish (temp file + rename), so two syscalls per iteration.

The other three of the eleven — `project/project-tools.test.ts`, `project/project-store.test.ts`, `multi-project.test.ts` — match the shape but already carry a bound, so a search for files still *lacking* one could not have seen them.

I did not chase down which pattern produced six; the two misses are both brace-bodied loops, so it was not the brace-less case.

## The annotations

Eight files get a named `*_MS` constant, copying `HISTORY_WRITE_TIMEOUT_MS` — a bound, never `Date.now() - t < N`. Each carries a comment saying what the per-iteration cost actually is, rather than restating the number.

One is worth flagging as the weakest of the set, and I said so in the comment rather than leaving it to be discovered: `flows.test.ts` matches on test 9, whose loop runs twice and whose saves are both rejected on the name before touching disk. The loop is not what costs there — the block around it is, since every valid test round-trips a flow through a real temp directory. The bound is cheap insurance; the alternative is a file that satisfies the guard by accident until someone adds a third iteration that writes.

## Verification

```
pnpm --filter @reticlehq/server vitest run src/tools/heavy-browser-tests-declare-a-timeout.test.ts   4 passed
pnpm format:check && pnpm lint && pnpm typecheck                                                     green
pnpm test:unit                                                                                       393 files, 3768 tests passed
```

Non-vacuous, same way `ring-buffer.test.ts` proves the first rule: dropping the bound from `run-store.test.ts` makes the new test name that file and print the actionable message.

Left alone deliberately: the two `it()`s still test the union of both heuristics, so a file matching either is only required to declare *some* timeout. That stays coarse in the way your comment at lines 26-34 already admits to. Happy to split them into separate reports if you'd rather each rule name its own files.