### PR TITLE
feat(predicate): add an inViewport element state so a scroll is verifiable (#398)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -349,7 +349,8 @@ A **predicate** declares what should be true. `reticle_assert` / `reticle_wait_f
 // An element exists / is in a state
 { "kind": "element", "query": { "role": "dialog", "name": "Confirm" }, "state": "visible" }
 // query supports: role, name, text, label, placeholder, testid, alt, scope
-// state: visible | hidden | enabled | disabled | checked | expanded | focused | present
+// state: visible | hidden | enabled | disabled | checked | expanded | focused | present | inViewport
+// inViewport asserts the element is in the viewport NOW (not just in the DOM), so a scrollIntoView is gradeable
 // add "absent": true to assert it is NOT there (regression / removal)
 
 // Visible text anywhere (optionally scoped via an element query instead)

--- a/packages/browser/src/dom/a11y.ts
+++ b/packages/browser/src/dom/a11y.ts
@@ -273,6 +273,23 @@ function selfHidden(el: Element): boolean {
  * static for the pass's duration — the cache MUST be a per-call Map, never module-level (that would go
  * stale the instant the app mutates, the same trap the shadow-root note in query.ts documents).
  */
+/**
+ * True when the element is inside the viewport right now: visible AND its bounding box intersects
+ * the window. This is what makes a scroll assertable (#398) — content below the fold of a scrolling
+ * container is `visible`/`present` before any scroll, so only a viewport-intersection check can tell
+ * "scrolled into view" from "was always in the DOM". Uses getBoundingClientRect (viewport-relative,
+ * already accounts for scroll position), not an IntersectionObserver, so it stays synchronous inside
+ * the predicate pass.
+ */
+export function isInViewport(el: Element, memo?: Map<Element, boolean>): boolean {
+  if (!isVisible(el, memo)) return false;
+  const view = el.ownerDocument.defaultView;
+  if (null === view) return false;
+  const r = el.getBoundingClientRect();
+  if (r.width <= 0 || r.height <= 0) return false;
+  return r.bottom > 0 && r.right > 0 && r.top < view.innerHeight && r.left < view.innerWidth;
+}
+
 export function isVisible(el: Element, memo?: Map<Element, boolean>): boolean {
   if (!el.isConnected) return false;
   const cached = memo?.get(el);

--- a/packages/browser/src/dom/in-viewport.test.ts
+++ b/packages/browser/src/dom/in-viewport.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ElementState } from '@reticlehq/core';
+import { isInViewport } from './a11y.js';
+import { matchQuery } from './query.js';
+
+/**
+ * #398: `visible`/`present` fold only aria-hidden/[hidden]/display/visibility/opacity, so content
+ * below the fold of a scrolling container is already `visible` and a scrollIntoView is ungradeable
+ * (act_and_wait returns already_true). An `inViewport` state, backed by getBoundingClientRect, makes
+ * the scroll assertable. jsdom does no layout, so the box is stubbed per element (window is 1024x768).
+ */
+function boxed(rect: Partial<DOMRect>, tag = 'div'): HTMLElement {
+  const el = document.createElement(tag);
+  document.body.appendChild(el);
+  el.getBoundingClientRect = () => ({
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    width: 0,
+    height: 0,
+    toJSON: () => ({}),
+    ...rect,
+  });
+  return el;
+}
+
+describe('isInViewport (#398)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('true when the box intersects the window', () => {
+    expect(
+      isInViewport(
+        boxed({ top: 100, left: 100, bottom: 220, right: 260, width: 160, height: 120 }),
+      ),
+    ).toBe(true);
+  });
+
+  it('false when the box is below the fold (top past innerHeight)', () => {
+    expect(
+      isInViewport(
+        boxed({ top: 2000, left: 100, bottom: 2120, right: 260, width: 160, height: 120 }),
+      ),
+    ).toBe(false);
+  });
+
+  it('false when the element is hidden, whatever the box says', () => {
+    const el = boxed({ top: 100, left: 100, bottom: 220, right: 260, width: 160, height: 120 });
+    el.style.display = 'none';
+    expect(isInViewport(el)).toBe(false);
+  });
+
+  it('false for a zero-size box', () => {
+    expect(
+      isInViewport(boxed({ top: 100, left: 100, bottom: 100, right: 100, width: 0, height: 0 })),
+    ).toBe(false);
+  });
+
+  it('the element predicate filters by inViewport end to end', () => {
+    // Two buttons named "Go"; only the first is scrolled into view.
+    const onScreen = boxed(
+      { top: 100, left: 100, bottom: 140, right: 200, width: 100, height: 40 },
+      'button',
+    );
+    onScreen.textContent = 'Go';
+    const belowFold = boxed(
+      { top: 3000, left: 100, bottom: 3040, right: 200, width: 100, height: 40 },
+      'button',
+    );
+    belowFold.textContent = 'Go';
+
+    const all = matchQuery({ role: 'button', name: 'Go' });
+    expect(all.count).toBe(2);
+    const inView = matchQuery({ role: 'button', name: 'Go' }, ElementState.IN_VIEWPORT);
+    expect(inView.count).toBe(1);
+  });
+});

