### PR TITLE
docs(tools): name the mock-rule shape in reticle_network_mock's mocks param

### DIFF
--- a/packages/server/src/input/network-mock-tools.test.ts
+++ b/packages/server/src/input/network-mock-tools.test.ts
@@ -76,4 +76,21 @@ describe('reticle_network_mock tool', () => {
     expect(res.applied).toBe(true);
     expect(res.count).toBe(0);
   });
+
+  it('names every mock-rule field in the mocks parameter description', () => {
+    // The agent-facing description must carry the rule shape; otherwise the shape
+    // is only discoverable by failing a call (issue #345).
+    const mocks = tool().inputSchema['mocks'] as { description?: string };
+    for (const field of [
+      'urlContains',
+      'method',
+      'status',
+      'body',
+      'contentType',
+      'delayMs',
+      'abort',
+    ]) {
+      expect(mocks.description).toContain(field);
+    }
+  });
 });

--- a/packages/server/src/input/network-mock-tools.ts
+++ b/packages/server/src/input/network-mock-tools.ts
@@ -89,7 +89,12 @@ export const NETWORK_MOCK_TOOLS: ToolDef[] = [
       'states without touching the backend ("verify the app handles a failed payment"). Pass `mocks` ' +
       '(first matching rule wins); pass an empty array or `clear: true` to turn mocking off.',
     inputSchema: {
-      mocks: z.array(ruleShape).optional().describe('Interception rules; omit/empty to clear.'),
+      mocks: z
+        .array(ruleShape)
+        .optional()
+        .describe(
+          'Interception rules, first match wins: { urlContains, method?, status?, body?, contentType?, delayMs?, abort? }. Omit or pass [] to clear.',
+        ),
       clear: z.boolean().optional().describe('Clear all active mocks (same as mocks: []).'),
       ...sessionIdShape,
     },


### PR DESCRIPTION
## What

Fixes #345. The `mocks` parameter of `reticle_network_mock` was described only as "Interception rules; omit/empty to clear." — it never named a field of a mock rule. The rule shape (`{ urlContains, method?, status?, body?, contentType?, delayMs?, abort? }`) lives on the nested zod object, but the agent-facing params view flattens the array's one-liner, so the shape was only discoverable by failing a call and reading the refusal.

## The measurement the issue asked for

I checked every tool's input schema before choosing an approach:

- `reticle_network_mock.mocks` — the only structured **input** whose fixed shape is invisible (just "Interception rules; omit/empty to clear.").
- `reticle_act_sequence.steps` — the description already names the shape (`{ ref, action, args? } objects`).
- `observe` predicates — the description already enumerates every kind inline.
- The other nested objects (`contract` flows, `coverage` untouched, `read` stores/cookies, `scroll` element) are all in **output** schemas, not agent-facing inputs.
- `reticle_run.args` is inherently dynamic (shape comes from the named tool), so a generic description is correct there.

Since it is exactly one tool, option 1 (put the shape in the description) is the honest fix; rendering nested schemas would be over-engineering.

## Change

- Put the rule shape in the `mocks` description, matching the refusal text `toRules` already emits.
- Add a guard test that fails if any rule field stops being named in the agent-facing description, so the shape cannot silently flatten away again.

Signed-off-by: Me106y <98393210+Me106y@users.noreply.github.com>