### PR TITLE
feat(server): body-free listing for reticle_network (#401)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -215,7 +215,7 @@ Compare what the API **returned** against what the page **renders**.
 
 Fast targeted lookups without a full timeline.
 
-- `reticle_network({ since?, method?, urlContains?, status? })` → `{ calls }`
+- `reticle_network({ since?, method?, urlContains?, status?, bodies? })` → `{ calls }`. Pass `bodies: false` for a body-free listing (method/url/status/timing only); bodies dominate the payload, so the common "did POST /x return 200?" read gets much cheaper.
 - `reticle_console({ level?, since? })` → `{ logs }`
 - `reticle_animations()` → running/recent animations.
 

--- a/packages/server/src/events/event-filters.test.ts
+++ b/packages/server/src/events/event-filters.test.ts
@@ -157,6 +157,30 @@ describe('compact projections (token leanness)', () => {
     expect(projectNetCall(e)).toEqual({ method: 'POST', url: '/api/x', status: 500, ms: 42 });
   });
 
+  it('projectNetCall includes bodies by default and drops them when includeBodies is false (#401)', () => {
+    const e = ev(EventType.NET_REQUEST, {
+      method: 'POST',
+      url: '/api/todos',
+      status: 201,
+      durationMs: 12,
+      requestBody: '{"title":"buy milk"}',
+      responseBody: '{"id":7}',
+      responseBodyTruncated: true,
+    });
+    // Default: bodies are present (unchanged behaviour).
+    const full = projectNetCall(e);
+    expect(full.requestBody).toBe('{"title":"buy milk"}');
+    expect(full.responseBody).toBe('{"id":7}');
+    expect(full.bodyTruncated).toBe(true);
+    // Body-free listing: method/url/status/timing survive, the bodies are gone.
+    expect(projectNetCall(e, false)).toEqual({
+      method: 'POST',
+      url: '/api/todos',
+      status: 201,
+      ms: 12,
+    });
+  });
+
   it('projectNetCall passes through a pending (no-status) request', () => {
     const e = ev(EventType.NET_PENDING, {
       method: 'GET',

--- a/packages/server/src/events/event-filters.ts
+++ b/packages/server/src/events/event-filters.ts
@@ -120,7 +120,7 @@ interface NetCallView {
    */
   oneWay?: boolean;
 }
-export function projectNetCall(e: ReticleEvent): NetCallView {
+export function projectNetCall(e: ReticleEvent, includeBodies = true): NetCallView {
   const status = e.data['status'];
   const ms = asNumber(e.data['durationMs']);
   const statusText = asString(e.data['statusText']);
@@ -136,9 +136,14 @@ export function projectNetCall(e: ReticleEvent): NetCallView {
   if (statusText !== undefined) view.statusText = statusText;
   if (contentType !== undefined) view.contentType = contentType;
   if (responseSize !== undefined) view.responseSize = responseSize;
-  if (requestBody !== undefined) view.requestBody = requestBody;
-  if (responseBody !== undefined) view.responseBody = responseBody;
-  if (true === e.data['requestBodyTruncated'] || true === e.data['responseBodyTruncated']) {
+  // Bodies dominate the payload of the most-called read tool, and are only occasionally the part
+  // anyone wanted — `bodies: false` on reticle_network drops them for a body-free listing (#401).
+  if (includeBodies && requestBody !== undefined) view.requestBody = requestBody;
+  if (includeBodies && responseBody !== undefined) view.responseBody = responseBody;
+  if (
+    includeBodies &&
+    (true === e.data['requestBodyTruncated'] || true === e.data['responseBodyTruncated'])
+  ) {
     view.bodyTruncated = true;
   }
   if (ms !== undefined) view.ms = ms;

--- a/packages/server/src/tools/network-bodies.test.ts
+++ b/packages/server/src/tools/network-bodies.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { EventType, type ReticleEvent } from '@reticlehq/core';
+import { OBSERVE_TOOLS } from './observe-tools.js';
+import { ReticleTool } from './tool-names.js';
+import type { ToolDeps } from './tools.js';
+import type { Session, SessionManager } from '../session/session.js';
+
+/**
+ * #401: `reticle_network` returned full request/response bodies with no way to ask for the list
+ * without them, so the cheapest read (method/url/status) paid for the most expensive field. A
+ * `bodies: false` switch returns a body-free listing. Adopted from Argus's compact network read.
+ */
+function ev(type: EventType, data: Record<string, unknown>, t = 1): ReticleEvent {
+  return { t, type, sessionId: 's', data };
+}
+
+function netDeps(events: ReticleEvent[]): ToolDeps {
+  const session = {
+    queryEvents: () => Promise.resolve(events),
+    bufferHealth: () => ({ total: events.length, dropped: 0 }),
+  } as unknown as Session;
+  const sessions = { resolve: () => session } as unknown as SessionManager;
+  return { sessions } as unknown as ToolDeps;
+}
+
+function networkTool() {
+  const t = OBSERVE_TOOLS.find((x) => x.name === ReticleTool.NETWORK);
+  if (t === undefined) throw new Error('no reticle_network tool');
+  return t;
+}
+
+const POST = ev(EventType.NET_REQUEST, {
+  method: 'POST',
+  url: '/api/todos',
+  status: 201,
+  durationMs: 8,
+  requestBody: '{"title":"buy milk"}',
+  responseBody: '{"id":7}',
+});
+
+type NetResult = { calls: Array<Record<string, unknown>>; bodiesNotCaptured?: string };
+
+describe('reticle_network bodies switch (#401)', () => {
+  it('includes bodies by default (unchanged behaviour)', async () => {
+    const res = (await networkTool().handler(netDeps([POST]), {})) as NetResult;
+    expect(res.calls[0]?.requestBody).toBe('{"title":"buy milk"}');
+    expect(res.calls[0]?.responseBody).toBe('{"id":7}');
+  });
+
+  it('drops bodies with bodies:false, keeping method/url/status/timing', async () => {
+    const res = (await networkTool().handler(netDeps([POST]), { bodies: false })) as NetResult;
+    expect(res.calls[0]).toEqual({ method: 'POST', url: '/api/todos', status: 201, ms: 8 });
+  });
+
+  it('does NOT raise the "bodies not captured" note when the caller asked for bodies:false', async () => {
+    // That note means "capture is OFF, this body is unseen". A caller who deliberately omitted
+    // bodies did not lose them to a missing config — without gating, stripping every body would
+    // make the note fire on every body-free read, advising a fix for a problem that isn't there.
+    const res = (await networkTool().handler(netDeps([POST]), { bodies: false })) as NetResult;
+    expect(res.bodiesNotCaptured).toBeUndefined();
+  });
+});

--- a/packages/server/src/tools/observe-tools.ts
+++ b/packages/server/src/tools/observe-tools.ts
@@ -492,6 +492,12 @@ export const OBSERVE_TOOLS: ToolDef[] = [
         .describe(
           'Keep only the most recent N matching calls (older are dropped and counted in droppedOldest) — cuts tokens on a wide window. Defaults to 200 when omitted; pass a higher number for more, or scope with since/until.',
         ),
+      bodies: z
+        .boolean()
+        .optional()
+        .describe(
+          'Include request/response bodies (default true). Pass false for a body-free listing — method, url, status, timing only — for the common "did POST /x return 200?" read. Bodies dominate the payload, so this cuts the cheap case by a large factor.',
+        ),
       ...sessionIdShape,
     },
     outputSchema: {
@@ -519,6 +525,8 @@ export const OBSERVE_TOOLS: ToolDef[] = [
       const status = asNumber(args['status']);
       const ok = 'boolean' === typeof args['ok'] ? args['ok'] : undefined;
       const limit = asNumber(args['limit']);
+      // Default true keeps the current shape; `bodies: false` returns the body-free listing (#401).
+      const bodies = 'boolean' === typeof args['bodies'] ? args['bodies'] : true;
       const buffer = bufferEnvelope(session);
       // Completed calls + unresolved in-flight requests (a hung request shows as pending).
       const allNet = reconcileNet(
@@ -538,7 +546,7 @@ export const OBSERVE_TOOLS: ToolDef[] = [
         matched,
         limit ?? DEFAULT_QUERY_LIMIT,
       );
-      const calls = budgeted.map(projectNetCall);
+      const calls = budgeted.map((e) => projectNetCall(e, bodies));
       // A zero-match FILTER already reports what did fire (netEmptyHint above). Zero calls at all
       // fell through as a bare `[]`, which is indistinguishable from an observer that is not
       // recording — and those need opposite responses. Say the look happened.
@@ -547,7 +555,7 @@ export const OBSERVE_TOOLS: ToolDef[] = [
           {
             calls,
             ...(droppedOldest > 0 ? { total: matched.length, droppedOldest } : {}),
-            ...bodiesNotCaptured(calls),
+            ...(bodies ? bodiesNotCaptured(calls) : {}),
             ...buffer,
           },
           'calls',


### PR DESCRIPTION
## What & why

`reticle_network` returned full request/response bodies with no way to ask for the list without them, so the cheapest read (method, url, status, start order) paid for the most expensive field. As #401 notes, bodies dominate the payload of the most-called read tool, and are only occasionally the part anyone wanted.

This adds the `bodies` switch the issue suggests:

```jsonc
reticle_network({ urlContains: "/api", bodies: false })
// → calls: [{ method, url, status, ms }, …]   — no request/response bodies
```

- **Default `true`** — fully non-breaking; existing callers see the same shape.
- `projectNetCall` gains an `includeBodies` parameter that drops `requestBody` / `responseBody` / `bodyTruncated`; the tool threads the arg through.
- **One subtlety handled:** the `bodiesNotCaptured` honesty note means *"capture is OFF, this body is unseen"*. With bodies stripped, every call looks body-less, so that note would fire on **every** body-free read and advise a fix for a problem that isn't there. It's gated on `bodies !== false`.

Adopted from a compact network read that defaults to method/url/status summaries for exactly this token cost.

Closes #401

## How it was verified

- `packages/server/src/events/event-filters.test.ts` — `projectNetCall` keeps bodies by default, drops them (and only them) when `includeBodies` is false.
- `packages/server/src/tools/network-bodies.test.ts` (new) — drives the tool handler: default keeps bodies; `bodies: false` returns `{ method, url, status, ms }`; and the honesty note does **not** fire under `bodies: false` (the gating regression).
- **Full server suite green: 402 files / 3860 tests.** Includes `e2e-surface-drift`, `output-schema`, `docs-index-coverage` (which caught, and I fixed, an em-dash in my usage.md line).
- `pnpm typecheck` (all packages) and `eslint` on the touched files: clean.

## Gates run

- [x] `pnpm lint && pnpm typecheck && pnpm test:unit` (~2 min — **always**) — ran the full server unit suite (3860 tests) locally
- [ ] `pnpm test:e2e` (~8 min) — _touches the tool surface + an observer, so this tier applies; I couldn't run the browser e2e in my environment, leaving it to CI (which runs everything regardless)_
- [ ] `pnpm gate:install`
- [ ] `pnpm test:e2e:desktop`

## Checklist

- [x] **Every commit is signed off** (`git commit -s`)
- [x] Tests added (RED → GREEN); the change is covered by tests that fail without it
- [x] No `any`, no free strings, no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 1000-line cap