### PR TITLE
fix(server): gate no longer false-passes on zero recorded flows

### DIFF
--- a/packages/server/src/cli/cli-flow-commands.test.ts
+++ b/packages/server/src/cli/cli-flow-commands.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import type { Coverage } from '../flows/coverage.js';
+import type { GateResult } from '../flows/gate.js';
+import { buildGateOutcome } from './cli-flow-commands.js';
+
+function dimension(total: number, covered: number) {
+  return {
+    total,
+    covered,
+    pct: 0 === total ? 100 : Math.round((covered / total) * 100),
+    uncovered: [],
+  };
+}
+
+function coverageOf(total: number, covered: number): Coverage {
+  const flows = dimension(total, covered);
+  const empty = dimension(0, 0);
+  return { testids: empty, signals: empty, flows, overallPct: flows.pct };
+}
+
+const CLEAN_RESULT: GateResult = {
+  pass: true,
+  uncovered: [],
+  quarantined: [],
+  downgraded: [],
+  deleted: [],
+};
+
+describe('buildGateOutcome', () => {
+  it('a project with zero recorded flows does not pass, even though gateDecision and coverage are both vacuously green', () => {
+    // This is the bug in #365: `affected` is empty (nothing to be affected by) and
+    // `coverage.flows.pct` is vacuously 100 (no declared surface) — both correct on their own, but
+    // together they used to report `pass: true` / `coverage.pct: 100` for a project that has never
+    // recorded a single flow.
+    const outcome = buildGateOutcome(CLEAN_RESULT, coverageOf(0, 0), true);
+    expect(outcome.pass).toBe(false);
+    expect(outcome.reason).toMatch(/no flows recorded/);
+    expect(outcome.coverage).toEqual({ pct: 100, covered: 0, total: 0 });
+  });
+
+  it('a project with recorded flows and nothing affected still passes cleanly (no false reason)', () => {
+    const outcome = buildGateOutcome(CLEAN_RESULT, coverageOf(3, 3), false);
+    expect(outcome.pass).toBe(true);
+    expect(outcome.reason).toBeUndefined();
+  });
+
+  it('a real uncovered flow still blocks, independently of the zero-flows check', () => {
+    const result: GateResult = {
+      pass: false,
+      uncovered: ['checkout'],
+      quarantined: [],
+      downgraded: [],
+      deleted: [],
+    };
+    const outcome = buildGateOutcome(result, coverageOf(2, 1), false);
+    expect(outcome.pass).toBe(false);
+    expect(outcome.uncovered).toEqual(['checkout']);
+    expect(outcome.reason).toBeUndefined();
+  });
+
+  it('downgraded and deletedCoverage are still surfaced when present', () => {
+    const result: GateResult = {
+      pass: false,
+      uncovered: [],
+      quarantined: [],
+      downgraded: [{ flow: 'checkout', steps: [1] }],
+      deleted: ['billing'],
+    };
+    const outcome = buildGateOutcome(result, coverageOf(2, 2), false);
+    expect(outcome.downgraded).toEqual([{ flow: 'checkout', steps: [1] }]);
+    expect(outcome.deletedCoverage).toEqual(['billing']);
+  });
+});

--- a/packages/server/src/cli/cli-flow-commands.ts
+++ b/packages/server/src/cli/cli-flow-commands.ts
@@ -14,13 +14,13 @@ import { FlowStore } from '../flows/flows.js';
 import { RunStore } from '../runs/run-store.js';
 import { createNodeFileSystem, type FileSystemPort } from '../project/fs-port.js';
 import { affectedSavedFlows, type NamedFlow } from '../flows/flow-sources.js';
-import { gateDecision } from '../flows/gate.js';
+import { gateDecision, type DowngradedFlow, type GateResult } from '../flows/gate.js';
 import { FlakeStore } from '../flows/flake-store.js';
 import { formatBuddyStatus } from '../flows/buddy-status.js';
 import { CapsuleStore } from '../capsule/capsule-store.js';
 import { AssertionTiersStore } from '../flows/assertion-tiers-store.js';
 import { detectDowngrades } from '../flows/assertion-integrity.js';
