### PR TITLE
fix(server): declare browser sources in turbo globalDependencies

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["packages/browser/src/**/*.ts"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

- Two server guards (`heavy-browser-tests-declare-a-timeout.test.ts` and `documented-names.test.ts`) scan `packages/browser/src` but turbo's cache key didn't include browser source changes
- A browser edit replayed a stale green from cache — the guard passed when it should have failed
- Adding `packages/browser/src/**/*.ts` to `globalDependencies` busts the cache whenever a browser source file changes

Core is already in the dependency graph via `^build` and doesn't need this treatment — only `browser` is scanned cross-package by guards that live in `server`.

Fixes #282

## Test plan

- [x] `npx turbo run test:unit --dry` confirms 177 global files detected from the glob
- [ ] Change a browser source file, run `turbo test:unit` twice — second run should miss cache (not replay stale green)
- [ ] Verify no unrelated cache invalidation (a server-only change still hits cache for browser tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)