### PR TITLE
fix(lease): route unadvertised reticle_lease through reticle_run + preflight the browser (#400)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -46,6 +46,7 @@ import { BrowserPool } from './pool/browser-pool.js';
 import { playwrightLauncher, resolveMaxContexts } from './pool/playwright-launcher.js';
 import { LeaseReaper } from './pool/lease-reaper.js';
 import { readJournalEnabled, readProjectId } from './cli/cli-port.js';
+import { probeChromium } from './cli/chromium-hint.js';
 import { makeJournalAttach } from './journal/attach-journal.js';
 import { makeSessionEnd } from './journal/session-end.js';
 import { AmbientStore } from './journal/ambient-store.js';
@@ -433,6 +434,7 @@ export async function start(options: StartOptions = {}): Promise<RunningServer> 
       reticleRoot,
       now,
       bridgePort: port,
+      browserProbe: probeChromium,
       // The daemon's OWN project, so a tool can tell "this session is mine" from "this session
       // belongs to a sibling app under the same daemon". contract_save refuses on the second.
       ...(activeProjectId === undefined ? {} : { projectId: activeProjectId }),
@@ -545,6 +547,7 @@ export async function startDaemon(options: StartOptions = {}): Promise<RunningSe
     reticleRoot,
     now,
     bridgePort: port,
+    browserProbe: probeChromium,
   };
   const profile = resolveToolSurface(options.toolProfile);
   const effectiveDeps = realInput !== undefined ? { ...deps, realInput } : deps;

--- a/packages/server/src/tools/error-recovery.test.ts
+++ b/packages/server/src/tools/error-recovery.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { TRANSPORT_LIMITS } from '@reticlehq/core';
 import { FEEDBACK_ASK, RECOVERY, buildErrorPayload, recoveryFor } from './error-recovery.js';
 import { TOOLS } from './tools.js';
