### PR TITLE
feat(snapshot): say when an overlay aria-hides the rest of the page (#397)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -91,7 +91,7 @@ List connected tabs. → `{ sessions: [{ sessionId, url, title, lastSeenMs, hidd
 A semantic, accessibility-tree view of the page.
 
 - **args:** `mode?: 'full' | 'interactive' | 'status'` (default `full`), `scope?` (CSS selector or ref), `diff?: boolean`, `sessionId?`.
-- **returns:** `{ tree, status: { route, title, visibleDialogs }, nodes, truncated, cost: { bytes, tokens } }`.
+- **returns:** `{ tree, status: { route, title, visibleDialogs, overlayHidingPage }, nodes, truncated, cost: { bytes, tokens } }`.
 - **`diff: true`** returns only what changed since your last snapshot of the same scope/mode: `{ mode: 'delta', delta: { added, removed, addedCount, removedCount } }` or `{ mode: 'unchanged' }` (no full tree). The first call (and any call after a route change) still returns the full tree. ~99% fewer tokens to re-look after an action; see [token-efficiency.md](token-efficiency.md).
 - **`cost`** is an estimated size of the result. Re-scope (`mode`/`scope`) before reading if large.
 

--- a/packages/browser/src/dom/overlay-hiding-page.test.ts
+++ b/packages/browser/src/dom/overlay-hiding-page.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { SnapshotMode } from '@reticlehq/core';
+import { buildSnapshot } from './snapshot.js';
+
+/**
+ * #397: a focus-trap modal aria-hides every sibling of its portal, and the snapshot walk correctly
+ * skips aria-hidden subtrees -- so a whole-page snapshot can come back with only the overlay and
+ * nothing else, indistinguishable from an empty page. When the rest of the page is entirely
+ * aria-hidden behind a visible overlay, status says so instead of returning a near-empty tree with
+ * no explanation.
+ */
+describe('overlayHidingPage status (#397)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('reports when the page outside a visible modal is entirely aria-hidden', () => {
+    document.body.innerHTML =
+      '<div aria-hidden="true"><button>Buy now</button><a href="/x">Home</a></div>' +
+      '<div><div role="dialog" aria-label="Confirm"><button>OK</button></div></div>';
+    const { status } = buildSnapshot({ mode: SnapshotMode.INTERACTIVE });
+    expect(status.overlayHidingPage).toBeDefined();
+    expect(String(status.overlayHidingPage)).toContain('overlay');
+  });
+
+  it('says nothing on a normal page with a dialog but no hidden siblings', () => {
+    document.body.innerHTML =
+      '<div><button>Buy now</button></div>' +
+      '<div role="dialog" aria-label="Confirm"><button>OK</button></div>';
+    const { status } = buildSnapshot({ mode: SnapshotMode.INTERACTIVE });
+    expect(status.overlayHidingPage).toBeUndefined();
+    // The dialog itself is still surfaced normally.
+    expect(status.visibleDialogs).toContain('Confirm');
+  });
+
+  it('says nothing when there is no dialog at all, even if a sibling is aria-hidden', () => {
+    document.body.innerHTML =
+      '<div aria-hidden="true"><button>Hidden</button></div>' +
+      '<div><button>Visible</button></div>';
+    const { status } = buildSnapshot({ mode: SnapshotMode.INTERACTIVE });
+    expect(status.overlayHidingPage).toBeUndefined();
+  });
+});

