### PR TITLE
docs: list every package and app in the architecture docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,17 +16,26 @@ packages/react         @reticlehq/react        — React adapter: DOM ref -> com
 packages/vite-plugin   @reticlehq/vite-plugin  — Vite integration: stamps source + auto-injects connect()
 packages/babel-plugin  @reticlehq/babel-plugin — stamps data-reticle-source (source mapping, React 19)
 packages/next          @reticlehq/next         — Next.js source mapping (keeps SWC) via withReticle (CJS)
+packages/electron      @reticlehq/electron     — Electron main-process adapter (IPC observer, capture)
+packages/tauri         reticle-tauri           — Tauri capture backend (RUST — outside every JS gate)
 packages/test          @reticlehq/test         — spec runner + matchers for CI (peer vitest)
 packages/eslint-plugin @reticlehq/eslint-plugin — dev-only lint rule: state changed ⇒ signal fired
-apps/bench-app         @reticlehq/bench-app    — Vite/React fixture used to dogfood Reticle
-apps/api               @reticlehq/api          — Express backend exercising real-world behaviors (CJS-ish .mjs)
-apps/next-smoke        @reticlehq/next-smoke   — Next.js 15 app verifying Reticle on Next
+apps/bench-app         @reticlehq/bench-app    — integration proof (Vite + React) AND the primary benchmark target
+apps/api               @reticlehq/api          — support infra: backend the web e2e battery drives against
+apps/next-smoke        @reticlehq/next-smoke   — integration proof: Next.js 15 App Router, RSC, SWC source mapping
+apps/electron-smoke    @reticlehq/electron-smoke — integration proof: real Electron app (Vite + React renderer)
+apps/tauri-smoke       @reticlehq/tauri-smoke  — integration proof: real Tauri v2 app (Rust commands via invoke)
+apps/e2e                @reticlehq/e2e          — support infra: the web e2e test runner itself
+apps/atlas             @reticlehq/atlas        — adversarial fixture: one realistically-sized app, emergent defects
+apps/large-dom-bench   @reticlehq/large-dom-bench — benchmark target: non-virtualized grid, vanilla (non-React) TS
+apps/vibe-builder-demo @reticlehq/vibe-builder-demo — product demo: AI app-builder with Reticle as the QA layer
+apps/examples          —                       — integration proof for frameworks with no smoke app (Remix, Astro)
 docs/                  — user-facing docs (getting-started, usage, token-efficiency, local-registry)
 SKILL.md               — PUBLIC skill for users integrating Reticle into their own project (the canonical paste-URL)
 plan/                  — research/design docs only, no code (ALWAYS gitignored)
 ```
 
-This is **one git repo** at the root (pnpm + turbo monorepo). The TS library packages are strict TypeScript; `@reticlehq/babel-plugin`/`@reticlehq/next` are plain CJS tooling and `apps/api`/ `apps/next-smoke` are local fixtures — all excluded from the build/lint/test gates.
+This is **one git repo** at the root (pnpm + turbo monorepo). The TS library packages are strict TypeScript; `@reticlehq/babel-plugin`/`@reticlehq/next` are plain CJS tooling, `packages/tauri` is Rust and invisible to every JS gate, and everything under `apps/` is a local fixture — all excluded from the build/lint/test gates. See [`apps/README.md`](apps/README.md) for what belongs under `apps/` and why.
 
 ## Service boundaries (who owns what)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,7 +43,7 @@ Reticle is a pnpm + Turborepo monorepo. The split is not cosmetic: each boundary
 | `@reticlehq/react` | the browser | The SDK **kit** you install in a browser app: re-exports the browser sensor (so one install gives both `reticle` and `install`) and maps a DOM node → React component → source `file:line` | Core works without the source-mapping half |
 | `@reticlehq/babel-plugin`, `@reticlehq/next`, `@reticlehq/vite-plugin` | build time | Stamp `data-reticle-source` for source mapping (and, for Vite, inject `connect()`) | Plain tooling |
 | `@reticlehq/electron` | Electron main process | Adapter for the desktop runtime: IPC observer, main-process capture | Desktop-only, outside the web gates |
-| `packages/tauri` (`reticle-tauri`) | Tauri (Rust) | Capture backend for the Tauri desktop runtime | Rust — outside every JS gate; compiled by CI's `rust`/`rust-macos` jobs |
+| `packages/tauri` (`reticle-tauri`) | Tauri (Rust) | Capture backend for the Tauri desktop runtime | Rust, outside every JS gate; compiled by CI's `rust`/`rust-macos` jobs |
 | `@reticlehq/test` | Node (dev dependency) | Spec runner + matchers used by CI's own test suites | Peer dependency on `vitest` |
 | `@reticlehq/eslint-plugin` | dev tooling | Repo-internal lint rule: a state change must fire a signal | Dev-only, never shipped in a user's bundle |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,10 @@ Reticle is a pnpm + Turborepo monorepo. The split is not cosmetic: each boundary
 | `@reticlehq/server` | Node | The bridge, the MCP server, the `reticle` CLI, flow/run storage | Never imports DOM APIs |
 | `@reticlehq/react` | the browser | The SDK **kit** you install in a browser app: re-exports the browser sensor (so one install gives both `reticle` and `install`) and maps a DOM node → React component → source `file:line` | Core works without the source-mapping half |
 | `@reticlehq/babel-plugin`, `@reticlehq/next`, `@reticlehq/vite-plugin` | build time | Stamp `data-reticle-source` for source mapping (and, for Vite, inject `connect()`) | Plain tooling |
+| `@reticlehq/electron` | Electron main process | Adapter for the desktop runtime: IPC observer, main-process capture | Desktop-only, outside the web gates |
+| `packages/tauri` (`reticle-tauri`) | Tauri (Rust) | Capture backend for the Tauri desktop runtime | Rust — outside every JS gate; compiled by CI's `rust`/`rust-macos` jobs |
+| `@reticlehq/test` | Node (dev dependency) | Spec runner + matchers used by CI's own test suites | Peer dependency on `vitest` |
+| `@reticlehq/eslint-plugin` | dev tooling | Repo-internal lint rule: a state change must fire a signal | Dev-only, never shipped in a user's bundle |
 
 > Note: pre-2.0, `@reticlehq/core` was a single umbrella package that re-exported all of the above under subpaths. In 2.0 the umbrella was retired and `@reticlehq/core` became the bottom-of-graph wire contract.
 


### PR DESCRIPTION
## What & why

Closes #378

`CLAUDE.md`'s monorepo layout listed 3 of the 10 directories under `apps/`, and `docs/architecture.md`'s package table listed 5 of the 11 under `packages/`. Both omitted `packages/electron` and `packages/tauri` entirely — a contributor reading either document formed a model of the repo missing the whole desktop half of the product.

`CLAUDE.md`'s layout table is the canonical one (`CONTRIBUTING.md`'s own copy already had the full package list right); this brings `docs/architecture.md`'s package table into agreement with it, and fills in `CLAUDE.md`'s app list from what's actually on disk under `apps/`.

Left out of scope: the issue also suggests a filesystem-drift guard so the two lists can't go stale again — happy to open that as a follow-up if still wanted, but wanted to land the doc-accuracy fix on its own first per the issue's suggested shape ("the guard" and "the doc fix" read as two separable pieces of work).

## How it was verified

Diffed the current `packages/*` and `apps/*` directory listings and each package's `package.json` `name` field against both documents by hand; every entry in the new tables corresponds to a real directory on disk.

## Gates run

- [x] `pnpm format:check` — docs-only change, no code touched (see `docs/gates.md` routing table: "Docs, README, comments only")
- [ ] `pnpm lint && pnpm typecheck && pnpm test:unit`
- [ ] `pnpm test:e2e`
- [ ] `pnpm gate:install`
- [ ] `pnpm test:e2e:desktop`
- [x] None of the code-gate tiers apply to this change

## Checklist

- [x] Every commit is signed off (`git commit -s`)
- [ ] Tests added/updated — N/A, no behavior change
- [x] No `any`, no free strings, no non-null `!` — N/A, docs only
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 1000-line cap
- [x] Docs updated (this PR is the docs update); no `CHANGELOG.md` entry — neither file documents a `@reticlehq/*` package behavior change
- [x] Not security-affecting