### PR TITLE
fix(server): hold doctor's row labels and the docs pages to each other

### DIFF
--- a/docs/cli/doctor.mdx
+++ b/docs/cli/doctor.mdx
@@ -52,6 +52,7 @@ When nothing has connected, the `sessions` line fails and the daemon's own diagn
 | `daemon` | Whether the port holds a Reticle daemon, a foreign process (named where possible), or nothing. Adds a `version` line when the daemon's version or contract fingerprint disagrees with the CLI's |
 | `sessions` | Whether any page has actually connected. Zero is a FAILING check rather than a neutral note, because it is the state the setup most often stalls in: wired correctly, daemon up, nothing dialled in. When it is zero the daemon's own no-session diagnosis prints below the checklist |
 | `bridge port` | The port your app must dial, spelled out because mixing it up with the dev server port is the most common setup failure |
+| `port check` | Only when your project's configured port disagrees with the one the daemon is on. Prints the mismatch rather than leaving you to spot it across two lines |
 | `daemon log` | Where the structured daemon log lives |
 | `tracing` | How to turn that log into a per-stage trace |
 | `desktop` | Only on a desktop project. Every Electron and Tauri misconfiguration here fails silently, so it is diagnosed explicitly |

--- a/packages/server/src/cli/cli-doctor.ts
+++ b/packages/server/src/cli/cli-doctor.ts
@@ -13,6 +13,7 @@ import { SERVER_VERSION } from '../version/server-version.js';
 import { CONTRACT_FINGERPRINT } from '@reticlehq/core';
 import { diagnoseDesktop, isDesktopProject } from '../init/desktop-doctor.js';
 import { diagnosePortMismatch, readProjectPort } from './cli-port.js';
+import { DoctorRow, doctorRow } from './doctor-rows.js';
 
 /**
  * `reticle doctor` — collapse the ~6 independent first-run failure modes into one command. Checks the
@@ -43,11 +44,11 @@ export async function handleDoctor(port: number): Promise<void> {
     process.stdout.write(`${s}\n`);
   };
   line('reticle doctor');
-  line(`  node         ${process.version}`);
+  line(doctorRow(DoctorRow.NODE, process.version));
   // Filled in only on the daemon branch — there is nothing to ask when no daemon is answering, and
   // the branches below already say so in their own terms.
   let sessions: SessionsLine | undefined;
-  line(`  chromium     ${chromiumHint(await probeChromium())}`);
+  line(doctorRow(DoctorRow.CHROMIUM, chromiumHint(await probeChromium())));
   // Ask the PORT, not just the pid file. "not running on :4400" has been printed about a port that
   // was demonstrably occupied, which sends the reader to start a daemon that cannot bind. The three
   // states are genuinely different problems with different fixes, so doctor names which one it is.
@@ -64,7 +65,7 @@ export async function handleDoctor(port: number): Promise<void> {
       contract: CONTRACT_FINGERPRINT,
     });
     line(built.text);
-    if (built.skew !== undefined) line(`  version      ✗ ${built.skew}`);
+    if (built.skew !== undefined) line(doctorRow(DoctorRow.VERSION, `✗ ${built.skew}`));
     // The same payload already carries whether anything has CONNECTED, and doctor was reading
     // `version` off it and dropping the rest. Without this the command is silent on the one step the
     // funnel stalls on: wired correctly, daemon up, and no page has ever dialled in.
@@ -76,24 +77,40 @@ export async function handleDoctor(port: number): Promise<void> {
     // `pid` is what our pid file recorded for this port. When it matches the process actually
     // holding it, this is our OWN daemon wedged, not a stranger — and the fix is different.
     line(
-      `  daemon       ✗ ${describeForeignHolder(port, findPortHolder(port, captureLookup), pid)}`,
+      doctorRow(
+        DoctorRow.DAEMON,
+        `✗ ${describeForeignHolder(port, findPortHolder(port, captureLookup), pid)}`,
+      ),
     );
   } else {
     line(
-      `  daemon       ✗ not running on :${port} — your agent runs \`reticle mcp\` (or \`reticle serve\`)`,
+      doctorRow(
+        DoctorRow.DAEMON,
+        `✗ not running on :${port} — your agent runs \`reticle mcp\` (or \`reticle serve\`)`,
+      ),
     );
   }
   if (sessions !== undefined) line(sessions.text);
-  line(`  bridge port  ${port}  (your app must dial THIS port, not your dev-server port)`);
+  line(
+    doctorRow(
+      DoctorRow.BRIDGE_PORT,
+      `${port}  (your app must dial THIS port, not your dev-server port)`,
+    ),
+  );
   const projectPort = readProjectPort(process.cwd());
   const mismatch = diagnosePortMismatch(port, projectPort);
-  if (mismatch !== undefined) line(`  port check   ✗ ${mismatch}`);
+  if (mismatch !== undefined) line(doctorRow(DoctorRow.PORT_CHECK, `✗ ${mismatch}`));
   // Where to LOOK when something is wrong. The daemon has always written a structured log here and
   // nothing ever said so, so the first move in every investigation was reading source instead of
   // reading the log. `RETICLE_TRACE=1` turns the same stream into a per-stage trace — see
   // docs/debugging.md.
-  line(`  daemon log   ${join(reticleStateHome(), `daemon-${String(port)}.log`)}`);
-  line(`  tracing      ${ReticleEnv.TRACE}=1 on the daemon for per-stage timings in that log`);
+  line(doctorRow(DoctorRow.DAEMON_LOG, join(reticleStateHome(), `daemon-${String(port)}.log`)));
+  line(
+    doctorRow(
+      DoctorRow.TRACING,
+      `${ReticleEnv.TRACE}=1 on the daemon for per-stage timings in that log`,
+    ),
+  );
 
   // Below the checklist rather than inline: it is a paragraph, and a paragraph in the middle of a
   // column of one-line checks buries the checks under it. This is the daemon's own no-session
@@ -118,7 +135,10 @@ export async function handleDoctor(port: number): Promise<void> {
   if (desktop.length > 0) {
     line('');
     line(
-      `  desktop      ✗ ${String(desktop.length)} issue(s) — the app will look fine and not work:`,
+      doctorRow(
+        DoctorRow.DESKTOP,
+        `✗ ${String(desktop.length)} issue(s) — the app will look fine and not work:`,
+      ),
     );
     for (const finding of desktop) {
       line(`                 ${finding.file}`);
@@ -128,6 +148,6 @@ export async function handleDoctor(port: number): Promise<void> {
   } else if (isDesktopProject(readProjectFile)) {
     // Say so explicitly. Silence would read as "not checked", which is the same ambiguity the
     // findings above exist to remove.
-    line('  desktop      ✓ desktop wiring looks right');
+    line(doctorRow(DoctorRow.DESKTOP, '✓ desktop wiring looks right'));
   }
 }

--- a/packages/server/src/cli/doctor-daemon-line.ts
+++ b/packages/server/src/cli/doctor-daemon-line.ts
@@ -15,6 +15,7 @@
  */
 
 import { describeSkew } from '../version/version-skew.js';
