### PR TITLE
docs(network-mock): name the rule fields in the `mocks` description (#345)

### DIFF
--- a/packages/server/src/input/network-mock-tools.test.ts
+++ b/packages/server/src/input/network-mock-tools.test.ts
@@ -77,3 +77,43 @@ describe('reticle_network_mock tool', () => {
     expect(res.count).toBe(0);
   });
 });
+
+describe('the mocks description names the rule shape (#345)', () => {
+  /** Field names the `mocks` description advertises, e.g. `{ urlContains, method?, ... }`. */
+  function advertisedFields(description: string): string[] {
+    const shape = /\{([^}]*)\}/.exec(description);
+    const inner = shape?.[1];
+    if (undefined === inner) return [];
+    return inner
+      .split(',')
+      .map((f) => f.trim().replace(/\?$/, ''))
+      .filter((f) => f.length > 0);
+  }
+
+  function mocksDescription(): string {
+    const schema = tool().inputSchema['mocks'];
+    if (undefined === schema) throw new Error('no mocks param');
+    return schema.description ?? '';
+  }
+
+  it('names every field of the rule schema', () => {
+    // The params view flattens nested schemas, so the array's own description is
+    // the only place an agent can learn the shape. If a field is added to the rule
+    // schema and not named here, the tool becomes uncallable-without-guessing again.
+    const advertised = advertisedFields(mocksDescription());
+
+    expect(advertised).toEqual([
+      'urlContains',
+      'method',
+      'status',
+      'body',
+      'contentType',
+      'delayMs',
+      'abort',
+    ]);
+  });
+
+  it('still says how to clear, which is the other half of the contract', () => {
+    expect(mocksDescription()).toMatch(/clear/i);
+  });
+});

--- a/packages/server/src/input/network-mock-tools.test.ts
+++ b/packages/server/src/input/network-mock-tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 import { CDP_NO_PROVIDER_REASON } from '@reticlehq/core';
 import { NETWORK_MOCK_TOOLS } from './network-mock-tools.js';
 import { ReticleTool } from '../tools/tool-names.js';
