### PR TITLE
fix(probe): stop reporting a compiling dev server as absent

### DIFF
--- a/packages/server/src/session/dev-server-probe.test.ts
+++ b/packages/server/src/session/dev-server-probe.test.ts
@@ -1,0 +1,67 @@
+import { createServer, type Server } from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { probeDevServers } from './dev-server-probe.js';
+
+const servers: Server[] = [];
+
+/** A dev-server stand-in on `host`, answering `/` with a document after `delayMs`. */
+async function serve(port: number, host: string, delayMs = 0): Promise<void> {
+  const server = createServer((_req, res) => {
+    const answer = (): void => {
+      res.writeHead(200, { 'content-type': 'text/html' });
+      res.end('<!doctype html><title>app</title>');
+    };
+    if (0 === delayMs) answer();
+    else setTimeout(answer, delayMs);
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(port, host, resolve));
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((s) => new Promise((r) => s.close(r))));
+});
+
+describe('dev server probe', () => {
+  it('finds a server bound to the IPv4 wildcard', async () => {
+    // The reported case: `--host` binds 0.0.0.0 rather than 127.0.0.1, and the user was told
+    // nothing was listening. Probing `localhost` covers this, because Node tries both address
+    // families — this test is here so that a future switch back to a pinned address fails loudly.
+    await serve(45011, '0.0.0.0');
+
+    await expect(probeDevServers([45011])).resolves.toEqual([45011]);
+  });
+
+  it('finds a server bound to the IPv6 wildcard', async () => {
+    await serve(45012, '::');
+
+    await expect(probeDevServers([45012])).resolves.toEqual([45012]);
+  });
+
+  it('finds a server bound to the IPv4 loopback only', async () => {
+    await serve(45013, '127.0.0.1');
+
+    await expect(probeDevServers([45013])).resolves.toEqual([45013]);
+  });
+
+  it('reports nothing on a port with no listener', async () => {
+    await expect(probeDevServers([45014])).resolves.toEqual([]);
+  });
+
+  it('finds a dev server that is slow to answer its first request', async () => {
+    // A dev server compiling on first hit does not answer in a few hundred milliseconds. The old
+    // 400ms budget gave up on it and the message then said nothing was listening — the same
+    // conclusion as an empty port, from evidence that is nothing like it.
+    await serve(45015, '0.0.0.0', 900);
+
+    await expect(probeDevServers([45015])).resolves.toEqual([45015]);
+  }, 10_000);
+
+  it('returns found ports in ascending order', async () => {
+    await serve(45017, '0.0.0.0');
+    await serve(45016, '0.0.0.0');
+
+    await expect(probeDevServers([45017, 45016])).resolves.toEqual([45016, 45017]);
+  });
+});

--- a/packages/server/src/session/dev-server-probe.ts
+++ b/packages/server/src/session/dev-server-probe.ts
@@ -14,8 +14,21 @@ import { request } from 'node:http';
 import { DEV_SERVER_PORTS } from '../cli/cli-port.js';
 import { looksLikeDevServer } from './looks-like-dev-server.js';
 
-/** Give up fast: an HTTP answer from localhost either lands quickly or nothing is there. */
-const HTTP_PROBE_TIMEOUT_MS = 400;
+/**
+ * How long to wait for `GET /` before treating the port as empty.
+ *
+ * This used to be 400ms, on the reasoning that an answer from localhost either lands quickly or
+ * nothing is there. That is true of a served file and false of the first request to a dev server:
+ * Vite, Next and Nuxt compile the entry route on demand, and the first hit after boot routinely
+ * takes over a second. The probe gave up, `listening` came back empty, and the no-session message
+ * told an agent nothing was listening while a Nuxt server answered on :5000 — the same conclusion
+ * as an empty port, drawn from evidence that is nothing like it.
+ *
+ * The ports are probed with `Promise.all`, so this is the cost of the slowest port rather than the
+ * sum, and it is paid on a background refresh that nothing waits on. Buying a real answer for a
+ * compiling dev server is worth more than the latency.
+ */
+const HTTP_PROBE_TIMEOUT_MS = 2000;
 /**
  * `localhost`, not `127.0.0.1` — so BOTH address families are tried.
  *
@@ -23,6 +36,13 @@ const HTTP_PROBE_TIMEOUT_MS = 400;
  * the IPv4 loopback cannot see it. The old TCP probe had the same blind spot, which meant the
  * diagnostic could miss the very dev server it exists to find while still reporting an unrelated
  * service that happens to bind both stacks (macOS AirPlay does).
+ *
+ * This also covers the wildcard binds a `--host` dev server uses. Measured on Windows against a
+ * server on `0.0.0.0:5199`: `localhost` connects, `::1` is refused. Node tries both families for a
+ * name that resolves to several (`autoSelectFamily`, on by default from Node 20, and this package
+ * requires >= 20), so the loopback failure does not end the attempt. dev-server-probe.test.ts pins
+ * `0.0.0.0` and `::` so that a future switch back to a pinned address fails loudly rather than
+ * silently reintroducing the blind spot.
  */
 const PROBE_HOST = 'localhost';
 


### PR DESCRIPTION
Wrote the test the issue asks for first — a scan against a listener bound to `0.0.0.0` — and it passed before any change. So the wildcard-bind diagnosis turns out not to be the cause, and the real one is next to it.

### What the probe already handles

Measured on Windows, the platform the reporter hit, against a server on `0.0.0.0:5199`:

| Probe host | Result |
|---|---|
| `localhost` | connects, 200 |
| `127.0.0.1` | connects, 200 |
| `::1` | `ECONNREFUSED` |

The probe uses `localhost`, and Node tries both address families for a name that resolves to several (`autoSelectFamily`, default-on from Node 20; this package requires `>=20`). The `::1` refusal does not end the attempt. A server on `0.0.0.0` or `::` is found today.

Three tests now pin that — `0.0.0.0`, `::`, and `127.0.0.1`-only — so a future switch back to a pinned address fails loudly instead of silently reintroducing the blind spot the file's comment already warns about.

### What actually reproduces the report

The 400ms budget. A dev server compiling its entry route on first hit does not answer in 400ms — Vite, Next and Nuxt all do this, and the report is from a Nuxt server. The probe gave up, `listening` came back empty, and the message said nothing was listening.

That is the failure mode this file exists to prevent: the same conclusion as an empty port, drawn from evidence that is nothing like it. Reproduced with a server answering after 900ms:

```
timeout 400ms   -> not found (timeout)
timeout 2000ms  -> found (200)
```

The failing test is in the diff, and it fails on an unmodified checkout.

### The change

`HTTP_PROBE_TIMEOUT_MS` 400 -> 2000, with the reasoning recorded where the old "give up fast" comment was. The ports are probed with `Promise.all`, so this is the cost of the slowest port, not the sum, and it is paid on a background refresh that nothing waits on.

### What I did not change

The issue also asks for the message to separate "no server" from "no SDK" from "no tab" rather than listing every cause at equal weight. I left that alone deliberately — #373 rewrites the same branch of `diagnoseNoSession` around config discovery, and two PRs editing that prose would conflict for no good reason. This one is confined to the probe, which is the half that was actually wrong. Happy to take the message half in a follow-up once #373 settles.

Worth noting the two halves of the reporter's complaint have different causes: the port claim was a timeout, the SDK hedge is the cwd problem in #373. Fixing only one still leaves the combined "Reticle is not set up here" reading.

### Checks

- `vitest run src/session/` — **272 passed**, 31 files
- New file: `dev-server-probe.test.ts`, 6 tests, no probe tests existed before
