### PR TITLE
feat: docs site gate — post-deploy check for broken pages

### DIFF
--- a/.github/workflows/docs-site-gate.yml
+++ b/.github/workflows/docs-site-gate.yml
@@ -1,0 +1,23 @@
+name: Docs site gate
+
+# Fetches every page listed in docs.json from the live docs site and fails on any non-200.
+# Runs daily and on manual dispatch — NOT on PRs, because the site lags the merge and a PR-time
+# check would report the previous state.
+
+on:
+  schedule:
+    - cron: '0 8 * * *' # daily at 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+      - run: node scripts/check-docs-site.mjs

--- a/scripts/check-docs-site.mjs
+++ b/scripts/check-docs-site.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Post-deploy docs site gate: fetches every page listed in docs.json from the live site and fails
+ * on any non-200. Derived from the navigation (not a filesystem walk) so it checks exactly what a
+ * user can reach.
+ *
+ * Usage:
+ *   node scripts/check-docs-site.mjs [--base https://docs.reticle.sh]
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const BASE_URL = process.argv.includes('--base')
+  ? process.argv[process.argv.indexOf('--base') + 1]
+  : 'https://docs.reticle.sh';
+
+const docsJsonPath = resolve(import.meta.dirname, '..', 'docs', 'docs.json');
+const docsJson = JSON.parse(readFileSync(docsJsonPath, 'utf8'));
+
+function extractPages(obj) {
+  const pages = [];
+  if (Array.isArray(obj)) {
+    for (const item of obj) {
+      if (typeof item === 'string') {
+        pages.push(item);
+      } else if (typeof item === 'object' && item !== null) {
+        pages.push(...extractPages(item));
+      }
+    }
+  } else if (typeof obj === 'object' && obj !== null) {
+    if (Array.isArray(obj.pages)) {
+      pages.push(...extractPages(obj.pages));
+    }
+    if (Array.isArray(obj.groups)) {
+      pages.push(...extractPages(obj.groups));
+    }
+    if (Array.isArray(obj.tabs)) {
+      pages.push(...extractPages(obj.tabs));
+    }
+    if (Array.isArray(obj.versions)) {
+      pages.push(...extractPages(obj.versions));
+    }
+  }
+  return pages;
+}
+
+const allPages = [...new Set(extractPages(docsJson.navigation))];
+
+if (allPages.length === 0) {
+  console.error('No pages found in docs.json navigation — check the structure.');
+  process.exit(1);
+}
+
+console.log(`Checking ${allPages.length} pages against ${BASE_URL} ...\n`);
+
+const failures = [];
+const CONCURRENCY = 5;
+let checked = 0;
+
+async function checkPage(page) {
+  const url = `${BASE_URL}/${page}`;
+  try {
+    const res = await fetch(url, { method: 'HEAD', redirect: 'follow' });
+    checked++;
+    if (res.status !== 200) {
+      failures.push({ page, status: res.status });
+      console.log(`  ✗ ${page} → ${res.status}`);
+    } else {
+      process.stdout.write(`\r  checked ${checked}/${allPages.length}`);
+    }
+  } catch (err) {
+    checked++;
+    failures.push({ page, status: `error: ${err.message}` });
+    console.log(`  ✗ ${page} → ${err.message}`);
+  }
+}
+
+async function run() {
+  for (let i = 0; i < allPages.length; i += CONCURRENCY) {
+    const batch = allPages.slice(i, i + CONCURRENCY);
+    await Promise.all(batch.map(checkPage));
+  }
+  console.log('\n');
+  if (failures.length > 0) {
+    console.error(`${failures.length} page(s) did not return 200:\n`);
+    for (const f of failures) {
+      console.error(`  ${f.page} → ${f.status}`);
+    }
+    process.exit(1);
+  }
+  console.log(`All ${allPages.length} pages returned 200.`);
+}
+
+run();

--- a/scripts/check-docs-site.mjs
+++ b/scripts/check-docs-site.mjs
@@ -4,6 +4,13 @@
  * on any non-200. Derived from the navigation (not a filesystem walk) so it checks exactly what a
  * user can reach.
  *
+ * Also checks the .md variant of each page (the agent reading path — what llms.txt links to) and
+ * /llms.txt itself (the entry point for the whole agent path).
+ *
+ * Assumes the site returns a real 404 (not a 200 SPA shell) and answers HEAD. Both are true today
+ * but neither is guaranteed by anything we control — if the host changes routing, this gate
+ * silently stops catching broken pages.
+ *
  * Usage:
  *   node scripts/check-docs-site.mjs [--base https://docs.reticle.sh]
  */
@@ -52,7 +59,20 @@ if (allPages.length === 0) {
   process.exit(1);
 }
 
-console.log(`Checking ${allPages.length} pages against ${BASE_URL} ...\n`);
+// The .md variant of each page is the agent reading path (what llms.txt links to). It is served
+// by a different route, so a page can be fine and its .md broken — and the reader it breaks is
+// the one we care most about.
+const mdPages = allPages.map((page) => `${page}.md`);
+
+// /llms.txt is the entry point for the whole agent path — if it 404s, every other page being
+// green is beside the point.
+const entryPoints = ['llms.txt'];
+
+const allChecks = [...allPages, ...mdPages, ...entryPoints];
+
+console.log(
+  `Checking ${allPages.length} pages + ${mdPages.length} .md variants + ${entryPoints.length} entry point(s) against ${BASE_URL} ...\n`,
+);
 
 const failures = [];
 const CONCURRENCY = 5;
@@ -67,7 +87,7 @@ async function checkPage(page) {
       failures.push({ page, status: res.status });
       console.log(`  ✗ ${page} → ${res.status}`);
     } else {
-      process.stdout.write(`\r  checked ${checked}/${allPages.length}`);
+      process.stdout.write(`\r  checked ${checked}/${allChecks.length}`);
     }
   } catch (err) {
     checked++;
@@ -77,8 +97,8 @@ async function checkPage(page) {
 }
 
 async function run() {
-  for (let i = 0; i < allPages.length; i += CONCURRENCY) {
-    const batch = allPages.slice(i, i + CONCURRENCY);
+  for (let i = 0; i < allChecks.length; i += CONCURRENCY) {
+    const batch = allChecks.slice(i, i + CONCURRENCY);
     await Promise.all(batch.map(checkPage));
   }
   console.log('\n');
@@ -89,7 +109,7 @@ async function run() {
     }
     process.exit(1);
   }
-  console.log(`All ${allPages.length} pages returned 200.`);
+  console.log(`All ${allChecks.length} URLs returned 200.`);
 }
 
 run();


### PR DESCRIPTION
## Summary

Closes #352 — adds the missing post-deploy check that would have caught the `/cli/doctor` and `/packages/core` 404s.

- **`scripts/check-docs-site.mjs`** — reads every page path from `docs.json` navigation, fetches it from the live site, fails on any non-200. Runs with `node scripts/check-docs-site.mjs` (optionally `--base <url>`).
- **`.github/workflows/docs-site-gate.yml`** — scheduled daily at 08:00 UTC + manual dispatch. NOT triggered on PRs, because the site lags the merge.
- Derives the page list from `docs.json` navigation (not filesystem) — so it checks exactly what a user navigates to.
- Found 99 pages, matching the issue's "all 99 sitemap URLs" count.

## Design decisions

Per the issue's guidance:
- Runs **after deploy**, not in PR CI (the site is a separate Mintlify deployment that lags)
- Derives from **`docs.json`** not a filesystem walk (a page that exists but isn't navigated is a different problem)
- Uses `HEAD` requests with `redirect: follow` (handles trailing-slash 308s correctly)
- Concurrency of 5 to be polite to the docs CDN

## Test plan

- [x] Page extraction finds all 99 pages from docs.json
- [x] Script exits 0 when all pages return 200
- [x] Script exits 1 and names the failing pages on non-200
- [x] `--base` override works for testing against staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)