### PR TITLE
fix(server): extend absence blind spot to VIRTUALIZED_UNMOUNTED and CLOSED_SHADOW_ROOT

### DIFF
--- a/packages/server/src/honesty/blind-spots.ts
+++ b/packages/server/src/honesty/blind-spots.ts
@@ -180,6 +180,51 @@ function droppedByTransport(events: readonly ReticleEvent[]): number {
   return dropped;
 }
 
+/**
+ * The narrow slice of a predicate the absence-blind-spot check needs.
+ *
+ * Kept minimal to avoid pulling the full Predicate type (and its transitive deps) into the
+ * honesty module. Anything that quacks like this works.
+ */
+interface AbsencePredicate {
+  kind: string;
+  absent?: boolean;
+  query?: { scope?: unknown };
+}
+
+/**
+ * When an absence assertion targets a page with regions Reticle cannot observe, "the element is
+ * absent" means only "it is absent in what I CAN see". This function returns a note when that
+ * distinction matters, and undefined otherwise.
+ *
+ * Fires on three blind-spot kinds:
+ *   - CROSS_ORIGIN_IFRAME (only when the predicate is scoped — an unscoped search that found
+ *     nothing still cannot prove it is absent inside a frame it never entered)
+ *   - VIRTUALIZED_UNMOUNTED — a row that was never rendered could hold the element
+ *   - CLOSED_SHADOW_ROOT — a subtree Reticle cannot see into
+ *
+ * The act path never called this, so `act_and_wait { until: { absent: true } }` got no caveat.
+ */
+export function absenceBlindSpotNote(
+  predicate: AbsencePredicate,
+  spots: readonly BlindSpot[],
+): string | undefined {
+  if ('element' !== predicate.kind || true !== predicate.absent) return undefined;
+
+  const relevant = spots.filter(
+    (spot) =>
+      spot.count > 0 &&
+      (spot.kind === BlindSpotKind.CROSS_ORIGIN_IFRAME
+        ? undefined !== predicate.query?.scope
+        : spot.kind === BlindSpotKind.VIRTUALIZED_UNMOUNTED ||
+          spot.kind === BlindSpotKind.CLOSED_SHADOW_ROOT),
+  );
+  if (0 === relevant.length) return undefined;
+
+  const statement = buildCoverageStatement(relevant);
+  return `the absence assertion targeted a region Reticle could not observe (${statement.note ?? 'partial coverage'}), so a passing DOM check cannot prove absence`;
+}
+
 /** The impeaching note for a transport gap, or undefined when the window was intact. */
 export function transportGapNote(events: readonly ReticleEvent[]): string | undefined {
   const dropped = droppedByTransport(events);

--- a/packages/server/src/honesty/blind-spots.ts
+++ b/packages/server/src/honesty/blind-spots.ts
@@ -194,16 +194,13 @@ interface AbsencePredicate {
 
 /**
  * When an absence assertion targets a page with regions Reticle cannot observe, "the element is
- * absent" means only "it is absent in what I CAN see". This function returns a note when that
- * distinction matters, and undefined otherwise.
+ * absent" means only "it is absent in what I CAN see". Returns a note when that distinction
+ * matters, undefined otherwise.
  *
  * Fires on three blind-spot kinds:
- *   - CROSS_ORIGIN_IFRAME (only when the predicate is scoped — an unscoped search that found
- *     nothing still cannot prove it is absent inside a frame it never entered)
+ *   - CROSS_ORIGIN_IFRAME (only when the predicate is scoped to a frame region)
  *   - VIRTUALIZED_UNMOUNTED — a row that was never rendered could hold the element
  *   - CLOSED_SHADOW_ROOT — a subtree Reticle cannot see into
- *
- * The act path never called this, so `act_and_wait { until: { absent: true } }` got no caveat.
  */
 export function absenceBlindSpotNote(
   predicate: AbsencePredicate,

--- a/packages/server/src/tools/act-tools.ts
+++ b/packages/server/src/tools/act-tools.ts
@@ -54,6 +54,7 @@ import { buildDivergenceCapsule } from '../capsule/capsule.js';
 import { predicateToExpectedLinks } from '../capsule/predicate-to-links.js';
 import { buildHonestyBlock } from '../honesty/honesty.js';
 import {
+  absenceBlindSpotNote,
   buildCoverageStatement,
   blindSpotsFromState,
   transportGapNote,
@@ -762,6 +763,7 @@ export const ACT_TOOLS: ToolDef[] = [
         // verdict didn't see everything — say so, never imply full coverage.
         const spots = blindSpotsFromState(session.blindSpots());
         const coverage = buildCoverageStatement(spots);
+        const absenceBlindSpot = absenceBlindSpotNote(until, spots);
         // Nothing subscribed ⇒ the state channel is dark, and the summary must say so rather than
         // report an empty diff list that reads like a fact about the app. See CausalSummary.
         const stateUnwatched = isStateUnwatched(spots);
@@ -869,6 +871,7 @@ export const ACT_TOOLS: ToolDef[] = [
           // the measured false red: a reload mid-wait, graded assertion_failed at the clicked
           // component's own file and line.
           ...(true === verdict.observationLost ? { observationLost: true } : {}),
+          ...(absenceBlindSpot === undefined ? {} : { absenceBlindSpot }),
           honesty,
           contradictions,
           ...(outcomePending ? { outcomePending } : {}),

--- a/packages/server/src/tools/act-verdict-parity.test.ts
+++ b/packages/server/src/tools/act-verdict-parity.test.ts
@@ -111,4 +111,11 @@ describe('act_and_wait and assert see the same evidence', () => {
     expect(act).toMatch(/[Ll]earning material/);
     expect(assert).toMatch(/LEARNING material/);
   });
+
+  it('both paths pass absenceBlindSpot to decideVerified', () => {
+    for (const file of [act, assert]) {
+      expect(file).toMatch(/absenceBlindSpotNote\(/);
+      expect(file).toMatch(/absenceBlindSpot === undefined \? \{\} : \{ absenceBlindSpot \}/);
+    }
+  });
 });

--- a/packages/server/src/tools/assert-coverage-honesty.test.ts
+++ b/packages/server/src/tools/assert-coverage-honesty.test.ts
@@ -1,14 +1,23 @@
 import { describe, expect, it } from 'vitest';
 import { LastAct } from '../session/last-act.js';
 import {
+  BlindSpotKind,
   EventType,
+  ReticleCommand,
   SessionState,
   Verified,
   VerifiedReason,
+  type CommandResult,
   type ReticleEvent,
 } from '@reticlehq/core';
 import { TOOLS, type ToolDef, type ToolDeps } from './tools.js';
 import { ReticleTool } from './tool-names.js';
+import { BaselineStore } from '../project/baselines.js';
+import { createNodeFileSystem } from '../project/fs-port.js';
+import { RecordingStore } from '../flows/recordings.js';
+import { FlowStore } from '../flows/flows.js';
+import { ProjectStore } from '../project/project-store.js';
+import { AnnotationStore } from '../flows/annotation-store.js';
 import type { Session, SessionManager } from '../session/session.js';
 
 /**
@@ -214,5 +223,97 @@ describe('reticle_assert carries the verdict, not just pass', () => {
   it('reports yes on a clean window', async () => {
     const result = (await runAssert([])) as Record<string, unknown>;
     expect(result['verified']).toBe(Verified.YES);
+  });
+});
+
+describe('reticle_act_and_wait downgrades absence when blind spots hide the target', () => {
+  function actSessionWithBlindSpots(blindSpots: Record<string, number>): ToolDeps {
+    const noEvents: ReticleEvent[] = [];
+    const command = (name: string): Promise<CommandResult> => {
+      if (name === ReticleCommand.MATCH) {
+        return Promise.resolve({
+          kind: 'command_result',
+          id: 'q1',
+          ok: true,
+          result: { matched: false, count: 0, elements: [] },
+        });
+      }
+      return Promise.resolve({
+        kind: 'command_result',
+        id: 'c1',
+        ok: true,
+        result: { dispatched: true, settled: true, effect: { domMutatedWithin: 1 } },
+      });
+    };
+    const session: Partial<Session> = {
+      id: 'demo',
+      url: 'http://localhost:5173/app',
+      elapsed: () => 1000,
+      lastAct: new LastAct(),
+      beginAction: () => 'a1',
+      finishAction: () => undefined,
+      command,
+      queryEvents: () => Promise.resolve(noEvents),
+      eventsSince: () => noEvents,
+      bufferHealth: () => ({ total: 10, dropped: 0 }),
+      lostSince: () => false,
+      blindSpots: () => blindSpots,
+      health: () => ({ lastSeenMs: 0, throttled: false, focused: true }),
+      throttled: () => false,
+      getState: () => SessionState.ACTIVE,
+      drainInbox: () => [],
+      inboxSize: () => 0,
+      onEvent: () => () => undefined,
+      ambientCounts: () => ({}),
+    };
+    const sessions: Partial<SessionManager> = { resolve: () => session as Session };
+    return {
+      sessions: sessions as SessionManager,
+      baselines: new BaselineStore(),
+      recordings: new RecordingStore(),
+      flows: new FlowStore(createNodeFileSystem(), '/tmp/reticle-test/.reticle', { now: () => 0 }),
+      project: new ProjectStore(createNodeFileSystem(), '/tmp/reticle-test/.reticle', {
+        now: () => 0,
+      }),
+      annotations: new AnnotationStore(),
+      fs: createNodeFileSystem(),
+      reticleRoot: '/tmp/reticle-test/.reticle',
+      now: () => 0,
+    };
+  }
+
+  const ACT_ABSENT = {
+    ref: 'e1',
+    action: 'click',
+    until: { kind: 'element', query: { by: 'testid', value: 'shipment-row' }, absent: true },
+  };
+
+  it('downgrades to UNKNOWN when virtualized rows hide where the element could be', async () => {
+    const deps = actSessionWithBlindSpots({ [BlindSpotKind.VIRTUALIZED_UNMOUNTED]: 1 });
+    const r = (await tool(ReticleTool.ACT_AND_WAIT).handler(deps, ACT_ABSENT)) as Record<
+      string,
+      unknown
+    >;
+    expect(r['verified']).toBe(Verified.UNKNOWN);
+    expect(r['verifiedReason']).toBe(VerifiedReason.ABSENCE_BLIND_SPOT);
+  });
+
+  it('downgrades to UNKNOWN when a closed shadow root hides subtrees', async () => {
+    const deps = actSessionWithBlindSpots({ [BlindSpotKind.CLOSED_SHADOW_ROOT]: 1 });
+    const r = (await tool(ReticleTool.ACT_AND_WAIT).handler(deps, ACT_ABSENT)) as Record<
+      string,
+      unknown
+    >;
+    expect(r['verified']).toBe(Verified.UNKNOWN);
+    expect(r['verifiedReason']).toBe(VerifiedReason.ABSENCE_BLIND_SPOT);
+  });
+
+  it('does NOT cite ABSENCE_BLIND_SPOT when no blind spot is present', async () => {
+    const deps = actSessionWithBlindSpots({});
+    const r = (await tool(ReticleTool.ACT_AND_WAIT).handler(deps, ACT_ABSENT)) as Record<
+      string,
+      unknown
+    >;
+    expect(r['verifiedReason']).not.toBe(VerifiedReason.ABSENCE_BLIND_SPOT);
   });
 });

--- a/packages/server/src/tools/assert-coverage-honesty.test.ts
+++ b/packages/server/src/tools/assert-coverage-honesty.test.ts
@@ -113,15 +113,26 @@ describe('reticle_assert discloses partial coverage', () => {
     expect(result['verified']).toBe(Verified.YES);
   });
 
-  it('keeps an unscoped element absence green when unrelated virtualized rows are unobserved', async () => {
+  it('downgrades an element absence to UNKNOWN when virtualized rows are unobserved', async () => {
     const result = (await tool(ReticleTool.ASSERT).handler(
       depsWithBlindSpots({ 'virtualized-unmounted': 1 }),
       absentElement,
     )) as Record<string, unknown>;
 
     expect(result['pass']).toBe(true);
-    expect(result['verified']).toBe(Verified.YES);
-    expect(result['verifiedReason']).toBe(VerifiedReason.PROVED);
+    expect(result['verified']).toBe(Verified.UNKNOWN);
+    expect(result['verifiedReason']).toBe(VerifiedReason.ABSENCE_BLIND_SPOT);
+  });
+
+  it('downgrades an element absence to UNKNOWN when a closed shadow root is unobserved', async () => {
+    const result = (await tool(ReticleTool.ASSERT).handler(
+      depsWithBlindSpots({ 'closed-shadow-root': 1 }),
+      absentElement,
+    )) as Record<string, unknown>;
+
+    expect(result['pass']).toBe(true);
+    expect(result['verified']).toBe(Verified.UNKNOWN);
+    expect(result['verifiedReason']).toBe(VerifiedReason.ABSENCE_BLIND_SPOT);
   });
 
   it('names which regions were unobservable, so the agent can act on it', async () => {

--- a/packages/server/src/tools/assert-verdict.ts
+++ b/packages/server/src/tools/assert-verdict.ts
@@ -1,4 +1,4 @@
-import { BlindSpotKind, CaptureLoss, PredicateKind } from '@reticlehq/core';
+import { CaptureLoss, PredicateKind } from '@reticlehq/core';
 import { gapsForAction } from '../honesty/instrumentation-gaps.js';
 import { noteSessionGaps } from '../honesty/gap-ledger.js';
 import { declaresState } from '../events/predicate-asks.js';
@@ -9,6 +9,7 @@ import type { Session } from '../session/session.js';
 import { findContradictions, type Contradiction } from '../events/contradictions.js';
 import { declaredExpectations, declaresBodyIndependentChannel } from '../events/declared.js';
 import {
+  absenceBlindSpotNote,
   blindSpotsFromState,
   buildCoverageStatement,
   Coverage,
@@ -23,26 +24,6 @@ import { describeWaitTarget } from '../honesty/unsettled.js';
 import { inFlightRequestLabels, repeatedRequestLabels } from './settle-in-flight.js';
 import { gradeOfPredicate } from './assert-grade.js';
 import { assertSource } from './assert-source.js';
-
-type StateBlindSpot = ReturnType<typeof blindSpotsFromState>[number];
-
-function absenceBlindSpotNote(
-  predicate: Predicate,
-  spots: readonly StateBlindSpot[],
-): string | undefined {
-  if (predicate.kind !== 'element' || predicate.absent !== true) return undefined;
-
-  const relevant = spots.filter(
-    (spot) =>
-      spot.count > 0 &&
-      spot.kind === BlindSpotKind.CROSS_ORIGIN_IFRAME &&
-      undefined !== predicate.query.scope,
-  );
-  if (0 === relevant.length) return undefined;
-
-  const statement = buildCoverageStatement(relevant);
-  return `the absence assertion targeted a region Reticle could not observe (${statement.note ?? 'partial coverage'}), so a passing DOM check cannot prove absence`;
-}
 
 /**
  * The honesty verdict for a plain `reticle_assert`.


### PR DESCRIPTION
## Summary

Reworked per maintainer review. The absence blind-spot mechanism already exists on main; this extends it rather than duplicating.

- Lift `absenceBlindSpotNote` from `assert-verdict.ts` into the shared `honesty/blind-spots.ts` module
- Wire it into `act-tools.ts` — `act_and_wait { until: { absent: true } }` was missing the caveat entirely
- Extend the filter to fire on `VIRTUALIZED_UNMOUNTED` and `CLOSED_SHADOW_ROOT` alongside the existing `CROSS_ORIGIN_IFRAME` check
- Add parity test asserting both verdict paths pass `absenceBlindSpot` to `decideVerified`
- Update coverage tests: virtualized-unmounted and closed-shadow-root now downgrade to UNKNOWN on element absence

## Test plan

- [x] `pnpm --filter @reticlehq/server typecheck` passes
- [x] `pnpm --filter @reticlehq/server lint` passes
- [x] `pnpm --filter @reticlehq/server test:unit` passes (4532 tests, 467 files)
- [x] Parity test proves both assert and act paths call `absenceBlindSpotNote` and pass result to `decideVerified`
- [x] Coverage test: `virtualized-unmounted` + `absent element` → `verified: "unknown"`
- [x] Coverage test: `closed-shadow-root` + `absent element` → `verified: "unknown"`
- [x] Existing test: `cross-origin-iframe` + `scoped absent element` → `verified: "unknown"` (unchanged)
- [x] Existing test: `cross-origin-iframe` + `unscoped absent element` → `verified: "yes"` (unchanged)

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)