### PR TITLE
fix(honesty): a recorded response body proves capture is on (#394)

### DIFF
--- a/packages/server/src/honesty/uncaptured-bodies.test.ts
+++ b/packages/server/src/honesty/uncaptured-bodies.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { bodiesNotCaptured } from './uncaptured-bodies.js';
+
+/**
+ * #394: the "bodies are not being recorded" note fired on a result that plainly recorded a body.
+ * `bodiesNotCaptured` decided purely on request bodies across body-bearing methods, so a call whose
+ * request body was not stringified (a multipart upload, an SDK-skipped body) tripped the warning
+ * even when a response body in the same result proved capture was on. A present response body is
+ * evidence that recording is enabled.
+ */
+describe('bodiesNotCaptured', () => {
+  it('fires when a body-bearing call carried no body at all', () => {
+    const out = bodiesNotCaptured([{ method: 'POST', url: '/api/pay' } as never]);
+    expect(out.bodiesNotCaptured).toContain('NOT being recorded');
+  });
+
+  it('stays silent when a response body was recorded, even if the request body was not (#394)', () => {
+    // A multipart upload the SDK did not stringify: no requestBody, but the response was captured.
+    // The old logic looked only at requestBody and cried "not recording" over a visible body.
+    const out = bodiesNotCaptured([
+      { method: 'POST', url: '/api/upload', responseBody: '{"id":9}' } as never,
+    ]);
+    expect(out.bodiesNotCaptured).toBeUndefined();
+  });
+
+  it('stays silent when a request body is present (unchanged)', () => {
+    const out = bodiesNotCaptured([
+      { method: 'POST', url: '/api/todos', requestBody: '{"title":"x"}' } as never,
+    ]);
+    expect(out.bodiesNotCaptured).toBeUndefined();
+  });
+
+  it('says nothing when there are no body-bearing calls', () => {
+    const out = bodiesNotCaptured([{ method: 'GET', url: '/api/todos' } as never]);
+    expect(out.bodiesNotCaptured).toBeUndefined();
+  });
+});

--- a/packages/server/src/honesty/uncaptured-bodies.ts
+++ b/packages/server/src/honesty/uncaptured-bodies.ts
@@ -11,14 +11,22 @@ const BODY_BEARING_METHODS = new Set(['POST', 'PUT', 'PATCH']);
  * every other field in the record agrees is a clean 200.
  *
  * So an omission is declared rather than left to inference, with the one line that fixes it. Present
- * only when a body-bearing call was returned AND none of them carried a body, so an app that already
- * captures bodies pays nothing and the field's PRESENCE is the warning.
+ * only when a body-bearing call was returned AND no body — request or response — was recorded
+ * anywhere in the result, so an app that already captures bodies pays nothing and the field's
+ * PRESENCE is the warning.
  */
-export function bodiesNotCaptured(calls: { method?: string; requestBody?: string }[]): {
+export function bodiesNotCaptured(
+  calls: { method?: string; requestBody?: string; responseBody?: string }[],
+): {
   bodiesNotCaptured?: string;
 } {
   const bodyBearing = calls.filter((c) => BODY_BEARING_METHODS.has((c.method ?? '').toUpperCase()));
   if (0 === bodyBearing.length) return {};
+  // A recorded response body anywhere in the result proves capture is ON. An absent request body
+  // then means this payload was not stringified (a multipart upload, a body the SDK skipped), not
+  // that recording is off — and firing the note would contradict the body sitting in the same
+  // result, exactly on the question the note exists to answer. (#394)
+  if (calls.some((c) => c.responseBody !== undefined)) return {};
   if (bodyBearing.some((c) => c.requestBody !== undefined)) return {};
   return {
     // Framework-neutral on purpose. The first version named vite.config, and driving a Next.js app


### PR DESCRIPTION
## What & why

`reticle_network` could return a row with a populated `responseBody` while the same result carried the note *"request/response bodies are NOT being recorded, so an absent body here means UNSEEN, not empty"*. The two contradict each other, landing exactly on the question the note exists to answer.

`bodiesNotCaptured` decided purely on **request** bodies across body-bearing methods, so a call whose request body was not stringified (a multipart upload, a body the SDK skipped) tripped the warning regardless of a response body in the same result that proves capture is on.

Per the issue: treat a present response body as evidence that capture is enabled. One predicate, one test.

```ts
// A recorded response body anywhere in the result proves capture is ON.
if (calls.some((c) => c.responseBody !== undefined)) return {};
```

Closes #394

## How it was verified

- New `packages/server/src/honesty/uncaptured-bodies.test.ts` — proven RED→GREEN: with the predicate removed, exactly the `#394` case (`responseBody` present, `requestBody` absent) fails and only that one; restored, all 4 pass. Also covers the unchanged cases (no body at all → fires; request body present → silent; no body-bearing calls → silent).
- **Full server suite green: 402 files / 3860 tests.** `pnpm typecheck` (all 21 packages) and `eslint` on the touched files: clean.

## Note on overlap with #408

Independent of #408. That PR gates the **call site** in `observe-tools.ts` (skip the note when the caller asked `bodies: false`); this fixes the **function** in `uncaptured-bodies.ts` (a recorded response body suppresses the note). Different files, no conflict, and they compose: a `bodies: false` read skips the note entirely, a default read no longer contradicts a visible body.

## Checklist

- [x] Commit signed off (`git commit -s`)
- [x] Test added, proven RED without the fix
- [x] No `any` in `src` (the `as never` casts are test-only fixtures), no free strings, no non-null `!`
- [x] Changed file under the 1000-line cap