### PR TITLE
fix(browser): synchronize controlled inputs and attribution on check/uncheck (#370)

### DIFF
--- a/packages/browser/src/actions/actions.check.test.ts
+++ b/packages/browser/src/actions/actions.check.test.ts
@@ -86,4 +86,75 @@ describe('check/uncheck drive the control instead of assigning it', () => {
     // succeed silently — a state no user could reach, returned as a green.
     await expect(executeAction(refs.refFor(el), ActionType.CHECK, {})).rejects.toThrow(/disabled/);
   });
+
+  it('dispatches input and change events so React controlled inputs update state', async () => {
+    const el = box();
+    const events: string[] = [];
+    el.addEventListener('input', () => events.push('input'));
+    el.addEventListener('change', () => events.push('change'));
+
+    await executeAction(refs.refFor(el), ActionType.CHECK, {});
+
+    expect(events).toContain('input');
+    expect(events).toContain('change');
+    expect(el.checked).toBe(true);
+  });
+
+  it('dispatches events when checking an already-checked box to sync value trackers', async () => {
+    const el = box({ checked: true });
+    const events: string[] = [];
+    el.addEventListener('input', () => events.push('input'));
+    el.addEventListener('change', () => events.push('change'));
+
+    await executeAction(refs.refFor(el), ActionType.CHECK, {});
+
+    expect(el.checked).toBe(true);
+    expect(events).toContain('input');
+    expect(events).toContain('change');
+  });
+
+  it('reports prevention even when stopPropagation is called on click', async () => {
+    const el = box();
+    el.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    });
+    const out = (await executeAction(refs.refFor(el), ActionType.CHECK, {})) as {
+      effect?: { defaultPrevented?: boolean };
+    };
+    expect(
+      out.effect?.defaultPrevented,
+      'capture-phase probe must catch cancelled activation despite stopPropagation',
+    ).toBe(true);
+    expect(el.checked, 'cancelled checkbox must not end up checked').toBe(false);
+  });
+
+  it('refuses to uncheck a radio button directly', async () => {
+    const radio = document.createElement('input');
+    radio.type = 'radio';
+    radio.checked = true;
+    document.body.appendChild(radio);
+
+    await expect(executeAction(refs.refFor(radio), ActionType.UNCHECK, {})).rejects.toThrow(
+      /cannot uncheck a radio button/,
+    );
+  });
+
+  it('dispatches exactly one input and change event per state change', async () => {
+    const el = box();
+    let inputCount = 0;
+    let changeCount = 0;
+    el.addEventListener('input', () => {
+      inputCount++;
+    });
+    el.addEventListener('change', () => {
+      changeCount++;
+    });
+
+    await executeAction(refs.refFor(el), ActionType.CHECK, {});
+
+    expect(el.checked).toBe(true);
+    expect(inputCount, 'must not double-dispatch input event').toBe(1);
+    expect(changeCount, 'must not double-dispatch change event').toBe(1);
+  });
 });

--- a/packages/browser/src/actions/actions.ts
+++ b/packages/browser/src/actions/actions.ts
@@ -7,7 +7,13 @@ import {
   SettleReason,
 } from '@reticlehq/core';
 import { echoRef, refs } from '../dom/refs.js';
-import { assertEditable, assertNotRichText, setNativeValue } from './value-input.js';
+import {
+  assertEditable,
+  assertNotRichText,
+  setNativeChecked,
+  setNativeValue,
+} from './value-input.js';
+
 import { getAccessibleName, getRole, isVisible, getStates } from '../dom/a11y.js';
 import { elementHasHoverHandlers, identifyComponent } from '../registry/adapters.js';
 import { isForm, isHtmlElement, isInput, isSelect, isTextArea } from '../dom/realm.js';
