### PR TITLE
fix(honesty): a satisfied until predicate is not overridden by settlement

### DIFF
--- a/packages/server/src/honesty/verified.test.ts
+++ b/packages/server/src/honesty/verified.test.ts
@@ -355,3 +355,45 @@ describe('every verdict names the clause that decided it', () => {
     expect([...Object.values(VerifiedReason)].filter((r) => !produced.has(r))).toEqual([]);
   });
 });
+
+describe('a satisfied until predicate is not overridden by settlement', () => {
+  it('is YES when pass:true + untilDeclared + settled:false', () => {
+    const v = decideVerified({
+      pass: true,
+      untilDeclared: true,
+      honesty: clean(),
+      settled: false,
+    });
+    expect(v.verified).toBe(Verified.YES);
+    expect(v.verifiedReason).toBe(VerifiedReason.PROVED);
+  });
+
+  it('is still UNKNOWN when pass:true + NO untilDeclared + settled:false (existing behavior)', () => {
+    const v = decideVerified({ pass: true, honesty: clean(), settled: false });
+    expect(v.verified).toBe(Verified.UNKNOWN);
+    expect(v.verifiedReason).toBe(VerifiedReason.UNSETTLED);
+  });
+
+  it('is NO when pass:false + untilDeclared + settled:false (failure still outranks)', () => {
+    const v = decideVerified({
+      pass: false,
+      untilDeclared: true,
+      honesty: clean(),
+      settled: false,
+    });
+    expect(v.verified).toBe(Verified.NO);
+    expect(v.verifiedReason).toBe(VerifiedReason.ASSERTION_FAILED);
+  });
+
+  it('is NO when pass:true + untilDeclared + observed contradiction + settled:false', () => {
+    const v = decideVerified({
+      pass: true,
+      untilDeclared: true,
+      honesty: clean(),
+      contradictions: [{ kind: 'ui-advanced-request-failed' }],
+      settled: false,
+    });
+    expect(v.verified).toBe(Verified.NO);
+    expect(v.verifiedReason).toBe(VerifiedReason.CONTRADICTED);
+  });
+});

--- a/packages/server/src/honesty/verified.ts
+++ b/packages/server/src/honesty/verified.ts
@@ -53,6 +53,12 @@ interface VerifiedInputs {
    */
   outcomeUnread?: boolean;
   /**
+   * The caller declared an explicit `until` predicate (not just the default settle-wait). When a
+   * declared predicate passes, settlement is corroborating evidence, not a veto — the caller said
+   * what to look for and it was found.
+   */
+  untilDeclared?: boolean;
+  /**
    * What the wait was for and what the window held when it ended — read ONLY by the two clauses that
    * answer UNSETTLED, which is the commonest reason a verdict comes back `unknown` and was also the
    * least actionable. Optional: without it those clauses say exactly what they said before.
@@ -230,7 +236,11 @@ export function decideVerified(inputs: VerifiedInputs): VerifiedVerdict {
   }
 
   // Never settled: the page may still be moving, so the observation window may have closed early.
-  if (false === settled) {
+  // Exception: when the caller declared an explicit `until` predicate and it passed, settlement is
+  // corroborating evidence, not a veto. The caller said what to look for, it was found, and the
+  // page merely never went idle — the common case on a throttled tab an agent drives while the
+  // human works elsewhere.
+  if (false === settled && !(true === inputs.untilDeclared && true === pass)) {
     return {
       verified: Verified.UNKNOWN,
       verifiedReason: VerifiedReason.UNSETTLED,

--- a/packages/server/src/tools/act-tools.ts
+++ b/packages/server/src/tools/act-tools.ts
@@ -600,9 +600,11 @@ export const ACT_TOOLS: ToolDef[] = [
         // this is the only one that has to be interpreted, and now it interprets itself.
         const outcomePending = hasAcceptedWrite(windowEvents);
         const outcomeUnread = hasUnreadWriteOutcome(windowEvents);
+        const untilDeclared = withUntil['until'] !== undefined;
         const decision = decideVerified({
           pass: verdict.pass,
           ...(alreadyTrue ? { alreadyTrue } : {}),
+          ...(untilDeclared ? { untilDeclared } : {}),
           // An assertion nobody could evaluate must not be reported as one the app failed.
           ...(verdict.inconclusive === undefined ? {} : { inconclusive: verdict.inconclusive }),
           // Nor must one nobody could OBSERVE. This is the act path, so it is the one that produced


### PR DESCRIPTION
## Summary

- When `act_and_wait` declares an explicit `until` predicate and it passes, settlement no longer vetoes the verdict
- Adds `untilDeclared` to `VerifiedInputs` — threads from `act-tools.ts` where the caller's intent is known
- 4 new tests pin every interaction: untilDeclared+pass bypasses settlement, no-untilDeclared preserves existing behavior, failure still outranks, contradiction still outranks

## Root cause

`decideVerified` treats `settled: false` as an absolute veto (→ UNKNOWN/UNSETTLED). But when the caller explicitly named what to look for via `until`, and it was found (`pass: true`), the page merely never going idle is not evidence against the outcome — it's the normal state of a throttled tab an agent drives while the human works elsewhere.

Five agent reports, four apps:
- Tab click + text predicate matched → UNSETTLED (SPA poll churn)
- Save flow + toast appeared + 204 → UNSETTLED (tab throttled)
- Login + text matched → UNSETTLED (throttled tab)
- Internally contradictory: `settled: true` in payload but still UNSETTLED
- Disabled button + zero mutations → UNSETTLED (ignored devTooling request)

## Fix

One guard on the settlement clause in `decideVerified`:

```typescript
if (false === settled && !(true === inputs.untilDeclared && true === pass)) {
```

When `untilDeclared` is true and `pass` is true, the settlement clause is skipped and the verdict falls through to PROVED. All other clauses (contradictions, unclean capture, already-true, etc.) still outrank — this only removes the idle-settlement veto for a satisfied declared predicate.

## Test plan

- [x] `npx vitest run packages/server/src/honesty/` — 111/111 pass (all existing + 4 new)
- [x] `pnpm format:check` — clean
- [x] `eslint` on changed files — clean
- [x] Server package typecheck — clean

Closes #375

Signed-off-by: Dev Chiniwala <dev.chiniwala@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)