### PR TITLE
fix(server): use Buffer.byteLength for UTF-8 bytes in sizeCost

### DIFF
--- a/packages/server/src/session/output-budget.test.ts
+++ b/packages/server/src/session/output-budget.test.ts
@@ -100,6 +100,13 @@ describe('sizeCost / withSizeCost', () => {
     expect(big.cost.tokens).toBeLessThan(1100);
   });
 
+  it('reports UTF-8 bytes, not UTF-16 code units, for multibyte content', () => {
+    // Japanese characters are 3 bytes each in UTF-8, 2 code units in UTF-16
+    const c = sizeCost({ text: '日本語' });
+    expect(c.bytes).toBe(Buffer.byteLength(JSON.stringify({ text: '日本語' }), 'utf8'));
+    expect(c.bytes).toBeGreaterThan(JSON.stringify({ text: '日本語' }).length);
+  });
+
   it('passes non-object results through unchanged', () => {
     expect(withSizeCost(null)).toBeNull();
     expect(withSizeCost('err')).toBe('err');

--- a/packages/server/src/session/output-budget.ts
+++ b/packages/server/src/session/output-budget.ts
@@ -85,7 +85,10 @@ interface SizeCost {
 
 export function sizeCost(payload: unknown): SizeCost {
   const json = JSON.stringify(payload) ?? '';
-  return { bytes: json.length, tokens: estimateTokens(json) };
+  // Actual UTF-8 wire bytes, not json.length (UTF-16 code units) — the field is labeled `bytes`
+  // and drives the large-snapshot recommendation, so a multibyte-heavy payload was under-counted.
+  const bytes = Buffer.byteLength(json, 'utf8');
+  return { bytes, tokens: estimateTokens(json) };
 }
 
 /**


### PR DESCRIPTION
## summary

`sizecost` was counting utf-16 characters instead of actual utf-8 bytes. this caused payloads with non-ascii characters, like emoji and cjk text, to report a smaller size than their real wire size.

the fix makes `sizecost` use `buffer.bytelength(json, 'utf8')`, matching the existing `costhint` behavior.

## testing

* added a unit test for multibyte content
* before the fix, `{ text: "日本語" }` reported 14 bytes
* after the fix, it correctly reports 20 bytes