+import { DoctorRow, doctorRow } from './doctor-rows.js';
 
 /** The fields of `/status` this line cares about. Both optional — an old daemon reports neither. */
 export interface DaemonIdentity {
@@ -62,6 +63,8 @@ export function daemonLine(
     { what: 'the daemon on this port', version: peer.version, contract: peer.contract, fix: FIX },
     self,
   );
-  const line: DaemonLine = { text: `  daemon       ✓ running on :${String(port)}${detail}` };
+  const line: DaemonLine = {
+    text: doctorRow(DoctorRow.DAEMON, `✓ running on :${String(port)}${detail}`),
+  };
   return skew === undefined ? line : { ...line, skew };
 }

--- a/packages/server/src/cli/doctor-rows.test.ts
+++ b/packages/server/src/cli/doctor-rows.test.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { DOCTOR_ROW_LABELS, DoctorRow, LABEL_COLUMN, doctorRow } from './doctor-rows.js';
+
+/**
+ * The guard for #340: `doctor`'s row vocabulary and the docs pages that reproduce its output must
+ * describe the same command, in both directions.
+ *
+ * The direction that actually bites is docs-missing-a-row. A row gets added to the checklist, the
+ * pages go on showing the old output, and a user hits a line nobody told them about on the one
+ * command they run when they are already stuck. Nothing here was catching that: the labels were
+ * free strings across three modules and the pages were prose.
+ *
+ * The reverse direction matters less often but is worse when it happens — a page showing a row the
+ * command cannot print sends someone hunting for output they will never see.
+ *
+ * Both expectations are derived from `DOCTOR_ROW_LABELS` rather than from a list kept here, so
+ * adding a row to the command is what updates the test's expectation. A hardcoded list would only
+ * catch the direction that does not bite.
+ */
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+
+/** The reference table of rows. This is the page that promises to list every line. */
+const ROW_TABLE_PAGE = join(REPO_ROOT, 'docs', 'cli', 'doctor.mdx');
+
+/** Every page that reproduces `doctor` output in a sample block. */
+const SAMPLE_PAGES = [
+  join(REPO_ROOT, 'docs', 'cli', 'doctor.mdx'),
+  join(REPO_ROOT, 'docs', 'cli.mdx'),
+  join(REPO_ROOT, 'docs', 'troubleshooting.mdx'),
+];
+
+function read(path: string): string {
+  return readFileSync(path, 'utf8');
+}
+
+/**
+ * Row labels appearing in fenced blocks that show `reticle doctor` output.
+ *
+ * Scoped to those blocks deliberately: the pages contain plenty of other indented output, and a
+ * guard that scanned every fence would fail on unrelated samples and get deleted.
+ */
+function labelsInSampleBlocks(markdown: string): string[] {
+  const found: string[] = [];
+  const blocks = markdown.split('```');
+  for (let index = 1; index < blocks.length; index += 2) {
+    const block = blocks[index];
+    if (undefined === block || !block.includes('reticle doctor')) continue;
+    for (const line of block.split('\n')) {
+      // A row is two spaces, the label, then at least two spaces before its value. The lazy
+      // quantifier stops the label swallowing the padding.
+      const match = /^ {2}([a-z][a-z ]*?) {2,}\S/.exec(line);
+      const label = match?.[1];
+      if (undefined !== label) found.push(label);
+    }
+  }
+  return found;
+}
+
+describe('the doctor row column', () => {
+  it('pads to the width the hand-written rows used', () => {
+    // 13 is what every call site padded to before these became a constant. Pinning it means a
+    // change to the column is deliberate and visible in a diff, rather than an invisible reflow
+    // of every sample block in the docs.
+    expect(LABEL_COLUMN).toBe(13);
+  });
+
+  it('builds a row the docs samples would recognise', () => {
+    expect(doctorRow(DoctorRow.NODE, 'v22.0.0')).toBe('  node         v22.0.0');
+    // The longest label still gets its two spaces, which is what makes the column hold.
+    expect(doctorRow(DoctorRow.BRIDGE_PORT, '4400')).toBe('  bridge port  4400');
+  });
+
+  it('has no duplicate labels', () => {
+    expect(new Set(DOCTOR_ROW_LABELS).size).toBe(DOCTOR_ROW_LABELS.length);
+  });
+});
+
+describe('every row doctor can print is documented (#340)', () => {
+  const table = read(ROW_TABLE_PAGE);
+
+  it.each([...DOCTOR_ROW_LABELS])('documents the `%s` row', (label) => {
+    // Backticked, as the table writes them. A bare substring match would let `daemon` satisfy the
+    // requirement for `daemon log`, which is the failure this guard is supposed to notice.
+    expect(table).toContain(`\`${label}\``);
+  });
+
+  it('covers the CONDITIONAL rows too, which are the ones a reader has never seen', () => {
+    // `version`, `port check` and `desktop` print only on skew, on a port mismatch, and on a
+    // desktop project. They are the rows least likely to be recognised and most likely to be
+    // missed by a guard built from one run's output — so they are named explicitly here.
+    for (const label of [DoctorRow.VERSION, DoctorRow.PORT_CHECK, DoctorRow.DESKTOP]) {
+      expect(table).toContain(`\`${label}\``);
+    }
+  });
+});
+
+describe('every row the docs show is one doctor can print (#340)', () => {
+  it.each(SAMPLE_PAGES)('%s shows no invented rows', (page) => {
+    const labels = labelsInSampleBlocks(read(page));
+    // A page with no doctor sample is fine; a page with one that shows nothing is not — that would
+    // mean the extractor stopped matching and this half of the guard silently passes forever.
+    const known = new Set<string>(DOCTOR_ROW_LABELS);
+    for (const label of labels) {
+      expect(known, `${page} shows a row \`${label}\` that doctor cannot print`).toContain(label);
+    }
+  });
+
+  it('actually extracts rows, so a passing guard means something', () => {
+    // The control. If the sample blocks stop being recognised, every assertion above passes
+    // vacuously — the same "gate that checks nothing" shape #340 is about.
+    const total = SAMPLE_PAGES.reduce(
+      (count, page) => count + labelsInSampleBlocks(read(page)).length,
+      0,
+    );
+    expect(total).toBeGreaterThan(0);
+  });
+});

