### PR TITLE
feat(daemon): find .reticle.json outside the daemon cwd

### DIFF
--- a/packages/server/src/cli/config-discovery.test.ts
+++ b/packages/server/src/cli/config-discovery.test.ts
@@ -1,0 +1,110 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { discoverConfigs, findRepoRoot } from './config-discovery.js';
+
+/**
+ * A monorepo whose config sits under `apps/web`, which is the shape the reporter hit: the daemon is
+ * started by the editor from somewhere else entirely and concludes the project is not wired.
+ */
+function buildMonorepo(root: string): void {
+  mkdirSync(join(root, '.git'), { recursive: true });
+  mkdirSync(join(root, 'apps', 'web'), { recursive: true });
+  mkdirSync(join(root, 'apps', 'docs'), { recursive: true });
+  mkdirSync(join(root, 'packages', 'ui'), { recursive: true });
+  writeFileSync(join(root, 'apps', 'web', '.reticle.json'), '{"port":4400}');
+}
+
+describe('config discovery', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'reticle-discovery-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('finds a config under apps/ when the cwd is the repo root', () => {
+    buildMonorepo(tmp);
+
+    const { configs } = discoverConfigs(tmp);
+
+    expect(configs).toEqual([join(tmp, 'apps', 'web', '.reticle.json')]);
+  });
+
+  it('finds a config in a sibling package from inside another one', () => {
+    buildMonorepo(tmp);
+
+    const { configs } = discoverConfigs(join(tmp, 'packages', 'ui'));
+
+    expect(configs).toContain(join(tmp, 'apps', 'web', '.reticle.json'));
+  });
+
+  it('reports every config rather than picking one', () => {
+    buildMonorepo(tmp);
+    writeFileSync(join(tmp, 'packages', 'ui', '.reticle.json'), '{}');
+
+    const { configs } = discoverConfigs(tmp);
+
+    expect(configs).toHaveLength(2);
+    expect(configs).toContain(join(tmp, 'apps', 'web', '.reticle.json'));
+    expect(configs).toContain(join(tmp, 'packages', 'ui', '.reticle.json'));
+  });
+
+  it('finds a config in a parent directory on the way up to the root', () => {
+    mkdirSync(join(tmp, '.git'), { recursive: true });
+    mkdirSync(join(tmp, 'src', 'admin'), { recursive: true });
+    writeFileSync(join(tmp, '.reticle.json'), '{}');
+
+    const { configs } = discoverConfigs(join(tmp, 'src', 'admin'));
+
+    expect(configs).toEqual([join(tmp, '.reticle.json')]);
+  });
+
+  it('reports where it looked when nothing is found', () => {
+    mkdirSync(join(tmp, '.git'), { recursive: true });
+    mkdirSync(join(tmp, 'apps', 'web'), { recursive: true });
+
+    const { configs, searched, repoRoot } = discoverConfigs(tmp);
+
+    expect(configs).toEqual([]);
+    expect(repoRoot).toBe(tmp);
+    expect(searched).toContain(tmp);
+    expect(searched).toContain(join(tmp, 'apps', 'web'));
+  });
+
+  it('stops at the repo root rather than walking into the user home', () => {
+    buildMonorepo(tmp);
+
+    const { searched, repoRoot } = discoverConfigs(join(tmp, 'apps', 'web'));
+
+    expect(repoRoot).toBe(tmp);
+    expect(searched.every((dir) => dir.startsWith(tmp))).toBe(true);
+  });
+
+  it('does not invent a repo root when there is no .git anywhere', () => {
+    mkdirSync(join(tmp, 'loose'), { recursive: true });
+
+    expect(findRepoRoot(join(tmp, 'loose'))).toBeUndefined();
+  });
+
+  it('still finds a config in the cwd when there is no repo around it', () => {
+    writeFileSync(join(tmp, '.reticle.json'), '{}');
+
+    const { configs, repoRoot } = discoverConfigs(tmp);
+
+    expect(repoRoot).toBeUndefined();
+    expect(configs).toEqual([join(tmp, '.reticle.json')]);
+  });
+
+  it('survives an unreadable workspace directory', () => {
+    mkdirSync(join(tmp, '.git'), { recursive: true });
+    writeFileSync(join(tmp, 'apps'), 'not a directory');
+
+    expect(() => discoverConfigs(tmp)).not.toThrow();
+  });
+});

