### PR TITLE
feat(predicate): a named state assertion reads scoped, not whole (#336)

### DIFF
--- a/packages/server/src/events/predicate-state-scoped.test.ts
+++ b/packages/server/src/events/predicate-state-scoped.test.ts
@@ -1,0 +1,188 @@
+/**
+ * A state assertion that NAMES its store should read only that path, not every store.
+ *
+ * Follow-up to the truncation fix in 60a13e20, which made the read CORRECT. This makes it CHEAP.
+ * `reticle_state` already has a scoped mode that selects the path out of the RAW store in-page, before
+ * the transport cap — the read tool's own comment is the argument:
+ *
+ *   > Forward path/depth so a CURRENT browser SDK scopes the read IN-PAGE, before the transport — the
+ *   > value never gets size-truncated in transit.
+ *
+ * The predicate path never learned that. When `store` is named, nothing around it needs the other
+ * stores, so a whole-store read only pays for a payload it throws away and risks a cap that a scoped
+ * read would never trip. So: a named store reads scoped, in one round trip.
+ *
+ * The unnamed case genuinely needs the wide read (it is how the path's store is discovered) and is
+ * left exactly as it was — covered by predicate-store-narrowing.test.ts.
+ *
+ * One property to preserve: a scoped read answers `found:false` for both "no such store" and "no such
+ * path". Those are different facts and stay distinguishable here, or the message regresses while the
+ * payload improves.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ReticleCommand, type CommandResult, type ReticleEvent } from '@reticlehq/core';
+import { evaluatePredicate } from './predicate.js';
+import type { PredicateSession } from './predicate.js';
+
+interface ScopedReply {
+  store?: string;
+  path?: string;
+  found?: boolean;
+  value?: unknown;
+  truncation?: Record<string, unknown>;
+  availableKeys?: string[];
+  storeNames: string[];
+}
+
+/**
+ * A session whose SDK actually honours the scoped read: given {store, path} it selects in-page and
+ * returns only the value, the way a current browser SDK does. Records every read so a test can assert
+ * that a named assertion made ONE scoped call, not a whole-store read.
+ */
+class ScopedStores implements PredicateSession {
+  readonly reads: Record<string, unknown>[] = [];
+  constructor(private readonly registered: Record<string, Record<string, unknown>>) {}
+  elapsed(): number {
+    return 0;
+  }
+  command(name: string, args?: Record<string, unknown>): Promise<CommandResult> {
+    if (name !== ReticleCommand.STATE_READ) {
+      return Promise.resolve({ kind: 'command_result', id: 'x', ok: true, result: {} });
+    }
+    const a = args ?? {};
+    this.reads.push(a);
+    const storeNames = Object.keys(this.registered);
+    const store = 'string' === typeof a['store'] ? a['store'] : undefined;
+    const path = 'string' === typeof a['path'] ? a['path'] : undefined;
+    // Scoped mode: the SDK walks `path` into the named store and returns just that.
+    if (store !== undefined && path !== undefined) {
+      const bag = this.registered[store];
+      const has = bag !== undefined && Object.prototype.hasOwnProperty.call(bag, path);
+      const reply: ScopedReply = {
+        store,
+        path,
+        found: has,
+        value: has ? bag[path] : undefined,
+        storeNames,
+        ...(has ? {} : { availableKeys: bag ? Object.keys(bag) : [] }),
+      };
+      return Promise.resolve({ kind: 'command_result', id: 'x', ok: true, result: reply });
+    }
+    // Whole-store read (unnamed path only reaches here).
+    return Promise.resolve({
+      kind: 'command_result',
+      id: 'x',
+      ok: true,
+      result: { stores: this.registered, storeNames },
+    });
+  }
+  eventsSince(): ReticleEvent[] {
+    return [];
+  }
+  onEvent(): () => void {
+    return () => undefined;
+  }
+}
+
+const APP = { app: { view: 'deployments', tab: 'overview' } };
+
+describe('a named store reads scoped, not whole', () => {
+  it('makes exactly one scoped read carrying the path, never a whole-store read', async () => {
+    const session = new ScopedStores(APP);
+    const r = await evaluatePredicate(session, {
+      kind: 'state',
+      store: 'app',
+      path: 'view',
+      equals: 'deployments',
+    });
+    expect(r.pass).toBe(true);
+    expect(session.reads).toHaveLength(1);
+    expect(session.reads[0]).toMatchObject({ store: 'app', path: 'view' });
+  });
+
+  it('resolves the small asserted value even when a sibling would blow the whole-store cap', async () => {
+    // The Atlas shape: `pendingDispatch` is tiny, `rows` beside it is huge. A whole-store read would
+    // truncate and, before the fix, compare against "[TRUNCATED]". The scoped read never sees `rows`,
+    // so the assertion that is TRUE is reported true — in one round trip, with nothing to re-read.
+    const session = new ScopedStores({
+      atlas: { rows: 'huge...', pendingDispatch: ['shp_000001'] },
+    });
+    const r = await evaluatePredicate(session, {
+      kind: 'state',
+      store: 'atlas',
+      path: 'pendingDispatch',
+      equals: { $contains: 'shp_000001' },
+    });
+    expect(r.pass).toBe(true);
+    expect(r.inconclusive).toBeUndefined();
+    expect(session.reads).toHaveLength(1);
+  });
+
+  it('keeps "no such store" distinct from "no such path"', async () => {
+    const missingStore = await evaluatePredicate(new ScopedStores(APP), {
+      kind: 'state',
+      store: 'nope',
+      path: 'view',
+    });
+    expect(missingStore.pass).toBe(false);
+    expect(missingStore.assertion).toBe('state.store-missing');
+    expect(missingStore.failureReason).toContain("no store named 'nope'");
+
+    const missingPath = await evaluatePredicate(new ScopedStores(APP), {
+      kind: 'state',
+      store: 'app',
+      path: 'absent',
+    });
+    expect(missingPath.pass).toBe(false);
+    expect(missingPath.assertion).toBe('state.path-missing');
+    expect(missingPath.failureReason).toContain("store 'app'");
+  });
+
+  it('is INCONCLUSIVE, not a failure, when even the scoped value is truncated', async () => {
+    const session = new ScopedStores(APP);
+    // Force a truncated scoped reply for the named read.
+    const truncating: PredicateSession = {
+      elapsed: () => 0,
+      command: (name: string) =>
+        name === ReticleCommand.STATE_READ
+          ? Promise.resolve({
+              kind: 'command_result',
+              id: 'x',
+              ok: true,
+              result: {
+                store: 'app',
+                path: 'view',
+                found: true,
+                value: '[TRUNCATED]',
+                truncation: { truncatedValues: 1, note: 'caps fired' },
+                storeNames: ['app'],
+              },
+            } satisfies CommandResult)
+          : Promise.resolve({ kind: 'command_result', id: 'x', ok: true, result: {} }),
+      eventsSince: () => [],
+      onEvent: () => () => undefined,
+    };
+    void session;
+    const r = await evaluatePredicate(truncating, {
+      kind: 'state',
+      store: 'app',
+      path: 'view',
+      equals: 'deployments',
+    });
+    expect(r.pass).toBe(false);
+    expect(r.inconclusive).toContain('truncat');
+  });
+
+  it('reports a genuine mismatch as a failure, not truncation', async () => {
+    const r = await evaluatePredicate(new ScopedStores(APP), {
+      kind: 'state',
+      store: 'app',
+      path: 'view',
+      equals: 'settings',
+    });
+    expect(r.pass).toBe(false);
+    expect(r.inconclusive).toBeUndefined();
+    expect(r.assertion).toBe('state.equals');
+  });
+});

--- a/packages/server/src/events/predicate.ts
+++ b/packages/server/src/events/predicate.ts
@@ -253,14 +253,120 @@ function asSelection(result: unknown): { found: boolean; value: unknown } | unde
     : undefined;
 }
 