--- a/packages/server/src/cli/doctor-rows.ts
+++ b/packages/server/src/cli/doctor-rows.ts
@@ -1,0 +1,62 @@
+/**
+ * The row labels `reticle doctor` can print, and the one place that pads them into a column.
+ *
+ * These were free strings before, hand-padded at every call site across three modules
+ * (`cli-doctor.ts`, `doctor-daemon-line.ts`, `doctor-sessions-line.ts`). Two problems with that,
+ * and the second is the one that motivated #340:
+ *
+ * 1. The padding was maintained by eye. Every label happened to be padded to the same column, but
+ *    nothing enforced it, and a label longer than the column would have quietly broken the
+ *    alignment of one row in a checklist whose whole readability is the column.
+ * 2. Nothing connected the labels to the docs pages that reproduce doctor's output. A row could be
+ *    added, renamed or removed and the three pages showing sample output would go on describing the
+ *    old vocabulary, with no gate noticing. `doctor` is the command a stuck user runs, and the docs
+ *    are what they read when its output does not match what they were told to expect.
+ *
+ * The label set is exported so the docs guard can derive its expectation from the command rather
+ * than from a hand-kept list, which is the direction that catches the case that actually bites: a
+ * row added and never documented.
+ *
+ * NOT every row prints on every run. `version` prints only on skew, `port check` only on a
+ * mismatch, `desktop` only on a desktop project, and `sessions` only when a daemon answered. The
+ * vocabulary is therefore "what this command can print", not "what one run printed" — a guard built
+ * by scraping a single invocation would silently stop covering the conditional rows, which are
+ * exactly the ones a reader is least likely to have seen before.
+ */
+
+/** Every row label `doctor` can emit. Values are the literal text at the head of the row. */
+export const DoctorRow = {
+  NODE: 'node',
+  CHROMIUM: 'chromium',
+  DAEMON: 'daemon',
+  VERSION: 'version',
+  SESSIONS: 'sessions',
+  BRIDGE_PORT: 'bridge port',
+  PORT_CHECK: 'port check',
+  DAEMON_LOG: 'daemon log',
+  TRACING: 'tracing',
+  DESKTOP: 'desktop',
+} as const;
+
+export type DoctorRowLabel = (typeof DoctorRow)[keyof typeof DoctorRow];
+
+export const DOCTOR_ROW_LABELS: readonly DoctorRowLabel[] = Object.values(DoctorRow);
+
+/** Indent every row carries, before the label. */
+const INDENT = '  ';
+
+/**
+ * Width the label column pads to.
+ *
+ * Derived from the longest label rather than hardcoded, so adding a longer row realigns the whole
+ * checklist instead of breaking one line of it. With the current set the longest is `bridge port`
+ * (11), so this is 13 — byte-identical to the hand-padding it replaces. A test pins that, so a
+ * change to the column is a deliberate, visible change rather than an invisible reflow.
+ */
+export const LABEL_COLUMN =
+  DOCTOR_ROW_LABELS.reduce((widest, label) => Math.max(widest, label.length), 0) + 2;
+
+/** Build one `doctor` row: the standard indent, the label padded to the column, then `rest`. */
+export function doctorRow(label: DoctorRowLabel, rest: string): string {
+  return `${INDENT}${label.padEnd(LABEL_COLUMN)}${rest}`;
+}

