### PR TITLE
feat(core): finding fingerprint for cross-session dedup

### DIFF
--- a/apps/e2e/specs/telemetry-events-test.mjs
+++ b/apps/e2e/specs/telemetry-events-test.mjs
@@ -297,7 +297,7 @@ await settle();
   // whether this kind was already seen this session — and says nothing about the app it was found in.
   // `bug_attribution` is ALWAYS present and is an owner, never a description of the app: `app` |
   // `request` | `reticle` | `unclassified`, from a closed list.
-  const BUG_FIELDS = new Set(['bug_falseGreen', 'bug_kind', 'bug_repeat', 'bug_source', 'bug_tool', 'bug_attribution']);
+  const BUG_FIELDS = new Set(['bug_falseGreen', 'bug_fingerprint', 'bug_kind', 'bug_repeat', 'bug_source', 'bug_tool', 'bug_attribution']);
   check('  carries only the classified kind, source, dedup flag and attribution', bugs.every((b) =>
     Object.keys(b.properties).filter((k) => k.startsWith('bug_')).every((k) => BUG_FIELDS.has(k))));
   // Whose fault it was. It shipped twice and was wrong both times — across two real drives every
@@ -323,6 +323,10 @@ await settle();
     '  and the defects are still counted',
     bugs.some((b) => b.properties.bug_kind === 'signal-contradicted') &&
       bugs.some((b) => b.properties.bug_kind === 'console-error'),
+  );
+  check(
+    '  carries a fingerprint for cross-session dedup',
+    bugs.every((b) => /^[0-9a-f]{8}$/.test(b.properties.bug_fingerprint ?? '')),
   );
 }
 

--- a/packages/core/src/contract-fingerprint.ts
+++ b/packages/core/src/contract-fingerprint.ts
@@ -24,7 +24,7 @@ import { ActionType, EventType, MessageKind, ReticleCommand } from './constants.
  * matter here — the comparison is equality between two builds of the same project, not a security
  * boundary.
  */
