### PR TITLE
fix(server): surface stall detection to user-facing output

### DIFF
--- a/packages/server/src/session/no-session-diagnosis.test.ts
+++ b/packages/server/src/session/no-session-diagnosis.test.ts
@@ -25,6 +25,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { diagnoseNoSession, type NoSessionFacts } from './no-session-diagnosis.js';
+import { STALL_AFTER_MS } from '../telemetry/instrumentation-stall.js';
 
 describe('diagnoseNoSession', () => {
   it('a session was here and left — say so, and say what to do', () => {
@@ -561,5 +562,71 @@ describe('every branch offers the no-shell escape hatch', () => {
       diagnoseNoSession(facts),
       'an agent with no shell and no session has no other way out of this branch',
     ).toContain('reticle_lease');
+  });
+});
+
+/**
+ * A daemon past the stall threshold with no app connected — the install never finished.
+ *
+ * This is the funnel's biggest silence: the daemon is up, the agent has the tools, and the app
+ * never arrived. The telemetry has known about it since day one; the user-facing diagnosis was
+ * silent about it, and a reader in that state was sent down an investigation that never mentioned
+ * the simplest explanation.
+ */
+describe('a stalled install is surfaced in the diagnosis', () => {
+  it('mentions the stall when daemon is past threshold and no app connected', () => {
+    const msg = diagnoseNoSession({
+      everConnected: false,
+      initialized: true,
+      listening: [5173],
+      port: 4400,
+      daemonUpMs: STALL_AFTER_MS + 1,
+    });
+    expect(msg).toMatch(/\d+ minutes/);
+    expect(msg).toMatch(/no.+app.+(connected|arrived)/i);
+  });
+
+  it('does NOT mention the stall when an app has connected', () => {
+    const msg = diagnoseNoSession({
+      everConnected: true,
+      initialized: true,
+      listening: [5173],
+      port: 4400,
+      daemonUpMs: STALL_AFTER_MS + 1,
+    });
+    expect(msg).not.toMatch(/\d+ minutes.*no.+app/i);
+  });
+
+  it('does NOT mention the stall below the threshold', () => {
+    const msg = diagnoseNoSession({
+      everConnected: false,
+      initialized: true,
+      listening: [5173],
+      port: 4400,
+      daemonUpMs: STALL_AFTER_MS - 1,
+    });
+    expect(msg).not.toMatch(/\d+ minutes.*no.+app/i);
+  });
+
+  it('still mentions it on the no-listener branch when initialized', () => {
+    const msg = diagnoseNoSession({
+      everConnected: false,
+      initialized: true,
+      listening: [],
+      port: 4400,
+      daemonUpMs: STALL_AFTER_MS + 1,
+    });
+    expect(msg).toMatch(/\d+ minutes/);
+  });
+
+  it('does NOT mention it when the project is not initialized', () => {
+    const msg = diagnoseNoSession({
+      everConnected: false,
+      initialized: false,
+      listening: [5173],
+      port: 4400,
+      daemonUpMs: STALL_AFTER_MS + 1,
+    });
+    expect(msg).not.toMatch(/\d+ minutes.*no.+app/i);
   });
 });

--- a/packages/server/src/session/no-session-diagnosis.ts
+++ b/packages/server/src/session/no-session-diagnosis.ts
@@ -20,6 +20,7 @@
  */
 
 import { DEV_SERVER_PORTS } from '../cli/cli-port.js';
+import { STALL_AFTER_MS } from '../telemetry/instrumentation-stall.js';
 
 export interface NoSessionFacts {
   /** Whether ANY session has connected to this daemon since it booted. */
@@ -100,6 +101,13 @@ export interface NoSessionFacts {
    * that a reader deserves to check it.
    */
   searchedDirectories?: readonly string[];
+  /**
+   * How long this daemon has been running with no app connected, in milliseconds.
+   *
+   * Present only when the stall clock is active and no app has arrived. Used to surface "the
+   * install never finished" to the user-facing diagnosis rather than only to telemetry.
+   */
+  daemonUpMs?: number;
 }
 
 /** The one framework whose most likely cause differs from every other framework's. */
@@ -363,6 +371,26 @@ function searchedClause(facts: NoSessionFacts): string {
   return ` I looked in: ${searched.join(', ')}. If your app is not in that list, that is the answer — this daemon is standing somewhere else.`;
 }
 
+/**
+ * A leading sentence when the daemon has been up long enough that no app is coming.
+ *
+ * Only fires for a WIRED project (initialized) that has NEVER connected and is past the
+ * threshold. An unwired project already names the install gap as its primary cause; adding a time
+ * sentence there would double-blame.
+ */
+function stallClause(facts: NoSessionFacts): string {
+  const { daemonUpMs, initialized, everConnected } = facts;
+  if (everConnected) return '';
+  if (!initialized) return '';
+  if (daemonUpMs === undefined || daemonUpMs < STALL_AFTER_MS) return '';
+  const minutes = Math.round(daemonUpMs / 60_000);
+  return (
+    `This daemon has been running for ${String(minutes)} minutes and no app has connected. ` +
+    'The most likely cause is that the dev server was not restarted after adding the Reticle ' +
+    'plugin, so the running bundle carries no SDK. Restart the dev server first. '
+  );
+}
+
 export function diagnoseNoSession(facts: NoSessionFacts): string {
   const { everConnected, initialized, listening, port } = facts;
   // Named when known: a claim about a missing file is a claim about ONE directory.
@@ -452,7 +480,7 @@ export function diagnoseNoSession(facts: NoSessionFacts): string {
       );
     }
     return (
-      `no browser session connected, and this daemon has never seen one. ${OPEN_THE_APP} ` +
+      `${stallClause(facts)}no browser session connected, and this daemon has never seen one. ${OPEN_THE_APP} ` +
       'Nothing is listening on the ports Reticle scans ' +
       `(${SCANNED_PORTS}) either, and the most common reason for that is a dev server that is not ` +
       'running: start it yourself in the background with the command in `next_action` — it is read ' +
@@ -489,7 +517,7 @@ export function diagnoseNoSession(facts: NoSessionFacts): string {
   }
 
   return (
-    'no browser session connected, and this daemon has never seen one for this project, which is ' +
+    `${stallClause(facts)}no browser session connected, and this daemon has never seen one for this project, which is ` +
     `wired for Reticle. ${OPEN_THE_APP} ${unattributedListeners(listening)} ` +
     'If the page IS open and still does not appear, the app is wired and the SDK is not reaching ' +
     `this daemon (on ${String(port)}). ${rankedCauses(facts)} ${SELF_SERVE} ${RETRY}`

--- a/packages/server/src/session/no-session-watch.ts
+++ b/packages/server/src/session/no-session-watch.ts
@@ -19,6 +19,7 @@ import { readProjectFramework, readProjectId, readProjectPort } from '../cli/cli
 import { discoverProjectConfigs } from '../cli/config-discovery.js';
 import { hasProjectConnectedBefore, rememberConnected } from './connection-memory.js';
 import { reticleStateHome } from '../daemon/daemon.js';
+import { stallUptime } from '../telemetry/instrumentation-stall.js';
 import type { SessionManager } from './session-manager.js';
 
 /** Slow enough to be free, fast enough that a dev server started 15s ago is already reflected. */
@@ -244,6 +245,12 @@ export function startNoSessionWatch(options: NoSessionWatchOptions): () => void 
           return framework === undefined ? {} : { framework };
         })(),
         leaseExpired: (options.reapedLeases?.() ?? 0) > 0,
+        // How long this daemon has been waiting with no app. The diagnosis uses it to surface
+        // "install never finished" — the same condition telemetry already knows about.
+        ...(() => {
+          const upMs = stallUptime(Date.now());
+          return upMs === undefined ? {} : { daemonUpMs: upMs };
+        })(),
         // Read here rather than at boot: `.reticle.json` can be written by `init` after this daemon
         // started, which is the ordinary first-install order, and a port cached from before it existed
         // would make the daemon confidently report no mismatch on the one run where there is one.

--- a/packages/server/src/telemetry/daemon-telemetry.ts
+++ b/packages/server/src/telemetry/daemon-telemetry.ts
@@ -13,7 +13,11 @@ import { profileProject } from './project-profile.js';
 import { startUpdateCheck } from '../update/update-nudge.js';
 import { markDaemonStart } from './mcp-connection.js';
 import { markInstrumentationClock } from './app-instrumented.js';
-import { markStallClock, reportInstrumentationStall } from './instrumentation-stall.js';
+import {
+  markStallClock,
+  reportInstrumentationStall,
+  STALL_AFTER_MS,
+} from './instrumentation-stall.js';
 import { readProjectId } from '../cli/cli-port.js';
 
 /** Let the daemon finish coming up before walking the source tree for a profile. */
@@ -102,7 +106,7 @@ export function installDaemonTelemetry(
     // after the early return would make the one case this event exists for the one case it never
     // sees. It is self-limiting (once per run, never after an app connects), so running it on every
     // tick costs a comparison.
-    reportInstrumentationStall(
+    const stalled = reportInstrumentationStall(
       {
         // Same test `app_instrumented` uses for the same field, so the success and failure events
         // stay directly comparable: a stamped projectId means `init` has run here.
@@ -111,6 +115,13 @@ export function installDaemonTelemetry(
       },
       now,
     );
+    if (stalled) {
+      const minutes = Math.round(STALL_AFTER_MS / 60_000);
+      process.stderr.write(
+        `[reticle] no app has connected after ${String(minutes)} minutes — ` +
+          'the install may be incomplete. Restart the dev server if you added the Reticle plugin.\n',
+      );
+    }
     if (metrics.empty) return; // an idle window is not worth an event
     // NOT daemon_stopped: the daemon is still running. See SESSION_PROGRESS.
     void getTelemetry().emit(TelemetryEventKind.SESSION_PROGRESS, {

--- a/packages/server/src/telemetry/instrumentation-stall.test.ts
+++ b/packages/server/src/telemetry/instrumentation-stall.test.ts
@@ -21,6 +21,7 @@ import {
   markStallClock,
   reportInstrumentationStall,
   resetInstrumentationStall,
+  stallUptime,
 } from './instrumentation-stall.js';
 import * as telemetry from './telemetry.js';
 import * as appInstrumented from './app-instrumented.js';
@@ -146,5 +147,24 @@ describe('instrumentation_stalled on the shutdown path', () => {
     noAppEverConnected();
     expect(reportInstrumentationStall(FACTS, () => 1000, { atShutdown: true })).toBe(false);
     expect(sent).toEqual([]);
+  });
+});
+
+describe('stallUptime — how long a daemon has waited with no app', () => {
+  it('returns the elapsed time when no app has connected', () => {
+    noAppEverConnected();
+    markStallClock(1000);
+    expect(stallUptime(11_000)).toBe(10_000);
+  });
+
+  it('returns undefined once an app has connected', () => {
+    vi.spyOn(appInstrumented, 'appEverConnected').mockReturnValue(true);
+    markStallClock(0);
+    expect(stallUptime(STALL_AFTER_MS * 2)).toBeUndefined();
+  });
+
+  it('returns undefined when the clock was never started', () => {
+    noAppEverConnected();
+    expect(stallUptime(99_999)).toBeUndefined();
   });
 });

--- a/packages/server/src/telemetry/instrumentation-stall.ts
+++ b/packages/server/src/telemetry/instrumentation-stall.ts
@@ -96,6 +96,18 @@ export function reportInstrumentationStall(
   return true;
 }
 
+/**
+ * How long this daemon has waited with no app, or undefined if the question is moot.
+ *
+ * Moot means: the clock was never started, or an app already connected. Callers use this to
+ * surface the stall to user-facing channels without coupling to the telemetry event itself.
+ */
+export function stallUptime(now: number): number | undefined {
+  if (daemonStartedAt === undefined) return undefined;
+  if (appEverConnected()) return undefined;
+  return now - daemonStartedAt;
+}
+
 /** Tests only. */
 export function resetInstrumentationStall(): void {
   reported = false;


### PR DESCRIPTION
## Summary

Closes #410.

The daemon already knows when an install never finished (no app connects past the 10-minute threshold) and tells telemetry only. This surfaces the same condition to the three places a stuck user or agent actually looks:

- **No-session diagnosis** — prepends a stall note ("this daemon has been running for N minutes and no app has connected") on the `!everConnected && initialized` branches, so both agents (via `reticle_sessions`) and humans (via `reticle status`) see it
- **Daemon stderr** — emits one line when the periodic flush first detects the stall, visible to whoever ran `reticle serve`
- **`reticle doctor`** — inherits the note through the existing `sessions.why` path

No new telemetry event. No change to the existing one. `stallUptime()` is the new pure reader that lets the diagnosis compute the condition without coupling to the telemetry module's internal state.

## Test plan

- [x] `stallUptime` returns elapsed ms when no app connected, undefined otherwise (3 new unit tests)
- [x] Diagnosis mentions stall when `daemonUpMs >= STALL_AFTER_MS && initialized && !everConnected` (5 new unit tests)
- [x] All 4454 existing server tests pass unchanged
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm format:check` green on server package

🤖 Generated with [Claude Code](https://claude.com/claude-code)