### PR TITLE
fix(server): scope the text predicate to a subtree (#399)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -352,8 +352,10 @@ A **predicate** declares what should be true. `reticle_assert` / `reticle_wait_f
 // state: visible | hidden | enabled | disabled | checked | expanded | focused | present
 // add "absent": true to assert it is NOT there (regression / removal)
 
-// Visible text anywhere (optionally scoped via an element query instead)
+// Visible text — page-wide, or `scope` it to a subtree (CSS selector or ref) so a match
+// in a background tab can't satisfy an assertion about the dialog that just opened
 { "kind": "text", "contains": "Saved successfully", "visible": true }
+{ "kind": "text", "contains": "Floor 3", "scope": "[role=dialog]" }
 
 // A network call happened
 { "kind": "net", "method": "POST", "urlContains": "/api/order", "status": 200, "since": 1820 }

--- a/packages/server/src/events/predicate-eval.ts
+++ b/packages/server/src/events/predicate-eval.ts
@@ -20,7 +20,7 @@ export type Predicate =
       state?: ElementState;
       absent?: boolean;
     }
-  | { kind: typeof PredicateKind.TEXT; contains: string; visible?: boolean; absent?: boolean }
+  | { kind: typeof PredicateKind.TEXT; contains: string; scope?: string; visible?: boolean; absent?: boolean }
   | {
       kind: typeof PredicateKind.NET;
       method?: string;
@@ -256,6 +256,11 @@ function predicateUnion() {
       .object({
         kind: z.literal(PredicateKind.TEXT),
         contains: z.string(),
+        // CSS selector or ref to confine the search to a subtree. Without it the match is
+        // page-wide, so a word that also appears in a background tab satisfies the predicate
+        // before the action — `act_and_wait` then returns `already_true` for a correct action.
+        // The scoping machinery already exists on `element`; this forwards it to `text`.
+        scope: z.string().optional(),
         visible: z.boolean().optional(),
         absent: z.boolean().optional(),
       })

--- a/packages/server/src/events/predicate.ts
+++ b/packages/server/src/events/predicate.ts
@@ -401,7 +401,7 @@ export async function evaluatePredicate(
     case PredicateKind.TEXT:
       return evalElement(
         session,
-        { text: predicate.contains },
+        { text: predicate.contains, scope: predicate.scope },
         true === predicate.visible ? ElementState.VISIBLE : undefined,
         predicate.absent ?? false,
         diagnose,

--- a/packages/server/src/events/text-predicate-scope.test.ts
+++ b/packages/server/src/events/text-predicate-scope.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import type { CommandResult, ElementQuery, MatchResult } from '@reticlehq/core';
+import { evaluatePredicate, type PredicateSession } from './predicate.js';
+
+/**
+ * Regression for #399: the `text` predicate could not be scoped to a subtree, so a match
+ * anywhere in the document satisfied it — a word present in a background tab AND in the dialog
+ * that just opened made `act_and_wait` return `already_true` for an action that did the right thing.
+ *
+ * `text` is evaluated through the same `evalElement`/MATCH path as `element`, and `ElementQuery`
+ * already carries `scope`; the TEXT branch simply dropped it. These tests pin that it now forwards.
+ */
+describe('text predicate scope (#399)', () => {
+  /** A session that records the MATCH query it was handed and only matches when scoped as asked. */
+  function scopedSession(matchWhenScopedTo: string | undefined): {
+    session: PredicateSession;
+    lastQuery: () => ElementQuery | undefined;
+  } {
+    let seen: ElementQuery | undefined;
+    const session = {
+      eventsSince: () => [],
+      elapsed: () => 0,
+      onEvent: () => () => undefined,
+      command: (_name: string, args: Record<string, unknown> = {}): Promise<CommandResult> => {
+        const query = args.query as ElementQuery;
+        seen = query;
+        const inScope = query.scope === matchWhenScopedTo;
+        const result: MatchResult = inScope
+          ? { matched: true, count: 1, elements: [] }
+          : { matched: false, count: 0, elements: [] };
+        return Promise.resolve({ kind: 'command_result', id: 'c', ok: true, result });
+      },
+    } as unknown as PredicateSession;
+    return { session, lastQuery: () => seen };
+  }
+
+  it('forwards scope into the MATCH query so the search is confined to a subtree', async () => {
+    const { session, lastQuery } = scopedSession('[role="dialog"]');
+    const r = await evaluatePredicate(session, {
+      kind: 'text',
+      contains: 'Floor',
+      scope: '[role="dialog"]',
+    });
+    expect(r.pass).toBe(true);
+    // The bug was that scope never reached the query; pin that it now does, alongside the text.
+    expect(lastQuery()?.scope).toBe('[role="dialog"]');
+    expect(lastQuery()?.text).toBe('Floor');
+  });
+
+  it('a scoped text predicate does NOT pass on a match outside its scope', async () => {
+    // The session only matches when scoped to the dialog. A predicate scoped elsewhere must fail,
+    // which is the whole point: "Floor" in a background tab no longer satisfies the dialog assertion.
+    const { session } = scopedSession('[role="dialog"]');
+    const r = await evaluatePredicate(session, {
+      kind: 'text',
+      contains: 'Floor',
+      scope: '#background-tab',
+    });
+    expect(r.pass).toBe(false);
+  });
+
+  it('stays page-wide when no scope is given (unchanged behaviour)', async () => {
+    const { session, lastQuery } = scopedSession(undefined);
+    const r = await evaluatePredicate(session, { kind: 'text', contains: 'Floor' });
+    expect(r.pass).toBe(true);
+    expect(lastQuery()?.scope).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What & why

The `text` predicate matched anywhere in the document, so a word present in a background tab **and** in the dialog that just opened satisfied it *before* the action ran — `act_and_wait` returned `already_true` for an action that did exactly the right thing.

As #399 notes, `ElementQuerySchema` already carries `scope`, so an `element` predicate can be scoped; the `text` branch was page-wide only. And `text` is already evaluated through the same `evalElement`/MATCH path as `element` (`predicate.ts` → `evalElement(session, { text: predicate.contains }, …)`), so it turned out the scoping machinery was one field away — the TEXT branch simply dropped `scope`.

This forwards it, mirrors `scope` onto the TEXT predicate schema + type, and documents the example.

```jsonc
{ "kind": "text", "contains": "Floor 3", "scope": "[role=dialog]" }
```

Closes #399

## How it was verified

- New `packages/server/src/events/text-predicate-scope.test.ts` (RED → GREEN): pins that `scope` reaches the MATCH query alongside `text`, that a match **outside** the scope no longer satisfies the predicate, and that omitting `scope` stays page-wide.
- Existing `src/events/` suite unchanged: **330 tests green**.
- `pnpm typecheck` (all packages) and `eslint` on the touched files: clean.

## Gates run

- [x] `pnpm lint && pnpm typecheck && pnpm test:unit` (~2 min — **always**)
- [ ] `pnpm test:e2e` (~8 min) — _touched the tool surface, `packages/core`, an observer, or telemetry_
- [ ] `pnpm gate:install` (~15 min)
- [ ] `pnpm test:e2e:desktop` (~3 min)
- [x] None of the heavier tiers apply — this is a server-side predicate change with unit coverage

## Checklist

- [x] **Every commit is signed off** (`git commit -s`)
- [x] Tests added (RED → GREEN); the change is covered by a test that would fail without it
- [x] No `any`, no free strings, no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 1000-line cap