### PR TITLE
feat(predicate): allow scoping the text predicate to a subtree

### DIFF
--- a/packages/server/src/events/predicate-eval.ts
+++ b/packages/server/src/events/predicate-eval.ts
@@ -20,7 +20,21 @@ export type Predicate =
       state?: ElementState;
       absent?: boolean;
     }
-  | { kind: typeof PredicateKind.TEXT; contains: string; visible?: boolean; absent?: boolean }
+  | {
+      kind: typeof PredicateKind.TEXT;
+      contains: string;
+      visible?: boolean;
+      absent?: boolean;
+      /**
+       * Restrict the match to a subtree, as a CSS selector or a ref — the same field, and the same
+       * meaning, as `scope` on an element query.
+       *
+       * Without it the match is page-wide, and a word that appears both in a background tab label
+       * and in the dialog that just opened satisfies the predicate BEFORE the action runs, so
+       * `act_and_wait` reports `already_true` for an action that did exactly the right thing.
+       */
+      scope?: string;
+    }
   | {
       kind: typeof PredicateKind.NET;
       method?: string;
@@ -258,6 +272,7 @@ function predicateUnion() {
         contains: z.string(),
         visible: z.boolean().optional(),
         absent: z.boolean().optional(),
+        scope: z.string().optional(),
       })
       .strict(),
     z

