### PR TITLE
docs(usage): document the text predicate `scope` field with an example

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -352,8 +352,10 @@ A **predicate** declares what should be true. `reticle_assert` / `reticle_wait_f
 // state: visible | hidden | enabled | disabled | checked | expanded | focused | present
 // add "absent": true to assert it is NOT there (regression / removal)
 
-// Visible text anywhere (optionally scoped via an element query instead)
+// Visible text: page-wide, or `scope` it to a subtree (CSS selector or ref) so a match
+// in a background tab can't satisfy an assertion about the dialog that just opened
 { "kind": "text", "contains": "Saved successfully", "visible": true }
+{ "kind": "text", "contains": "Floor 3", "scope": "[role=dialog]" }
 
 // A network call happened
 { "kind": "net", "method": "POST", "urlContains": "/api/order", "status": 200, "since": 1820 }


### PR DESCRIPTION
Splitting the docs half of #407 into its own PR, as offered in the thread there. The `scope` field on the `text` predicate (narrow a text assertion to a subtree, so a match elsewhere on the page can't satisfy it) had no documentation; this adds it to the predicate reference with a worked example:

```jsonc
{ "kind": "text", "contains": "Floor 3", "scope": "[role=dialog]" }
```

**Sequencing:** `scope` is implemented by #405 — land this after that merges, or the example describes a field that isn't wired up yet.

**One fix worth noting:** the original line in #407 put an em dash inside the jsonc comment. That passes the prose-only check (`e2e-surface-drift`) but **fails the whole-file one** (`docs-index-coverage` → "no page uses an em dash"), so #407 was quietly red on that check. This PR uses a colon instead; both doc tests are green.

## Gates run

- [x] `pnpm lint && pnpm typecheck && pnpm test:unit` — docs-only change; `e2e-surface-drift` and `docs-index-coverage` (the two that police docs) both pass locally.

## Checklist

- [x] Commit signed off (`git commit -s`)
- [x] Docs-only; no code paths touched
- [x] No em dashes (both doc-lint tests green)