--- a/packages/server/src/cli/config-discovery.ts
+++ b/packages/server/src/cli/config-discovery.ts
@@ -1,0 +1,111 @@
+/**
+ * Where the project's `.reticle.json` actually is, rather than where the daemon happens to stand.
+ *
+ * The daemon's working directory is an artifact of how the editor launched it. Cursor and friends
+ * start MCP servers from the user's home directory as often as not, so "no `.reticle.json` in the
+ * cwd" is a fact about our process, not about the user's project. A monorepo makes that obvious —
+ * the config sits under `apps/web` while the daemon stands at `C:\Users\<user>` — but it is equally
+ * true of any editor that does not chdir first.
+ *
+ * So: walk up to the repo root, then look in the conventional workspace locations under it. Report
+ * every config found rather than silently picking one, and report where we looked when there are
+ * none. An agent can choose between two candidates; it cannot choose from a message that says none
+ * exist.
+ */
+
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+/** Directories under the repo root that conventionally hold workspace packages. */
+const WORKSPACE_DIRS = ['apps', 'packages'] as const;
+
+/** Stop the upward walk here. Guards against runaway loops on a detached or unusual filesystem. */
+const MAX_WALK_DEPTH = 40;
+
+export interface ConfigDiscovery {
+  /** Repo root, identified by a `.git` entry. Undefined when the walk found none. */
+  repoRoot?: string;
+  /** Every `.reticle.json` found, absolute, in discovery order. Empty when there are none. */
+  configs: readonly string[];
+  /** Directories actually examined, absolute — what the message means by "where we looked". */
+  searched: readonly string[];
+}
+
+/** Is there a `.git` here? Works for both a real repo and a worktree/submodule file. */
+function isRepoRoot(dir: string): boolean {
+  return existsSync(join(dir, '.git'));
+}
+
+/**
+ * Walk up from `start` looking for a `.git`. Returns undefined rather than guessing when the walk
+ * reaches the filesystem root — a home directory with no repo in it is a real case, and pretending
+ * the root is a project would make the search below scan the user's entire home.
+ */
+export function findRepoRoot(start: string): string | undefined {
+  let dir = resolve(start);
+  for (let depth = 0; depth < MAX_WALK_DEPTH; depth += 1) {
+    if (isRepoRoot(dir)) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+  return undefined;
+}
+
+/** Immediate subdirectories of `dir`, or nothing if it is absent or unreadable. */
+function subdirectories(dir: string): string[] {
+  try {
+    return readdirSync(dir)
+      .map((entry) => join(dir, entry))
+      .filter((path) => {
+        try {
+          return statSync(path).isDirectory();
+        } catch {
+          return false;
+        }
+      });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Find every `.reticle.json` reachable from `start`: the cwd itself, each directory up to and
+ * including the repo root, then one level inside each conventional workspace directory under that
+ * root.
+ *
+ * Never throws. An unreadable directory is skipped rather than failing the whole search — this runs
+ * to build an error message, and a diagnostic that can itself fail is worse than a vague one.
+ */
+export function discoverConfigs(start: string): ConfigDiscovery {
+  const searched: string[] = [];
+  const configs: string[] = [];
+  const seen = new Set<string>();
+
+  const look = (dir: string): void => {
+    const absolute = resolve(dir);
+    if (seen.has(absolute)) return;
+    seen.add(absolute);
+    searched.push(absolute);
+    const candidate = join(absolute, '.reticle.json');
+    if (existsSync(candidate)) configs.push(candidate);
+  };
+
+  let dir = resolve(start);
+  const repoRoot = findRepoRoot(dir);
+  for (let depth = 0; depth < MAX_WALK_DEPTH; depth += 1) {
+    look(dir);
+    if (dir === repoRoot) break;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  if (undefined !== repoRoot) {
+    for (const workspace of WORKSPACE_DIRS) {
+      for (const packageDir of subdirectories(join(repoRoot, workspace))) look(packageDir);
+    }
+  }
+
+  return { repoRoot, configs, searched };
+}

--- a/packages/server/src/cli/config-discovery.ts
+++ b/packages/server/src/cli/config-discovery.ts
@@ -24,7 +24,7 @@ const MAX_WALK_DEPTH = 40;
 
 export interface ConfigDiscovery {
   /** Repo root, identified by a `.git` entry. Undefined when the walk found none. */
-  repoRoot?: string;
+  repoRoot?: string | undefined;
   /** Every `.reticle.json` found, absolute, in discovery order. Empty when there are none. */
   configs: readonly string[];
   /** Directories actually examined, absolute — what the message means by "where we looked". */

--- a/packages/server/src/session/no-session-diagnosis.test.ts
+++ b/packages/server/src/session/no-session-diagnosis.test.ts
@@ -429,3 +429,57 @@ describe('a configured port that disagrees with the bound port is named, not hin
     expect(why).not.toContain('disagree');
   });
 });
+
+describe('config discovery in the not-initialized message', () => {
+  const unwired = {
+    everConnected: false,
+    initialized: false,
+    listening: [] as number[],
+    port: 4400,
+    directory: '/home/user',
+  };
+
+  it('names the config it found instead of claiming there is none', () => {
+    // The reported shape: daemon in the home directory, config under apps/web.
+    const why = diagnoseNoSession({
+      ...unwired,
+      discoveredConfigs: ['/repo/apps/web/.reticle.json'],
+      searchedDirectories: ['/home/user', '/repo', '/repo/apps/web'],
+    });
+
+    expect(why).toContain('/repo/apps/web/.reticle.json');
+    // The old message's claim must not survive alongside the path that disproves it.
+    expect(why).not.toContain('There is no `.reticle.json` in');
+  });
+
+  it('names every config when there is more than one, and picks none', () => {
+    const why = diagnoseNoSession({
+      ...unwired,
+      discoveredConfigs: ['/repo/apps/web/.reticle.json', '/repo/apps/admin/.reticle.json'],
+      searchedDirectories: ['/repo'],
+    });
+
+    expect(why).toContain('/repo/apps/web/.reticle.json');
+    expect(why).toContain('/repo/apps/admin/.reticle.json');
+    expect(why).toContain('2 exist');
+  });
+
+  it('says where it looked when the search came back empty', () => {
+    const why = diagnoseNoSession({
+      ...unwired,
+      discoveredConfigs: [],
+      searchedDirectories: ['/repo', '/repo/apps/web'],
+    });
+
+    expect(why).toContain('/repo/apps/web');
+    expect(why).toContain('anywhere we looked');
+  });
+
+  it('keeps the old wording when no search was run', () => {
+    // An older caller that supplies no discovery must not be told a search found nothing.
+    const why = diagnoseNoSession(unwired);
+
+    expect(why).toContain('There is no `.reticle.json` in');
+    expect(why).not.toContain('anywhere we looked');
+  });
+});

--- a/packages/server/src/session/no-session-diagnosis.ts
+++ b/packages/server/src/session/no-session-diagnosis.ts
@@ -262,13 +262,13 @@ export function diagnoseNoSession(facts: NoSessionFacts): string {
               // rather than about our cwd, so it can be stated plainly — with where we looked, so
               // the reader can see whether their app was even in scope.
               `(2) No \`.reticle.json\` anywhere we looked (${listPaths(searched, 4)}). That is ` +
-              "the file `reticle init` writes, so the app may carry no Reticle SDK — though an app " +
+              'the file `reticle init` writes, so the app may carry no Reticle SDK — though an app ' +
               'wired by the Vite or Babel plugin carries the SDK without that file at all. If the ' +
               'app lives outside those directories, run `reticle init` in it.'
             : // No search result at all: an older caller, or discovery not run. Keep the previous
               // wording rather than overstate what one directory can prove.
               `(2) There is no \`.reticle.json\` in ${where}. That is the ` +
-              "file `reticle init` writes, so the app may carry no Reticle SDK — but check the " +
+              'file `reticle init` writes, so the app may carry no Reticle SDK — but check the ' +
               "app's OWN directory before re-running `init`: in a monorepo the daemon often runs " +
               'at the root while the app lives in a subdirectory, and an app wired by the Vite or ' +
               'Babel plugin carries the SDK without that file at all.';

--- a/packages/server/src/session/no-session-diagnosis.ts
+++ b/packages/server/src/session/no-session-diagnosis.ts
@@ -56,6 +56,28 @@ interface NoSessionFacts {
    * no `.reticle.json` at all and is working perfectly.
    */
   projectPort?: number;
+  /**
+   * Every `.reticle.json` found by searching outward from this daemon's directory — up to the repo
+   * root, then through the conventional workspace locations under it. See cli/config-discovery.ts.
+   *
+   * The daemon's cwd is an artifact of how the editor launched it, so its emptiness says nothing
+   * about the user's project. Reported from a Cursor monorepo: the daemon stood in the user's home
+   * directory, the config sat in `apps/web`, and the message concluded the project was not wired.
+   *
+   * Present and non-empty turns "there is no config" into "here is where it is". Present and empty
+   * is a much stronger claim than the old one, because the search was not confined to one directory
+   * — which is why `searchedDirectories` is reported alongside it rather than left implicit.
+   */
+  discoveredConfigs?: readonly string[];
+  /** Directories the search above actually examined. Names what "we looked" means. */
+  searchedDirectories?: readonly string[];
+}
+
+/** At most `limit` paths, comma-joined, with an honest tail when there are more. */
+function listPaths(paths: readonly string[], limit: number): string {
+  const shown = paths.slice(0, limit).join(', ');
+  const rest = paths.length - limit;
+  return rest > 0 ? `${shown}, and ${String(rest)} more` : shown;
 }
 
 /**
@@ -217,17 +239,47 @@ export function diagnoseNoSession(facts: NoSessionFacts): string {
     // So: report what was actually checked, name the directory, and name the case where the absence
     // is expected rather than diagnostic.
     if (!initialized) {
+      const found = facts.discoveredConfigs ?? [];
+      const searched = facts.searchedDirectories ?? [];
+      // What the second half says depends on what the search actually turned up, because the three
+      // cases call for three different next actions and the old single sentence covered only one.
+      const configHalf =
+        found.length > 0
+          ? // The reported case: the config exists, just not where this daemon stands. Naming the
+            // paths is the whole point — an agent can pick between two, and cannot pick from
+            // "there is none". Never silently choose one here.
+            `(2) This daemon's directory has no \`.reticle.json\`, but ${
+              1 === found.length ? 'one exists' : `${String(found.length)} exist`
+            } in this repo: ${listPaths(found, 4)}. The daemon's directory is set by whatever ` +
+            'launched it and often has nothing to do with the app, so this is very likely a ' +
+            `wired project rather than an uninitialised one. ${
+              1 === found.length
+                ? 'Restart the dev server from that directory, or point the daemon at it.'
+                : 'Pick the one for the app being worked on, and restart the dev server there.'
+            }`
+          : searched.length > 0
+            ? // Nothing found, but the search was wide. This is now a real claim about the project
+              // rather than about our cwd, so it can be stated plainly — with where we looked, so
+              // the reader can see whether their app was even in scope.
+              `(2) No \`.reticle.json\` anywhere we looked (${listPaths(searched, 4)}). That is ` +
+              "the file `reticle init` writes, so the app may carry no Reticle SDK — though an app " +
+              'wired by the Vite or Babel plugin carries the SDK without that file at all. If the ' +
+              'app lives outside those directories, run `reticle init` in it.'
+            : // No search result at all: an older caller, or discovery not run. Keep the previous
+              // wording rather than overstate what one directory can prove.
+              `(2) There is no \`.reticle.json\` in ${where}. That is the ` +
+              "file `reticle init` writes, so the app may carry no Reticle SDK — but check the " +
+              "app's OWN directory before re-running `init`: in a monorepo the daemon often runs " +
+              'at the root while the app lives in a subdirectory, and an app wired by the Vite or ' +
+              'Babel plugin carries the SDK without that file at all.';
+
       return (
         'no browser session connected. Two things to weigh, and neither of them is proof. ' +
         `(1) Nothing is listening on the ports Reticle scans (${SCANNED_PORTS}), so the dev server ` +
         'may not be running — ask the human to start it (`npm run dev`). That scan is narrow ' +
         'though: a server on any other port is invisible to it, so if the app IS running, ask for ' +
         'its URL rather than assuming it is down, and open it with `reticle open <url>`. ' +
-        `(2) There is no \`.reticle.json\` in ${where}. That is the ` +
-        "file `reticle init` writes, so the app may carry no Reticle SDK — but check the app's " +
-        'OWN directory before re-running `init`: in a monorepo the daemon often runs at the root ' +
-        'while the app lives in a subdirectory, and an app wired by the Vite or Babel plugin ' +
-        `carries the SDK without that file at all. ${RETRY}`
+        `${configHalf} ${RETRY}`
       );
     }
     return (

--- a/packages/server/src/session/no-session-watch.ts
+++ b/packages/server/src/session/no-session-watch.ts
@@ -13,6 +13,7 @@
 import { probeDevServers } from './dev-server-probe.js';
 import { diagnoseNoSession } from './no-session-diagnosis.js';
 import { readProjectPort } from '../cli/cli-port.js';
+import { discoverConfigs } from '../cli/config-discovery.js';
 import type { SessionManager } from './session-manager.js';
 
 /** Slow enough to be free, fast enough that a dev server started 15s ago is already reflected. */
@@ -77,6 +78,13 @@ function startNoSessionWatch(options: NoSessionWatchOptions): () => void {
       ...(() => {
         const configured = readProjectPort(options.directory ?? process.cwd());
         return configured === undefined ? {} : { projectPort: configured };
+      })(),
+      // Searched here rather than at boot, for the same reason as the port above: `init` can write
+      // the config after this daemon started. Cheap enough to redo per hint — it stats a handful of
+      // directories, and only ever runs while building an error message.
+      ...(() => {
+        const { configs, searched } = discoverConfigs(options.directory ?? process.cwd());
+        return { discoveredConfigs: configs, searchedDirectories: searched };
       })(),
     }),
   );


### PR DESCRIPTION
Makes config discovery search outward from the daemon's directory instead of reading only the cwd, and rewrites the second half of the no-session message around what the search actually found.

### Test first, against the reported shape

`config-discovery.test.ts` builds a fixture monorepo whose config sits under `apps/web` while the process cwd is somewhere else entirely — the case from the issue. 9 tests, all passing.

### `cli/config-discovery.ts`

`discoverConfigs(start)` returns `{ repoRoot, configs, searched }`:

- walks **up** from `start` to the repo root, marked by a `.git` entry
- then looks one level inside `apps/*` and `packages/*` under that root
- never throws — an unreadable directory is skipped. This runs only to build an error message, and a diagnostic that can itself fail is worse than a vague one
- returns `repoRoot: undefined` rather than guessing when there is no `.git` anywhere. Otherwise a daemon started in a home directory would treat it as a project root and scan the user's entire home

I did not read the workspace manifest for package globs, which the issue mentions as an option. `apps/*` and `packages/*` cover the reported case and the common layouts without taking on pnpm/yarn/npm/turbo manifest parsing. Happy to add it if you want the coverage.

### The message

The old branch had one sentence for a claim that now has three distinct states, so it splits:

| Search result | What the message says |
|---|---|
| One or more configs found | Names them, and says the daemon's directory is set by whatever launched it — so this is very likely a wired project, not an uninitialised one |
| Search ran, found nothing | "No `.reticle.json` anywhere we looked (…)", naming the directories |
| No search supplied | Unchanged from today |

Following the issue: **when more than one is found the message names them all and picks none.** A test pins that, because silently choosing one is exactly the failure the issue describes in reverse.

That third row matters for the standard this file holds itself to. `discoveredConfigs` is optional, so a caller that supplies nothing must not be told a search came back empty — that would be a stronger claim than the evidence supports, which is the failure mode documented all through this file. A test pins it.

Paths are capped at 4 with an "and N more" tail rather than pasting an unbounded list into an agent's context.

### Not addressed

The issue also floats letting the MCP client pass its workspace root, which is the information we actually want. That is a protocol change and I left it alone — this makes the daemon self-sufficient in the meantime.

### Checks

- `vitest run` on the server package: **3865 passed, 1 failed**
- The one failure is `project-identity.test.ts > projectFingerprint > reports `cwd` only when there is nothing else to key on`, which fails **identically on an unmodified checkout** — I verified both ways with `git stash`. Not from this change, though given it is about `cwd` fingerprinting you may want to look at it separately.
- `tsc --noEmit` reports `TS2307: Cannot find module '@reticlehq/core'` across the package — the workspace dependency is unbuilt in my checkout, present before my changes too. No errors in any file this PR touches.

Closes #373