--- a/packages/browser/src/dom/query.ts
+++ b/packages/browser/src/dom/query.ts
@@ -21,7 +21,14 @@ import {
 } from '@reticlehq/core';
 import { isFrame, isHtmlElement } from './realm.js';
 import { capturedRootOf } from './shadow-registry.js';
-import { getAccessibleName, getRole, describe, getStates, isVisible } from './a11y.js';
+import {
+  getAccessibleName,
+  getRole,
+  describe,
+  getStates,
+  isInViewport,
+  isVisible,
+} from './a11y.js';
 import { isIgnored } from './dom-ignore.js';
 import { isSensitiveKey } from '../security/serialization.js';
 import { getCapabilities } from '../registry/capabilities.js';
@@ -344,6 +351,10 @@ function projectAttrs(el: Element, keys: readonly string[]): Record<string, stri
 }
 
 function inState(el: Element, state: ElementState, memo?: Map<Element, boolean>): boolean {
+  // inViewport is computed on demand rather than listed in getStates, so it stays assertable without
+  // adding a state to every element in every snapshot (it would bloat the wire and churn every
+  // describe). The predicate path is the only consumer that needs it. (#398)
+  if (ElementState.IN_VIEWPORT === state) return isInViewport(el, memo);
   return getStates(el, isVisible(el, memo)).includes(state);
 }
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -602,6 +602,14 @@ export const ElementState = {
   EXPANDED: 'expanded',
   FOCUSED: 'focused',
   PRESENT: 'present',
+  /**
+   * Inside the viewport right now (getBoundingClientRect intersects the window). Distinct from
+   * `visible`, which folds only aria-hidden/[hidden]/display/visibility/opacity and so is already
+   * true for content below the fold of a scrolling container. Without this, `scrollIntoView` is
+   * ungradeable: the target satisfied `visible`/`present` before the scroll, so act_and_wait
+   * returns already_true. (#398)
+   */
+  IN_VIEWPORT: 'inViewport',
 } as const;
 export type ElementState = (typeof ElementState)[keyof typeof ElementState];
 


### PR DESCRIPTION
## What & why

There is no predicate for "this element is inside the viewport". `isVisible` folds only aria-hidden / [hidden] / display / visibility / opacity, so content below the fold of a scrolling container is already `visible` and `present`, and a scroll cannot be verified: `reticle_act_and_wait` with `scrollIntoView` and a `text` / `element` predicate returns `already_true`, because the target satisfied the predicate before the action ran. Overflow panels, infinite lists and sticky-header behaviour are all ungradeable for this reason.

Adds an `inViewport` element state backed by `getBoundingClientRect` intersection with the window:

```jsonc
{ "kind": "element", "query": { "testid": "row-500" }, "state": "inViewport" }
```

- Computed **on demand in `inState`**, not listed in `getStates` — so it's assertable without adding a state to every element in every snapshot (that would bloat the wire and churn every `describe`). The predicate path is the only consumer that needs it.
- The element-state schema is `z.nativeEnum(ElementState)`, so the new value flows through validation end to end with **no schema change**.
- `getBoundingClientRect` is viewport-relative and already accounts for scroll position, so it stays synchronous inside the predicate pass (no IntersectionObserver).

Closes #398

## How it was verified

- New `packages/browser/src/dom/in-viewport.test.ts` — the helper (in-view / below-the-fold / hidden / zero-size) **and** the end-to-end predicate (`matchQuery({role,name}, 'inViewport')` filters two same-named buttons to the one on screen). Proven RED→GREEN: removing the `inState` case makes exactly the end-to-end filter test fail while the helper tests still pass.
- **Full suites green: core 22/211, browser 102/937, server 401/3856.** `pnpm typecheck` (21 packages) and `eslint` on the touched files: clean.

## Checklist

- [x] Commit signed off (`git commit -s`)
- [x] Test added, proven RED without the fix
- [x] No `any`, no free strings, no non-null `!`
- [x] `note`-free; the new state rides the existing `z.nativeEnum(ElementState)` schema
- [x] Changed files under the 1000-line cap