@@ -90,27 +91,34 @@ describe('the mocks description names the rule shape (#345)', () => {
       .filter((f) => f.length > 0);
   }
 
-  function mocksDescription(): string {
+  function mocksSchema(): z.ZodTypeAny {
     const schema = tool().inputSchema['mocks'];
     if (undefined === schema) throw new Error('no mocks param');
-    return schema.description ?? '';
+    return schema;
+  }
+
+  function mocksDescription(): string {
+    return mocksSchema().description ?? '';
+  }
+
+  /** The rule schema's own field names, read off the wired tool. */
+  function ruleFields(): string[] {
+    const mocks = mocksSchema();
+    const array: unknown = mocks instanceof z.ZodOptional ? mocks.unwrap() : mocks;
+    if (!(array instanceof z.ZodArray)) throw new Error('mocks is no longer an array schema');
+    const element: unknown = array.element;
+    if (!(element instanceof z.ZodObject)) throw new Error('mocks elements are no longer objects');
+    const shape: unknown = element.shape;
+    if (null === shape || 'object' !== typeof shape) throw new Error('rule schema has no shape');
+    return Object.keys(shape);
   }
 
   it('names every field of the rule schema', () => {
     // The params view flattens nested schemas, so the array's own description is
-    // the only place an agent can learn the shape. If a field is added to the rule
-    // schema and not named here, the tool becomes uncallable-without-guessing again.
-    const advertised = advertisedFields(mocksDescription());
-
-    expect(advertised).toEqual([
-      'urlContains',
-      'method',
-      'status',
-      'body',
-      'contentType',
-      'delayMs',
-      'abort',
-    ]);
+    // the only place an agent can learn the shape. Deriving the expectation from
+    // the schema is what makes this catch the direction that bites: a field added
+    // to the rule and never advertised. A hardcoded list only catches the reverse.
+    expect(advertisedFields(mocksDescription())).toEqual(ruleFields());
   });
 
   it('still says how to clear, which is the other half of the contract', () => {

--- a/packages/server/src/input/network-mock-tools.ts
+++ b/packages/server/src/input/network-mock-tools.ts
@@ -89,7 +89,16 @@ export const NETWORK_MOCK_TOOLS: ToolDef[] = [
       'states without touching the backend ("verify the app handles a failed payment"). Pass `mocks` ' +
       '(first matching rule wins); pass an empty array or `clear: true` to turn mocking off.',
     inputSchema: {
-      mocks: z.array(ruleShape).optional().describe('Interception rules; omit/empty to clear.'),
+      // The rule fields each carry their own `.describe()` on `ruleShape`, but the params
+      // view reads only the top-level description of each entry, so those are flattened
+      // away before an agent sees them. Naming the shape here is what keeps the tool
+      // callable from its own description instead of by guessing and failing first.
+      mocks: z
+        .array(ruleShape)
+        .optional()
+        .describe(
+          'Interception rules, first match wins: { urlContains, method?, status?, body?, contentType?, delayMs?, abort? }. Omit or pass [] to clear.',
+        ),
       clear: z.boolean().optional().describe('Clear all active mocks (same as mocks: []).'),
       ...sessionIdShape,
     },


### PR DESCRIPTION
Closes #345.

Option 1 — but the issue asks for the count before choosing, since option 2 is only worth it if this is a class rather than a one-off. **It is one tool.**

## The measurement

I checked every `inputSchema` in `packages/server/src` for params whose schema is an object or an array of objects, since those are what `paramInfo()` in `tools/dynamic-tools.ts` flattens — it reads only the top-level `schema.description` of each entry. Three candidates came out; only one has the defect:

| Tool | Param | Affected? | Why |
|---|---|---|---|
| `reticle_network_mock` | `mocks` | **yes** | `ruleShape` has a `.describe()` on all seven fields — every one lost |
| `reticle_visual_diff` | `masks`, `clip` | no | `rectShape` fields are bare `z.number()`; nothing to lose, and the tool description already spells out `{x,y,width,height}` |
| `reticle_act_sequence` | `steps` | no | `z.array(z.record(z.unknown()))`, and its own describe already names `{ ref, action, args? }` |

So option 2 would be generalising over a set of one, and option 1 is the honest answer — which matches the call you'd already framed in the issue.

## The change

One description, using your proposed wording:

```
Interception rules, first match wins: { urlContains, method?, status?, body?, contentType?, delayMs?, abort? }. Omit or pass [] to clear.
```

I kept it to the shape and the clear-contract, and put the *reason* (nested descriptions are flattened) in a code comment rather than in the string — the description is agent-facing and paid for per call, so the maintainer-facing half doesn't belong in it.

Two guards in `network-mock-tools.test.ts`: one asserts the advertised field list equals `ruleShape`'s exactly, the other that it still says how to clear. I verified the first actually fails by dropping `abort` from the description — it reddens with `- "abort"` — because a guard I hadn't seen fail isn't a guard.

## Verification

```
pnpm format:check                                    # clean
eslint (changed files)                               # clean
tsc -b (packages/server)                             # clean
vitest src/input/ src/tools/                         # 855 passed (87 files)
vitest src/tools/e2e-surface-drift.test.ts           # 51 passed
```

**Not run:** `pnpm test:e2e`. CLAUDE.md asks for it when touching the tool surface, and I couldn't run the battery in this environment. The change is a description string plus a test, and `e2e-surface-drift` (which covers the name-lookup half in the fast gate) is green — but flagging it rather than implying I ran it.

## Note

Not in scope, but adjacent: `reticle_visual_diff`'s `masks` and `clip` have **no top-level `.describe()` at all**, so the params view renders them with an empty description. The shape is recoverable from the tool description, so it's a smaller problem than this one was — but it's the same surface, and worth an issue if you want it closed.