### PR TITLE
feat(actions): press sets modifier keys so Cmd+K shortcuts are driveable (#393)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -411,7 +411,7 @@ A `state` assertion is graded as a **consequence** (a wrong element or stale ren
 | `select` | `{ value }` | `<select>` option |
 | `check` / `uncheck` | n/a | checkbox/radio |
 | `submit` | n/a | submits the element's `<form>` |
-| `press` | `{ key }` | keydown/up (default `Enter`) |
+| `press` | `{ key, modifiers? }` | keydown/up (default `Enter`); `modifiers`: an array of `Meta` / `Control` / `Shift` / `Alt` for Cmd+K-style shortcuts |
 | `scrollIntoView` | n/a |  |
 | `upload` | `{ name, content?, type? }` | sets a file on `<input type=file>` |
 | `drag` | `{ toRef }` | pointer-based drag (dnd-kit / rbd) + HTML5 DnD |

--- a/packages/browser/src/actions/actions.press-modifiers.test.ts
+++ b/packages/browser/src/actions/actions.press-modifiers.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { ActionType } from '@reticlehq/core';
+import { executeAction } from './actions.js';
+import { refs } from '../dom/refs.js';
+
+/**
+ * #393: `press` synthesised a KeyboardEvent with no modifier flags, so a Cmd+K / Ctrl+Shift
+ * shortcut arrived with metaKey/ctrlKey/shiftKey/altKey all false. The app's own check never
+ * matched, nothing observable happened, and Reticle reported no error -- a false negative, the
+ * expensive direction.
+ */
+describe('press sets modifier flags (#393)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('fires a metaKey+shiftKey shortcut the app only responds to with both', async () => {
+    const el = document.createElement('button');
+    document.body.appendChild(el);
+    let fired = false;
+    el.addEventListener('keydown', (e) => {
+      if (e.metaKey && e.shiftKey) fired = true;
+    });
+    await executeAction(refs.refFor(el), ActionType.PRESS, {
+      key: 'k',
+      modifiers: ['Meta', 'Shift'],
+    });
+    expect(fired).toBe(true);
+  });
+
+  it('sets each flag independently and leaves the rest false', async () => {
+    const el = document.createElement('button');
+    document.body.appendChild(el);
+    const seen: KeyboardEvent[] = [];
+    el.addEventListener('keydown', (e) => seen.push(e));
+    await executeAction(refs.refFor(el), ActionType.PRESS, { key: 'a', modifiers: ['Control'] });
+    expect(seen[0]?.ctrlKey).toBe(true);
+    expect(seen[0]?.metaKey).toBe(false);
+    expect(seen[0]?.altKey).toBe(false);
+  });
+
+  it('accepts the common aliases (Cmd, Option)', async () => {
+    const el = document.createElement('button');
+    document.body.appendChild(el);
+    let ok = false;
+    el.addEventListener('keydown', (e) => {
+      if (e.metaKey && e.altKey) ok = true;
+    });
+    await executeAction(refs.refFor(el), ActionType.PRESS, {
+      key: 'p',
+      modifiers: ['Cmd', 'Option'],
+    });
+    expect(ok).toBe(true);
+  });
+
+  it('also sets the flags on keyup', async () => {
+    const el = document.createElement('button');
+    document.body.appendChild(el);
+    let upMeta = false;
+    el.addEventListener('keyup', (e) => {
+      upMeta = e.metaKey;
+    });
+    await executeAction(refs.refFor(el), ActionType.PRESS, { key: 'k', modifiers: ['Meta'] });
+    expect(upMeta).toBe(true);
+  });
+
+  it('with no modifiers every flag stays false (unchanged behaviour)', async () => {
+    const el = document.createElement('button');
+    document.body.appendChild(el);
+    let anyMod = true;
+    el.addEventListener('keydown', (e) => {
+      anyMod = e.metaKey || e.ctrlKey || e.shiftKey || e.altKey;
+    });
+    await executeAction(refs.refFor(el), ActionType.PRESS, { key: 'Enter' });
+    expect(anyMod).toBe(false);
+  });
+});