-function fnv1a(input: string): string {
+export function fnv1a(input: string): string {
   let hash = 0x811c9dc5;
   for (let i = 0; i < input.length; i++) {
     hash ^= input.charCodeAt(i);

--- a/packages/core/src/finding-fingerprint.test.ts
+++ b/packages/core/src/finding-fingerprint.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { fingerprintFinding } from './finding-fingerprint.js';
+
+describe('fingerprintFinding', () => {
+  it('produces the same hash for the same inputs (stability)', () => {
+    const a = fingerprintFinding({
+      kind: 'signal-contradicted',
+      source: 'contradiction',
+      route: '/dashboard',
+    });
+    const b = fingerprintFinding({
+      kind: 'signal-contradicted',
+      source: 'contradiction',
+      route: '/dashboard',
+    });
+    expect(a).toBe(b);
+  });
+
+  it('produces a different hash when the kind changes', () => {
+    const a = fingerprintFinding({
+      kind: 'signal-contradicted',
+      source: 'contradiction',
+      route: '/',
+    });
+    const b = fingerprintFinding({ kind: 'response-ignored', source: 'contradiction', route: '/' });
+    expect(a).not.toBe(b);
+  });
+
+  it('produces a different hash when the route changes', () => {
+    const a = fingerprintFinding({
+      kind: 'signal-contradicted',
+      source: 'contradiction',
+      route: '/a',
+    });
+    const b = fingerprintFinding({
+      kind: 'signal-contradicted',
+      source: 'contradiction',
+      route: '/b',
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it('produces a different hash when the source changes', () => {
+    const a = fingerprintFinding({ kind: 'console-error', source: 'crawl', route: '/' });
+    const b = fingerprintFinding({ kind: 'console-error', source: 'assertion', route: '/' });
+    expect(a).not.toBe(b);
+  });
+
+  it('treats absent route as a distinct identity from any present route', () => {
+    const noRoute = fingerprintFinding({ kind: 'signal-contradicted', source: 'contradiction' });
+    const rootRoute = fingerprintFinding({
+      kind: 'signal-contradicted',
+      source: 'contradiction',
+      route: '/',
+    });
+    expect(noRoute).not.toBe(rootRoute);
+  });
+
+  it('returns an 8-character hex string', () => {
+    const fp = fingerprintFinding({ kind: 'dead-control', source: 'crawl' });
+    expect(fp).toMatch(/^[0-9a-f]{8}$/);
+  });
+});

--- a/packages/core/src/finding-fingerprint.ts
+++ b/packages/core/src/finding-fingerprint.ts
@@ -1,0 +1,30 @@
+/**
+ * A stable, privacy-safe fingerprint for a finding — so the same defect can be recognised across
+ * sessions without sending any app-specific data over the wire.
+ *
+ * The hash travels in `bug_found`; the inputs (route, selector) never do. Same pattern as
+ * `projectId`: hash the identifying bits, send only the hash, let the analytics side group by it.
+ */
+
+import { fnv1a } from './contract-fingerprint.js';
+
+export interface FindingIdentity {
+  /** The classified kind from Reticle's findings vocabulary (`signal-contradicted`, `console-error`, …). */
+  kind: string;
+  /** How Reticle found it (`contradiction`, `crawl`, `assertion`, `replay`). */
+  source: string;
+  /** The route the app was on when this was found. Hashed, never sent raw. */
+  route?: string;
+}
+
+/**
+ * Produce a short hex fingerprint that identifies a finding stably across sessions.
+ *
+ * Same inputs = same output, regardless of when or where it runs. A changed route or a changed
+ * kind = a different fingerprint = a different defect. The analytics side can then answer "was this
+ * fixed?" by checking whether a fingerprint stops appearing.
+ */
+export function fingerprintFinding(identity: FindingIdentity): string {
+  const canonical = [identity.kind, identity.source, identity.route ?? ''].join('\x00');
+  return fnv1a(canonical);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,4 +39,5 @@ export * from './upgrade.js'; // self-update policy shared by the CLI
 export * from './telemetry.js';
 export * from './telemetry-session.js'; // the session/project rollup payloads
 export * from './telemetry-feedback.js'; // the two things a PERSON writes: feedback + a self-declared identity // anonymous adoption telemetry wire contract (DAU/WAU/MAU/installs)
-export { CONTRACT_FINGERPRINT, fingerprintOf } from './contract-fingerprint.js';
+export { CONTRACT_FINGERPRINT, fnv1a, fingerprintOf } from './contract-fingerprint.js';
+export { fingerprintFinding, type FindingIdentity } from './finding-fingerprint.js';

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -555,6 +555,19 @@ export const BugFoundSchema = z.object({
    * `BugAttribution` for why `app` needs positive evidence.
    */
   attribution: z.nativeEnum(BugAttribution),
+  /**
+   * A stable hash identifying THIS defect across sessions — same kind at the same route = same
+   * fingerprint, regardless of when or where it was found.
+   *
+   * The inputs (route, selector) never travel raw — only the 8-char hex hash does, following the
+   * same privacy pattern as `projectId`. The analytics side groups on it to answer "was this bug
+   * fixed?" (the fingerprint stops appearing) and to deduplicate the same defect found by parallel
+   * agents in one run.
+   *
+   * OPTIONAL because old senders and the `reticle verify` CLI path do not yet compute it. Absent
+   * means "not fingerprinted", never "a different defect from one that has a fingerprint".
+   */
+  fingerprint: z.string().max(16).optional(),
 });
 export type BugFound = z.infer<typeof BugFoundSchema>;
 

--- a/packages/server/src/telemetry/bug-found.test.ts
+++ b/packages/server/src/telemetry/bug-found.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { bugsInResult } from './bug-found.js';
-import { BugAttribution, BugSource, ContradictionKind } from '@reticlehq/core';
+import { bugsInResult, routeOf } from './bug-found.js';
+import { BugAttribution, BugSource, ContradictionKind, fingerprintFinding } from '@reticlehq/core';
 
 /**
  * The outcome metric — the only number that can honestly be published or shown to an investor,
@@ -319,5 +319,64 @@ describe('every defect names an owner, and app is never a guess', () => {
     expect(
       bugsInResult('reticle_assert', { pass: false, assertion: 'element.present' }).length,
     ).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * Route extraction: `routeOf` reads the route from whichever shape the tool result carries it in,
+ * so the fingerprint can distinguish the same class of defect at different locations.
+ */
+describe('routeOf extracts route from the result for fingerprinting', () => {
+  it('reads from status.route (the snapshot shape)', () => {
+    expect(routeOf({ status: { route: '/dashboard' } })).toBe('/dashboard');
+  });
+
+  it('reads from a top-level route field', () => {
+    expect(routeOf({ route: '/settings' })).toBe('/settings');
+  });
+
+  it('prefers status.route over top-level route', () => {
+    expect(routeOf({ route: '/old', status: { route: '/current' } })).toBe('/current');
+  });
+
+  it('returns undefined when no route is present', () => {
+    expect(routeOf({ anomalies: [{ kind: 'console-error' }] })).toBeUndefined();
+  });
+
+  it('returns undefined for an empty string', () => {
+    expect(routeOf({ status: { route: '' } })).toBeUndefined();
+  });
+});
+
+/**
+ * The fingerprint integrates: given bugs + route, a caller produces a stable identity that persists
+ * across sessions. Reverting this code must make these tests RED.
+ */
+describe('fingerprintFinding integrates with bugsInResult to produce cross-session identity', () => {
+  it('same contradiction at the same route = same fingerprint across sessions', () => {
+    const result = {
+      pass: true,
+      contradictions: [{ kind: 'signal-contradicted' }],
+      status: { route: '/checkout' },
+    };
+    const bugs = bugsInResult('reticle_assert', result);
+    const route = routeOf(result)!;
+    const fp = fingerprintFinding({ kind: bugs[0]!.kind, source: bugs[0]!.source, route });
+    const fp2 = fingerprintFinding({
+      kind: 'signal-contradicted',
+      source: BugSource.CONTRADICTION,
+      route: '/checkout',
+    });
+    expect(fp).toBe(fp2);
+  });
+
+  it('same kind at a different route = different fingerprint (different bug)', () => {
+    const bugs = bugsInResult('reticle_assert', {
+      pass: true,
+      contradictions: [{ kind: 'signal-contradicted' }],
+    });
+    const fpA = fingerprintFinding({ kind: bugs[0]!.kind, source: bugs[0]!.source, route: '/a' });
+    const fpB = fingerprintFinding({ kind: bugs[0]!.kind, source: bugs[0]!.source, route: '/b' });
+    expect(fpA).not.toBe(fpB);
   });
 });

--- a/packages/server/src/telemetry/bug-found.test.ts
+++ b/packages/server/src/telemetry/bug-found.test.ts
@@ -360,8 +360,11 @@ describe('fingerprintFinding integrates with bugsInResult to produce cross-sessi
       status: { route: '/checkout' },
     };
     const bugs = bugsInResult('reticle_assert', result);
-    const route = routeOf(result)!;
-    const fp = fingerprintFinding({ kind: bugs[0]!.kind, source: bugs[0]!.source, route });
+    const route = routeOf(result);
+    if (route === undefined) throw new Error('expected route');
+    const firstBug = bugs[0];
+    if (firstBug === undefined) throw new Error('expected at least one bug');
+    const fp = fingerprintFinding({ kind: firstBug.kind, source: firstBug.source, route });
     const fp2 = fingerprintFinding({
       kind: 'signal-contradicted',
       source: BugSource.CONTRADICTION,
@@ -375,8 +378,10 @@ describe('fingerprintFinding integrates with bugsInResult to produce cross-sessi
       pass: true,
       contradictions: [{ kind: 'signal-contradicted' }],
     });
-    const fpA = fingerprintFinding({ kind: bugs[0]!.kind, source: bugs[0]!.source, route: '/a' });
-    const fpB = fingerprintFinding({ kind: bugs[0]!.kind, source: bugs[0]!.source, route: '/b' });
+    const firstBug = bugs[0];
+    if (firstBug === undefined) throw new Error('expected at least one bug');
+    const fpA = fingerprintFinding({ kind: firstBug.kind, source: firstBug.source, route: '/a' });
+    const fpB = fingerprintFinding({ kind: firstBug.kind, source: firstBug.source, route: '/b' });
     expect(fpA).not.toBe(fpB);
   });
 });

--- a/packages/server/src/telemetry/bug-found.ts
+++ b/packages/server/src/telemetry/bug-found.ts
@@ -250,4 +250,18 @@ export function bugsInResult(toolName: string, result: Record<string, unknown>):
  * fault, quietly deflating the exact number we intend to publish. A copied enum is a drift hazard
  * wherever it appears; it is a correctness hazard when the thing that drifts is a public claim.
  */
+/**
+ * The route the app was on when this result was produced — extracted from the tool result so the
+ * fingerprint can identify the same defect across sessions without sending the route itself.
+ */
+export function routeOf(result: Record<string, unknown>): string | undefined {
+  const status = result['status'];
+  if ('object' === typeof status && status !== null) {
+    const r = (status as Record<string, unknown>)['route'];
+    if ('string' === typeof r && r.length > 0) return r;
+  }
+  const r = result['route'];
+  return 'string' === typeof r && r.length > 0 ? r : undefined;
+}
+
 const CONTRADICTION_KINDS: ReadonlySet<string> = new Set(Object.values(ContradictionKind));

--- a/packages/server/src/tools/invoke-tool.ts
+++ b/packages/server/src/tools/invoke-tool.ts
@@ -4,13 +4,14 @@ import {
   TelemetryActor,
   TelemetryEventKind,
   TRANSPORT_LIMITS,
+  fingerprintFinding,
 } from '@reticlehq/core';
 import { getSessionMetrics } from '../telemetry/session-metrics.js';
 import { getTelemetry } from '../telemetry/telemetry.js';
 import { takeUpdateNudge } from '../update/update-nudge.js';
 import { takeVersionSkew } from '../version/version-nudge.js';
 import { noteToolCall } from '../daemon/daemon-usefulness.js';
-import { bugsInResult } from '../telemetry/bug-found.js';
+import { bugsInResult, routeOf } from '../telemetry/bug-found.js';
 import { noteToolServed, reportToolRefused } from '../telemetry/tool-refused.js';
 import { buildErrorPayload, refusalReasonFor } from './error-recovery.js';
 import { resultIsError } from '../mcp/mcp-is-error.js';
@@ -158,14 +159,20 @@ function reportBugsFound(toolName: string, result: Record<string, unknown>): voi
   const bugs = bugsInResult(toolName, result);
   if (0 === bugs.length) return;
   const metrics = getSessionMetrics();
+  const route = routeOf(result);
   for (const bug of bugs) {
     // `recordBug` answers whether this kind is new to the session, which is the only thing that
     // separates "another defect" from "the same defect again". Counting instances as defects is how
     // a published number inflates itself.
     const first = metrics.recordBug(bug.kind);
+    const identity =
+      route !== undefined
+        ? { kind: bug.kind, source: bug.source, route }
+        : { kind: bug.kind, source: bug.source };
+    const fingerprint = fingerprintFinding(identity);
     void getTelemetry().emit(TelemetryEventKind.BUG_FOUND, {
       actor: TelemetryActor.AGENT,
-      bug: { ...bug, repeat: !first },
+      bug: { ...bug, repeat: !first, fingerprint },
     });
   }
 }


### PR DESCRIPTION
## Summary

- Add `fingerprintFinding({ kind, source, route? })` pure function in `@reticlehq/core` — hashes a finding's stable identity into an 8-char hex string using the existing `fnv1a` hash
- Add optional `fingerprint` field to `BugFoundSchema` in telemetry — the hash travels, the raw route never does (same privacy pattern as `projectId`)
- Compute and attach fingerprint at the `reportBugsFound` emission chokepoint in `invoke-tool.ts`

The analytics side can now answer:
- "Was this bug fixed?" — fingerprint stops appearing across sessions
- "Is this the same defect found by parallel agents?" — deduplicate within one run
- "Which defects recur most?" — group by fingerprint across all sessions for a project

Addresses #172

## Test plan

- [x] Core: 6 tests pinning stability, collision avoidance (kind/source/route), format
- [x] Server: `routeOf` extraction from both `status.route` and top-level `route` shapes
- [x] Server: integration test showing `bugsInResult` + `fingerprintFinding` produce matching fingerprints for same inputs
- [x] Telemetry contract test still passes (46 tests) — new field is optional, no breakage
- [ ] Verify fingerprint appears in real `bug_found` events via `telemetry-events-test` (e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)