--- a/packages/browser/src/dom/snapshot.ts
+++ b/packages/browser/src/dom/snapshot.ts
@@ -65,6 +65,11 @@ interface SnapshotStatus {
   title: string;
   /** Open dialogs, OMITTED when there are none — absence means "no dialog is up". */
   visibleDialogs?: string[];
+  /**
+   * Present ONLY when a whole-page snapshot came back near-empty because an open overlay
+   * aria-hidden the rest of the page (#397). Absence means the page is not hidden behind an overlay.
+   */
+  overlayHidingPage?: string;
 }
 
 export interface SnapshotResult {
@@ -242,12 +247,47 @@ function collectDialogs(root: ParentNode): string[] {
  * case, so the field was almost pure repetition; a reader learns nothing from its presence and
  * everything from it.
  */
+/**
+ * A focus-trap modal (Radix and friends) marks every sibling of the portal root aria-hidden. The
+ * snapshot walk correctly skips aria-hidden subtrees, so a whole-page snapshot can return only the
+ * overlay's own nodes and nothing else -- indistinguishable from "this page is empty". If the
+ * overlay's cleanup is stuck (common on a throttled tab), every later action then dispatches with no
+ * effect because the overlay genuinely captures pointer events. Say so instead of returning a
+ * near-empty tree with no explanation. (#397)
+ */
+function overlayHidingPage(root: ParentNode): string | undefined {
+  // Only meaningful for a whole-page snapshot; a scoped snapshot is the subtree the caller chose.
+  if (root !== document.body) return undefined;
+  const dialogs = document.body.querySelectorAll(
+    '[role="dialog"], dialog[open], [aria-modal="true"]',
+  );
+  let modal: Element | undefined;
+  for (const d of dialogs) {
+    if (isVisible(d)) {
+      modal = d;
+      break;
+    }
+  }
+  if (modal === undefined) return undefined;
+  const modalEl = modal;
+  const outside = Array.from(document.body.children).filter((c) => !c.contains(modalEl));
+  if (0 === outside.length) return undefined;
+  if (!outside.every((c) => 'true' === c.getAttribute('aria-hidden'))) return undefined;
+  return (
+    'the rest of the page is aria-hidden behind an open overlay (a focus-trap modal), so this ' +
+    'snapshot shows only the overlay. If it will not close its cleanup may be stuck on a throttled ' +
+    'tab: dismiss the overlay, or snapshot with { scope } inside it.'
+  );
+}
+
 function buildStatus(root: ParentNode): SnapshotStatus {
   const visibleDialogs = collectDialogs(root);
+  const overlay = overlayHidingPage(root);
   return {
     route: `${location.pathname}${location.search}${location.hash}`,
     title: document.title,
     ...(visibleDialogs.length > 0 ? { visibleDialogs } : {}),
+    ...(overlay !== undefined ? { overlayHidingPage: overlay } : {}),
   };
 }
 

--- a/packages/server/src/tools/tools.ts
+++ b/packages/server/src/tools/tools.ts
@@ -149,7 +149,14 @@ const RAW_TOOLS: ToolDef[] = [
         .string()
         .optional()
         .describe('Indented ARIA tree of every element on the page (or the scoped subtree).'),
-      status: z.object({ route: z.string(), title: z.string().optional() }).optional(),
+      status: z
+        .object({
+          route: z.string(),
+          title: z.string().optional(),
+          visibleDialogs: z.array(z.string()).optional(),
+          overlayHidingPage: z.string().optional(),
+        })
+        .optional(),
       mode: z
         .string()
         .optional()


### PR DESCRIPTION
## What & why

When a modal/popover is open, focus-trap libraries (Radix and friends) mark every sibling of the portal root `aria-hidden="true"`. The snapshot walk skips aria-hidden subtrees — correctly, since they aren't in the accessibility tree — so a whole-page `reticle_snapshot({ mode: "interactive" })` can return **only the popover's nodes and nothing else**, indistinguishable from "this page is empty". If the popover fails to close (which happens on a throttled tab, where the library's cleanup is deferred), every later action dispatches with no effect because the overlay genuinely captures pointer events. Reticle isn't wrong here; it's unreadable, and figuring out what you're looking at has cost agents a long run of tool calls, a dev-server restart and a reload.

The snapshot already collects visible dialogs for its `status` block. This adds `overlayHidingPage` to `status`, set only when a whole-page snapshot has a **visible** overlay AND every top-level sibling outside it is `aria-hidden`:

> the rest of the page is aria-hidden behind an open overlay (a focus-trap modal)... dismiss the overlay, or snapshot with { scope } inside it.

Scoped to whole-page snapshots (a `{ scope }` snapshot is the subtree the caller chose), and gated on a real visible overlay + all-siblings-hidden so it can't false-positive on an ordinary page.

Closes #397

## How it was verified

- New `packages/browser/src/dom/overlay-hiding-page.test.ts` — the stuck-overlay fixture (aria-hidden page + visible dialog) reports; a normal page with a dialog but visible siblings does **not** (and still surfaces `visibleDialogs`); an aria-hidden sibling with **no** dialog does not. Proven RED→GREEN: with the detector disabled, only the positive case fails.
- Declared `overlayHidingPage` (and the pre-existing `visibleDialogs`) on the snapshot tool's `status` output schema, and documented it in usage.md.
- **Full suites green: browser 102/935, server 401/3856.** `pnpm typecheck` (21 packages) and `eslint` on the touched files: clean.

## Checklist

- [x] Commit signed off (`git commit -s`)
- [x] Test + fixture added, proven RED without the fix
- [x] No `any`, no free strings, no non-null `!`
- [x] Reuses the existing status block; omitted at its uninformative default like every other status field
- [x] Changed files under the 1000-line cap