-import { computeCoverage } from '../flows/coverage.js';
+import { computeCoverage, type Coverage } from '../flows/coverage.js';
 import { createWatchBatcher } from '../flows/watch-batcher.js';
 import { watch } from 'node:fs';
 import { log } from '../log.js';
@@ -155,6 +155,54 @@ export async function handleCapsules(): Promise<void> {
   }
 }
 
+export interface GateOutcome extends Record<string, unknown> {
+  pass: boolean;
+  uncovered: string[];
+  quarantined: string[];
+  downgraded?: DowngradedFlow[];
+  deletedCoverage?: string[];
+  /** Present when the outcome was forced non-pass for a reason `gateDecision` doesn't itself see. */
+  reason?: string;
+  coverage: { pct: number; covered: number; total: number };
+}
+
+/**
+ * Shape the `reticle_gate` log payload from a `gateDecision` result plus the run's flow coverage.
+ * Pure — split out of `handleGate` so this policy is unit-testable without the real filesystem.
+ *
+ * `noFlowsRecorded` overrides `pass` to `false` even though `gateDecision` correctly reports `true`
+ * for it in isolation: with zero flows, `affected` is vacuously empty (nothing to be affected by) and
+ * `coverage.flows.pct` is vacuously 100 (no declared surface to fall short of) — both right on their
+ * own terms, but combined they let `reticle gate` exit 0 on a project that has never recorded a single
+ * flow. That is the same false green `buildSuiteVerdict` was fixed for on the verify side (see
+ * `decision.ts`): the purest pass that can never go red. Kept out of `gateDecision` itself so its
+ * affected-flow-coverage contract — and its existing tests — stay untouched.
+ */
+export function buildGateOutcome(
+  result: GateResult,
+  coverage: Coverage,
+  noFlowsRecorded: boolean,
+): GateOutcome {
+  return {
+    pass: result.pass && !noFlowsRecorded,
+    uncovered: result.uncovered,
+    quarantined: result.quarantined,
+    ...(result.downgraded.length > 0 ? { downgraded: result.downgraded } : {}),
+    ...(result.deleted.length > 0 ? { deletedCoverage: result.deleted } : {}),
+    ...(noFlowsRecorded
+      ? {
+          reason:
+            'no flows recorded — record one (e.g. via `reticle drive`), then `reticle_flow_save`',
+        }
+      : {}),
+    coverage: {
+      pct: coverage.flows.pct,
+      covered: coverage.flows.covered,
+      total: coverage.flows.total,
+    },
+  };
+}
+
 /**
  * `reticle gate <file...>` — exit non-zero unless passing artifacts cover the flows affected by the
  * changed files. Flaky flows are quarantined (surfaced, not blocking). The environment-side enforcement
@@ -204,19 +252,9 @@ export async function handleGate(files: string[], since: string | undefined): Pr
       { testids: [], signals: [], flows: allFlows.map((f) => f.name) },
       { testids: [], signals: [], flows: passing },
     );
-    log('reticle_gate', {
-      pass: result.pass,
-      uncovered: result.uncovered,
-      quarantined: result.quarantined,
-      ...(result.downgraded.length > 0 ? { downgraded: result.downgraded } : {}),
-      ...(result.deleted.length > 0 ? { deletedCoverage: result.deleted } : {}),
-      coverage: {
-        pct: coverage.flows.pct,
-        covered: coverage.flows.covered,
-        total: coverage.flows.total,
-      },
-    });
-    if (!result.pass) process.exitCode = 1;
+    const outcome = buildGateOutcome(result, coverage, 0 === allFlows.length);
+    log('reticle_gate', outcome);
+    if (!outcome.pass) process.exitCode = 1;
   } catch (error) {
     log('reticle_gate_failed', { error: error instanceof Error ? error.message : String(error) });
     process.exitCode = 1;

--- a/packages/server/src/flows/gate.ts
+++ b/packages/server/src/flows/gate.ts
@@ -7,7 +7,7 @@
  */
 
 /** A flow whose assertions were WEAKENED since its last passing run. */