+import { ReticleTool } from './tool-names.js';
 import { diagnoseNoSession } from '../session/no-session-diagnosis.js';
 
 describe('recoveryFor — every known error carries an actionable next move', () => {
@@ -29,6 +30,15 @@ describe('recoveryFor — every known error carries an actionable next move', ()
         'refusing to act: tab throttled; timer/rAF/pointer gestures may silently no-op — refocus before driving',
       ),
     ).toBe(RECOVERY.THROTTLED);
+  });
+
+  it('names reticle_lease through reticle_run, since it is unadvertised by default (#400)', () => {
+    // The throttled-tab timeout recovery told the agent to "drive your own browser with
+    // reticle_lease" — a tool the default profile does not advertise, so an agent that had not
+    // already called reticle_tools could not call it and had no way to learn it goes through
+    // reticle_run. The recovery now names the call that actually reaches it.
+    expect(RECOVERY.COMMAND_TIMEOUT).toContain('reticle_run { tool: "reticle_lease"');
+    expect(RECOVERY.COMMAND_TIMEOUT).not.toMatch(/with reticle_lease\b/);
   });
 
   it('maps a missing baseline / recording to the create-it-first hint', () => {
@@ -74,7 +84,17 @@ describe('buildErrorPayload — the MCP-boundary envelope', () => {
  * the strings are prose, and prose is not type-checked.
  */
 describe('every tool a recovery hint names must still be advertised', () => {
-  const advertised = new Set(TOOLS.map((tool) => tool.name));
+  // TOOLS is the underlying tool table; the two META-tools (reticle_run to dispatch, reticle_tools
+  // to discover) are added by dynamic-tools.ts and are advertised under the default/hybrid profiles
+  // — the very profiles these recovery hints are written for. A hint may name them to route to a
+  // tool the profile does not advertise directly (e.g. reticle_run { tool: "reticle_lease" }), so
+  // they count as reachable here. Under `full` every tool is advertised directly, so the routing
+  // clause is merely redundant, not a dangling door.
+  const advertised = new Set([
+    ...TOOLS.map((tool) => tool.name),
+    ReticleTool.RUN,
+    ReticleTool.TOOLS,
+  ]);
 
   it.each(Object.entries(RECOVERY))('%s names only reachable tools', (_name, hint) => {
     for (const mentioned of hint.match(/reticle_[a-z_]+/g) ?? []) {

--- a/packages/server/src/tools/error-recovery.ts
+++ b/packages/server/src/tools/error-recovery.ts
@@ -144,7 +144,9 @@ export const RECOVERY = {
     'The page did not answer within the command window. That is a fact about the page, not a Reticle ' +
     'failure: check reticle_sessions for `throttled`/`stale` on this session — a backgrounded tab is ' +
     'throttled and may never answer, so ask the human to bring it to the front or drive your own ' +
-    'browser with reticle_lease. If the tab is in front, the page is busy or blocked (a long ' +
+    'browser with reticle_run { tool: "reticle_lease", action: "acquire", url } — reticle_lease is ' +
+    'not advertised under the default profile, so it is reached through reticle_run, not called ' +
+    'directly. If the tab is in front, the page is busy or blocked (a long ' +
     'synchronous task, an alert/confirm dialog); reticle_console usually shows what it hit. Retry ' +
     'once the cause is addressed.',
   FLOW_STEP_MISSING:

--- a/packages/server/src/tools/lease-tools.test.ts
+++ b/packages/server/src/tools/lease-tools.test.ts
@@ -114,6 +114,38 @@ describe('reticle_lease_acquire failure surfaces a clean message', () => {
   });
 });
 
+describe('reticle_lease_acquire preflights the browser (#400)', () => {
+  it('refuses at the first call with the install fix when Chromium is absent, without a round trip', async () => {
+    const { pool, acquired } = fakePool();
+    await expect(
+      tool(ReticleTool.LEASE_ACQUIRE)(
+        { ...baseDeps, pool, browserProbe: () => Promise.resolve({ exists: false }) },
+        { url: 'http://localhost:3000/' },
+      ),
+      // Carries "Chromium is not installed" so error-recovery routes it to the NO_POOL fix rather
+      // than the misleading "is the app running?" a launch failure inside acquire would have produced.
+    ).rejects.toThrow(/Chromium is not installed/);
+    // The point of a PREflight: the pool was never asked to open anything.
+    expect(acquired).toHaveLength(0);
+  });
+
+  it('proceeds normally when the probe says Chromium is present', async () => {
+    const { pool, acquired } = fakePool();
+    const result = (await tool(ReticleTool.LEASE_ACQUIRE)(
+      { ...baseDeps, pool, browserProbe: () => Promise.resolve({ exists: true }) },
+      { url: 'http://localhost:3000/' },
+    )) as { sessionId: string };
+    expect(result.sessionId).toMatch(/^lease-/);
+    expect(acquired).toHaveLength(1);
+  });
+
+  it('skips the preflight entirely when no probe is wired (unchanged default)', async () => {
+    const { pool, acquired } = fakePool();
+    await tool(ReticleTool.LEASE_ACQUIRE)({ ...baseDeps, pool }, { url: 'http://localhost:3000/' });
+    expect(acquired).toHaveLength(1);
+  });
+});
+
 describe('waitForLeasedSession', () => {
   it('resolves true as soon as the tab is connected (no waiting)', async () => {
     const sleeper = (): Promise<void> => Promise.reject(new Error('should not sleep'));

--- a/packages/server/src/tools/lease-tools.ts
+++ b/packages/server/src/tools/lease-tools.ts
@@ -15,6 +15,7 @@ import { RETICLE_URL_PARAM, RETICLE_DEFAULT_PORT } from '@reticlehq/core';
 import { ReticleTool } from './tool-names.js';
 import type { ToolDef, ToolDeps } from './tool-kit.js';
 import { asString } from './tools-helpers.js';
+import { chromiumHint } from '../cli/chromium-hint.js';
 
 const POOL_UNAVAILABLE =
   'browser pool unavailable — the lease tools need the daemon-managed pool (start Reticle via `reticle mcp`).';
@@ -195,6 +196,17 @@ export const LEASE_TOOLS: ToolDef[] = [
       const url = asString(args['url']);
       if (url === undefined || 0 === url.length)
         throw new Error('reticle_lease{action:"acquire"} requires a url');
+      // Preflight the browser before spending the round trip. Without it a missing Playwright Chromium
+      // only surfaces inside pool.acquire, where the launch failure is caught and reported as
+      // "could not open <url> — is the app running?" — sending the caller to debug an app that is
+      // fine. Say the real thing at the first refusal instead. The phrasing carries "Chromium is not
+      // installed" so error-recovery routes it to the NO_POOL fix (install + drive a human tab).
+      if (deps.browserProbe !== undefined) {
+        const probe = await deps.browserProbe();
+        if (!probe.exists) {
+          throw new Error(`Chromium is not installed for Playwright — ${chromiumHint(probe)}`);
+        }
+      }
       const projectId = asString(args['projectId']);
       const sessionId = newLeaseId();
       const navUrl = appendReticleParams(url, sessionId, projectId);

--- a/packages/server/src/tools/tool-kit.ts
+++ b/packages/server/src/tools/tool-kit.ts
@@ -16,11 +16,19 @@ import type { FlowStore } from '../flows/flows.js';
 import type { ProjectStore } from '../project/project-store.js';
 import type { AnnotationStore } from '../flows/annotation-store.js';
 import type { BrowserPool } from '../pool/browser-pool.js';
+import type { ChromiumProbe } from '../cli/chromium-hint.js';
 
 export interface ToolDeps {
   sessions: SessionManager;
   /** shared one-browser/N-context pool for headless leases. undefined ⇒ lease tools report unavailable. */
   pool?: BrowserPool;
+  /**
+   * Probe for a launchable Chromium, so the lease path can refuse at the FIRST call with the install
+   * fix rather than failing several calls in with a message that reads as "the app is not running".
+   * Optional: absent ⇒ no preflight — every existing test construction of ToolDeps keeps working, and
+   * the fake-pool lease tests are deliberately runnable without a real Chromium.
+   */
+  browserProbe?: () => Promise<ChromiumProbe>;
   baselines: BaselineStore;
   recordings: RecordingStore;
   /** on-disk anchored-flow store (.reticle/flows/). */


### PR DESCRIPTION
Closes #400.

An agent handed only a hidden, throttled tab follows the recovery text embedded in the flow, and each hop names something the next hop rejects. Two changes remain (the port fight and `doctor`'s Chromium report are already fixed), and this does both.

## 1. Name the call that actually reaches the tool

The throttled-tab timeout recovery told the agent to drive its own browser **`with reticle_lease`** — a tool the default profile does not advertise. An agent that had not already called `reticle_tools` cannot see it and has no way to learn it must go through `reticle_run`. The recovery now names the reaching call:

```
reticle_run { tool: "reticle_lease", action: "acquire", url }
```

The `every tool a recovery hint names must still be advertised` guardrail built its advertised set from the underlying `TOOLS` table, which omits the two **meta-tools** (`reticle_run` to dispatch, `reticle_tools` to discover) that `dynamic-tools.ts` adds under the default/hybrid profiles — the very profiles these hints are written for. It now counts them as reachable, so a recovery may legitimately route through them. Under `full` every tool is advertised directly, so the routing clause is redundant there, not a dangling door.

## 2. Preflight the browser before the round trip

A missing Playwright Chromium was only discovered *inside* `pool.acquire`, where the launch failure is caught and reported as `could not open <url> — is the app running?` — sending the caller to debug an app that is fine, several calls in. The lease path now preflights before spending the round trip and refuses at the first call with the install fix. The thrown message carries `Chromium is not installed`, so `error-recovery` routes it to the `NO_POOL` fix (install command + drive a human tab meanwhile) rather than the misleading nav error.

The probe is an **optional** `browserProbe` on `ToolDeps` (same pattern as `realInput?`/`bridgePort?`): absent means no preflight, so the fake-pool lease tests — deliberately runnable without a real Chromium — are unchanged. Production wires it to `probeChromium`.

## Tests

- `error-recovery.test.ts`: the `COMMAND_TIMEOUT` recovery names `reticle_run { tool: "reticle_lease"` and no longer names `reticle_lease` bare; the advertised-tools guardrail accepts the meta-tools.
- `lease-tools.test.ts`: with `browserProbe` reporting Chromium absent, acquire refuses with the install fix and **never calls `pool.acquire`** (a real preflight); with it present, acquire proceeds; with no probe wired, the default path is unchanged.

RED→GREEN: without the change, the routing and preflight tests fail; with it, all pass. `src/tools` + `src/session` stay green (1010 tests). Typecheck and lint clean.