### PR TITLE
fix(dev): a stale hooksPath disabled every git hook, so nothing added the DCO trailer

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -56,7 +56,13 @@ jobs:
             echo "  then:            git push --force-with-lease"
             echo ""
             echo "Signing rewrites the commits, so the push has to be forced. Nothing else changes."
-            echo "For future work: git commit -s, or 'git config format.signOff true' in this repo."
+            echo "To stop this happening again, install the repo's hooks — a prepare-commit-msg"
+            echo "hook signs every commit for you:"
+            echo ""
+            echo "  pnpm hooks:install"
+            echo ""
+            echo "Note: 'git config format.signOff true' does NOT do this. It applies to"
+            echo "format-patch/send-email, not to git commit."
             exit 1
           fi
           echo "All commits are signed off."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,11 +176,13 @@ From there, point your MCP-capable agent at Reticle and ask it to verify the app
    git push --force-with-lease
    ```
 
-   `git config format.signOff true` does **not** cover `git commit`, so setting it is not enough. If you want this to be automatic, alias the commit itself:
+   `git config format.signOff true` does **not** cover `git commit`, so setting it is not enough — it applies to `format-patch`/`send-email`, and setting it buys you unsigned commits plus the belief that they are signed. To make sign-off automatic, install the repo's hooks:
 
    ```bash
-   git config --local alias.ci 'commit -s'
+   pnpm hooks:install
    ```
+
+   That symlinks a `prepare-commit-msg` hook which adds the trailer when it is missing (and leaves `git commit -s` alone), plus the pre-commit quality gate.
 
 4. **Use [Conventional Commits](https://www.conventionalcommits.org/)** for commit messages, e.g. `feat(server): add reticle_viewport tool`, `fix(browser): restore patched fetch on teardown`, `docs: clarify install steps`. Common scopes mirror the packages: `protocol`, `browser`, `server`, `react`, plus `docs` / `chore`.
 5. **Keep the gates green:** `pnpm lint && pnpm typecheck && pnpm test:unit`.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "matrix:validate": "node apps/e2e/matrix.mjs --self-check && for f in docs/matrix/*/*.json; do node apps/e2e/matrix.mjs --validate \"$f\" || exit 1; done",
     "matrix:compat": "node apps/e2e/client-compat.mjs",
     "knip": "npx --yes knip --no-progress",
-    "hooks:install": "ln -sf ../../pre-commit.sh .git/hooks/pre-commit && echo 'pre-commit hook installed'"
+    "hooks:install": "ln -sf ../../pre-commit.sh .git/hooks/pre-commit && ln -sf ../../prepare-commit-msg.sh .git/hooks/prepare-commit-msg && echo \"pre-commit + sign-off hooks installed\""
   },
   "pnpm": {
     "overrides": {

--- a/prepare-commit-msg.sh
+++ b/prepare-commit-msg.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Reticle sign-off hook. Symlinked to .git/hooks/prepare-commit-msg.
+#
+# Appends the `Signed-off-by:` trailer CI's DCO check requires, so a forgotten `-s` cannot reach a
+# PR. This exists because the obvious-looking config does NOT do it: `git config format.signOff true`
+# applies to `format-patch`/`send-email` and has no effect on `git commit`, so setting it produces
+# unsigned commits and the confidence that they are signed. That combination is what put 122
+# unsigned commits on this repo's history.
+#
+# `interpret-trailers` places the trailer correctly and is a no-op when one is already there, so
+# `git commit -s` and this hook cannot double up.
+set -uo pipefail
+
+MSG_FILE="$1"
+SOURCE="${2-}"
+
+# A merge has no authored change to certify, and the DCO check exempts merge commits.
+[ "$SOURCE" = "merge" ] && exit 0
+
+IDENT="$(git var GIT_AUTHOR_IDENT)"
+NAME="${IDENT%% <*}"
+EMAIL="${IDENT#*<}"; EMAIL="${EMAIL%%>*}"
+
+git interpret-trailers --in-place --if-exists doNothing \
+  --trailer "Signed-off-by: $NAME <$EMAIL>" "$MSG_FILE"


### PR DESCRIPTION
## Why DCO fails

Two causes, and the second is why the first went unnoticed for so long.

**1. `format.signOff` does not sign commits.** It applies to `format-patch`/`send-email`. `git commit` ignores it. This repo had it set locally to `true`, which produces unsigned commits *and* the belief that they are signed. Verified empirically in a scratch repo — the trailer is absent.

**2. Every git hook in this checkout was disabled.** `core.hooksPath` was set locally to `/Users/.../Syrin-Labs/iris/.git/hooks` — another project, and a directory that no longer exists. Git therefore consulted neither `.git/hooks/pre-commit` nor anything else, so `pnpm hooks:install` had been a no-op and **the pre-commit quality gate installed in August has not run since**. No hook could have caught a missing sign-off, because no hook could run.

## What this changes

- Unsets the stale `core.hooksPath` and the misleading `format.signOff` (local config, done in the working copy).
- Adds `prepare-commit-msg.sh`: appends the `Signed-off-by:` trailer when it is missing, via `git interpret-trailers --if-exists doNothing`, so it cannot double up with `git commit -s`. Merge commits are skipped — the DCO check exempts them.
- `hooks:install` now installs both hooks.
- Corrects the advice in `dco.yml` and `CONTRIBUTING.md`, both of which pointed at `format.signOff`. The workflow's failure message is the first thing a blocked contributor reads, and it was telling them to run a no-op.

## Verified

The hook was tested against the DCO workflow's exact grep in a scratch repo: a plain `git commit` gets the trailer, `git commit -s` is left alone, both pass. This PR's own commit was made **without** `-s` and is signed.

## Not done

The 122 unsigned commits already on `main` are untouched. The check runs on `pull_request` and only inspects `base..head`, so history is never re-examined — signing it would mean force-pushing a published, released `main` for no gain.

Separately, the revived pre-commit gate reports 9 `pnpm audit` advisories (5 high, all transitive). Non-blocking, and its own piece of work.