### PR TITLE
feat(inspect): say why component.source is missing

### DIFF
--- a/packages/browser/src/commands/commands.ts
+++ b/packages/browser/src/commands/commands.ts
@@ -21,7 +21,7 @@ import {
   type ActionStep,
 } from '../actions/actions.js';
 import { describe } from '../dom/a11y.js';
-import { sourceFor, formatSource } from '../dom/source.js';
+import { documentHasSourceStamps, sourceFor, formatSource } from '../dom/source.js';
 import { themeReport } from '../dom/theme.js';
 import { echoRef, refs } from '../dom/refs.js';
 import { isButton, isInput } from '../dom/realm.js';
@@ -116,6 +116,16 @@ function inspect(ref: string): unknown {
   // stamped host. `act` already did this; inspect did not, so the two tools disagreed about the same
   // ref and inspect — the tool you reach for to ask where something lives — was the one saying null.
   const source = formatSource(sourceFor(el, component?.source));
+  // Say WHY the source is missing rather than omitting the field and leaving the caller to guess.
+  // No stamp anywhere in the document is decisive: the loader is not running, so no element will
+  // have one this session, and the fix is a build-config change rather than anything about this
+  // element. Only computed when `source` is already absent, so the ordinary path pays nothing.
+  const sourceUnavailable =
+    source !== undefined
+      ? undefined
+      : documentHasSourceStamps(el.ownerDocument)
+        ? 'This element has no source stamp. Others on the page do, so the stamping loader is running — the nearest stamped ancestor is out of range, or this element is rendered outside instrumented code.'
+        : 'No element in this document carries a source stamp, so the stamping loader is not running: an older adapter, a bundler whose hook never ran, or a build the plugin was dropped from. Add @reticlehq/vite-plugin (or @reticlehq/babel-plugin) to the dev build and restart the dev server to get `file:line` back.';
   const scroll = {
     scrollTop: el.scrollTop,
     scrollHeight: el.scrollHeight,
@@ -125,6 +135,7 @@ function inspect(ref: string): unknown {
   return {
     ...describe(el),
     ...(source !== undefined ? { source } : {}),
+    ...(sourceUnavailable !== undefined ? { sourceUnavailable } : {}),
     tag: el.tagName.toLowerCase(),
     href: el.getAttribute('href') ?? undefined,
     formAction:

--- a/packages/browser/src/dom/source.stamps.test.ts
+++ b/packages/browser/src/dom/source.stamps.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { documentHasSourceStamps, sourceFromDom } from './source.js';
+
+/**
+ * Telling "this element has no stamp" apart from "nothing on this page has one".
+ *
+ * The two look identical from a missing `source` field and call for completely different next
+ * actions: the first is ordinary, the second means the stamping loader is not running and no
+ * element will carry a source this session.
+ */
+function render(html: string): void {
+  document.body.innerHTML = html;
+}
+
+describe('source stamp presence', () => {
+  beforeEach(() => render(''));
+
+  it('is false when the loader never ran', () => {
+    render('<div><button id="b">Save</button></div>');
+
+    expect(documentHasSourceStamps(document)).toBe(false);
+  });
+
+  it('is true when any element carries a stamp, even a distant one', () => {
+    render(
+      '<header data-reticle-source="src/Header.tsx:12:4">nav</header>' +
+        '<main><button id="b">Save</button></main>',
+    );
+
+    expect(documentHasSourceStamps(document)).toBe(true);
+  });
+
+  it('separates the two cases for the same unstamped element', () => {
+    // Same element, same missing source, two different diagnoses — which is the whole point.
+    render('<div><button id="b">Save</button></div>');
+    const unstamped = document.getElementById('b');
+    expect(unstamped).not.toBeNull();
+    expect(sourceFromDom(unstamped as Element)).toBeUndefined();
+    expect(documentHasSourceStamps(document)).toBe(false);
+
+    render(
+      '<header data-reticle-source="src/Header.tsx:12:4">nav</header>' +
+        '<main><button id="b2">Save</button></main>',
+    );
+    const stillUnstamped = document.getElementById('b2');
+    expect(stillUnstamped).not.toBeNull();
+    expect(sourceFromDom(stillUnstamped as Element)).toBeUndefined();
+    expect(documentHasSourceStamps(document)).toBe(true);
+  });
+
+  it('is true for a stamped ancestor of the element itself', () => {
+    render('<div data-reticle-source="src/App.tsx:104:10"><button id="b">Save</button></div>');
+    const el = document.getElementById('b');
+    expect(el).not.toBeNull();
+
+    expect(sourceFromDom(el as Element)).toEqual({ file: 'src/App.tsx', line: 104 });
+    expect(documentHasSourceStamps(document)).toBe(true);
+  });
+});

--- a/packages/browser/src/dom/source.ts
+++ b/packages/browser/src/dom/source.ts
@@ -57,6 +57,23 @@ export function sourceFor(
 }
 
 /**
+ * Does ANY element in this document carry a source stamp?
+ *
+ * The difference between "this element has no stamp" and "the stamping loader is not running at
+ * all" — two answers that look identical from a single missing `source` field, and that call for
+ * completely different next actions. The first is ordinary: not every element sits under a stamped
+ * host. The second means "fix at file:line", the single most-cited reason to reach for Reticle over
+ * a generic DOM tool, is silently unavailable for the whole session — and it has been discovered by
+ * reading the adapter's source rather than from anything Reticle said.
+ *
+ * One `querySelector`, which stops at the first hit, so this is cheap enough to answer on a
+ * single-element path like inspect. It is only consulted when a source is already missing.
+ */
+export function documentHasSourceStamps(doc: Document): boolean {
+  return doc.querySelector(`[${SOURCE_ATTR}]`) !== null;
+}
+
+/**
  * `file:line` — the form an agent can act on directly.
  *
  * Deliberately a single compact string rather than an object: it costs a couple of dozen bytes on a

--- a/packages/server/src/tools/tools.ts
+++ b/packages/server/src/tools/tools.ts
@@ -455,6 +455,15 @@ const RAW_TOOLS: ToolDef[] = [
        */
       source: z.string().optional(),
       /**
+       * Why `source` is missing, when it is.
+       *
+       * Distinguishes "this element has no stamp" from "nothing on this page has one, so the
+       * stamping loader is not running" — the second means `file:line` is unavailable for the
+       * whole session and the fix is a build-config change, which used to be discoverable only by
+       * reading the adapter's own source.
+       */
+      sourceUnavailable: z.string().optional(),
+      /**
        * Component identity from the framework adapter (@reticlehq/react).
        *
        * Declared to match what the handler actually returns. It previously declared


### PR DESCRIPTION
`reticle_inspect` now says *why* a source is missing instead of dropping the field.

### The two cases the issue asks to separate

| Situation | What inspect now returns |
|---|---|
| This element has no stamp, others do | `sourceUnavailable`: the loader is running, the nearest stamped ancestor is out of range or the element is rendered outside instrumented code |
| Nothing in the document has a stamp | `sourceUnavailable`: the loader is not running — older adapter, bundler hook that never ran, plugin dropped from the build — plus the fix: add the vite/babel plugin to the dev build and restart |

The check is the cheap one the issue points at: `document.querySelector('[data-reticle-source]')`, which stops at the first hit. It only runs when `source` is already absent, so the ordinary path pays nothing for it.

### Shape

`documentHasSourceStamps(doc)` lives in `dom/source.ts`, next to the two existing lookups and sharing their `SOURCE_ATTR`.

`sourceUnavailable` is a separate optional field rather than a sentinel inside `source`. `source` is documented as `file:line` — the form an agent acts on directly — and putting prose there would break every consumer that opens an editor with it.

Declared in the `reticle_inspect` `outputSchema` too. That file already carries a note about a wrong declaration having been worse than a missing one, and in the schema-carrying surface the MCP layer validates tool output, so an undeclared field would have been dropped or rejected.

### Checks

- `vitest run` on `@reticlehq/browser` — **936 passed**, 102 files
- `tsc --noEmit` on the browser package — clean
- 4 new tests in `source.stamps.test.ts`, including the one that matters: the *same* unstamped element gets two different diagnoses depending on whether anything else on the page is stamped

Note for anyone reproducing: the browser package's tests need `pnpm --filter @reticlehq/core build` first, otherwise vitest cannot resolve `@reticlehq/core`.

Closes #396