+/**
+ * A NAMED store needs no whole-store read. `reticle_state`'s scoped mode selects the path out of the
+ * RAW store IN-PAGE and returns only it, so the assertion resolves in one round trip against a payload
+ * the size of the value — not the store. The unnamed case below still needs the wide read, because
+ * that is how it discovers WHICH store carries the path; only the named branch changes.
+ *
+ * A scoped read answers `found: false` for both "no such store" and "no such path", so the two are
+ * kept distinct here using the `storeNames` list the reply always carries — otherwise the payload gets
+ * cheaper while the message gets worse.
+ */
+async function evalStateNamed(
+  session: PredicateSession,
+  p: Extract<Predicate, { kind: typeof PredicateKind.STATE }>,
+  storeName: string,
+): Promise<EvalResult> {
+  const scoped = await session.command(ReticleCommand.STATE_READ, {
+    store: storeName,
+    path: p.path,
+  });
+  if (!scoped.ok) {
+    return {
+      pass: false,
+      failureReason: 'state read failed',
+      observed: 'the store could not be read',
+      expected: 'a readable registered store',
+      assertion: 'state.unreadable',
+    };
+  }
+  const reply = (scoped.result ?? {}) as {
+    stores?: Record<string, unknown>;
+    storeNames?: unknown;
+    availableKeys?: unknown;
+  };
+  const names = Array.isArray(reply.storeNames) ? (reply.storeNames as string[]) : [];
+
+  // Resolve the value. A CURRENT SDK honours the scoped read and answers `{ found, value }` selected
+  // in-page — the whole point of this path. An OLDER SDK (version skew) or any transport that ignores
+  // `path` answers the whole-store shape `{ stores }`; walk the path server-side there so the verdict
+  // stays correct across SDK versions. The scoped win is simply unavailable on the old ones.
+  const scopedSel = asSelection(scoped.result);
+  const wholeStores = reply.stores;
+  const scopedKeys = Array.isArray(reply.availableKeys)
+    ? (reply.availableKeys as string[])
+    : undefined;
+  let selection: { found: boolean; value?: unknown; availableKeys?: string[] };
+  if (scopedSel !== undefined) {
+    selection =
+      scopedKeys === undefined
+        ? { found: scopedSel.found, value: scopedSel.value }
+        : { found: scopedSel.found, value: scopedSel.value, availableKeys: scopedKeys };
+  } else if (wholeStores !== undefined) {
+    selection = selectPath(wholeStores[storeName], p.path);
+  } else {
+    selection = { found: false };
+  }
+
+  // "no store named X" and "X has no such path" both surface as found:false; keep them distinct using
+  // the store list the reply carries, or the message regresses while the payload improves.
+  const storeAbsent =
+    wholeStores !== undefined
+      ? !(storeName in wholeStores)
+      : names.length > 0 && !names.includes(storeName);
+  if (!selection.found && storeAbsent) {
+    return {
+      pass: false,
+      failureReason: `no store named '${storeName}' is registered (${names.join(', ')})`,
+      observed: `store '${storeName}' is not registered`,
+      expected: `a registered store named '${storeName}'`,
+      assertion: 'state.store-missing',
+      evidence: { searchedStores: names },
+    };
+  }
+  // A scoped sub-tree can itself be too big for the caps; a comparison against a value known to be
+  // incomplete is an unanswered question, not a failure. Same rule the whole-store path applies.
+  if (truncationOf(scoped.result) !== undefined) {
+    const reason =
+      `state '${p.path}' could not be read intact — the transport caps truncated it, so the ` +
+      'value was never compared. Assert a narrower path, or a smaller field inside it';
+    return { pass: false, failureReason: reason, inconclusive: reason };
+  }
+  if (!selection.found) {
+    return {
+      pass: false,
+      failureReason: `state path '${p.path}' not found in store '${storeName}'`,
+      observed: `no path '${p.path}' in store '${storeName}'`,
+      expected: `store '${storeName}' to expose '${p.path}'`,
+      assertion: 'state.path-missing',
+      evidence: { availableKeys: selection.availableKeys },
+    };
+  }
+  const want = p.equals === undefined ? '*' : p.equals;
+  if (matchValue(selection.value, want)) {
+    return {
+      pass: true,
+      evidence: { store: storeName, path: p.path, value: capDepth(selection.value, 1) },
+    };
+  }
+  return {
+    pass: false,
+    failureReason: `state '${p.path}' is ${JSON.stringify(capDepth(selection.value, 0))}, expected ${JSON.stringify(want)}`,
+    observed: `${p.path} = ${JSON.stringify(capDepth(selection.value, 0))}`,
+    expected: `${p.path} = ${JSON.stringify(want)}`,
+    assertion: 'state.equals',
+    evidence: { store: storeName, path: p.path, value: capDepth(selection.value, 1) },
+  };
+}
+
 async function evalState(
   session: PredicateSession,
   p: Extract<Predicate, { kind: typeof PredicateKind.STATE }>,
 ): Promise<EvalResult> {
-  const res = await session.command(
-    ReticleCommand.STATE_READ,
-    p.store !== undefined ? { store: p.store } : {},
-  );
+  // Named store: one scoped read, no whole-store payload (issue #336).
+  if (p.store !== undefined) return await evalStateNamed(session, p, p.store);
+  const res = await session.command(ReticleCommand.STATE_READ, {});
   if (!res.ok) {
     return {
       pass: false,


### PR DESCRIPTION
Closes #336.

## What

`evalState` always issued a whole-store `STATE_READ` and walked the path server-side, even when the predicate named its store. `reticle_state` already has a scoped mode that selects the path out of the RAW store in-page, before the transport cap (its own comment: *"Forward path/depth so a CURRENT browser SDK scopes the read IN-PAGE, before the transport — the value never gets size-truncated in transit"*). The predicate path never learned that.

Now a **named** store reads scoped: one round trip, a payload the size of the value rather than the store, and no cap to trip in the first place. The **unnamed** case is unchanged — it genuinely needs the wide read to discover which store carries the path (covered by `predicate-store-narrowing.test.ts`).

## Correctness across SDK versions

A current SDK answers the scoped `{ found, value }` shape. An older SDK (version skew) or any transport that ignores `path` answers the whole-store `{ stores }` shape; the path is walked server-side there, so the verdict is identical across SDK versions. The scoped payload win is simply unavailable on the old ones. Small stores stay one read with the same verdict.

## Keeping the message honest

A scoped read returns `found: false` for both "no such store" and "no such path". As the issue warns, that would make the message worse while the payload gets better. The `storeNames` list the reply always carries keeps them distinct: a genuinely-absent named store now reports `state.store-missing` instead of collapsing into a path-missing message.

## Cost

Per the repo rule that only the benchmark settles cost, the claim here is deliberately narrow and matches what the tests pin: **zero change on small stores** (one read, identical verdict) and a **payload** reduction on large stores (the value, not the whole store). The expected win is on payload rather than latency; a large-store benchmark run would confirm the magnitude.

## Tests

New `predicate-state-scoped.test.ts`:
- a named assertion makes exactly one scoped read carrying the path, never a whole-store read
- the small asserted value resolves even when a sibling would blow the whole-store cap (the Atlas shape), in one round trip
- "no such store" stays distinct from "no such path"
- a truncated scoped value is inconclusive, not a failure
- a genuine mismatch is still a failure, not truncation

RED→GREEN: without the change, the scoped-read-carries-path and store-missing assertions fail; with it, all pass. Full `src/events`, `src/flows`, `src/honesty` suites stay green (824 tests), including `predicate-store-narrowing` and `predicate-truncated-state`. Typecheck and lint clean.