### PR TITLE
feat(ci): add post-merge benchmark gate workflow

### DIFF
--- a/.github/workflows/benchmark-gate.yml
+++ b/.github/workflows/benchmark-gate.yml
@@ -1,0 +1,63 @@
+name: Benchmark Gate
+
+# Post-merge only: runs after a commit lands on main, reports regressions without blocking.
+# Attribution is precise (one commit), and the baseline in bench/history.jsonl is stable.
+# See #351 for why this is post-merge rather than blocking PRs.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: # manual trigger for testing
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+
+      # The benchmark suite boots real fixtures (api + bench-app in a real browser) and drives them
+      # via MCP, measuring token cost and detection accuracy. Default pass is REPLAY only (fast,
+      # deterministic, pure Reticle) — the full OBSERVATION-COST pass is slower and not required for
+      # the regression gate's hard floor.
+      - name: Run benchmark suite (REPLAY pass)
+        run: pnpm bench
+        env:
+          # Telemetry off: this is a deterministic measurement run, not a user session.
+          RETICLE_TELEMETRY: '0'
+          # Raise fixture ready timeout for CI: shared runners are slower than local dev machines.
+          BENCH_FIXTURE_READY_MS: '45000'
+          BENCH_RETICLE_READY_MS: '5000'
+
+      # The gate compares fresh results (bench/raw/*.json) against the last row in history.jsonl and
+      # fails on regression: efficiency drop > 3%, token rise > 5%, detection not full. Reported here
+      # rather than blocking, so a legitimate cost increase (bought information) doesn't wedge merges.
+      - name: Check for regressions
+        run: pnpm bench:gate
+        # Non-blocking: a regression here is a REPORT, not a gate. The failure lands in this job's
+        # log and is visible immediately (one commit attribution), but does not red the workflow or
+        # block future merges. A gate that cannot tell "we paid for this" from "we regressed" blocks
+        # good changes, and option 1 from #351 explicitly chose reporting over blocking.
+        continue-on-error: true
+
+      # Upload raw results and gate output on failure so triaging a regression doesn't require
+      # re-running the 50-minute benchmark locally.
+      - name: Upload benchmark artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: benchmark-gate-results
+          path: |
+            bench/raw/*.json
+            bench/history.jsonl
+          if-no-files-found: ignore
+          retention-days: 30


### PR DESCRIPTION
Wires `bench/harness/gate.mjs` into CI as a post-merge, non-blocking job that runs on main after a commit lands. Catches token regressions and detection drops with precise one-commit attribution, without blocking PRs or requiring every contributor to re-run a 50-minute benchmark.

## What this implements

Option 1 from #351: **post-merge reporting** rather than blocking, because a gate that cannot distinguish a legitimate cost increase (bought information) from a true regression blocks good changes.

- Runs REPLAY pass only (fast, deterministic, pure Reticle floor)
- Compares against `bench/history.jsonl` last row
- `continue-on-error: true` — reports, doesn't block
- Artifacts uploaded on failure for triage without local re-run

## Why post-merge, non-blocking

From the issue:
> A blocking cost gate has a failure mode of its own. A legitimate change that buys more information for more tokens is a regression by this metric […] A gate that cannot tell 'we paid for this' from 'we regressed' will either block good changes or be muted, and both end the same way.

This workflow **reports** immediately (one commit attribution), but does not red CI or block future merges. A regression is visible in the workflow log the moment it lands, which is actionable — and it doesn't wedge merges for changes where the cost was deliberate.

## Testing

- Workflow syntax validated (YAML structure)
- Commands tested locally: `pnpm bench && pnpm bench:gate` works
- Follows existing CI patterns from `ci.yml`
- Timeout (50min) covers the REPLAY pass comfortably

Fixes #351