### PR TITLE
fix(browser): classify 3xx fetch responses as ok (parity with XHR)

### DIFF
--- a/packages/browser/src/observers/network.test.ts
+++ b/packages/browser/src/observers/network.test.ts
@@ -449,6 +449,36 @@ describe('installNetwork (fetch)', () => {
     expect(net[1]?.data['id']).toBe(net[0]?.data['id']);
   });
 
+  it('classifies a 3xx redirect as ok (matching XHR behavior)', async () => {
+    window.fetch = vi.fn(() => Promise.resolve(fakeResponse(303)));
+    const { emit, events } = collect();
+    teardown = installNetwork(emit);
+
+    await window.fetch('http://localhost:8787/api/login');
+    await flushBody();
+
+    expect(eventOf(events, EventType.NET_REQUEST)).toMatchObject({
+      status: 303,
+      ok: true,
+      initiator: 'fetch',
+    });
+  });
+
+  it('classifies a 4xx as not ok via fetch', async () => {
+    window.fetch = vi.fn(() => Promise.resolve(fakeResponse(404)));
+    const { emit, events } = collect();
+    teardown = installNetwork(emit);
+
+    await window.fetch('http://localhost:8787/api/missing');
+    await flushBody();
+
+    expect(eventOf(events, EventType.NET_REQUEST)).toMatchObject({
+      status: 404,
+      ok: false,
+      initiator: 'fetch',
+    });
+  });
+
   it('captures the method from init for a POST (completion is the second event)', async () => {
     window.fetch = vi.fn(() => Promise.resolve(fakeResponse(200)));
     const { emit, events } = collect();
@@ -708,5 +738,22 @@ describe('installNetwork (XMLHttpRequest)', () => {
     expect(done.length).toBe(2); // NOT 3 — the first send's listener must not re-fire on the second
     expect(done.map((e) => e.data['url'])).toEqual(['/first', '/second']);
     expect(done.map((e) => e.data['status'])).toEqual([200, 201]);
+  });
+
+  it('classifies a 3xx XHR as ok (matching fetch)', () => {
+    window.XMLHttpRequest = FakeXHR as unknown as typeof XMLHttpRequest;
+    const { emit, events } = collect();
+    const teardown = installNetwork(emit);
+    const xhr = new window.XMLHttpRequest() as unknown as FakeXHR;
+    xhr.open('POST', '/api/login');
+    xhr.send();
+    xhr.complete({ status: 303 });
+    teardown();
+
+    expect(events.find((e) => e.type === EventType.NET_REQUEST)?.data).toMatchObject({
+      status: 303,
+      ok: true,
+      initiator: 'xhr',
+    });
   });
 });

--- a/packages/browser/src/observers/network.ts
+++ b/packages/browser/src/observers/network.ts
@@ -286,7 +286,7 @@ export function installNetwork(emit: Emit, opts: NetworkOptions = {}): Teardown 
           method,
           url,
           status: res.status,
-          ok: res.ok,
+          ok: res.status >= 200 && res.status < 400,
           durationMs: Math.round(headersAt - start),
           initiator: 'fetch',
           ...initiatorFields,


### PR DESCRIPTION
## Summary

- Fixes #367: fetch observer used `res.ok` (200-299 only) while XHR used `status >= 200 && status < 400`
- A POST-redirect-GET login (303) via fetch was graded as failed, triggering false `UI_ADVANCED_REQUEST_FAILED` contradictions
- Aligns fetch to the same `status >= 200 && status < 400` boundary the XHR path uses

## Test plan

- [x] Added fetch 3xx test: `classifies a 3xx redirect as ok (matching XHR behavior)` — asserts `ok: true` for status 303
- [x] Added fetch 4xx test: `classifies a 4xx as not ok via fetch` — asserts `ok: false` for status 404
- [x] Added XHR 3xx mirror test: `classifies a 3xx XHR as ok (matching fetch)` — confirms existing XHR behavior
- [x] Contradiction detector (`contradictions.ts`) already uses `(status ?? 0) < 400` — no change needed
- [ ] `pnpm test:e2e` (touches the observer wire surface)

Signed-off-by: Dev Chiniwala <dev.chiniwala@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)