### PR TITLE
fix(server): flow_replay returns `unverifiable` for assertion-free flows

### DIFF
--- a/packages/core/src/flow-constants.ts
+++ b/packages/core/src/flow-constants.ts
@@ -94,6 +94,7 @@ export const ReplayStatus = {
   OK: 'ok', // every anchor resolved and every step ran green
   DRIFT: 'drift', // an anchor missed (testid renamed / signal not observed) — legible drift returned
   ERROR: 'error', // the flow could not load or a resolved action failed
+  UNVERIFIABLE: 'unverifiable', // steps ran green but the flow asserts no observable consequence
 } as const;
 export type ReplayStatus = (typeof ReplayStatus)[keyof typeof ReplayStatus];
 

--- a/packages/core/src/flow-types.ts
+++ b/packages/core/src/flow-types.ts
@@ -295,6 +295,8 @@ export interface FlowReplayResult {
   decision?: ReplayDecision;
   /** Set when status === 'error' (load failure or resolved action failure). */
   error?: { code: string; message: string };
+  /** Set when status === 'unverifiable': why this flow cannot prove anything. */
+  unverifiable_reason?: string;
   /**
    * The confident rebind proposals aggregated across drifted steps (additive,
    * optional — present only when at least one drifted step has a confident nearest match).

--- a/packages/server/src/flows/decision.test.ts
+++ b/packages/server/src/flows/decision.test.ts
@@ -307,4 +307,18 @@ describe('buildSuiteVerdict — a flow that cannot fail is not a pass', () => {
     expect(v.status).toBe('pass');
     expect(v.passed).toBe(1);
   });
+
+  it('a replay with status UNVERIFIABLE is counted as unverifiable without re-classifying', () => {
+    const replay: FlowReplayResult = {
+      name: 'bare-ok',
+      status: ReplayStatus.UNVERIFIABLE,
+      steps: [{ step: 0, tool: 'reticle_act', anchor: 'x', ok: true }],
+      unverifiable_reason: 'This flow asserts no observable consequence.',
+    };
+    const v = buildSuiteVerdict([{ replay, flow: assertingFlow('bare-ok') }]);
+    expect(v.status).toBe('unverifiable');
+    expect(v.passed).toBe(0);
+    expect(v.unverifiable?.[0]?.flow).toBe('bare-ok');
+    expect(v.unverifiable?.[0]?.reason).toContain('consequence');
+  });
 });

--- a/packages/server/src/flows/decision.ts
+++ b/packages/server/src/flows/decision.ts
@@ -142,6 +142,12 @@ export function buildSuiteVerdict(
   const unverifiable: { flow: string; reason: string }[] = [];
   let passed = 0;
   for (const { replay, flow } of runs) {
+    if (replay.status === ReplayStatus.UNVERIFIABLE) {
+      const reason =
+        replay.unverifiable_reason ?? unverifiableReason(flow) ?? 'assertion-free flow';
+      unverifiable.push({ flow: replay.name, reason });
+      continue;
+    }
     if (replay.status === ReplayStatus.OK) {
       const reason = unverifiableReason(flow);
       // A green that cannot go red is not a pass. Counted apart, so `passed` stays a count of things

--- a/packages/server/src/flows/flow-replay-run.ts
+++ b/packages/server/src/flows/flow-replay-run.ts
@@ -15,6 +15,7 @@ import { asString } from '../tools/tools-helpers.js';
 import { replayFlow } from './flow-replay.js';
 import { assertSuccess, dynamicTestids, successLabel, SUCCESS_STEP_TOOL } from './flow-success.js';
 import { buildDecision } from './decision.js';
+import { classifyFlowAssertions, FlowAssertionGrade } from './flow-classify.js';
 import { waitForPredicate } from '../events/predicate.js';
 import { computeSegments } from '../journal/rollups.js';
 import { AssertionTiersStore } from './assertion-tiers-store.js';
@@ -58,6 +59,7 @@ export function flowErrorMessage(code: FlowErrorCode): string {
 function replayToRunStatus(status: ReplayStatus): RunStatus {
   switch (status) {
     case ReplayStatus.OK:
+    case ReplayStatus.UNVERIFIABLE:
       return RunStatus.PASS;
     case ReplayStatus.DRIFT:
       return RunStatus.DRIFT;
@@ -192,7 +194,8 @@ export async function replayNamedFlow(
   }
   const driftSteps = steps.filter((s) => s.drift !== undefined).length;
   const allOk = steps.every((s) => s.ok);
-  const status = driftSteps > 0 ? ReplayStatus.DRIFT : allOk ? ReplayStatus.OK : ReplayStatus.ERROR;
+  let status: ReplayStatus =
+    driftSteps > 0 ? ReplayStatus.DRIFT : allOk ? ReplayStatus.OK : ReplayStatus.ERROR;
   await recordReplayRun(deps, name, status, driftSteps, deps.now() - startedAt, projectId);
   // Anti-reward-hacking baseline: record what this flow asserted ONLY when it passed clean. A
   // failing run must never become the baseline a later weakening is measured against.
@@ -206,6 +209,18 @@ export async function replayNamedFlow(
       // Record what this flow COVERS so a later deletion can be scoped to the files that changed.
       toFlowSources([{ name, steps: loaded.value.steps }])[0]?.sources ?? [],
     );
+  }
+  // A green that cannot go red is not an "ok" — it is unverifiable. Matching the suite vocabulary
+  // so an agent reading a single-flow replay gets the same signal flow_verify gives the suite.
+  let unverifiableReason: string | undefined;
+  if (status === ReplayStatus.OK) {
+    const classification = classifyFlowAssertions(loaded.value);
+    if (classification.grade === FlowAssertionGrade.ASSERTION_FREE) {
+      status = ReplayStatus.UNVERIFIABLE;
+      unverifiableReason =
+        classification.warning ??
+        'This flow asserts no observable consequence, so it passes even if the feature is broken.';
+    }
   }
   // Push-default: the deviation report over this drive's segments, learned across runs. Best-effort.
   const deviation = await computeReplayDeviation(deps, session, replayFloor);
@@ -223,7 +238,10 @@ export async function replayNamedFlow(
     return errored;
   }
   const result: FlowReplayResult = { name, status, steps };
-  if (status !== ReplayStatus.OK) result.decision = buildDecision(result, loaded.value);
+  if (unverifiableReason !== undefined) result.unverifiable_reason = unverifiableReason;
+  if (status !== ReplayStatus.OK && status !== ReplayStatus.UNVERIFIABLE) {
+    result.decision = buildDecision(result, loaded.value);
+  }
   applyStartPathHint(result, startPathHint);
   if (deviation !== undefined) result.deviation = deviation;
   return result;

--- a/packages/server/src/flows/flow-tools.ts
+++ b/packages/server/src/flows/flow-tools.ts
@@ -311,8 +311,14 @@ export const FLOW_TOOLS: ToolDef[] = [
       // The flow's name — always present in FlowReplayResult (the description promises `{ name, … }`),
       // but omitted here, so a validating profile stripped it and a replay result arrived anonymous.
       name: z.string(),
-      status: z.string().describe('ok | drift | error'),
+      status: z.string().describe('ok | drift | error | unverifiable'),
       steps: z.array(z.unknown()),
+      unverifiable_reason: z
+        .string()
+        .optional()
+        .describe(
+          'Present when status is unverifiable: why this flow cannot prove anything (assertion-free).',
+        ),
       proposals: z.array(z.unknown()).optional(),
       deviation: z
         .unknown()

--- a/packages/server/src/flows/tools.flow-replay.test.ts
+++ b/packages/server/src/flows/tools.flow-replay.test.ts
@@ -131,7 +131,7 @@ describe('reticle_flow_replay handler — temp dir, never touches the repo', () 
     if (!res.ok) throw new Error(`save failed: ${res.code}`);
   }
 
-  it('A: a flow whose testids all resolve replays with status ok', async () => {
+  it('A: an assertion-free flow reports unverifiable rather than bare ok', async () => {
     await saveFlow('green', [actStep('chat-send'), actStep('chat-input')]);
     const session = scriptedSession((testid) => ({ elements: [{ ref: `e-${testid}` }] }));
     const deps = fakeDeps(fs, root, session);
@@ -139,10 +139,23 @@ describe('reticle_flow_replay handler — temp dir, never touches the repo', () 
     const res = (await tool(ReticleTool.FLOW_REPLAY).handler(deps, {
       flowName: 'green',
     })) as FlowReplayResult;
-    expect(res.status).toBe(ReplayStatus.OK);
+    expect(res.status).toBe(ReplayStatus.UNVERIFIABLE);
+    expect(res.unverifiable_reason).toBeDefined();
     expect(res.name).toBe('green');
     expect(res.steps).toHaveLength(2);
     expect(res.steps.every((s) => s.ok)).toBe(true);
+  });
+
+  it('unverifiable carries a reason the agent can read', async () => {
+    await saveFlow('bare', [actStep('chat-send')]);
+    const session = scriptedSession((testid) => ({ elements: [{ ref: `e-${testid}` }] }));
+    const deps = fakeDeps(fs, root, session);
+
+    const res = (await tool(ReticleTool.FLOW_REPLAY).handler(deps, {
+      flowName: 'bare',
+    })) as FlowReplayResult;
+    expect(res.status).toBe(ReplayStatus.UNVERIFIABLE);
+    expect(res.unverifiable_reason).toContain('consequence');
   });
 
   it('B: a flow with one renamed testid returns status drift with a computed nearest', async () => {


### PR DESCRIPTION
## Summary

- **New status:** `reticle_flow_replay` now returns `status: "unverifiable"` (with an `unverifiable_reason` field) for flows that assert no observable consequence — matching the vocabulary `reticle_flow_verify` already uses in suite verdicts.
- **Core change:** Added `UNVERIFIABLE` to `ReplayStatus` and `unverifiable_reason` to `FlowReplayResult` in `@reticlehq/core`.
- **Suite integration:** `buildSuiteVerdict` handles the pre-classified `UNVERIFIABLE` status directly, avoiding redundant re-classification.

Previously, an assertion-free flow replaying cleanly returned `{ status: "ok", steps: [...] }` with no signal that it proved nothing — an agent reading "ok" had no way to know the flow was vacuously green.

## Test plan

- [x] `tools.flow-replay.test.ts`: assertion-free flow now gets `status: "unverifiable"` with a reason
- [x] `decision.test.ts`: `buildSuiteVerdict` handles `UNVERIFIABLE` replay status correctly
- [x] All 52 tests across flow-replay, decision, and empty-suite files pass
- [x] `pnpm lint` and `pnpm typecheck` (server + core) clean

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)