### PR TITLE
fix(annotate): grade the success-state so annotate and flow_save agree (#395)

### DIFF
--- a/packages/server/src/flows/annotate-tools.ts
+++ b/packages/server/src/flows/annotate-tools.ts
@@ -140,6 +140,9 @@ export const ANNOTATE_TOOLS: ToolDef[] = [
       recovery: z.string().optional(),
       target: z.string().optional(),
       compiled: z.string().optional(),
+      // Set when the compiled annotation would overstate what a replay can check — e.g. a
+      // success-state that flow_save will grade assertion-free (#395).
+      note: z.string().optional(),
       code: z.string().optional(),
     },
     handler: (deps: ToolDeps, args): Promise<AnnotateResult> => {

--- a/packages/server/src/flows/annotate.compile.test.ts
+++ b/packages/server/src/flows/annotate.compile.test.ts
@@ -88,6 +88,42 @@ describe('compileAnnotation pure compiler', () => {
     expect(describeCompiled(a)).toContain('no console.error');
   });
 
+  // #395: annotate and flow_save must not tell the caller opposite things about the same
+  // success-state. A non-consequence end-condition carries the grade flow_save will give it, so the
+  // caller cannot save a "success" that then quietly grades assertion-free and can never go red.
+  it('success-state with a console condition notes it grades assertion-free (#395)', () => {
+    const a: Annotation = {
+      kind: AnnotationKind.SUCCESS_STATE,
+      console: { level: 'error', absent: true },
+    };
+    const out = compileAnnotation(a, 4);
+    expect(out.result.ok).toBe(true);
+    if (!out.result.ok) throw new Error('expected ok');
+    expect(out.result.note).toContain('assertion-free');
+  });
+
+  it('success-state with a testid notes it grades presence-only (#395)', () => {
+    const a: Annotation = { kind: AnnotationKind.SUCCESS_STATE, testid: 'done' };
+    const out = compileAnnotation(a, 4);
+    if (!out.result.ok) throw new Error('expected ok');
+    expect(out.result.note).toContain('presence-only');
+  });
+
+  it('a consequence success-state (signal / net / state) carries NO grade warning (#395)', () => {
+    for (const a of [
+      { kind: AnnotationKind.SUCCESS_STATE, signal: 'diff:shown' },
+      {
+        kind: AnnotationKind.SUCCESS_STATE,
+        net: { method: 'POST', urlContains: '/api/x', count: 1 },
+      },
+      { kind: AnnotationKind.SUCCESS_STATE, statePath: 'cart.items', store: 'app' },
+    ] as Annotation[]) {
+      const out = compileAnnotation(a, 4);
+      if (!out.result.ok) throw new Error('expected ok');
+      expect(out.result.note).toBeUndefined();
+    }
+  });
+
   it('assert-state compiles to step.expect.state on the LAST step', () => {
     const a: Annotation = {
       kind: AnnotationKind.ASSERT_STATE,

--- a/packages/server/src/flows/annotate.ts
+++ b/packages/server/src/flows/annotate.ts
@@ -3,8 +3,11 @@ import {
   AnnotationKind,
   AnnotationTarget,
   COMPILED_PREDICATE_PREFIX,
+  flowExpectHasConsequence,
+  flowExpectIsPresenceOnly,
   type Annotation,
   type AnnotateOutcome,
+  type AnnotateResult,
   type FlowExpect,
 } from '@reticlehq/core';
 
@@ -98,11 +101,28 @@ function stepPatch(a: Annotation, stepCount: number, stepExpect: FlowExpect): An
   };
 }
 
+// A success end-condition that is not an observable CONSEQUENCE (signal / net / state) cannot lift
+// the flow above the grade flow_save will give it. Saying "will succeed when ..." without that
+// caveat is the #395 contradiction: annotate promises a check that flow_save then grades
+// assertion-free, so a flow that only checks the console replays green through any regression. Name
+// the grade here, using the same consequence/presence classification every grader shares.
+const SUCCESS_ASSERTION_FREE_NOTE =
+  'This success-state is not an observable consequence, so flow_save will grade the flow assertion-free — it passes even when the feature is broken. Use a signal / net / state success-state to give the flow something that can fail.';
+const SUCCESS_PRESENCE_ONLY_NOTE =
+  'This success-state only checks element presence, so flow_save will grade the flow presence-only — a locator healed to the wrong element still passes it. Use a signal / net / state success-state to assert an observable consequence.';
+
 function flowSuccess(a: Annotation, success: FlowExpect): AnnotateOutcome {
-  return {
-    result: { ok: true, target: AnnotationTarget.FLOW, compiled: describeCompiled(a) },
-    patch: { success },
+  const result: AnnotateResult = {
+    ok: true,
+    target: AnnotationTarget.FLOW,
+    compiled: describeCompiled(a),
   };
+  if (!flowExpectHasConsequence(success)) {
+    result.note = flowExpectIsPresenceOnly(success)
+      ? SUCCESS_PRESENCE_ONLY_NOTE
+      : SUCCESS_ASSERTION_FREE_NOTE;
+  }
+  return { result, patch: { success } };
 }
 
 /**


### PR DESCRIPTION
## What & why

`reticle_annotate` with a success-state of `{ console: { absent: true, level: 'error' } }` returns `ok: true` and reports the flow will succeed. The immediately following `reticle_flow_save` grades that same flow `assertion-free` (`hasConsequenceAssertion: false`). The two tools tell the caller **opposite things about the same annotation**, and the second one decides whether a replay can ever go red — so a caller who believed the first has a saved "success" that cannot fail through any regression.

Per the issue: `annotate` should return the grade the annotation will produce, and warn when it cannot lift the flow above assertion-free.

`flowSuccess` now runs the **same** consequence/presence classification every grader shares (`flowExpectHasConsequence` / `flowExpectIsPresenceOnly` from core), so the two tools can't drift:

```ts
if (!flowExpectHasConsequence(success)) {
  result.note = flowExpectIsPresenceOnly(success) ? SUCCESS_PRESENCE_ONLY_NOTE : SUCCESS_ASSERTION_FREE_NOTE;
}
```

- A **console** success-state → `note` naming `assertion-free`.
- An **element** success-state → `note` naming `presence-only`.
- A **signal / net / state** success-state → no note (it genuinely lifts the flow to `asserted`).

This reuses the existing `note` field, whose doc comment already describes exactly this case ("the compiled annotation... would overstate it... a false green in the feature whose whole job is to catch them"); it's now declared on the tool's output schema.

Closes #395

## How it was verified

- `annotate.compile.test.ts` — proven RED→GREEN: with the classification removed, exactly the two note cases (console→assertion-free, element→presence-only) fail and only those; the consequence case still passes. Restored, all green.
- **Full server suite: 401 files / 3859 tests** (includes `envelope-keys-declared`, which validates the new `note` output-schema key, and the two doc em-dash checks). `pnpm typecheck` (21 packages) and `eslint` on the touched files: clean.

## Checklist

- [x] Commit signed off (`git commit -s`)
- [x] Test added, proven RED without the fix
- [x] No `any`, no free strings (warnings are named consts), no non-null `!`
- [x] Reuses the single consequence/presence source in `@reticlehq/core` — no second classifier
- [x] Changed files under the 1000-line cap