@@ -202,7 +208,12 @@ const FILL_LIKE = new Set<string>([
 const isFillLike = (action: string): boolean => FILL_LIKE.has(action);
 
 /** Actions that resolve to a point and so benefit from off-viewport scroll + occlusion hit-test. */
-const CLICK_LIKE = new Set<string>([ActionType.CLICK, ActionType.DBLCLICK]);
+const CLICK_LIKE = new Set<string>([
+  ActionType.CLICK,
+  ActionType.DBLCLICK,
+  ActionType.CHECK,
+  ActionType.UNCHECK,
+]);
 
 function dangerousActionContext(el: HTMLElement): string {
   const form = el.closest('form');
@@ -320,6 +331,8 @@ function assertActionAllowed(el: HTMLElement, action: string, args: Record<strin
   const canTrigger =
     action === ActionType.CLICK ||
     action === ActionType.DBLCLICK ||
+    action === ActionType.CHECK ||
+    action === ActionType.UNCHECK ||
     action === ActionType.DRAG ||
     action === ActionType.SUBMIT ||
     // Read through the SAME resolver as the dispatch below. Reading a different argument here meant
@@ -572,29 +585,29 @@ async function dispatchOther(
           `cannot ${action} a disabled control — a real user could not, so neither will Reticle`,
         );
       }
-      const wanted = action === ActionType.CHECK;
-      // Already there: report success and touch nothing. `check` means "end up checked", not
-      // "toggle", so clicking here would flip it OFF and hand the app an event no user produced.
-      if (el.checked === wanted) return false;
-      // `click()`, never `el.checked = …`. Assigning the property flips the pixel and tells no
-      // framework: React binds a checkbox's onChange to the CLICK event, and its value tracker
-      // dedups the change it would otherwise synthesise from a direct assignment — so a controlled
-      // `checked={state}` box never heard from us while the action reported success. `click()` is
-      // the one DOM call that runs the element's ACTIVATION BEHAVIOUR (the native toggle) as well
-      // as firing the event; `dispatchEvent` does not.
-      let prevented = false;
-      // On window, so it runs after every listener on the element itself whenever they were added.
-      const probe = (e: Event): void => {
-        prevented = e.defaultPrevented;
-      };
-      window.addEventListener('click', probe, { once: true, capture: false });
-      try {
-        el.click();
-      } finally {
-        window.removeEventListener('click', probe, false);
+      const wanted = ActionType.CHECK === action;
+      if ('radio' === el.type && !wanted) {
+        throw new Error(
+          'cannot uncheck a radio button — a real user could not, radio buttons can only be deselected by selecting another radio in the group',
+        );
       }
-      return prevented;
+      // When already in the target state: run setNativeChecked so value trackers and controlled
+      // listeners receive events, without clicking and flipping the state off.
+      if (wanted === el.checked) {
+        return setNativeChecked(el, wanted);
+      }
+
+      // When state differs: dispatching a real click runs activation behaviour (native toggle + events)
+      // without duplicate event emission.
+      const event = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      });
+      const notPrevented = el.dispatchEvent(event);
+      return !notPrevented || event.defaultPrevented;
     }
+
     case ActionType.SUBMIT: {
       const form = isForm(el) ? el : el.closest('form');
       if (null === form) throw new Error('no form to submit');

--- a/packages/browser/src/actions/value-input.ts
+++ b/packages/browser/src/actions/value-input.ts
@@ -1,4 +1,4 @@
-import { captureValueSetter } from '../patching/capture-method.js';
+import { captureCheckedSetter, captureValueSetter } from '../patching/capture-method.js';
 import { valuePrototypeOf } from '../dom/realm.js';
 
 /**
@@ -21,6 +21,24 @@ export function setNativeValue(el: HTMLInputElement | HTMLTextAreaElement, value
     setter.call(el, value);
   } else {
     el.value = value;
+  }
+  const notPrevented = el.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
+  el.dispatchEvent(new Event('change', { bubbles: true }));
+  return !notPrevented;
+}
+
+/**
+ * Set checked on a controlled checkbox/radio the way React expects (native setter + input & change events).
+ * Returns true if defaultPrevented was triggered by any listener, false otherwise.
+ */
+export function setNativeChecked(el: HTMLInputElement, checked: boolean): boolean {
+  // Realm-aware: a controlled input inside a same-origin frame has its own prototype.
+  const proto = valuePrototypeOf(el);
+  const setter = proto === undefined ? undefined : captureCheckedSetter(proto);
+  if (setter !== undefined) {
+    setter.call(el, checked);
+  } else {
+    el.checked = checked;
   }
   const notPrevented = el.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
   el.dispatchEvent(new Event('change', { bubbles: true }));

--- a/packages/browser/src/patching/capture-method.ts
+++ b/packages/browser/src/patching/capture-method.ts
@@ -36,3 +36,17 @@ export function captureValueSetter(
   const setter = captureMethod(descriptor, 'set');
   return setter as ((this: HTMLElement, value: string) => void) | undefined;
 }
+
+/**
+ * The `checked` setter defined on a prototype, for inputs whose checked state must be set the way
+ * the browser does it — React installs its own descriptor, and assigning `el.checked` directly skips
+ * the tracker it relies on to notice a change.
+ */
+export function captureCheckedSetter(
+  proto: object,
+): ((this: HTMLElement, value: boolean) => void) | undefined {
+  const descriptor = Object.getOwnPropertyDescriptor(proto, 'checked');
+  if (descriptor === undefined) return undefined;
+  const setter = captureMethod(descriptor, 'set');
+  return setter as ((this: HTMLElement, value: boolean) => void) | undefined;
+}

--- a/packages/react/src/actions-controlled.test.ts
+++ b/packages/react/src/actions-controlled.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { act, createElement, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { ActionType } from '@reticlehq/core';
+import { executeAction, refs } from '@reticlehq/browser';
+
+describe('React controlled inputs integration with check/uncheck actions', () => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  function ControlledCheckbox(): ReturnType<typeof createElement> {
+    const [checked, setChecked] = useState(false);
+    return createElement(
+      'label',
+      null,
+      createElement('input', {
+        type: 'checkbox',
+        'data-testid': 'agree-box',
+        checked,
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) => setChecked(e.target.checked),
+      }),
+      createElement('span', { 'data-testid': 'status-text' }, checked ? 'AGREED' : 'NOT_AGREED'),
+    );
+  }
+
+  it('updates React controlled component state and triggers re-render on check and uncheck', async () => {
+    const root = createRoot(container);
+    try {
+      act(() => root.render(createElement(ControlledCheckbox)));
+      const input = container.querySelector<HTMLInputElement>('[data-testid="agree-box"]');
+      const status = container.querySelector<HTMLElement>('[data-testid="status-text"]');
+      expect(input).not.toBeNull();
+      expect(status).not.toBeNull();
+      if (!input || !status) return;
+
+      expect(input.checked).toBe(false);
+      expect(status.textContent).toBe('NOT_AGREED');
+
+      await act(async () => {
+        await executeAction(refs.refFor(input), ActionType.CHECK, {});
+      });
+
+      expect(input.checked).toBe(true);
+      expect(status.textContent, 'React component re-rendered with new state').toBe('AGREED');
+
+      await act(async () => {
+        await executeAction(refs.refFor(input), ActionType.UNCHECK, {});
+      });
+
+      expect(input.checked).toBe(false);
+      expect(status.textContent, 'React component re-rendered back to unchecked state').toBe(
+        'NOT_AGREED',
+      );
+    } finally {
+      act(() => root.unmount());
+    }
+  });
+
+  function ControlledRadioGroup(): ReturnType<typeof createElement> {
+    const [selected, setSelected] = useState('a');
+    return createElement(
+      'div',
+      null,
+      createElement('input', {
+        type: 'radio',
+        name: 'group',
+        value: 'a',
+        'data-testid': 'radio-a',
+        checked: 'a' === selected,
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) => setSelected(e.target.value),
+      }),
+      createElement('input', {
+        type: 'radio',
+        name: 'group',
+        value: 'b',
+        'data-testid': 'radio-b',
+        checked: 'b' === selected,
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) => setSelected(e.target.value),
+      }),
+
+      createElement('span', { 'data-testid': 'selected-val' }, selected),
+    );
+  }
+
+  it('correctly transitions React controlled radio group selection', async () => {
+    const root = createRoot(container);
+    try {
+      act(() => root.render(createElement(ControlledRadioGroup)));
+      const radioA = container.querySelector<HTMLInputElement>('[data-testid="radio-a"]');
+      const radioB = container.querySelector<HTMLInputElement>('[data-testid="radio-b"]');
+      const span = container.querySelector<HTMLElement>('[data-testid="selected-val"]');
+      expect(radioA).not.toBeNull();
+      expect(radioB).not.toBeNull();
+      expect(span).not.toBeNull();
+      if (!radioA || !radioB || !span) return;
+
+      expect(radioA.checked).toBe(true);
+      expect(radioB.checked).toBe(false);
+      expect(span.textContent).toBe('a');
+
+      await act(async () => {
+        await executeAction(refs.refFor(radioB), ActionType.CHECK, {});
+      });
+
+      expect(radioB.checked).toBe(true);
+      expect(radioA.checked).toBe(false);
+      expect(span.textContent, 'React state updated from radio change').toBe('b');
+    } finally {
+      act(() => root.unmount());
+    }
+  });
+
+  it('is idempotent on already-checked React controlled component', async () => {
+    const root = createRoot(container);
+    try {
+      act(() => root.render(createElement(ControlledCheckbox)));
+      const input = container.querySelector<HTMLInputElement>('[data-testid="agree-box"]');
+      const status = container.querySelector<HTMLElement>('[data-testid="status-text"]');
+      expect(input).not.toBeNull();
+      expect(status).not.toBeNull();
+      if (!input || !status) return;
+
+      // First check: transitions false -> true
+      await act(async () => {
+        await executeAction(refs.refFor(input), ActionType.CHECK, {});
+      });
+      expect(input.checked).toBe(true);
+      expect(status.textContent).toBe('AGREED');
+
+      // Second check: already checked, remains checked and agreed
+      await act(async () => {
+        await executeAction(refs.refFor(input), ActionType.CHECK, {});
+      });
+      expect(input.checked, 'subsequent check must remain checked').toBe(true);
+      expect(status.textContent, 'component state remains AGREED').toBe('AGREED');
+    } finally {
+      act(() => root.unmount());
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #370.

This patch addresses three issues in `@reticlehq/browser` when executing `action: "check"` or `"uncheck"`:
1. **Missing Geometry & Attribution**: `CLICK_LIKE` previously omitted `CHECK` and `UNCHECK`, causing point geometry, off-viewport auto-scrolling, hit-test occlusion detection, and `component` / `source` attribution to be dropped from `ActionResult`.
2. **False Green on Same-State Execution**: When `wanted === el.checked`, Reticle previously returned early without dispatching events, leaving React-controlled inputs (`checked={val}`, `onChange={...}`) and framework value trackers desynchronized. We now invoke `setNativeChecked` (using realm-aware prototype setter capture and `input` / `change` event dispatch) to ensure frameworks observe the state while preserving cancellation status.
3. **Activation & Cancellation Semantics**: When `wanted !== el.checked`, dispatches a cancelable `MouseEvent('click')` running the browser's native activation behavior, correctly capturing `defaultPrevented` even if child listeners invoke `stopPropagation()`, and avoiding duplicate event dispatches.
4. **Radio Invariant**: Explicitly refuses direct `UNCHECK` actions on radio buttons with a clear error (`cannot uncheck a radio button — radio buttons can only be deselected by selecting another radio in the group`).

## Changes
- `packages/browser/src/actions/actions.ts`: Include `CHECK` / `UNCHECK` in `CLICK_LIKE` and `canTrigger`; harden `CHECK` / `UNCHECK` dispatch.
- `packages/browser/src/patching/capture-method.ts`: Export `captureCheckedSetter(proto)`.
- `packages/browser/src/actions/value-input.ts`: Implement `setNativeChecked(el, checked)`.
- `packages/browser/src/actions/actions.check.test.ts`: Add tests for cancellation, same-state dispatch, exact event counts, and radio refusal.
- `packages/react/src/actions-controlled.test.ts`: Add end-to-end integration tests with React 19 controlled checkboxes and radio groups.

## Validation Evidence
- `pnpm build`: 11/11 packages built successfully.
- `pnpm --filter @reticlehq/browser test:unit`: 101/101 test files passed (937/937 tests).
- `pnpm --filter @reticlehq/react test:unit`: 11/11 test files passed (67/67 tests).
- `pnpm lint`: 0 errors across all 16 packages.
