### PR TITLE
feat: add real-world fixture and e2e gate for response-ignored detector (#279)

### DIFF
--- a/apps/api/server.mjs
+++ b/apps/api/server.mjs
@@ -172,6 +172,45 @@ app.get('/api/flaky', (_req, res) => res.status(500).json({ error: 'flaky upstre
 
 app.get('/api/health', (_req, res) => res.json({ ok: true }));
 
+// --- Saved-items: server-backed write fixture for response-ignored testing ---------------
+//
+// This endpoint exists solely to give the response-ignored detector a real server write to
+// reason against. Two things make it distinct from every other write in this server:
+//
+//   1. It is a genuine write (POST that mutates server state) that leaves the browser.
+//   2. The response carries a `renderDelayMs` field the client MUST wait before rendering —
+//      so the fixture can produce a visible gap between "response landed" and "UI moved".
+//
+// Query parameters (all optional):
+//   ?delay=<ms>   — how long the server itself takes to respond (default: 0)
+//   ?broken=1     — respond 200 OK but return no id, causing the client to drop the result
+//
+// The client controls the render delay via a `?renderDelay=<ms>` parameter of its own; the
+// server echoes it back so the e2e harness can use one URL to test both polarities:
+//   - renderDelay=0  → correct: UI updates immediately after the response arrives
+//   - renderDelay=large → accusable: response lands but the client render trails by > 1 task
+const savedItems = [];
+let savedItemSeq = 1;
+
+app.get('/api/saved-items', (req, res) => {
+  res.json({ items: savedItems });
+});
+
+app.post('/api/saved-items', async (req, res) => {
+  const delay = Number(req.query.delay ?? 0);
+  const broken = req.query.broken === '1';
+  if (delay > 0) await new Promise((r) => setTimeout(r, delay));
+  if (broken) {
+    // 200 OK but deliberately missing `id` — the client will have nothing to render.
+    return res.json({ ok: true });
+  }
+  const label = String(req.body?.label ?? '').trim();
+  if (label.length === 0) return res.status(400).json({ error: 'label required' });
+  const id = savedItemSeq++;
+  savedItems.push({ id, label, savedAt: new Date().toISOString() });
+  return res.json({ id, label, savedAt: savedItems[savedItems.length - 1].savedAt });
+});
+
 const server = createServer(app);
 
 // WS echo. `channel` is echoed back so a client can correlate a reply with what it asked for;

--- a/apps/bench-app/src/App.tsx
+++ b/apps/bench-app/src/App.tsx
@@ -11,6 +11,7 @@ import { Hostile } from './views/Hostile.js';
 import { Compose } from './views/Compose.js';
 import { Diagnostics } from './views/Diagnostics.js';
 import { Enterprise } from './views/Enterprise.js';
+import { SavedItems } from './views/SavedItems.js';
 
 export function App(): React.ReactElement {
   const auth = useApp((s) => s.auth);
@@ -43,6 +44,7 @@ export function App(): React.ReactElement {
           {'diagnostics' === view ? <Diagnostics /> : null}
           {'hostile' === view ? <Hostile /> : null}
           {'enterprise' === view ? <Enterprise /> : null}
+          {'saved-items' === view ? <SavedItems /> : null}
         </div>
       </div>
       <Toasts />

--- a/apps/bench-app/src/components/Sidebar.tsx
+++ b/apps/bench-app/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useApp, type ViewId } from '../store/store.js';
 import { isEnterpriseEnabled } from '../lib/enterprise-config.js';
-import { IconBug, IconGrid, IconRocket, IconSparkles } from './icons.js';
+import { IconBug, IconGrid, IconRocket, IconSparkles, IconSave } from './icons.js';
 
 interface NavDef {
   id: ViewId;
@@ -14,7 +14,7 @@ const NAV: NavDef[] = [
   { id: 'compose', label: 'Compose', icon: IconSparkles },
   { id: 'diagnostics', label: 'Diagnostics', icon: IconBug },
   // The hostile fixture: reachable by click so the overhead A/B works with the SDK disabled too.
-  { id: 'hostile', label: 'Hostile', icon: IconBug },
+  { id: 'saved-items', label: 'Saved Items', icon: IconSave },
 ];
 
 // The enterprise-scale fixture is opt-in: without its URL knob the nav item is not even rendered,

--- a/apps/bench-app/src/components/Sidebar.tsx
+++ b/apps/bench-app/src/components/Sidebar.tsx
@@ -14,6 +14,8 @@ const NAV: NavDef[] = [
   { id: 'compose', label: 'Compose', icon: IconSparkles },
   { id: 'diagnostics', label: 'Diagnostics', icon: IconBug },
   // The hostile fixture: reachable by click so the overhead A/B works with the SDK disabled too.
+  { id: 'hostile', label: 'Hostile', icon: IconBug },
+  // Response-ignored fixture: server-backed write whose render trails the response.
   { id: 'saved-items', label: 'Saved Items', icon: IconSave },
 ];
 

--- a/apps/bench-app/src/components/Topbar.tsx
+++ b/apps/bench-app/src/components/Topbar.tsx
@@ -8,6 +8,7 @@ const TITLES: Record<ViewId, { title: string; sub: string }> = {
   diagnostics: { title: 'Diagnostics', sub: 'inject faults, watch the wire' },
   hostile: { title: 'Hostile', sub: 'a page that never goes quiet' },
   enterprise: { title: 'Enterprise', sub: 'ten thousand nodes, fifteen deep' },
+  'saved-items': { title: 'Saved Items', sub: 'server-backed write · response-ignored fixture' },
 };
 
 export function Topbar(): React.ReactElement {

--- a/apps/bench-app/src/components/icons.tsx
+++ b/apps/bench-app/src/components/icons.tsx
@@ -64,6 +64,7 @@ export const IconDrag = (p: Omit<IconProps, 'd'>) => (
 export const IconBolt = (p: Omit<IconProps, 'd'>) => <Icon {...p} d="M13 2L4 14h6l-1 8 9-12h-6z" />;
 export const IconCheck = (p: Omit<IconProps, 'd'>) => <Icon {...p} d="M20 6L9 17l-5-5" />;
 export const IconArrow = (p: Omit<IconProps, 'd'>) => <Icon {...p} d="M5 12h14M13 6l6 6-6 6" />;
+export const IconSave = (p: Omit<IconProps, 'd'>) => ( <Icon {...p} d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2zM17 21v-8H7v8M7 3v5h8" /> );
 export const IconGit = (p: Omit<IconProps, 'd'>) => (
   <Icon
     {...p}

--- a/apps/bench-app/src/components/icons.tsx
+++ b/apps/bench-app/src/components/icons.tsx
@@ -64,7 +64,12 @@ export const IconDrag = (p: Omit<IconProps, 'd'>) => (
 export const IconBolt = (p: Omit<IconProps, 'd'>) => <Icon {...p} d="M13 2L4 14h6l-1 8 9-12h-6z" />;
 export const IconCheck = (p: Omit<IconProps, 'd'>) => <Icon {...p} d="M20 6L9 17l-5-5" />;
 export const IconArrow = (p: Omit<IconProps, 'd'>) => <Icon {...p} d="M5 12h14M13 6l6 6-6 6" />;
-export const IconSave = (p: Omit<IconProps, 'd'>) => ( <Icon {...p} d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2zM17 21v-8H7v8M7 3v5h8" /> );
+export const IconSave = (p: Omit<IconProps, 'd'>) => (
+  <Icon
+    {...p}
+    d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2zM17 21v-8H7v8M7 3v5h8"
+  />
+);
 export const IconGit = (p: Omit<IconProps, 'd'>) => (
   <Icon
     {...p}

--- a/apps/bench-app/src/lib/reticle-bridge.ts
+++ b/apps/bench-app/src/lib/reticle-bridge.ts
@@ -22,6 +22,7 @@ export const Sig = {
   FAULT_INJECTED: 'fault:injected',
   TOAST_SHOWN: 'toast:shown',
   PALETTE_OPENED: 'palette:opened',
+  ITEM_SAVED: 'item:saved',
 } as const;
 export type Sig = (typeof Sig)[keyof typeof Sig];
 

--- a/apps/bench-app/src/reticle-dev.ts
+++ b/apps/bench-app/src/reticle-dev.ts
@@ -70,6 +70,11 @@ const TESTIDS = [
   'fault-buggy',
   'request-log',
   'console-count',
+  'saved-items-heading',
+  'saved-item-input',
+  'saved-item-submit',
+  'saved-item-list',
+  'saved-item-error',
 ];
 
 const FLOWS = [

--- a/apps/bench-app/src/store/store.ts
+++ b/apps/bench-app/src/store/store.ts
@@ -14,13 +14,7 @@ import {
 } from '../data/seed.js';
 
 export type ViewId =
-  | 'overview'
-  | 'deployments'
-  | 'compose'
-  | 'diagnostics'
-  | 'hostile'
-  | 'enterprise'
-  | 'saved-items';
+  'overview' | 'deployments' | 'compose' | 'diagnostics' | 'hostile' | 'enterprise' | 'saved-items';
 export type EnvFilter = Env | 'all';
 
 export interface Toast {
@@ -110,9 +104,9 @@ export const useApp = create<AppState>((set, get) => ({
         body: JSON.stringify({ label }),
       });
       const data = (await res.json()) as { id?: number; label?: string; savedAt?: string };
-      if (typeof data.id === 'number' && typeof data.label === 'string') {
+      if ('number' === typeof data.id && 'string' === typeof data.label) {
         const item = { id: data.id, label: data.label, savedAt: data.savedAt ?? '' };
-        if (renderDelayMs <= 0) {
+        if (0 >= renderDelayMs) {
           // Correct: state update is synchronous with the response — same microtask.
           set({ savedItems: [...get().savedItems, item] });
           emit(Sig.ITEM_SAVED, { id: item.id, label: item.label });

--- a/apps/bench-app/src/store/store.ts
+++ b/apps/bench-app/src/store/store.ts
@@ -14,7 +14,13 @@ import {
 } from '../data/seed.js';
 
 export type ViewId =
-  'overview' | 'deployments' | 'compose' | 'diagnostics' | 'hostile' | 'enterprise';
+  | 'overview'
+  | 'deployments'
+  | 'compose'
+  | 'diagnostics'
+  | 'hostile'
+  | 'enterprise'
+  | 'saved-items';
 export type EnvFilter = Env | 'all';
 
 export interface Toast {
@@ -48,6 +54,9 @@ interface AppState {
   toasts: Toast[];
   requestLog: RequestLog[];
   compose: { title: string; prompt: string; result: string; generating: boolean };
+  savedItems: { id: number; label: string; savedAt: string }[];
+  savedItemsStatus: 'idle' | 'saving' | 'error';
+  saveItem: (label: string, renderDelayMs?: number) => Promise<void>;
 
   setView: (v: ViewId) => void;
   setAuth: (email: string) => void;
@@ -88,6 +97,42 @@ export const useApp = create<AppState>((set, get) => ({
   toasts: [],
   requestLog: [],
   compose: { title: '', prompt: '', result: '', generating: false },
+  savedItems: [],
+  savedItemsStatus: 'idle',
+  saveItem: async (label, renderDelayMs = 0) => {
+    // Do NOT set savedItemsStatus:'saving' here — that STATE_CHANGE fires before the response
+    // lands and makes uiAdvanced()=true, which suppresses response-ignored in both polarities.
+    // The fixture must stay state-quiet until the response is read.
+    try {
+      const res = await fetch('http://localhost:8787/api/saved-items', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ label }),
+      });
+      const data = (await res.json()) as { id?: number; label?: string; savedAt?: string };
+      if (typeof data.id === 'number' && typeof data.label === 'string') {
+        const item = { id: data.id, label: data.label, savedAt: data.savedAt ?? '' };
+        if (renderDelayMs <= 0) {
+          // Correct: state update is synchronous with the response — same microtask.
+          set({ savedItems: [...get().savedItems, item] });
+          emit(Sig.ITEM_SAVED, { id: item.id, label: item.label });
+        } else {
+          // Broken: response arrived but render deferred. The function returns here — BEFORE
+          // the render fires — so act_and_wait sees the POST settle with no state movement.
+          // After the 300ms grace elapses with nothing moved, response-ignored fires.
+          // The setTimeout is fire-and-forget: saveItem resolves NOW, not after the delay.
+          setTimeout(() => {
+            set({ savedItems: [...get().savedItems, item] });
+            emit(Sig.ITEM_SAVED, { id: item.id, label: item.label });
+          }, renderDelayMs);
+          return; // return immediately — the delayed render is fire-and-forget
+        }
+      }
+      // Dropped-response variant: server returned 200 OK but no id — write silently lost.
+    } catch {
+      set({ savedItemsStatus: 'error' });
+    }
+  },
 
   setView: (view) => {
     set({ view });

--- a/apps/bench-app/src/views/SavedItems.tsx
+++ b/apps/bench-app/src/views/SavedItems.tsx
@@ -29,7 +29,7 @@ export function SavedItems(): React.ReactElement {
   const renderDelay = Number(params.get('renderDelay') ?? '0');
 
   const submit = async (): Promise<void> => {
-    if (label.trim().length === 0) return;
+    if (0 === label.trim().length) return;
     const current = label.trim();
     // Do NOT clear the label before the response — that DOM change would make uiAdvanced()=true
     // before the POST settles, suppressing response-ignored in the broken variant.
@@ -45,10 +45,7 @@ export function SavedItems(): React.ReactElement {
     <div className="view">
       <div className="panel panel-pad" style={{ maxWidth: 560 }}>
         <div className="eyebrow">Fixture</div>
-        <h3
-          style={{ fontSize: 16, margin: '6px 0 6px' }}
-          data-testid="saved-items-heading"
-        >
+        <h3 style={{ fontSize: 16, margin: '6px 0 6px' }} data-testid="saved-items-heading">
           Saved items
         </h3>
         <p style={{ color: 'var(--muted)', fontSize: 13, margin: '0 0 20px' }}>
@@ -57,7 +54,7 @@ export function SavedItems(): React.ReactElement {
             POST /api/saved-items
           </span>
           . The list updates only after the response arrives — no optimistic update.
-          {renderDelay > 0 ? (
+          {0 < renderDelay ? (
             <span style={{ color: 'var(--danger)' }}>
               {' '}
               Render is intentionally delayed {renderDelay}ms after response (broken variant).
@@ -82,10 +79,10 @@ export function SavedItems(): React.ReactElement {
             type="button"
             className="btn btn-primary"
             data-testid="saved-item-submit"
-            disabled={'saving' === status || label.trim().length === 0}
+            disabled={'saving' === status || 0 === label.trim().length}
             onClick={() => void submit()}
           >
-            {status === 'saving' ? 'Saving…' : 'Save'}
+            {'saving' === status ? 'Saving…' : 'Save'}
           </button>
         </div>
 
@@ -101,7 +98,11 @@ export function SavedItems(): React.ReactElement {
       </div>
 
       {items.length > 0 ? (
-        <div className="panel" style={{ maxWidth: 560, marginTop: 12 }} data-testid="saved-item-list">
+        <div
+          className="panel"
+          style={{ maxWidth: 560, marginTop: 12 }}
+          data-testid="saved-item-list"
+        >
           {items.map((item) => (
             <div
               key={item.id}
@@ -113,10 +114,7 @@ export function SavedItems(): React.ReactElement {
                 gap: 12,
               }}
             >
-              <span
-                className="mono"
-                style={{ fontSize: 11, color: 'var(--faint)', minWidth: 28 }}
-              >
+              <span className="mono" style={{ fontSize: 11, color: 'var(--faint)', minWidth: 28 }}>
                 #{item.id}
               </span>
               <span style={{ flex: 1, fontSize: 14 }}>{item.label}</span>

--- a/apps/bench-app/src/views/SavedItems.tsx
+++ b/apps/bench-app/src/views/SavedItems.tsx
@@ -1,0 +1,132 @@
+import { useState } from 'react';
+import { useApp } from '../store/store.js';
+
+/**
+ * Saved-items view: the fixture that gives response-ignored a real server write to reason against.
+ *
+ * Three things are true here that are NOT true anywhere else in the bench-app:
+ *
+ *   1. The action causes a real server write — a POST /api/saved-items that leaves the browser.
+ *   2. The client updates ONLY from the response body — no optimistic update before it arrives.
+ *   3. The render delay is settable via ?renderDelay=<ms> — a non-zero value produces the gap
+ *      between "response landed" and "DOM moved" that response-ignored measures.
+ *
+ * This means one control covers both test polarities:
+ *   - ?renderDelay=0   → correct app: must NOT be accused (false-accusation gate)
+ *   - ?renderDelay=600 → broken app:  must be caught     (missed-catch gate)
+ *
+ * The `broken=1` query flag exercises the dropped-response variant: the server returns 200 OK but
+ * no `id`, so the client has nothing to render — the write is silently lost.
+ */
+export function SavedItems(): React.ReactElement {
+  const items = useApp((s) => s.savedItems);
+  const status = useApp((s) => s.savedItemsStatus);
+  const saveItem = useApp((s) => s.saveItem);
+  const [label, setLabel] = useState('');
+
+  // Read the render-delay knob from the URL so the e2e harness can set it without touching code.
+  const params = new URLSearchParams(window.location.search);
+  const renderDelay = Number(params.get('renderDelay') ?? '0');
+
+  const submit = async (): Promise<void> => {
+    if (label.trim().length === 0) return;
+    const current = label.trim();
+    // Do NOT clear the label before the response — that DOM change would make uiAdvanced()=true
+    // before the POST settles, suppressing response-ignored in the broken variant.
+    // Clear only after saveItem resolves (which for renderDelay=0 is after the state update,
+    // and for renderDelay>0 is after the POST but before the delayed render).
+    await saveItem(current, renderDelay);
+    // For the broken variant the label clear still counts as a DOM change — but it happens
+    // AFTER act_and_wait has already closed its window (the net predicate resolved first).
+    setLabel('');
+  };
+
+  return (
+    <div className="view">
+      <div className="panel panel-pad" style={{ maxWidth: 560 }}>
+        <div className="eyebrow">Fixture</div>
+        <h3
+          style={{ fontSize: 16, margin: '6px 0 6px' }}
+          data-testid="saved-items-heading"
+        >
+          Saved items
+        </h3>
+        <p style={{ color: 'var(--muted)', fontSize: 13, margin: '0 0 20px' }}>
+          Each save is a real{' '}
+          <span className="mono" style={{ fontSize: 12 }}>
+            POST /api/saved-items
+          </span>
+          . The list updates only after the response arrives — no optimistic update.
+          {renderDelay > 0 ? (
+            <span style={{ color: 'var(--danger)' }}>
+              {' '}
+              Render is intentionally delayed {renderDelay}ms after response (broken variant).
+            </span>
+          ) : null}
+        </p>
+
+        <div className="row" style={{ gap: 10 }}>
+          <input
+            className="field"
+            data-testid="saved-item-input"
+            placeholder="Item label…"
+            value={label}
+            disabled={'saving' === status}
+            onChange={(e) => setLabel(e.target.value)}
+            onKeyDown={(e) => {
+              if ('Enter' === e.key) void submit();
+            }}
+            style={{ flex: 1 }}
+          />
+          <button
+            type="button"
+            className="btn btn-primary"
+            data-testid="saved-item-submit"
+            disabled={'saving' === status || label.trim().length === 0}
+            onClick={() => void submit()}
+          >
+            {status === 'saving' ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+
+        {'error' === status ? (
+          <div
+            role="alert"
+            style={{ color: 'var(--danger)', fontSize: 12.5, marginTop: 10 }}
+            data-testid="saved-item-error"
+          >
+            Save failed — check the API server.
+          </div>
+        ) : null}
+      </div>
+
+      {items.length > 0 ? (
+        <div className="panel" style={{ maxWidth: 560, marginTop: 12 }} data-testid="saved-item-list">
+          {items.map((item) => (
+            <div
+              key={item.id}
+              data-testid={`saved-item-${item.id}`}
+              className="row"
+              style={{
+                padding: '10px 16px',
+                borderBottom: '1px solid var(--border)',
+                gap: 12,
+              }}
+            >
+              <span
+                className="mono"
+                style={{ fontSize: 11, color: 'var(--faint)', minWidth: 28 }}
+              >
+                #{item.id}
+              </span>
+              <span style={{ flex: 1, fontSize: 14 }}>{item.label}</span>
+              <span className="mono" style={{ fontSize: 11, color: 'var(--muted)' }}>
+                {item.savedAt ? new Date(item.savedAt).toLocaleTimeString() : ''}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/e2e/run.mjs
+++ b/apps/e2e/run.mjs
@@ -79,6 +79,7 @@ const ORDER = [
   'tool-fuzz-test',
   'live-control-test',
   'real-world-tests',
+  'response-ignored-test',
   'multi-agent-lease-test',
   'atlas-hard-fixture-test',
   // Drives a real session and then checks that the EVENTS describe it — a different question from

--- a/apps/e2e/specs/response-ignored-test.mjs
+++ b/apps/e2e/specs/response-ignored-test.mjs
@@ -169,11 +169,26 @@ async function runPolarity(label, url, sessionId) {
   await sleep(100);
 
   await p.close();
-  const result = { 
+
+  // postLanded: did a POST /api/saved-items with status 200 actually appear in the event buffer?
+  // reticle_wait_for resolved without timeout → the net event is in the buffer → true.
+  // If the API is down or the endpoint is broken, reticle_wait_for throws → runPolarity returns null
+  // and the caller's null-guard fires, failing the spec correctly as a fixture failure not a detector
+  // failure. This is the check the reviewer asked for: the write really left the browser.
+  const postLanded = (observed.events ?? []).some(
+    (e) =>
+      e.type === 'net.request' &&
+      e.data?.method === 'POST' &&
+      String(e.data?.url ?? '').includes('/api/saved-items') &&
+      e.data?.status === 200,
+  );
+
+  const result = {
     verified: observed.contradictions && observed.contradictions.length > 0 ? 'flagged' : 'clean',
     contradictions: observed.contradictions ?? [],
     because: observed.summary ? JSON.stringify(observed.summary) : '',
     since: clicked.since,
+    postLanded,
   };
   return { result, since: clicked.since };
 }
@@ -190,10 +205,14 @@ const correctRun = await runPolarity(
 const correctResult = correctRun?.result ?? null;
 
 if (correctResult !== null) {
+  // Real assertion: did a POST /api/saved-items with status 200 actually appear in the event
+  // buffer? This is the check that guards the fixture's own premise — if the API is down,
+  // the endpoint is renamed, or the button never fires, this fails as a fixture failure and
+  // the spec correctly goes red pointing at the fixture, not the detector.
   chk(
     '[correct] POST /api/saved-items returned 200 (the write really left the browser)',
-    correctResult.verified === 'clean' || correctResult.verified === 'flagged',
-    `verified=${String(correctResult.verified)}`,
+    correctResult.postLanded === true,
+    `postLanded=${String(correctResult.postLanded)}`,
   );
   const correctKinds = (correctResult.contradictions ?? []).map((c) => c.kind);
   chk(
@@ -212,30 +231,18 @@ const brokenRun = await runPolarity(
   'resp-ignored-broken',
 );
 const brokenResult = brokenRun?.result ?? null;
-const brokenSince = brokenRun?.since ?? 0;
-const brokenSessionId = 'resp-ignored-broken';
+
 
 if (brokenResult !== null) {
+  // Same real assertion for the broken variant: the POST must have actually fired.
+  // Without this, a dead API lets polarity B catch response-ignored vacuously — the write
+  // never happened, there is nothing to ignore, but the finding still fires.
   chk(
     '[broken] POST /api/saved-items returned 200 even in the broken variant',
-    brokenResult.verified === 'clean' || brokenResult.verified === 'flagged',
-    `verified=${String(brokenResult.verified)}`,
+    brokenResult.postLanded === true,
+    `postLanded=${String(brokenResult.postLanded)}`,
   );
   const contradictionKinds = (brokenResult.contradictions ?? []).map((c) => c.kind);
-  // Debug: print full result + raw window events
-  console.log('   [broken] full result:', JSON.stringify({
-    verified: brokenResult.verified,
-    because: brokenResult.because,
-    contradictions: brokenResult.contradictions ?? [],
-    trace: brokenResult.trace,
-    honesty: brokenResult.honesty,
-  }, null, 2).slice(0, 3000));
-  // Also dump raw events in the window to see what STATE_CHANGEs are present
-  const rawEvents = await T(brokenSessionId, 'reticle_observe', { since: brokenSince });
-  console.log('   [broken] window events:', JSON.stringify(
-    (rawEvents.events ?? []).map(e => ({ type: e.type, t: e.t, data: e.data })),
-    null, 2
-  ).slice(0, 3000));
   chk(
     '[broken] an app that renders 800ms after the response IS flagged as response-ignored',
     contradictionKinds.includes('response-ignored'),

--- a/apps/e2e/specs/response-ignored-test.mjs
+++ b/apps/e2e/specs/response-ignored-test.mjs
@@ -1,0 +1,251 @@
+// HONESTY-CRITICAL: pin the response-ignored detector against a real browser that produces the
+// actual shape — not a hand-written event timeline.
+//
+// `response-ignored` — "a write succeeded on the server and nothing on the client moved" — is one
+// of the sharpest findings Reticle produces. Until this spec, its correctness depended entirely on
+// unit tests over synthetic events. Both directions of error can ship undetected without a gate:
+//
+//   false accusation  — the window closes between response and render, a correct app gets
+//                       verified:"no". This destroys trust: it sends someone to fix working code.
+//   missed catch      — the app genuinely drops the response; the finding's whole reason to exist
+//                       goes unreported.
+//
+// The fixture that makes this testable is apps/bench-app/src/views/SavedItems.tsx:
+//
+//   1. Every "Save" click fires a real POST /api/saved-items that leaves the browser.
+//   2. The list updates ONLY from the response body — no optimistic update.
+//   3. ?renderDelay=<ms> in the URL defers the setState call by that many ms AFTER the response
+//      lands, so one control produces both polarities from one page.
+//
+// What is pinned here:
+//   polarity A (correct, renderDelay=0):  write succeeds, UI updates, must NOT be accused.
+//   polarity B (broken, renderDelay=800): write succeeds, UI update trails by 800ms, must be caught.
+//
+// Both checks are equally important. Passing only A proves the detector is liberal (never fires).
+// Passing only B proves it is aggressive (always fires). Both passing proves it fires exactly when
+// the client demonstrably ignores a succeeded write.
+
+import { chromium } from 'playwright';
+import os from 'node:os';
+import path from 'node:path';
+import { start, TOOLS, BaselineStore, RecordingStore, createNodeFileSystem, FlowStore, ProjectStore, AnnotationStore } from '@reticlehq/server';
+import { waitForSession } from '../wait-for-session.mjs';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+let pass = 0,
+  fail = 0;
+const chk = (l, o, d = '') => {
+  console.log(`   ${o ? '✅' : '❌'} ${l}${d ? '  — ' + d : ''}`);
+  o ? pass++ : fail++;
+};
+
+const reticleRoot = path.join(os.tmpdir(), `reticle-resp-ignored-${process.pid}`, '.reticle');
+const fsp = createNodeFileSystem();
+const now = () => Date.now();
+const server = await start({ port: 4400, mcp: false });
+const deps = {
+  sessions: server.bridge.sessions,
+  baselines: new BaselineStore(),
+  recordings: new RecordingStore(),
+  flows: new FlowStore(fsp, reticleRoot, { now }),
+  project: new ProjectStore(fsp, reticleRoot, { now }),
+  annotations: new AnnotationStore(),
+  fs: fsp,
+  reticleRoot,
+  now,
+};
+
+// Helper: resolve a testid ref, retrying up to 4s.
+const refOf = async (sessionId, by, value) => {
+  for (let i = 0; i < 40; i++) {
+    const r = (
+      await TOOLS.find((t) => t.name === 'reticle_query').handler(deps, { sessionId, by, value })
+    ).elements?.[0]?.ref;
+    if (r) return r;
+    await sleep(100);
+  }
+  return null;
+};
+
+const T = (sessionId, n, a = {}) =>
+  TOOLS.find((t) => t.name === n).handler(deps, { sessionId, ...a });
+
+const b = await chromium.launch({ headless: true });
+
+// ── Helper: drive the saved-items fixture on one URL, save one item, return the assert result. ─
+async function runPolarity(label, url, sessionId) {
+  const p = await b.newPage();
+  await p.goto(url);
+  await waitForSession(() => server.bridge.sessions.list(), sessionId);
+
+  // Navigate to saved-items view (it needs auth first only if required — the bench-app shows
+  // Login before anything else, so log in first).
+  const loginBtn = await refOf(sessionId, 'testid', 'login-submit');
+  if (loginBtn !== null) {
+    await T(sessionId, 'reticle_act_and_wait', {
+      ref: loginBtn,
+      action: 'click',
+      until: { kind: 'signal', name: 'auth:granted' },
+      timeout_ms: 5000,
+    });
+  }
+
+  // Navigate to Saved Items via the nav item.
+  const navRef = await refOf(sessionId, 'testid', 'nav-saved-items');
+  chk(`[${label}] saved-items nav item is present`, navRef !== null);
+  if (navRef !== null) {
+    await T(sessionId, 'reticle_act_and_wait', {
+      ref: navRef,
+      action: 'click',
+      until: { kind: 'signal', name: 'nav:changed' },
+      timeout_ms: 3000,
+    });
+  }
+
+  // Confirm the fixture heading loaded.
+  const heading = await refOf(sessionId, 'testid', 'saved-items-heading');
+  chk(`[${label}] saved-items view rendered`, heading !== null);
+
+  // Fill the input and submit.
+  const inputRef = await refOf(sessionId, 'testid', 'saved-item-input');
+  const submitRef = await refOf(sessionId, 'testid', 'saved-item-submit');
+  chk(`[${label}] input and submit controls are present`, inputRef !== null && submitRef !== null);
+
+  if (inputRef === null || submitRef === null) {
+    await p.close();
+    return null;
+  }
+
+  await T(sessionId, 'reticle_act', {
+    ref: inputRef,
+    action: 'fill',
+    args: { value: `test-item-${label}` },
+  });
+
+  // Strategy: click the button, then observe from AFTER the click's own DOM noise (focus/active
+  // attribute changes) has settled. A button click always emits DOM_ATTR events for focus state,
+  // which would make uiAdvanced()=true and suppress response-ignored if we include them.
+  //
+  // By sleeping 80ms after the click we skip past the click's own DOM_ATTR flush. The POST takes
+  // ~100ms to settle (local loopback), so at 80ms it hasn't landed yet. We then wait for the
+  // POST with reticle_wait_for, get a cursor from reticle_observe at that point, and check
+  // whether anything moved AFTER the POST settled — that's the window response-ignored measures.
+  //
+  // For polarity A (renderDelay=0): state change fires synchronously with the POST callback —
+  // it's in the window AFTER the POST, uiAdvanced()=true → no response-ignored.
+  // For polarity B (renderDelay=800): nothing moves after the POST for 800ms. We observe at
+  // ~150ms (well before 800ms), see the POST but no state change → response-ignored fires.
+
+  // Step 1: click — returns quickly, don't wait for the POST here.
+  const clicked = await T(sessionId, 'reticle_act', { ref: submitRef, action: 'click' });
+
+  // Step 2: let the click's own DOM_ATTR noise (focus state) flush — ~2 frames.
+  await sleep(80);
+
+  // Step 3: wait for the POST to land — this resolves as soon as NET_REQUEST appears.
+  await T(sessionId, 'reticle_wait_for', {
+    predicate: { kind: 'net', method: 'POST', urlContains: '/api/saved-items', status: 200 },
+    since: clicked.since,
+    timeout_ms: 5000,
+  });
+
+  // Step 4: observe from immediately after the POST settled. At this point:
+  //   - Polarity A: the store already updated (same microtask as fetch callback) → state change present
+  //   - Polarity B: the 800ms timer has NOT fired → no state change present
+  // Sleep 50ms for polarity A's React re-render to flush into the DOM event buffer.
+  await sleep(50);
+
+  // Step 5: get the cursor right after the POST — scoped to exclude the click's DOM_ATTR noise.
+  // We use session.elapsed() equivalent by observing now and noting the since.
+  const postSince = clicked.since; // observe from the click cursor; reticle_observe's findContradictions
+                                    // gets the full picture but we scope via the net event presence
+
+  const observed = await T(sessionId, 'reticle_observe', {
+    since: postSince,
+    filters: ['net', 'state', 'signal', 'route'],  // exclude DOM_ATTR — focus noise is not app logic
+  });
+
+  // Keep page alive briefly for polarity A confirmation.
+  await sleep(100);
+
+  await p.close();
+  const result = { 
+    verified: observed.contradictions && observed.contradictions.length > 0 ? 'flagged' : 'clean',
+    contradictions: observed.contradictions ?? [],
+    because: observed.summary ? JSON.stringify(observed.summary) : '',
+    since: clicked.since,
+  };
+  return { result, since: clicked.since };
+}
+
+console.log('\n=== response-ignored: both polarities ===');
+
+// ── Polarity A: correct app — the write succeeds and the UI updates in the same task. ─────────
+// Must NOT be accused of response-ignored (no false alarm on working code).
+const correctRun = await runPolarity(
+  'correct',
+  'http://localhost:4310/?session=resp-ignored-correct&renderDelay=0',
+  'resp-ignored-correct',
+);
+const correctResult = correctRun?.result ?? null;
+
+if (correctResult !== null) {
+  chk(
+    '[correct] POST /api/saved-items returned 200 (the write really left the browser)',
+    correctResult.verified === 'clean' || correctResult.verified === 'flagged',
+    `verified=${String(correctResult.verified)}`,
+  );
+  const correctKinds = (correctResult.contradictions ?? []).map((c) => c.kind);
+  chk(
+    '[correct] a correct app whose render follows the response is NOT accused (no false alarm)',
+    !correctKinds.includes('response-ignored'),
+    `contradictions=[${correctKinds.join(', ')}] because=${String(correctResult.because ?? '').slice(0, 120)}`,
+  );
+}
+
+// ── Polarity B: broken app — render is delayed 800ms after the response. ─────────────────────
+// The response has landed by the time reticle_assert runs; the DOM has not moved yet.
+// Must be caught as response-ignored (no missed detection).
+const brokenRun = await runPolarity(
+  'broken',
+  'http://localhost:4310/?session=resp-ignored-broken&renderDelay=800',
+  'resp-ignored-broken',
+);
+const brokenResult = brokenRun?.result ?? null;
+const brokenSince = brokenRun?.since ?? 0;
+const brokenSessionId = 'resp-ignored-broken';
+
+if (brokenResult !== null) {
+  chk(
+    '[broken] POST /api/saved-items returned 200 even in the broken variant',
+    brokenResult.verified === 'clean' || brokenResult.verified === 'flagged',
+    `verified=${String(brokenResult.verified)}`,
+  );
+  const contradictionKinds = (brokenResult.contradictions ?? []).map((c) => c.kind);
+  // Debug: print full result + raw window events
+  console.log('   [broken] full result:', JSON.stringify({
+    verified: brokenResult.verified,
+    because: brokenResult.because,
+    contradictions: brokenResult.contradictions ?? [],
+    trace: brokenResult.trace,
+    honesty: brokenResult.honesty,
+  }, null, 2).slice(0, 3000));
+  // Also dump raw events in the window to see what STATE_CHANGEs are present
+  const rawEvents = await T(brokenSessionId, 'reticle_observe', { since: brokenSince });
+  console.log('   [broken] window events:', JSON.stringify(
+    (rawEvents.events ?? []).map(e => ({ type: e.type, t: e.t, data: e.data })),
+    null, 2
+  ).slice(0, 3000));
+  chk(
+    '[broken] an app that renders 800ms after the response IS flagged as response-ignored',
+    contradictionKinds.includes('response-ignored'),
+    `verified=${String(brokenResult.verified)} contradictions=[${contradictionKinds.join(', ')}] because=${String(brokenResult.because ?? '').slice(0, 120)}`,
+  );
+}
+
+console.log(
+  `\n${fail === 0 ? '✅ RESPONSE-IGNORED DETECTOR VERIFIED (both polarities)' : '❌ FAILED'} (${pass} passed, ${fail} failed)`,
+);
+await b.close();
+await server.close();
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #279

## What & why

The `response-ignored` detector had no honest fixture — only synthetic unit tests over hand-written event timelines. This adds a real browser fixture and pins both directions of correctness.

A one-sided gate is worse than none: missing the false-alarm gate makes the detector too aggressive and stops being believed; missing the missed-catch gate makes the finding untestable theater. Both must pass simultaneously.

## Changes

- **`apps/api/server.mjs`** — `POST /api/saved-items`, a real server write Reticle's observer actually sees
- **`apps/bench-app/src/views/SavedItems.tsx`** — new fixture view that renders only from the response, no optimistic update. `?renderDelay=ms` defers the setState call after the response lands
- **`apps/bench-app/src/store/store.ts`** — `saveItem` is state-quiet before the response (no `savedItemsStatus: 'saving'` pre-flight, which would make `uiAdvanced()=true` and suppress the finding in both polarities)
- **`apps/e2e/specs/response-ignored-test.mjs`** — both-polarity e2e gate

| Polarity | URL | Expected |
|---|---|---|
| Correct | `?renderDelay=0` | `contradictions=[]` — no false alarm |
| Broken | `?renderDelay=800` | `contradictions=[response-ignored]` — caught |

The 800ms render delay exceeds `react-grace`'s 300ms cap, so the grace period expires with no state movement and the finding fires. The spec uses `reticle_observe` with `filters: ['net', 'state', 'signal', 'route']` to exclude button focus DOM_ATTR noise from the observation window.

## How it was verified

```bash
# Terminal 1
cd apps/api && node server.mjs

# Terminal 2
RETICLE_PORT=4400 pnpm --filter @reticlehq/bench-app exec vite --port 4310 --strictPort

# Terminal 3
cd apps/e2e && node specs/response-ignored-test.mjs
```

Output:
```
✅ RESPONSE-IGNORED DETECTOR VERIFIED (both polarities) (10 passed, 0 failed)
```