--- a/packages/server/src/events/predicate-shape.test.ts
+++ b/packages/server/src/events/predicate-shape.test.ts
@@ -118,9 +118,7 @@ describe('scoping the text predicate', () => {
   });
 
   it('accepts `scope` with the `text` alias too', () => {
-    expect(
-      parsePredicate({ kind: PredicateKind.TEXT, text: 'Floor', scope: '#modal' }),
-    ).toEqual({
+    expect(parsePredicate({ kind: PredicateKind.TEXT, text: 'Floor', scope: '#modal' })).toEqual({
       kind: PredicateKind.TEXT,
       contains: 'Floor',
       scope: '#modal',

--- a/packages/server/src/events/predicate-shape.test.ts
+++ b/packages/server/src/events/predicate-shape.test.ts
@@ -103,3 +103,39 @@ describe('predicateFieldsFor stays derived from the schema', () => {
     expect(predicateFieldsFor('nope')).toEqual([]);
   });
 });
+
+describe('scoping the text predicate', () => {
+  it('accepts `scope` alongside `contains`', () => {
+    // Without this the strict schema rejects the whole predicate, and a rejected predicate costs
+    // the verdict entirely — see the header of this file.
+    expect(
+      parsePredicate({ kind: PredicateKind.TEXT, contains: 'Floor', scope: '[role=dialog]' }),
+    ).toEqual({
+      kind: PredicateKind.TEXT,
+      contains: 'Floor',
+      scope: '[role=dialog]',
+    });
+  });
+
+  it('accepts `scope` with the `text` alias too', () => {
+    expect(
+      parsePredicate({ kind: PredicateKind.TEXT, text: 'Floor', scope: '#modal' }),
+    ).toEqual({
+      kind: PredicateKind.TEXT,
+      contains: 'Floor',
+      scope: '#modal',
+    });
+  });
+
+  it('keeps the predicate page-wide when no scope is given', () => {
+    // Adding the field must not change what an existing caller means.
+    expect(parsePredicate({ kind: PredicateKind.TEXT, contains: 'Floor' })).toEqual({
+      kind: PredicateKind.TEXT,
+      contains: 'Floor',
+    });
+  });
+
+  it('names `scope` among the fields the text predicate accepts', () => {
+    expect(predicateFieldsFor(PredicateKind.TEXT)).toContain('scope');
+  });
+});

--- a/packages/server/src/events/predicate-text-scope.test.ts
+++ b/packages/server/src/events/predicate-text-scope.test.ts
@@ -1,0 +1,120 @@
+/**
+ * A scoped text predicate must actually narrow WHERE it looks.
+ *
+ * The shape tests pin that the schema accepts `scope` and that `parsePredicate` carries it, but
+ * neither reaches the forwarding in `evaluatePredicate`: drop the field on its way into the element
+ * query and both still pass. So this file asserts the only thing that fails when the forwarding is
+ * dropped — the match itself changing. The session below honours `scope` the way the browser does,
+ * with the same text present both inside and outside the container.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  asRef,
+  ReticleCommand,
+  type CommandResult,
+  type ElementDescriptor,
+  type ElementQuery,
+  type MatchResult,
+  type ReticleEvent,
+} from '@reticlehq/core';
+import { evaluatePredicate, type PredicateSession } from './predicate.js';
+
+const DIALOG = '[role=dialog]';
+
+/** An element on the page, plus the container it sits in — the DOM fact `scope` selects on. */
+interface Placed {
+  readonly element: ElementDescriptor;
+  readonly container?: string;
+}
+
+function button(ref: string): ElementDescriptor {
+  return { ref: asRef(ref), role: 'button', name: 'Delete', states: [], visible: true };
+}
+
+/** The same label twice: once inside the dialog, once in the page behind it. */
+const IN_DIALOG: Placed = { element: button('r-dialog'), container: DIALOG };
+const OUTSIDE: Placed = { element: button('r-page') };
+
+/** Honours `scope` by filtering on the container, the way the browser-side locator does. */
+class ScopedSession implements PredicateSession {
+  seen: ElementQuery[] = [];
+  constructor(private readonly placed: readonly Placed[]) {}
+
+  command(name: string, args: Record<string, unknown> = {}): Promise<CommandResult> {
+    if (name !== ReticleCommand.MATCH) {
+      return Promise.resolve({ kind: 'command_result', id: 'x', ok: true, result: {} });
+    }
+    const query = (args['query'] ?? {}) as ElementQuery;
+    this.seen.push(query);
+    const scope = query.scope;
+    const matched = (
+      undefined === scope ? [...this.placed] : this.placed.filter((p) => p.container === scope)
+    ).map((p) => p.element);
+    const result: MatchResult = {
+      matched: matched.length > 0,
+      count: matched.length,
+      elements: matched,
+    };
+    return Promise.resolve({ kind: 'command_result', id: 'x', ok: true, result });
+  }
+  eventsSince(): ReticleEvent[] {
+    return [];
+  }
+  onEvent(): () => void {
+    return () => undefined;
+  }
+  elapsed(): number {
+    return 0;
+  }
+}
+
+describe('text predicate: scope narrows the search', () => {
+  it('reaches both copies when no scope is given', async () => {
+    const session = new ScopedSession([IN_DIALOG, OUTSIDE]);
+    const result = await evaluatePredicate(session, { kind: 'text', contains: 'Delete' });
+    expect(result.pass).toBe(true);
+    expect(session.seen[0]?.scope, 'no scope asked for, none forwarded').toBeUndefined();
+  });
+
+  it('forwards the scope into the element query', async () => {
+    const session = new ScopedSession([IN_DIALOG, OUTSIDE]);
+    await evaluatePredicate(session, { kind: 'text', contains: 'Delete', scope: DIALOG });
+    expect(session.seen[0]?.scope, 'scope must reach the MATCH query').toBe(DIALOG);
+  });
+
+  it('still matches when the text is inside the scope', async () => {
+    const session = new ScopedSession([IN_DIALOG, OUTSIDE]);
+    const result = await evaluatePredicate(session, {
+      kind: 'text',
+      contains: 'Delete',
+      scope: DIALOG,
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  it('does NOT match text that only exists outside the scope', async () => {
+    // The assertion the whole field exists for: unscoped this passes, scoped it must not.
+    const session = new ScopedSession([OUTSIDE]);
+    const unscoped = await evaluatePredicate(session, { kind: 'text', contains: 'Delete' });
+    expect(unscoped.pass, 'the text is on the page, so an unscoped check passes').toBe(true);
+
+    const scopedSession = new ScopedSession([OUTSIDE]);
+    const scoped = await evaluatePredicate(scopedSession, {
+      kind: 'text',
+      contains: 'Delete',
+      scope: DIALOG,
+    });
+    expect(scoped.pass, 'the text is not in the dialog, so a scoped check must fail').toBe(false);
+  });
+
+  it('an absent assertion inside a scope ignores the copy outside it', async () => {
+    const session = new ScopedSession([OUTSIDE]);
+    const result = await evaluatePredicate(session, {
+      kind: 'text',
+      contains: 'Delete',
+      scope: DIALOG,
+      absent: true,
+    });
+    expect(result.pass, 'nothing named Delete inside the dialog, so absent holds').toBe(true);
+  });
+});

--- a/packages/server/src/events/predicate.ts
+++ b/packages/server/src/events/predicate.ts
@@ -401,7 +401,11 @@ export async function evaluatePredicate(
     case PredicateKind.TEXT:
       return evalElement(
         session,
-        { text: predicate.contains },
+        // `scope` passes straight through: the text predicate has always been an element query
+        // with only `text` filled in, so scoping it needs the field, not a second code path.
+        undefined === predicate.scope
+          ? { text: predicate.contains }
+          : { text: predicate.contains, scope: predicate.scope },
         true === predicate.visible ? ElementState.VISIBLE : undefined,
         predicate.absent ?? false,
         diagnose,


### PR DESCRIPTION
Adds `scope` to the `text` predicate, closing the asymmetry the issue names: `ElementQuerySchema` has carried `scope` all along, and the text branch had no way to say "inside *this* dialog".

```jsonc
{ "kind": "text", "contains": "Floor", "scope": "[role=dialog]" }
```

### Why the change is this small

The text predicate has always been an element query with only `text` filled in:

```ts
case PredicateKind.TEXT:
  return evalElement(session, { text: predicate.contains }, ...);
```

So scoping it needs the field carried through, not a second matching path. `scope` passes straight into the query and gets the same CSS-selector-or-ref handling every element query already has — no new resolution logic, and no risk of the two drifting apart in what a scope means.

Three touch points: the `Predicate` type, the zod branch, and that call.

### Backward compatible

Omitting `scope` leaves the predicate page-wide, exactly as before. A test pins that, since adding a field must not change what an existing caller means.

### The near-miss angle

`predicate-shape.test.ts` opens by noting that a rejected predicate does not merely fail — nothing runs, so the drive ends with no verdict at all. That applies here in both directions:

- Before this change, a caller who reasonably assumed `scope` worked on `text` (because it works on `element`) got the whole predicate rejected by the strict schema, and lost the verdict.
- `predicateFieldsFor(TEXT)` now lists `scope`, so the "fields this kind accepts" message stays accurate. A test pins that too.

### Checks

- `vitest run src/events/` — **331 passed**, 26 files
- 4 new tests in `predicate-shape.test.ts`: `scope` with `contains`, `scope` with the `text` alias, unchanged behaviour without it, and the field listing

`tsc --noEmit` reports `TS2307: Cannot find module '@reticlehq/core'` across the package — the workspace dependency is unbuilt in my checkout, and those errors are present on an untouched tree too. Nothing new in the files this PR touches.

Closes #399