-interface DowngradedFlow {
+export interface DowngradedFlow {
   flow: string;
   /** Step indices whose mustHold dropped from a consequence to presence-only. */
   steps: number[];
@@ -26,7 +26,7 @@ interface GateInput {
   deleted?: readonly string[];
 }
 
-interface GateResult {
+export interface GateResult {
   /** True when every affected, non-flaky flow has a passing artifact AND nothing was weakened/deleted. */
   pass: boolean;
   /** Affected flows with no passing artifact and not flaky — these block the gate. */


### PR DESCRIPTION
## What & why

Closes #365.

`reticle gate` reported `pass: true` with `coverage.pct: 100` for a project that has never recorded a single flow. Both were correct in isolation — `affected` is vacuously empty (nothing to be affected by) and `coverage.flows.pct` is vacuously 100 (no declared surface to fall short of) — but combined they let the gate exit 0 on a project where no verification has ever run. Same false-green class `buildSuiteVerdict` was already fixed for on the verify side (`decision.ts`): the purest pass that can never go red.

## How it was verified

Extracted the `reticle_gate` log-payload shaping out of `handleGate` into a pure, exported `buildGateOutcome(result, coverage, noFlowsRecorded)` in `packages/server/src/cli/cli-flow-commands.ts`, so this policy is unit-testable without the real filesystem. `gateDecision`'s existing affected-flow-coverage contract (and its own tests in `gate.test.ts`) are untouched — `noFlowsRecorded` is layered on top rather than folded in.

New test file `packages/server/src/cli/cli-flow-commands.test.ts`, 4 cases against `buildGateOutcome` directly:
- zero flows recorded → `pass: false`, `reason` mentions "no flows recorded" (this is the RED→GREEN case: reverting the fix to `pass: result.pass` — no `noFlowsRecorded` guard — makes this fail with `expected true to be false`, confirmed locally before restoring the fix).
- flows recorded, nothing affected → stays a clean pass, no spurious `reason`.
- a real uncovered flow still blocks, independently of the zero-flows check.
- `downgraded` / `deletedCoverage` still surface when present.

One incidental fix needed along the way: `GateOutcome` had to extend `Record<string, unknown>` so it type-checks against `log()`'s `fields: Record<string, unknown>` parameter — the original inline object literal never hit this, since object literals get a pass TypeScript doesn't give a named interface passed by variable.

## Gates run

- [x] `pnpm lint && pnpm typecheck && pnpm test:unit` (~2 min — **always**)
- [ ] `pnpm test:e2e` (~8 min)
- [ ] `pnpm gate:install` (~15 min)
- [ ] `pnpm test:e2e:desktop` (~3 min)
- [x] None of the other tiers apply — this only touches `packages/server`'s CLI/flows layer, no tool surface, wire contract, observer, install path, or desktop code.

Note on `pnpm test:unit`: the targeted test file passes (4/4), and the full run is 399/402 files, 3854/3860 tests green. The 3 failures are pre-existing timeouts unrelated to this change — `src/cli/suggested-commands-exist.test.ts`, `src/telemetry/no-field-numbers.test.ts`, and `src/tools/docs-index-coverage.test.ts`, all `Test timed out in 5000ms` on doc/telemetry consistency checks I never touched, under heavy parallel build load on this machine. Happy to re-run if useful context, but nothing in the diff here comes near those files.

## Checklist

- [x] Every commit is signed off (`git commit -s`)
- [x] Tests added/updated (RED → GREEN); the change is covered by a test that would fail without it
- [x] No `any`, no free strings, no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 1000-line cap
- [ ] Docs/`CHANGELOG.md` — this changes the `reticle_gate` log payload shape (adds an optional `reason` field, and `pass` can now be `false` with zero flows), which is user-visible in CI logs; happy to add a changelog entry if that's the right call, didn't want to presume the wording.
- [ ] Not security-affecting.

🤖 Generated with the help of Claude Code, reviewed and tested by me before opening.