### PR TITLE
fix(server): say when a replayed flow proved nothing, as the suite does

### DIFF
--- a/packages/core/src/flow-types.ts
+++ b/packages/core/src/flow-types.ts
@@ -296,6 +296,14 @@ export interface FlowReplayResult {
   /** Set when status === 'error' (load failure or resolved action failure). */
   error?: { code: string; message: string };
   /**
+   * Set on an `ok` replay whose flow cannot fail: it asserts no observable consequence, or has no
+   * steps at all. The replay genuinely completed, so the status stays `ok` — but a bare `ok` read
+   * as proof the feature works is exactly the false confidence `flow-risk.ts` argues against, and
+   * `reticle_flow_verify` already refuses to count these as passes. This carries the same reason,
+   * from the same function, to the single-flow caller who would otherwise never see it.
+   */
+  unverifiable?: { reason: string };
+  /**
    * The confident rebind proposals aggregated across drifted steps (additive,
    * optional — present only when at least one drifted step has a confident nearest match).
    */

--- a/packages/server/src/flows/decision.ts
+++ b/packages/server/src/flows/decision.ts
@@ -122,7 +122,7 @@ function suiteVerdictOf(status: ReplayStatus): 'pass' | 'drift' | 'fail' {
  * turned that warning into "all 1 flow pass", which is a false green in the exact feature sold as
  * the regression suite. Classified only when the flow file is available; never guessed.
  */
-function unverifiableReason(flow: FlowFile | undefined): string | undefined {
+export function unverifiableReason(flow: FlowFile | undefined): string | undefined {
   if (flow === undefined) return undefined;
   if (0 === flow.steps.length) {
     return 'the flow has no steps — it replays green whatever the app does. Record it again, or add steps with reticle_annotate.';

--- a/packages/server/src/flows/flow-replay-run.ts
+++ b/packages/server/src/flows/flow-replay-run.ts
@@ -14,7 +14,7 @@ import {
 import { asString } from '../tools/tools-helpers.js';
 import { replayFlow } from './flow-replay.js';
 import { assertSuccess, dynamicTestids, successLabel, SUCCESS_STEP_TOOL } from './flow-success.js';
-import { buildDecision } from './decision.js';
+import { buildDecision, unverifiableReason } from './decision.js';
 import { waitForPredicate } from '../events/predicate.js';
 import { computeSegments } from '../journal/rollups.js';
 import { AssertionTiersStore } from './assertion-tiers-store.js';
@@ -223,6 +223,12 @@ export async function replayNamedFlow(
     return errored;
   }
   const result: FlowReplayResult = { name, status, steps };
+  // A green that cannot go red is not a pass. `reticle_flow_verify` already refuses to count these,
+  // via this same function -- a single-flow caller saw a bare `ok` and had no way to learn the flow
+  // asserts nothing. Derived from the same helper on purpose: two copies of this judgement would
+  // drift, and the sibling tools would then disagree about the same flow.
+  const cannotFail = status === ReplayStatus.OK ? unverifiableReason(loaded.value) : undefined;
+  if (cannotFail !== undefined) result.unverifiable = { reason: cannotFail };
   if (status !== ReplayStatus.OK) result.decision = buildDecision(result, loaded.value);
   applyStartPathHint(result, startPathHint);
   if (deviation !== undefined) result.deviation = deviation;

--- a/packages/server/src/flows/flow-tools.ts
+++ b/packages/server/src/flows/flow-tools.ts
@@ -287,7 +287,9 @@ export const FLOW_TOOLS: ToolDef[] = [
       'stale ref. On an anchor MISS returns legible DRIFT { step, anchor, drift:{ reasonKind, reason, ' +
       'nearest } } (the closest surviving testid) and stops — the "whose fault is it" contract. ' +
       'Returns { name, status: ok|drift|error, steps:[...] }; missing/malformed files and action ' +
-      'failures are status:error with a structured code (distinct from contract-changed drift).',
+      'failures are status:error with a structured code (distinct from contract-changed drift). ' +
+      'An ok replay of a flow that asserts no consequence also carries unverifiable:{reason} — it ' +
+      'would read ok even if the feature were broken, so do NOT treat that ok as proof.',
     inputSchema: {
       flow: z
         .string()
@@ -321,6 +323,14 @@ export const FLOW_TOOLS: ToolDef[] = [
           'Push-default deviation report over the replay segments: ranked deviations vs the learned envelope + a nominal count, or a fall-back note below 3 runs.',
         ),
       error: z.object({ code: z.string(), message: z.string() }).optional(),
+      // Declared here or a validating profile strips it -- the same way `name` was stripped once.
+      // A field the handler sets and the schema omits arrives as nothing, silently.
+      unverifiable: z
+        .object({ reason: z.string() })
+        .optional()
+        .describe(
+          'Set on an ok replay that cannot fail: the flow asserts no observable consequence, so it passes even when the feature is broken. Same reason reticle_flow_verify reports.',
+        ),
       decision: z
         .object({
           verdict: z.string(),

--- a/packages/server/src/flows/tools.flow-replay.test.ts
+++ b/packages/server/src/flows/tools.flow-replay.test.ts
@@ -17,10 +17,11 @@ import {
   type FlowReplayResult,
 } from '@reticlehq/core';
 import { TOOLS, type ToolDeps } from '../tools/tools.js';
+import { buildSuiteVerdict } from './decision.js';
 import { ReticleTool } from '../tools/tool-names.js';
 import { BaselineStore } from '../project/baselines.js';
 import { RecordingStore } from './recordings.js';
-import { FlowStore } from './flows.js';
+import { FlowStore, type FlowAnnotations } from './flows.js';
 import { ProjectStore } from '../project/project-store.js';
 import { AnnotationStore } from './annotation-store.js';
 import { createNodeFileSystem, type FileSystemPort } from '../project/fs-port.js';
@@ -267,5 +268,100 @@ describe('reticle_flow_replay handler — temp dir, never touches the repo', () 
 
     expect(actArgs[0]).not.toHaveProperty(DANGEROUS_ACTION_CONFIRM_ARG);
     expect(actArgs[1]).toMatchObject({ [DANGEROUS_ACTION_CONFIRM_ARG]: true });
+  });
+});
+
+/**
+ * #341: a single-flow replay of a flow that asserts nothing returned a bare `ok`.
+ *
+ * `reticle_flow_verify` already refuses to count those as passes and says why. The single-flow
+ * tool did not, so an agent replaying one flow and reading `status: "ok"` had no way to learn the
+ * flow would read `ok` even if the feature were entirely broken.
+ *
+ * The status stays `ok` deliberately. `buildSuiteVerdict` reaches its unverifiable branch ONLY
+ * through `ReplayStatus.OK` and pushes everything else onto `failures`, so introducing an
+ * `unverifiable` status would make the suite report an unasserted flow as a FAILED one — a worse
+ * lie than the one being fixed, because it sends someone debugging an app that is fine.
+ */
+describe('reticle_flow_replay — a green that cannot go red (#341)', () => {
+  let dir: string;
+  let root: string;
+  let fs: FileSystemPort;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'reticle-unverifiable-'));
+    root = join(dir, '.reticle');
+    fs = createNodeFileSystem();
+  });
+
+  afterEach(async () => {
+    await removeTempDir(dir);
+  });
+
+  async function save(
+    name: string,
+    steps: RecordedStep[],
+    annotations?: FlowAnnotations,
+  ): Promise<void> {
+    const res = await new FlowStore(fs, root, clock).save(program(name, steps), annotations);
+    if (!res.ok) throw new Error(`save failed: ${res.code}`);
+  }
+
+  function resolvingSession(): Partial<Session> {
+    return scriptedSession((testid) => ({ elements: [{ ref: `e-${testid}` }] }));
+  }
+
+  async function replay(name: string): Promise<FlowReplayResult> {
+    const deps = fakeDeps(fs, root, resolvingSession());
+    return (await tool(ReticleTool.FLOW_REPLAY).handler(deps, {
+      flowName: name,
+    })) as FlowReplayResult;
+  }
+
+  it('an assertion-free flow replays ok AND says it proved nothing', async () => {
+    await save('asserts-nothing', [actStep('login-submit')]);
+
+    const res = await replay('asserts-nothing');
+
+    // Still ok: the replay genuinely completed. That is the point — the status alone was never
+    // going to carry this, which is why a bare `ok` was misleading rather than wrong.
+    expect(res.status).toBe(ReplayStatus.OK);
+    expect(res.unverifiable?.reason).toBeDefined();
+    expect(res.unverifiable?.reason).toMatch(/asserts no observable consequence/);
+  });
+
+  it('a flow with a consequence assertion carries no such caveat', async () => {
+    // The control. Without it, a bug that attached the caveat unconditionally would pass every
+    // other assertion here — and would tell an agent that a genuinely verified flow proved nothing.
+    await save('asserts-something', [actStep('login-submit')], {
+      stepExpect: new Map(),
+      dynamic: [],
+      success: { signal: 'auth:logged-in' },
+    });
+
+    const res = await replay('asserts-something');
+
+    expect(res.unverifiable).toBeUndefined();
+  });
+
+  it('the single-flow result and the suite agree about the same flow', async () => {
+    // The actual invariant. Asserting the field exists in isolation would let the two tools drift
+    // apart again, which is the whole defect: two answers to one question about one flow.
+    await save('asserts-nothing', [actStep('login-submit')]);
+    const flow = await new FlowStore(fs, root, clock).load('asserts-nothing');
+    if (!flow.ok) throw new Error('load failed');
+
+    const single = await replay('asserts-nothing');
+    const suite = buildSuiteVerdict([{ replay: single, flow: flow.value }]);
+
+    expect(suite.status).toBe('unverifiable');
+    expect(suite.unverifiable?.[0]?.reason).toBe(single.unverifiable?.reason);
+  });
+
+  it('the reason is declared on the tool output schema, or a profile strips it', () => {
+    // `name` was omitted here once and arrived stripped, which is why this is asserted rather
+    // than trusted: a field the handler sets and the schema omits returns as nothing, silently.
+    const schema = tool(ReticleTool.FLOW_REPLAY).outputSchema;
+    expect(schema).toHaveProperty('unverifiable');
   });
 });


### PR DESCRIPTION
Closes #341.

## I did not take the shape the issue leans toward, and this is why

The issue suggests matching the suite's vocabulary with an `unverifiable` **status**. That reads right until you follow what `buildSuiteVerdict` does with it:

```ts
if (replay.status === ReplayStatus.OK) {
  const reason = unverifiableReason(flow);
  if (reason !== undefined) unverifiable.push({ flow: replay.name, reason });
  else passed += 1;
  continue;
}
// ...everything else falls through:
failures.push(row);
```

The unverifiable branch is reachable **only** through `ReplayStatus.OK`. Add `UNVERIFIABLE` to the enum and set it, and an assertion-free flow stops matching that guard, falls past the `continue`, and lands in `failures` — so `reticle_flow_verify` would begin reporting *"this flow asserts nothing"* as **"this flow failed"**, and the suite status would flip `unverifiable` → `fail`.

That is a regression in the tool the issue opens by saying already gets this right, and it is a **worse** lie than the one being fixed: it sends someone debugging an app that is fine.

So the status stays `ok` and the caveat rides as an optional `unverifiable: { reason }`. The vocabulary still matches where it counts — the reason is `unverifiableReason()` itself, now exported rather than copied, so the single-flow reason and the suite reason are the same string from the same function. Two statements of one judgement would drift, and then the siblings would disagree about the same flow again, one layer down.

## The allowlists you warned about

Found two, and the codebase already carries the scar. `flow-tools.ts`:

```ts
// The flow's name — always present in FlowReplayResult ... but omitted here,
// so a validating profile stripped it and a replay result arrived anonymous.
name: z.string(),
```

So: `FlowReplayResult` in `packages/core/src/flow-types.ts` **and** `outputSchema` in `flow-tools.ts`, plus the tool description. There is no zod schema for the result in core — the `outputSchema` block *is* the validating surface. A test asserts the schema declares the field, because "the handler sets it and the schema drops it" fails silently by design.

I also checked the thing I said I would rather raise than assume: `replayNamedFlow` holds the `FlowFile` as `loaded.value` throughout, so `unverifiableReason` is reachable with a real flow and cannot quietly classify nothing.

## Tests

Four added; the third is the one that matters.

- an assertion-free flow replays `ok` **and** carries the reason
- **the control**: a flow *with* a `success` assertion carries no caveat — without this, a bug attaching it unconditionally passes everything else and tells an agent a genuinely verified flow proved nothing
- **the invariant**: the single-flow result and `buildSuiteVerdict` agree about the *same* flow. Asserting the field exists in isolation would let the two drift apart again, which is the entire defect
- the schema declares it

**Mutation-checked.** Removing only the attachment line reddens the two substantive tests:

```
3 failed | 10 passed
  ✗ an assertion-free flow replays ok AND says it proved nothing
  ✗ the single-flow result and the suite agree about the same flow
```

Honest note on that third red: `B: a flow with one renamed testid returns status drift` also appears failed in that run, at 1190875ms. That is a timeout artifact — the run exceeded my harness limit and was killed mid-test. It passes at ~1270ms on the clean tree and the mutation does not touch its path. Reporting it because the raw output says "3 failed" and I would rather explain the third than let the number look better than it is.

## Verification

```
prettier --check          All matched files use Prettier code style
core   tsc --noEmit       clean      vitest  22 files, 211 passed
server tsc --noEmit       clean      eslint  clean on all changed files
server vitest run         400 files, 3835 passed, 3 skipped
```

Not run: `pnpm test:e2e`. This touches the tool surface, so by `CLAUDE.md` it wants the battery — I do not have a working Playwright/browser setup on this machine and would rather say so than imply coverage I did not produce. Also worth knowing: `pnpm typecheck` through turbo fails here with `Unable to find package manager binary` under the corepack shim, so the per-package `tsc` above is how I got the same answer.

`packages/core` needs a `pnpm run build` before `packages/server` typechecks against the new field — server resolves core from `dist`, not source.