--- a/packages/browser/src/actions/actions.ts
+++ b/packages/browser/src/actions/actions.ts
@@ -243,6 +243,29 @@ function pressKey(args: Record<string, unknown>): string {
 }
 
 /**
+ * Modifier flags for a `press`, from `args.modifiers`: an array of Meta / Control / Shift / Alt
+ * (case-insensitive, with the usual aliases). Without them a Cmd+K / Ctrl+Shift shortcut receives a
+ * keydown with every modifier false, so the app's own `event.metaKey` check never matches and
+ * nothing observable happens -- a false negative Reticle reports as no error. (#393)
+ */
+function pressModifiers(args: Record<string, unknown>): {
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+} {
+  const raw = args['modifiers'];
+  const names = Array.isArray(raw) ? raw.map((m) => asString(m).toLowerCase()) : [];
+  const has = (...aliases: string[]): boolean => aliases.some((a) => names.includes(a));
+  return {
+    metaKey: has('meta', 'cmd', 'command', 'super', 'win'),
+    ctrlKey: has('control', 'ctrl'),
+    shiftKey: has('shift'),
+    altKey: has('alt', 'option', 'opt'),
+  };
+}
+
+/**
  * The PHYSICAL key identity — `event.code` — derived from the logical key.
  *
  * A real browser always sends both, and a meaningful class of library reads only `code`, because it
@@ -604,10 +627,11 @@ async function dispatchOther(
     case ActionType.PRESS: {
       const key = pressKey(args);
       const code = pressCode(args, key);
+      const mods = pressModifiers(args);
       const down = el.dispatchEvent(
-        new KeyboardEvent('keydown', { key, code, bubbles: true, cancelable: true }),
+        new KeyboardEvent('keydown', { key, code, bubbles: true, cancelable: true, ...mods }),
       );
-      el.dispatchEvent(new KeyboardEvent('keyup', { key, code, bubbles: true }));
+      el.dispatchEvent(new KeyboardEvent('keyup', { key, code, bubbles: true, ...mods }));
       return !down;
     }
     case ActionType.SCROLL_INTO_VIEW:

--- a/packages/server/src/tools/act-tools.ts
+++ b/packages/server/src/tools/act-tools.ts
@@ -99,7 +99,7 @@ export const ACT_TOOLS: ToolDef[] = [
         .record(z.unknown())
         .optional()
         .describe(
-          'Action-specific arguments: { value } for fill/select, { text } for type/press (the key NAME, e.g. Escape or Tab), { toRef } for drag (the ref to drop ON — without it the drag lands nowhere), { native: true } to force a trusted native click, { holdMs: N } to keep the pointer DOWN for N ms (hold-to-confirm controls; effect.heldMs reports what was achieved), { confirmDangerous: true } to allow a potentially destructive control — a permission gate, NOT a duration.',
+          'Action-specific arguments: { value } for fill/select, { text } for type/press (the key NAME, e.g. Escape or Tab), { modifiers: ["Meta","Shift"] } for a press shortcut (Meta/Control/Shift/Alt — a Cmd+K), { toRef } for drag (the ref to drop ON — without it the drag lands nowhere), { native: true } to force a trusted native click, { holdMs: N } to keep the pointer DOWN for N ms (hold-to-confirm controls; effect.heldMs reports what was achieved), { confirmDangerous: true } to allow a potentially destructive control — a permission gate, NOT a duration.',
         ),
       refuseWhenThrottled: z
         .boolean()
@@ -303,7 +303,7 @@ export const ACT_TOOLS: ToolDef[] = [
         .record(z.unknown())
         .optional()
         .describe(
-          'Action-specific arguments: { value } for fill/select, { text } for type/press (the key NAME, e.g. Escape or Tab), { toRef } for drag (the ref to drop ON — without it the drag lands nowhere), { confirmDangerous: true } for a potentially destructive control.',
+          'Action-specific arguments: { value } for fill/select, { text } for type/press (the key NAME, e.g. Escape or Tab), { modifiers: ["Meta","Shift"] } for a press shortcut (Meta/Control/Shift/Alt), { toRef } for drag (the ref to drop ON — without it the drag lands nowhere), { confirmDangerous: true } for a potentially destructive control.',
         ),
       predicate: PredicateSchema.optional().describe(
         'Alias for `until` (the name reticle_assert / reticle_wait_for use).',


### PR DESCRIPTION
## What & why

The `press` action synthesised a `KeyboardEvent` from the key name but never set the modifier flags. An app implementing a Cmd+K-style global shortcut, or a shortcut-recording UI that reads `event.metaKey`, received a keydown with `metaKey` / `ctrlKey` / `shiftKey` / `altKey` all false. Its own check does not match, nothing observable happens, and Reticle reports no error — so it reads as the app being broken rather than as a call Reticle cannot make. That is a false negative, the expensive direction.

Accept `args.modifiers` and set the flags on **both** the keydown and the keyup:

```jsonc
reticle_act { action: "press", args: { key: "k", modifiers: ["Meta", "Shift"] } }
```

`modifiers` is an array of `Meta` / `Control` / `Shift` / `Alt`, case-insensitive and with the usual aliases (`Cmd`, `Ctrl`, `Option`). The act tool's `args` is already a loose record, so nothing else in the schema changes; the argument is now documented in the tool description and usage.md.

Closes #393

## How it was verified

- New `packages/browser/src/actions/actions.press-modifiers.test.ts` — the failing test the issue asks for (a listener that only responds to `metaKey && shiftKey`, driven by `press`), plus per-flag independence, alias handling, keyup coverage, and the unchanged no-modifiers case. Proven RED→GREEN: without the flags, the four modifier tests fail and only "no modifiers → all false" passes.
- **Full suites green: browser 102/937, server 401/3856.** `pnpm typecheck` (21 packages) and `eslint` on the touched files: clean.

## Checklist

- [x] Commit signed off (`git commit -s`)
- [x] Test added, proven RED without the fix (the exact test the issue prescribes)
- [x] No `any`, no free strings, no non-null `!`
- [x] Rides the existing loose `args` record — no schema change
- [x] Changed files under the 1000-line cap