### PR TITLE
feat: note scroll container hint when the document does not scroll

### DIFF
--- a/packages/server/src/input/scroll-find.test.ts
+++ b/packages/server/src/input/scroll-find.test.ts
@@ -86,4 +86,40 @@ describe('scrollToFind', () => {
     expect(scrollArgs.every((a) => 'e9' === (a as { ref?: string }).ref)).toBe(true);
     expect(scrollArgs.length).toBe(2);
   });
+
+  it('7: notes that the document would not scroll when no container is given', async () => {
+    const { session } = fakeSession({ scrolledFalseAt: 1 });
+    const r = await scrollToFind(session, Q, { maxScrolls: 10 });
+    expect(r.found).toBe(false);
+    expect(r.exhausted).toBe(true);
+    expect(r.note).toContain('scroll container');
+  });
+
+  it('8: keeps the note off when a container is explicitly given', async () => {
+    const { session } = fakeSession({ scrolledFalseAt: 1 });
+    const r = await scrollToFind(session, { ...Q, container: 'e9' }, { maxScrolls: 10 });
+    expect(r.found).toBe(false);
+    expect(r.exhausted).toBe(true);
+    expect(r.note).toBeUndefined();
+  });
+
+  it('9: keeps the note off on genuine end-of-scroll exhaustion', async () => {
+    const { session } = fakeSession({ atEndAtScroll: 2 });
+    const r = await scrollToFind(session, Q, { maxScrolls: 10 });
+    expect(r.found).toBe(false);
+    expect(r.exhausted).toBe(true);
+    expect(r.note).toBeUndefined();
+  });
+
+  it('10: notes when bisection jumps land on a non-scrolling document', async () => {
+    const { session } = fakeSession({ scrolledFalseAt: 1 });
+    const r = await scrollToFind(
+      session,
+      { ...Q, targetIndex: 500, totalCount: 1000 },
+      { maxScrolls: 10 },
+    );
+    expect(r.found).toBe(false);
+    expect(r.exhausted).toBe(true);
+    expect(r.note).toContain('scroll container');
+  });
 });

--- a/packages/server/src/input/scroll-find.ts
+++ b/packages/server/src/input/scroll-find.ts
@@ -32,6 +32,12 @@ export interface ScrollFindResult {
    * help). false ⇒ stopped at the maxScrolls budget (more rows may exist further down).
    */
   exhausted: boolean;
+  /**
+   * Present only when informative: the document itself did not scroll (nothing scrollable), so the
+   * target is likely inside a list with its own scroll container. A genuine exhaustion — reaching
+   * the real end of a scrolled container — stays quiet.
+   */
+  note?: string;
 }
 
 /** One query for the target; returns the first matching element descriptor or undefined. */
@@ -47,6 +53,20 @@ async function queryFirst(
   const elements = asRecord(res.result)['elements'];
   if (Array.isArray(elements) && elements.length > 0) return asRecord(elements[0]);
   return undefined;
+}
+
+/**
+ * A note attached to `{ found: false, exhausted: true }` only when the failure is
+ * actually informative: the document itself had nothing to scroll (scrolled:false with
+ * no explicit container), so the target is likely inside a list with its own scroll
+ * container. Reaching the genuine end of a scrolled container stays quiet.
+ */
+function exhaustNote(q: ScrollFindQuery, data: Record<string, unknown>): { note?: string } {
+  if (q.container !== undefined) return {};
+  if (false !== data['scrolled']) return {};
+  return {
+    note: "The document did not scroll — the target may be inside a list with its own scroll container. Pass that container's ref as `container`.",
+  };
 }
 
 /**
@@ -80,7 +100,7 @@ export async function scrollToFind(
     // Fall through to linear refinement from current position (already near the target).
     const data = asRecord(sr.result);
     if (true === data['atEnd'] || false === data['scrolled']) {
-      return { found: false, scrolls, exhausted: true };
+      return { found: false, scrolls, exhausted: true, ...exhaustNote(q, data) };
     }
   }
 
@@ -97,7 +117,7 @@ export async function scrollToFind(
 
     // Reached the bottom or the container would not move — no more rows to reveal.
     if (true === data['atEnd'] || false === data['scrolled']) {
-      return { found: false, scrolls, exhausted: true };
+      return { found: false, scrolls, exhausted: true, ...exhaustNote(q, data) };
     }
   }
   return { found: false, scrolls, exhausted: false }; // spent the budget; more may lie further down

--- a/packages/server/src/input/scroll-tools.ts
+++ b/packages/server/src/input/scroll-tools.ts
@@ -62,6 +62,12 @@ export const SCROLL_TOOLS: ToolDef[] = [
       element: z.object({ ref: z.string(), role: z.string(), name: z.string() }).optional(),
       scrolls: z.number(),
       exhausted: z.boolean(),
+      note: z
+        .string()
+        .optional()
+        .describe(
+          'Present only when informative: the document itself did not scroll, so the target may be inside a list with its own scroll container — pass its ref as `container`.',
+        ),
     },
     handler: (deps: ToolDeps, args) => {
       const session = deps.sessions.resolve(asString(args['sessionId']));


### PR DESCRIPTION
## Summary

Fixes #344 - when `reticle_scroll_to` ends with `{ found: false, exhausted: true }` and **no `container` was passed**, the document itself had nothing to scroll (`scrolled: false`). That is a distinguishable state from a genuine end-of-scroll, and it reads as "the row is not in this list" when the real answer is "the list scrolls inside its own element."

### Change

- `ScrollFindResult` gains an optional `note` field.
- `scrollToFind` attaches a note only when the failure is informative: `scrolled: false` with no explicit container - pointing the agent at passing the list's scroll container ref as `container`.
- Genuine exhaustion (real `atEnd` after scrolling, or an explicit container that won't move) stays quiet, so the note doesn't become noise.
- `reticle_scroll_to` output schema exposes the optional `note`.
- Bisection path covered too.

### Validation

- `pnpm --filter @reticlehq/server build` OK
- `pnpm --filter @reticlehq/server test:unit` - 3825 passed, 3 skipped OK (new tests: 10 in `scroll-find.test.ts`)
- `eslint` on changed files OK
- `prettier --check` OK
