### PR TITLE
fix(browser): classify 3xx redirects as ok:true in fetch observer

### DIFF
--- a/packages/browser/src/observers/network.test.ts
+++ b/packages/browser/src/observers/network.test.ts
@@ -499,6 +499,32 @@ describe('installNetwork (fetch)', () => {
     });
   });
 
+  it('classifies a 3xx redirect as ok:true (matching XHR behavior)', async () => {
+    window.fetch = vi.fn(() => Promise.resolve(fakeResponse(303)));
+    const { emit, events } = collect();
+    teardown = installNetwork(emit);
+    await window.fetch('http://localhost:8787/login', { method: 'POST' });
+    await flushBody();
+    expect(eventOf(events, EventType.NET_REQUEST)).toMatchObject({
+      method: 'POST',
+      status: 303,
+      ok: true,
+      initiator: 'fetch',
+    });
+  });
+
+  it('classifies a 4xx as ok:false via fetch (same as XHR)', async () => {
+    window.fetch = vi.fn(() => Promise.resolve(fakeResponse(404)));
+    const { emit, events } = collect();
+    teardown = installNetwork(emit);
+    await window.fetch('http://localhost:8787/missing');
+    await flushBody();
+    expect(eventOf(events, EventType.NET_REQUEST)).toMatchObject({
+      status: 404,
+      ok: false,
+    });
+  });
+
   it('restores the original fetch on teardown', () => {
     // Read as stored values on both sides: the assertion is about WHICH FUNCTION OBJECT sits in the
     // slot before and after, which is exactly what a descriptor read returns and what teardown has
@@ -708,5 +734,20 @@ describe('installNetwork (XMLHttpRequest)', () => {
     expect(done.length).toBe(2); // NOT 3 — the first send's listener must not re-fire on the second
     expect(done.map((e) => e.data['url'])).toEqual(['/first', '/second']);
     expect(done.map((e) => e.data['status'])).toEqual([200, 201]);
+  });
+
+  it('classifies a 3xx XHR as ok:true (matching fetch)', () => {
+    window.XMLHttpRequest = FakeXHR as unknown as typeof XMLHttpRequest;
+    const { emit, events } = collect();
+    const teardown = installNetwork(emit);
+    const xhr = new window.XMLHttpRequest() as unknown as FakeXHR;
+    xhr.open('POST', '/login');
+    xhr.send();
+    xhr.complete({ status: 303 });
+    teardown();
+
+    const done = events.find((e) => e.type === EventType.NET_REQUEST);
+    expect(done?.data['status']).toBe(303);
+    expect(done?.data['ok']).toBe(true);
   });
 });

--- a/packages/browser/src/observers/network.ts
+++ b/packages/browser/src/observers/network.ts
@@ -286,7 +286,7 @@ export function installNetwork(emit: Emit, opts: NetworkOptions = {}): Teardown 
           method,
           url,
           status: res.status,
-          ok: res.ok,
+          ok: res.status >= 200 && res.status < 400,
           durationMs: Math.round(headersAt - start),
           initiator: 'fetch',
           ...initiatorFields,


### PR DESCRIPTION
## Summary

- Aligns the fetch observer's `ok` classification with XHR: `status >= 200 && status < 400` instead of `Response.ok` (200–299 only)
- A POST-redirect-GET login (303) via fetch was graded as a failed request, triggering false `UI_ADVANCED_REQUEST_FAILED` contradictions — the most common auth flow on the web could not produce a clean verdict
- Adds regression tests pinning fetch/XHR parity for 3xx and 4xx status codes

## Root cause

The two network observers disagreed on what constitutes a successful request:
- **Fetch path** (line 289): `ok: res.ok` → true only for 200–299
- **XHR path** (line 437): `ok: this.status >= 200 && this.status < 400` → includes redirects

The contradiction detector trusts `ok` as authoritative when present, so a 303 arriving through fetch was stamped as a failure before it even reached the verdict logic.

## Fix

One-line change in the fetch observer + 3 regression tests (2 fetch, 1 XHR) that pin both transports to the same classification for the same status code, so they cannot drift apart again.

## Test plan

- [x] `pnpm --filter @reticlehq/browser exec vitest run src/observers/network.test.ts` — 45/45 pass
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — clean (pre-existing bench-app warning only)
- [x] Browser package typecheck — clean

Closes #367

Signed-off-by: Dev Chiniwala <dev.chiniwala@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)