--- a/packages/server/src/cli/doctor-sessions-line.ts
+++ b/packages/server/src/cli/doctor-sessions-line.ts
@@ -1,4 +1,5 @@
 import { SELF_RECOVERING_MARKER } from '../session/no-session-diagnosis.js';
+import { DoctorRow, doctorRow } from './doctor-rows.js';
 
 /**
  * The line `doctor` was missing: is anything actually CONNECTED?
@@ -68,11 +69,16 @@ export function sessionsLine(facts: SessionFacts): SessionsLine {
     // An older daemon that does not report it. Saying "0 connected" here would be a claim about the
     // app made from a payload that never mentioned the app — the exact kind of confident wrong
     // sentence the no-session diagnosis exists to avoid.
-    return { text: '  sessions     ? this daemon did not report connected pages (older build)' };
+    return {
+      text: doctorRow(
+        DoctorRow.SESSIONS,
+        '? this daemon did not report connected pages (older build)',
+      ),
+    };
   }
   if (count > 0) {
     const plural = 1 === count ? 'page' : 'pages';
-    return { text: `  sessions     ✓ ${String(count)} ${plural} connected` };
+    return { text: doctorRow(DoctorRow.SESSIONS, `✓ ${String(count)} ${plural} connected`) };
   }
   const why =
     'string' === typeof facts.why && facts.why.length > 0 ? forAHuman(facts.why) : undefined;
@@ -80,7 +86,7 @@ export function sessionsLine(facts: SessionFacts): SessionsLine {
     // Deliberately ✗ rather than a neutral note. Zero connected pages is why somebody is running
     // doctor, and a ✓-coloured checklist that hides the one failing thing is how the old output
     // convinced people their setup was fine.
-    text: '  sessions     ✗ no page has connected to this daemon',
+    text: doctorRow(DoctorRow.SESSIONS, '✗ no page has connected to this daemon'),
     ...(why === undefined ? {} : { why }),
   };
 }


### PR DESCRIPTION
Closes #340.

**The guard's first run found a real hole: `port check` was undocumented on all three pages.** Documented in this PR. That is the whole case for the issue, so I want to lead with it rather than bury it under the refactor.

## What was actually wrong

Two things, and the second is the one #340 asks about.

**The labels were free strings**, hand-padded to a 13-character column at every call site. Every row happened to line up, but nothing enforced it — a label longer than the column would have quietly broken the alignment of one line in a checklist whose entire readability is that column.

**Nothing connected the labels to the docs.** A row could be added, renamed or removed and `docs/cli.mdx`, `docs/troubleshooting.mdx` and `docs/cli/doctor.mdx` would go on describing the old vocabulary. On the one command a stuck user runs.

## The detail that changed the shape of the work

As I flagged on the issue: the vocabulary is **not** all in `cli-doctor.ts`. `daemon` is built in `doctor-daemon-line.ts` and `sessions` in `doctor-sessions-line.ts`. A constant living inside `cli-doctor.ts` would have passed its own guard while two labels stayed free strings in their own files — the same "checks the wrong thing" shape as the issue itself. So `doctor-rows.ts` sits where all three can import it.

## Conditional rows: I treated the vocabulary as "can print"

`version` (skew only), `port check` (mismatch only), `desktop` (desktop projects only) and `sessions` (only when a daemon answered) do not print on every run. I asked on the issue whether these should be exempt and went ahead on "can print" rather than block — the finding settles it, I think:

**The conditional rows were exactly the under-documented ones.** `port check` appeared nowhere on any of the three pages. Exempting conditional rows would have produced a guard that passed while leaving the drift in place, and these are precisely the rows a reader is least likely to have seen before and most needs the page for.

This also rules out building the guard by scraping one invocation's output — it would silently stop covering them. Both expectations derive from `DOCTOR_ROW_LABELS` instead.

Happy to switch to exempting them if you disagree; it is a small change.

## The column width is derived, not hardcoded

`LABEL_COLUMN` comes from the longest label plus two. With the current set that is **13 — byte-identical to the hand-padding it replaces**, which is why the 11 existing `doctor-daemon-line` / `doctor-sessions-line` tests pass untouched. Adding a longer row now realigns the checklist instead of breaking one line of it. A test pins 13 so a reflow is a deliberate, visible diff rather than an invisible change to every sample block in the docs.

## The guard

Bidirectional, as the issue asked:

- every label `doctor` can print appears in the row table on `docs/cli/doctor.mdx`
- every row the sample blocks show is one `doctor` can print

Two details worth calling out:

- Matching is on the **backticked** label. A bare substring match would let `daemon` satisfy the requirement for `daemon log`, which is exactly the failure this is supposed to notice.
- There is a **control test** asserting the extractor finds a non-zero number of rows. Without it, an extractor that stopped matching would make every other assertion pass vacuously — the same gate-that-checks-nothing shape #340 is about. Sample-block scanning is scoped to fences containing `reticle doctor`, since the pages carry plenty of other indented output and a guard that failed on unrelated samples would get deleted.

## Verification

- `pnpm format:check` — clean
- `tsc --noEmit`, `eslint` on all changed files — clean
- **`vitest run` in `@reticlehq/server`: 401 files, 3849 passed, 3 skipped**

Note for anyone reproducing on Windows: `pnpm typecheck` through turbo fails with `Unable to find package manager binary` under the corepack shim, so I ran the package's own `tsc`/`eslint`/`vitest` directly. Unrelated to this change.

Not widened to `status` / `open` / `gate`. If the shape works here those are a follow-up.