### PR TITLE
fix(server): explicit until predicate overrides settlement heuristic

### DIFF
--- a/packages/server/src/honesty/verified.test.ts
+++ b/packages/server/src/honesty/verified.test.ts
@@ -355,3 +355,45 @@ describe('every verdict names the clause that decided it', () => {
     expect([...Object.values(VerifiedReason)].filter((r) => !produced.has(r))).toEqual([]);
   });
 });
+
+describe('an explicit until predicate that passed overrides settlement', () => {
+  it('pass:true + untilDeclared + settled:false = PROVED (not UNSETTLED)', () => {
+    const v = decideVerified({
+      pass: true,
+      honesty: clean(),
+      settled: false,
+      untilDeclared: true,
+    });
+    expect(v.verified).toBe(Verified.YES);
+    expect(v.verifiedReason).toBe(VerifiedReason.PROVED);
+  });
+
+  it('pass:true + NO untilDeclared + settled:false = still UNSETTLED (existing behavior)', () => {
+    const v = decideVerified({ pass: true, honesty: clean(), settled: false });
+    expect(v.verified).toBe(Verified.UNKNOWN);
+    expect(v.verifiedReason).toBe(VerifiedReason.UNSETTLED);
+  });
+
+  it('pass:false + untilDeclared + settled:false = ASSERTION_FAILED (failure still outranks)', () => {
+    const v = decideVerified({
+      pass: false,
+      honesty: clean(),
+      settled: false,
+      untilDeclared: true,
+    });
+    expect(v.verified).toBe(Verified.NO);
+    expect(v.verifiedReason).toBe(VerifiedReason.ASSERTION_FAILED);
+  });
+
+  it('pass:true + untilDeclared + observed contradiction + settled:false = CONTRADICTED', () => {
+    const v = decideVerified({
+      pass: true,
+      honesty: clean(),
+      settled: false,
+      untilDeclared: true,
+      contradictions: [{ kind: 'ui-advanced-request-failed' }],
+    });
+    expect(v.verified).toBe(Verified.NO);
+    expect(v.verifiedReason).toBe(VerifiedReason.CONTRADICTED);
+  });
+});

--- a/packages/server/src/honesty/verified.ts
+++ b/packages/server/src/honesty/verified.ts
@@ -52,6 +52,8 @@ interface VerifiedInputs {
    * never read. See `hasUnreadWriteOutcome` — the status line describes the transport, not the result.
    */
   outcomeUnread?: boolean;
+  /** True when the caller passed an explicit `until` predicate to the tool. */
+  untilDeclared?: boolean;
   /**
    * What the wait was for and what the window held when it ended — read ONLY by the two clauses that
    * answer UNSETTLED, which is the commonest reason a verdict comes back `unknown` and was also the
@@ -230,7 +232,11 @@ export function decideVerified(inputs: VerifiedInputs): VerifiedVerdict {
   }
 
   // Never settled: the page may still be moving, so the observation window may have closed early.
-  if (false === settled) {
+  // Exception: when the caller declared an explicit `until` predicate and it passed, the predicate
+  // IS the evidence — settlement is a fallback heuristic, not a higher authority. Five agent reports
+  // across four apps showed the predicate satisfied but verdict overridden to unknown/unsettled
+  // because idle never arrived (poll churn, throttled tab).
+  if (false === settled && !(true === inputs.untilDeclared && true === pass)) {
     return {
       verified: Verified.UNKNOWN,
       verifiedReason: VerifiedReason.UNSETTLED,

--- a/packages/server/src/tools/act-tools.ts
+++ b/packages/server/src/tools/act-tools.ts
@@ -600,6 +600,7 @@ export const ACT_TOOLS: ToolDef[] = [
         // this is the only one that has to be interpreted, and now it interprets itself.
         const outcomePending = hasAcceptedWrite(windowEvents);
         const outcomeUnread = hasUnreadWriteOutcome(windowEvents);
+        const untilDeclared = withUntil['until'] !== undefined;
         const decision = decideVerified({
           pass: verdict.pass,
           ...(alreadyTrue ? { alreadyTrue } : {}),
@@ -613,6 +614,7 @@ export const ACT_TOOLS: ToolDef[] = [
           contradictions,
           ...(outcomePending ? { outcomePending } : {}),
           ...(outcomeUnread ? { outcomeUnread } : {}),
+          ...(untilDeclared ? { untilDeclared } : {}),
           // `settled` is genuinely optional: a wait that declared no predicate never measured it, and
           // passing `false` there would report "never settled" about something never asked to settle.
           ...(settledOutcome === undefined ? {} : { settled: settledOutcome }),


### PR DESCRIPTION
## Summary

- Fixes #375: `act_and_wait { until }` was returning `unknown/unsettled` even when the declared predicate passed, because the settlement clause fired unconditionally
- Five agent reports across four apps showed the predicate satisfied but verdict overridden because idle never arrived (poll churn, throttled tab)
- Gates the settlement clause: when `untilDeclared && pass`, the predicate IS the evidence — skip the unsettled override and let verdict reach PROVED

## Test plan

- [x] `pass:true + untilDeclared + settled:false` → PROVED (the fix)
- [x] `pass:true + NO untilDeclared + settled:false` → still UNSETTLED (existing behavior preserved)
- [x] `pass:false + untilDeclared + settled:false` → ASSERTION_FAILED (failure still outranks)
- [x] `pass:true + untilDeclared + observed contradiction + settled:false` → CONTRADICTED (contradiction still outranks)
- [x] Existing test `'is UNKNOWN when the page never settled'` passes unchanged (no `untilDeclared`)
- [ ] `pnpm test:e2e` (touches the tool surface)

Signed-off-by: Dev Chiniwala <dev.chiniwala@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)