### PR TITLE
feat(server): persist project storage profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
+### Added
+
+- **`@reticlehq/server` - authenticated pooled leases can keep an opt-in project storage profile.** `reticle_lease {action:"acquire"}` accepts `persistStorage:true` with a `projectId`, restores that project's Playwright cookies and local storage into the new isolated context, then captures the updated state atomically on release. Profiles live outside the checkout under the Reticle state directory, use hashed project keys and owner-only permissions, never appear in tool output or telemetry, and cannot cross project boundaries. `resetStorage:true` explicitly discards an expired or poisoned profile before opening the clean context. A failed save is disclosed without echoing its path or credential material and still frees the browser-pool slot. ([#334](https://github.com/reticlehq/reticle/issues/334))
+
 ## [2.9.0] — 2026-08-20
 
 ### BREAKING — read before upgrading

--- a/apps/e2e/specs/multi-agent-lease-test.mjs
+++ b/apps/e2e/specs/multi-agent-lease-test.mjs
@@ -6,6 +6,7 @@ import {
   start,
   TOOLS,
   BrowserPool,
+  NodeStorageProfileStore,
   playwrightLauncher,
   appendReticleParams,
   BaselineStore,
@@ -17,6 +18,7 @@ import {
 } from '@reticlehq/server';
 import os from 'node:os';
 import path from 'node:path';
+import { rm } from 'node:fs/promises';
 
 const APP = 'http://localhost:4310/';
 let pass = 0,
@@ -58,7 +60,11 @@ const pool = new BrowserPool(
     launches += 1;
     return playwrightLauncher({ headless: true })();
   },
-  { maxContexts: 3, genSessionId: () => `g${process.pid}-${launches}` },
+  {
+    maxContexts: 3,
+    genSessionId: () => `g${process.pid}-${launches}`,
+    storageProfiles: new NodeStorageProfileStore(path.join(reticleRoot, 'storage-profiles')),
+  },
 );
 
 console.log('\n=== multi-agent leases against the live bench-app (cap 3) ===');
@@ -111,7 +117,68 @@ chk('each leased tab connected as its own session (distinct)', new Set(ok.map((r
 chk('each agent drove the live dashboard (found buttons)', ok.length > 0 && ok.every((r) => r.buttons > 0), `buttons=${ok.map((r) => r.buttons).join('/')}`);
 chk('no leaked contexts after all agents done', pool.activeCount() === 0);
 
+console.log('\n=== project-scoped persistent browser storage ===');
+
+const refOf = async (sessionId, testid) => {
+  const q = await T('reticle_query', { sessionId, by: 'testid', value: testid });
+  return q.elements?.[0]?.ref;
+};
+const acquireProject = async (projectId) => {
+  const sid = `storage-${projectId}-${process.pid}-${Date.now()}`;
+  const lease = await pool.acquire(appendReticleParams(APP, sid, projectId), {
+    sessionId: sid,
+    persistStorage: { projectId },
+  });
+  const connected = await waitUntil(() => server.bridge.sessions.get(sid) !== undefined, 30000);
+  if (!connected) {
+    await lease.release();
+    throw new Error(`${sid} never connected`);
+  }
+  return { sid, lease };
+};
+const hasPersistedAuth = async (sessionId) => {
+  const local = await T('reticle_storage', {
+    sessionId,
+    area: 'local',
+    key: 'reticle.bench.authToken',
+  });
+  const cookie = await T('reticle_storage', {
+    sessionId,
+    area: 'cookies',
+    key: 'bench_session',
+  });
+  return local.found === true && cookie.found === true;
+};
+
+const firstA = await acquireProject('project-a');
+const loginRef = await refOf(firstA.sid, 'login-submit');
+if (loginRef === undefined) throw new Error('project-a clean context did not show login');
+await T('reticle_act_and_wait', {
+  sessionId: firstA.sid,
+  ref: loginRef,
+  action: 'click',
+  until: { kind: 'signal', name: 'auth:granted' },
+  timeout_ms: 5000,
+});
+const firstRelease = await pool.release(firstA.sid);
+chk('release captured project A cookies and local storage', firstRelease.storageSaved === true);
+
+const restoredA = await acquireProject('project-a');
+chk('same project reports that its profile was restored', restoredA.lease.storageRestored === true);
+chk('same project restores its auth token and cookie', await hasPersistedAuth(restoredA.sid));
+await restoredA.lease.release();
+
+const cleanB = await acquireProject('project-b');
+chk('different project cannot see project A auth', !(await hasPersistedAuth(cleanB.sid)));
+await cleanB.lease.release();
+
+chk('explicit reset removes project A profile', await pool.resetStorageProfile('project-a'));
+const resetA = await acquireProject('project-a');
+chk('reset project has no auth token or cookie', !(await hasPersistedAuth(resetA.sid)));
+await resetA.lease.release();
+
 await pool.shutdown();
 await server.close();
+await rm(path.dirname(reticleRoot), { recursive: true, force: true });
 console.log(`\n${fail === 0 ? '✅' : '❌'} MULTI-AGENT LEASE: ${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);

--- a/docs/multi-agent-testing.md
+++ b/docs/multi-agent-testing.md
@@ -36,6 +36,23 @@ reticle_lease {action:"release"} { sessionId }    # free the slot
 
 `reticle_lease {action:"acquire"}` opens a fresh isolated headless context against your **already-running** app, stamps the lease identity into the URL so the app's own SDK registers under a sessionId you can target, and waits until that tab has connected (`ready: true`) before returning, so the sessionId is usable immediately. Release when the flow finishes.
 
+### Keep an authenticated session across leases
+
+Storage is isolated and disposable by default. For a login-heavy suite, opt one project into a persisted Playwright storage profile:
+
+```json
+{
+  "action": "acquire",
+  "url": "http://localhost:3000/dashboard",
+  "projectId": "my-app",
+  "persistStorage": true
+}
+```
+
+The first lease starts clean and saves its cookies and local storage when released. A later acquire with the same `projectId` restores them and reports `storageRestored: true`. The profile is stored outside the checkout under Reticle's state directory, keyed by a hash of `projectId`, and restricted to the current OS user. Its contents are never returned by a tool or sent through telemetry.
+
+To discard an expired or poisoned login, acquire with both `persistStorage: true` and `resetStorage: true`. The reset applies only to that `projectId`; another project's profile remains isolated.
+
 ## 10 agents, 10 flows, one dashboard
 
 This is the design target, and it needs no special setup:

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -230,6 +230,8 @@ export const ReticleDir = {
   AMBIENT_FILE: 'ambient.json',
   /** per-flow flake ledger — replay outcomes that decide intermittent-failure quarantine. */
   FLAKE_FILE: 'flake.json',
+  /** Owner-only Playwright auth state, keyed by a hash of projectId (never committed). */
+  STORAGE_PROFILES_SUBDIR: 'storage-profiles',
   /** Per-flow assertion tiers recorded on each PASSING replay — the gate's anti-downgrade baseline. */
   TIERS_FILE: 'assertion-tiers.json',
   /**

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -46,6 +46,7 @@ import { statusPayload } from './status-payload.js';
 import { CdpRealInputProvider, LaunchedRealInputProvider } from './input/real-input.js';
 import { cpus } from 'node:os';
 import { BrowserPool } from './pool/browser-pool.js';
+import { NodeStorageProfileStore } from './pool/storage-profile.js';
 import { playwrightLauncher, resolveMaxContexts } from './pool/playwright-launcher.js';
 import { LeaseReaper } from './pool/lease-reaper.js';
 import { readJournalEnabled, readProjectId } from './cli/cli-port.js';
@@ -108,6 +109,7 @@ export { crawl } from './crawl/crawl.js';
 export { MCP_SSE_PATH, MCP_MESSAGE_PATH } from '@reticlehq/core';
 export { BrowserPool, DEFAULT_LEASE_TTL_MS } from './pool/browser-pool.js';
 export type { Lease, Launcher, PooledBrowser } from './pool/browser-pool.js';
+export { NodeStorageProfileStore } from './pool/storage-profile.js';
 export { playwrightLauncher, resolveMaxContexts } from './pool/playwright-launcher.js';
 export { appendReticleParams } from './tools/lease-tools.js';
 export { writePid, removePid, isRunning, logPath, readPid, isAlive } from './daemon/daemon.js';
@@ -265,7 +267,14 @@ function createBrowserPool(headless: boolean): BrowserPool {
         ? globalThis.crypto.randomUUID()
         : String(Date.now())
     }`;
-  return new BrowserPool(playwrightLauncher({ headless }), { maxContexts, genSessionId });
+  const storageProfiles = new NodeStorageProfileStore(
+    join(reticleStateHome(), ReticleDir.STORAGE_PROFILES_SUBDIR),
+  );
+  return new BrowserPool(playwrightLauncher({ headless }), {
+    maxContexts,
+    genSessionId,
+    storageProfiles,
+  });
 }
 
 /**

--- a/packages/server/src/pool/browser-pool.test.ts
+++ b/packages/server/src/pool/browser-pool.test.ts
@@ -12,6 +12,7 @@ import {
   type PooledContext,
   type PooledPage,
 } from './browser-pool.js';
+import type { StorageProfileStore } from './storage-profile.js';
 
 class FakePage implements PooledPage {
   gotoUrls: string[] = [];
@@ -37,6 +38,7 @@ class FakePage implements PooledPage {
 
 class FakeContext implements PooledContext {
   readonly pages: FakePage[] = [];
+  readonly savedStoragePaths: string[] = [];
   closed = false;
   constructor(private readonly failNav = false) {}
   newPage(): Promise<PooledPage> {
@@ -49,17 +51,23 @@ class FakeContext implements PooledContext {
     this.closed = true;
     return Promise.resolve();
   }
+  saveStorageState(path: string): Promise<void> {
+    this.savedStoragePaths.push(path);
+    return Promise.resolve();
+  }
 }
 
 class FakeBrowser implements PooledBrowser {
   readonly contexts: FakeContext[] = [];
+  readonly contextOptions: Array<{ storageStatePath?: string } | undefined> = [];
   failNav = false;
   #connected = true;
   #onDisc: (() => void) | undefined;
   isConnected(): boolean {
     return this.#connected;
   }
-  newContext(): Promise<PooledContext> {
+  newContext(opts?: { storageStatePath?: string }): Promise<PooledContext> {
+    this.contextOptions.push(opts);
     const c = new FakeContext(this.failNav);
     this.contexts.push(c);
     return Promise.resolve(c);
@@ -94,6 +102,31 @@ function fakeLauncher(): { launch: Launcher; browsers: FakeBrowser[] } {
   return { launch, browsers };
 }
 
+function fakeStorageProfiles(paths: Record<string, string> = {}): {
+  store: StorageProfileStore;
+  saved: Array<{ projectId: string; leaseId: string; path: string }>;
+  reset: string[];
+} {
+  const saved: Array<{ projectId: string; leaseId: string; path: string }> = [];
+  const reset: string[] = [];
+  return {
+    saved,
+    reset,
+    store: {
+      loadPath: (projectId) => Promise.resolve(paths[projectId]),
+      save: async (projectId, leaseId, capture) => {
+        const path = `/profiles/${projectId}-${leaseId}.tmp`;
+        await capture(path);
+        saved.push({ projectId, leaseId, path });
+      },
+      reset: (projectId) => {
+        reset.push(projectId);
+        return Promise.resolve(true);
+      },
+    },
+  };
+}
+
 describe('BrowserPool', () => {
   it('leases an isolated context+page navigated to the url', async () => {
     const { launch, browsers } = fakeLauncher();
@@ -121,6 +154,94 @@ describe('BrowserPool', () => {
     expect(browsers[0]?.contexts).toHaveLength(2); // TWO contexts
     expect(a.sessionId).not.toBe(b.sessionId);
     expect(pool.activeCount()).toBe(2);
+  });
+
+  it('restores and saves an opted-in project storage profile across leases', async () => {
+    const { launch, browsers } = fakeLauncher();
+    const profiles = fakeStorageProfiles({ 'project-a': '/profiles/project-a.json' });
+    const pool = new BrowserPool(launch, {
+      maxContexts: 2,
+      genSessionId: counterIds(),
+      storageProfiles: profiles.store,
+    });
+
+    const lease = await pool.acquire('http://localhost:3000/', {
+      persistStorage: { projectId: 'project-a' },
+    });
+
+    expect(browsers[0]?.contextOptions[0]).toEqual({
+      storageStatePath: '/profiles/project-a.json',
+    });
+    const result = await pool.release(lease.sessionId);
+    expect(result.storageSaved).toBe(true);
+    expect(profiles.saved).toEqual([
+      { projectId: 'project-a', leaseId: 's1', path: '/profiles/project-a-s1.tmp' },
+    ]);
+    expect(browsers[0]?.contexts[0]?.savedStoragePaths).toEqual(['/profiles/project-a-s1.tmp']);
+  });
+
+  it('never restores one project storage profile into another project context', async () => {
+    const { launch, browsers } = fakeLauncher();
+    const profiles = fakeStorageProfiles({
+      'project-a': '/profiles/a.json',
+      'project-b': '/profiles/b.json',
+    });
+    const pool = new BrowserPool(launch, {
+      maxContexts: 2,
+      genSessionId: counterIds(),
+      storageProfiles: profiles.store,
+    });
+
+    await pool.acquire('http://localhost:3000/a', {
+      persistStorage: { projectId: 'project-a' },
+    });
+    await pool.acquire('http://localhost:3000/b', {
+      persistStorage: { projectId: 'project-b' },
+    });
+
+    expect(browsers[0]?.contextOptions).toEqual([
+      { storageStatePath: '/profiles/a.json' },
+      { storageStatePath: '/profiles/b.json' },
+    ]);
+  });
+
+  it('resets only the requested project storage profile', async () => {
+    const { launch } = fakeLauncher();
+    const profiles = fakeStorageProfiles();
+    const pool = new BrowserPool(launch, {
+      maxContexts: 1,
+      genSessionId: counterIds(),
+      storageProfiles: profiles.store,
+    });
+
+    await expect(pool.resetStorageProfile('project-a')).resolves.toBe(true);
+    expect(profiles.reset).toEqual(['project-a']);
+  });
+
+  it('releases the slot and redacts a storage capture failure', async () => {
+    const { launch } = fakeLauncher();
+    const store: StorageProfileStore = {
+      loadPath: () => Promise.resolve(undefined),
+      save: () => Promise.reject(new Error('cookie=top-secret at /Users/alice/profile.json')),
+      reset: () => Promise.resolve(false),
+    };
+    const pool = new BrowserPool(launch, {
+      maxContexts: 1,
+      genSessionId: counterIds(),
+      storageProfiles: store,
+    });
+    const lease = await pool.acquire('http://localhost:3000/', {
+      persistStorage: { projectId: 'project-a' },
+    });
+
+    const result = await pool.release(lease.sessionId);
+
+    expect(result).toEqual({
+      released: true,
+      storageSaved: false,
+      storageError: 'storage profile could not be saved',
+    });
+    expect(pool.activeCount()).toBe(0);
   });
 
   it('release frees the slot and closes the context', async () => {

--- a/packages/server/src/pool/browser-pool.ts
+++ b/packages/server/src/pool/browser-pool.ts
@@ -10,6 +10,8 @@
  * the thin Playwright adapter that satisfies these interfaces lives separately.
  */
 
+import type { StorageProfileStore } from './storage-profile.js';
+
 /** The minimal page surface the pool drives. Real Playwright `Page` satisfies this. */
 export interface PooledPage {
   goto(url: string, opts?: { timeoutMs?: number }): Promise<unknown>;
@@ -21,13 +23,15 @@ export interface PooledPage {
 /** An isolated browsing context (cookies/storage). Real Playwright `BrowserContext` satisfies this. */
 export interface PooledContext {
   newPage(): Promise<PooledPage>;
+  /** Capture cookies/local storage to a Playwright storage-state file. */
+  saveStorageState(path: string): Promise<void>;
   close(): Promise<void>;
 }
 
 /** The launched browser. Real Playwright `Browser` satisfies this. */
 export interface PooledBrowser {
   isConnected(): boolean;
-  newContext(): Promise<PooledContext>;
+  newContext(opts?: { storageStatePath?: string }): Promise<PooledContext>;
   close(): Promise<void>;
   /** Fires when the browser process dies/crashes so the pool can relaunch on the next acquire. */
   onDisconnected(handler: () => void): void;
@@ -40,7 +44,15 @@ export type Launcher = () => Promise<PooledBrowser>;
 export interface Lease {
   readonly sessionId: string;
   readonly url: string;
+  readonly storageRestored?: boolean;
   release(): Promise<void>;
+}
+
+/** Result of an explicit pool release. A persistence failure never leaks the browser slot. */
+export interface ReleaseResult {
+  released: boolean;
+  storageSaved?: boolean;
+  storageError?: string;
 }
 
 /** Default lease time-to-live: a lease untouched for this long is presumed orphaned and reclaimed. */
@@ -60,6 +72,8 @@ interface BrowserPoolOptions {
   leaseTtlMs?: number;
   /** Per-lease navigation timeout — a page that won't load fails its own lease, never blocks a slot. */
   navTimeoutMs?: number;
+  /** Optional owner-only store used only when an acquire explicitly opts into persistence. */
+  storageProfiles?: StorageProfileStore;
 }
 
 interface ActiveLease {
@@ -68,6 +82,8 @@ interface ActiveLease {
   url: string;
   /** Last time an agent touched this lease (acquire or any tool call); drives orphan reclaim. */
   touchedAt: number;
+  /** Present only for an acquire that explicitly opted into project-scoped persistence. */
+  storageProjectId?: string;
 }
 
 /**
@@ -81,6 +97,7 @@ export class BrowserPool {
   readonly #now: () => number;
   readonly #ttl: number;
   readonly #navTimeout: number;
+  readonly #storageProfiles: StorageProfileStore | undefined;
 
   #browser: PooledBrowser | undefined;
   #launching: Promise<PooledBrowser> | undefined;
@@ -109,6 +126,7 @@ export class BrowserPool {
     this.#now = opts.now ?? ((): number => Date.now());
     this.#ttl = opts.leaseTtlMs ?? DEFAULT_LEASE_TTL_MS;
     this.#navTimeout = opts.navTimeoutMs ?? DEFAULT_NAV_TIMEOUT_MS;
+    this.#storageProfiles = opts.storageProfiles;
   }
 
   /** The TTL configured for leases — how long an untouched lease lives before the reaper reclaims it. */
@@ -142,8 +160,14 @@ export class BrowserPool {
    * that named its own session is not the id the pool navigated with. Releasing by that name used to
    * be a silent no-op that left the slot held until the reaper took it.
    */
-  release(sessionId: string): Promise<void> {
+  release(sessionId: string): Promise<ReleaseResult> {
     return this.#release(this.#leaseIdOf(sessionId));
+  }
+
+  /** Discard one project's persisted auth state without touching any active lease. */
+  resetStorageProfile(projectId: string): Promise<boolean> {
+    if (this.#storageProfiles === undefined) return Promise.resolve(false);
+    return this.#storageProfiles.reset(projectId);
   }
 
   /**
@@ -207,9 +231,16 @@ export class BrowserPool {
    */
   async acquire(
     url: string,
-    opts: { signal?: AbortSignal; sessionId?: string } = {},
+    opts: {
+      signal?: AbortSignal;
+      sessionId?: string;
+      persistStorage?: { projectId: string };
+    } = {},
   ): Promise<Lease> {
     if (this.#closed) throw new Error('browser pool is shut down');
+    if (opts.persistStorage !== undefined && this.#storageProfiles === undefined) {
+      throw new Error('browser storage profile store is unavailable');
+    }
     // #waitForSlot claims the slot synchronously (bumps #occupied) before returning, so the cap holds
     // even when many acquires race through the gate in the same tick.
     await this.#waitForSlot(opts.signal);
@@ -217,7 +248,13 @@ export class BrowserPool {
     let context: PooledContext | undefined;
     try {
       const browser = await this.#ensureBrowser();
-      context = await browser.newContext();
+      const storageStatePath =
+        opts.persistStorage === undefined
+          ? undefined
+          : await this.#storageProfiles?.loadPath(opts.persistStorage.projectId);
+      context = await browser.newContext(
+        storageStatePath === undefined ? undefined : { storageStatePath },
+      );
       const page = await context.newPage();
       // Per-page crash isolation: if THIS renderer dies, reclaim only this lease — the shared browser
       // and every other agent's context keep running. (A full browser death is handled by #onCrash.)
@@ -230,11 +267,24 @@ export class BrowserPool {
       // the slot count out of sync (drifting below #active.size, eventually exceeding the cap). If we're
       // no longer the live browser, bail — the catch below closes the context and returns the slot.
       if (this.#browser !== browser) throw new Error('browser crashed during navigation');
-      this.#active.set(sessionId, { context, page, url, touchedAt: this.#now() });
+      this.#active.set(sessionId, {
+        context,
+        page,
+        url,
+        touchedAt: this.#now(),
+        ...(opts.persistStorage === undefined
+          ? {}
+          : { storageProjectId: opts.persistStorage.projectId }),
+      });
       return {
         sessionId,
         url,
-        release: () => this.#release(sessionId),
+        ...(opts.persistStorage === undefined
+          ? {}
+          : { storageRestored: storageStatePath !== undefined }),
+        release: async () => {
+          await this.#release(sessionId);
+        },
       };
     } catch (err) {
       // Setup failed after we claimed the slot — give it back so a queued acquire isn't stuck, and
@@ -267,17 +317,37 @@ export class BrowserPool {
     for (const waiter of this.#waiters.splice(0)) waiter();
   }
 
-  async #release(sessionId: string): Promise<void> {
+  async #release(sessionId: string): Promise<ReleaseResult> {
     const lease = this.#active.get(sessionId);
-    if (lease === undefined) return; // already released or lost to a crash
+    if (lease === undefined) return { released: false }; // already released or lost to a crash
     this.#active.delete(sessionId);
     // Drop any alias pointing here, or the map grows for the life of the daemon and a later lease
     // reusing that registered name would resolve to a context that is already closed.
     for (const [registered, leaseId] of this.#aliases) {
       if (leaseId === sessionId) this.#aliases.delete(registered);
     }
+    let storageSaved: boolean | undefined;
+    let storageError: string | undefined;
+    if (lease.storageProjectId !== undefined && this.#storageProfiles !== undefined) {
+      try {
+        await this.#storageProfiles.save(lease.storageProjectId, sessionId, (path) =>
+          lease.context.saveStorageState(path),
+        );
+        storageSaved = true;
+      } catch {
+        storageSaved = false;
+        // A Playwright/fs error often includes the owner home path and may include browser state.
+        // The tool result needs to disclose the failure without echoing credential material.
+        storageError = 'storage profile could not be saved';
+      }
+    }
     await lease.context.close().catch(() => undefined);
     this.#releaseSlot();
+    return {
+      released: true,
+      ...(storageSaved === undefined ? {} : { storageSaved }),
+      ...(storageError === undefined ? {} : { storageError }),
+    };
   }
 
   /** Synchronously claim a slot if under the cap. Returns true on success (caller proceeds). */

--- a/packages/server/src/pool/playwright-launcher.ts
+++ b/packages/server/src/pool/playwright-launcher.ts
@@ -39,8 +39,10 @@ export function gotoOptions(timeoutMs: number | undefined): {
 function wrapBrowser(browser: Browser): PooledBrowser {
   return {
     isConnected: () => browser.isConnected(),
-    newContext: async (): Promise<PooledContext> => {
-      const context = await browser.newContext();
+    newContext: async (opts): Promise<PooledContext> => {
+      const context = await browser.newContext(
+        opts?.storageStatePath === undefined ? undefined : { storageState: opts.storageStatePath },
+      );
       return {
         newPage: async (): Promise<PooledPage> => {
           const page = await context.newPage();
@@ -50,6 +52,7 @@ function wrapBrowser(browser: Browser): PooledBrowser {
             onCrash: (handler) => page.on('crash', handler),
           };
         },
+        saveStorageState: (path) => context.storageState({ path }).then(() => undefined),
         close: () => context.close(),
       };
     },

--- a/packages/server/src/pool/storage-profile.test.ts
+++ b/packages/server/src/pool/storage-profile.test.ts
@@ -1,0 +1,87 @@
+import { mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { NodeStorageProfileStore } from './storage-profile.js';
+
+const roots: string[] = [];
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'reticle-storage-profile-'));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('NodeStorageProfileStore', () => {
+  it('publishes a project-scoped profile atomically with owner-only permissions', async () => {
+    const root = await tempRoot();
+    const store = new NodeStorageProfileStore(root);
+
+    await store.save('project-a', 'lease-a', async (path) => {
+      await writeFile(path, '{"cookies":[]}');
+    });
+
+    const path = await store.loadPath('project-a');
+    expect(path).toBeDefined();
+    expect(await readFile(path ?? '', 'utf8')).toBe('{"cookies":[]}');
+    if ('win32' !== process.platform) {
+      expect((await stat(path ?? '')).mode & 0o777).toBe(0o600);
+      expect((await stat(root)).mode & 0o777).toBe(0o700);
+    }
+    await expect(readdir(root)).resolves.toHaveLength(1);
+  });
+
+  it('hashes project ids so an untrusted id cannot escape the profile directory', async () => {
+    const root = await tempRoot();
+    const store = new NodeStorageProfileStore(root);
+
+    await store.save('../../outside', 'lease-a', async (path) => {
+      await writeFile(path, '{}');
+    });
+
+    const path = await store.loadPath('../../outside');
+    expect(path?.startsWith(`${root}/`)).toBe(true);
+    expect(path).not.toContain('..');
+  });
+
+  it('keeps projects isolated and resets only the requested profile', async () => {
+    const root = await tempRoot();
+    const store = new NodeStorageProfileStore(root);
+    const write =
+      (value: string) =>
+      async (path: string): Promise<void> => {
+        await writeFile(path, value);
+      };
+    await store.save('project-a', 'lease-a', write('a'));
+    await store.save('project-b', 'lease-b', write('b'));
+
+    await expect(store.reset('project-a')).resolves.toBe(true);
+    await expect(store.loadPath('project-a')).resolves.toBeUndefined();
+    const projectB = await store.loadPath('project-b');
+    expect(await readFile(projectB ?? '', 'utf8')).toBe('b');
+    await expect(store.reset('project-a')).resolves.toBe(false);
+  });
+
+  it('removes a failed temporary write without replacing the last good profile', async () => {
+    const root = await tempRoot();
+    const store = new NodeStorageProfileStore(root);
+    await store.save('project-a', 'lease-a', async (path) => {
+      await writeFile(path, 'good');
+    });
+
+    await expect(
+      store.save('project-a', 'lease-b', async (path) => {
+        await writeFile(path, 'partial');
+        throw new Error('capture failed');
+      }),
+    ).rejects.toThrow('capture failed');
+
+    const path = await store.loadPath('project-a');
+    expect(await readFile(path ?? '', 'utf8')).toBe('good');
+    await expect(readdir(root)).resolves.toHaveLength(1);
+  });
+});

--- a/packages/server/src/pool/storage-profile.ts
+++ b/packages/server/src/pool/storage-profile.ts
@@ -1,0 +1,78 @@
+/**
+ * Owner-only Playwright storage profiles for pooled browser leases.
+ *
+ * A profile contains live cookies and local storage, so it is treated as a credential: project ids
+ * are hashed before becoming path segments, the directory/file modes are tightened on every write,
+ * and a failed capture never replaces the last known-good profile.
+ */
+
+import { createHash } from 'node:crypto';
+import { access, chmod, mkdir, rename, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const PROFILE_EXT = '.json';
+const TEMP_EXT = '.tmp';
+const OWNER_DIRECTORY_MODE = 0o700;
+const OWNER_FILE_MODE = 0o600;
+
+export interface StorageProfileStore {
+  loadPath(projectId: string): Promise<string | undefined>;
+  save(projectId: string, leaseId: string, capture: (path: string) => Promise<void>): Promise<void>;
+  reset(projectId: string): Promise<boolean>;
+}
+
+function digest(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function exists(path: string): Promise<boolean> {
+  return access(path).then(
+    () => true,
+    () => false,
+  );
+}
+
+/** Filesystem-backed profile store rooted outside the project checkout (normally ~/.reticle). */
+export class NodeStorageProfileStore implements StorageProfileStore {
+  readonly #root: string;
+
+  constructor(root: string) {
+    this.#root = root;
+  }
+
+  #profilePath(projectId: string): string {
+    return join(this.#root, `${digest(projectId)}${PROFILE_EXT}`);
+  }
+
+  async loadPath(projectId: string): Promise<string | undefined> {
+    const path = this.#profilePath(projectId);
+    return (await exists(path)) ? path : undefined;
+  }
+
+  async save(
+    projectId: string,
+    leaseId: string,
+    capture: (path: string) => Promise<void>,
+  ): Promise<void> {
+    await mkdir(this.#root, { recursive: true, mode: OWNER_DIRECTORY_MODE });
+    await chmod(this.#root, OWNER_DIRECTORY_MODE);
+    const path = this.#profilePath(projectId);
+    const tempPath = join(this.#root, `${digest(projectId)}-${digest(leaseId)}${TEMP_EXT}`);
+    try {
+      await capture(tempPath);
+      await chmod(tempPath, OWNER_FILE_MODE);
+      await rename(tempPath, path);
+      await chmod(path, OWNER_FILE_MODE);
+    } catch (error) {
+      await rm(tempPath, { force: true }).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  async reset(projectId: string): Promise<boolean> {
+    const path = this.#profilePath(projectId);
+    if (!(await exists(path))) return false;
+    await rm(path, { force: true });
+    return true;
+  }
+}

--- a/packages/server/src/tools/lease-tools.test.ts
+++ b/packages/server/src/tools/lease-tools.test.ts
@@ -24,25 +24,51 @@ function tool(name: string): (deps: ToolDeps, args: Record<string, unknown>) => 
 /** A pool stub that records acquire calls and tracks active count. */
 function fakePool(): {
   pool: BrowserPool;
-  acquired: { url: string; sessionId: string | undefined }[];
+  acquired: {
+    url: string;
+    sessionId: string | undefined;
+    persistStorage: { projectId: string } | undefined;
+  }[];
+  reset: string[];
   /** Every (registeredId, leaseId) pair the lease told the pool about. */
   aliased: [string, string][];
 } {
-  const acquired: { url: string; sessionId: string | undefined }[] = [];
+  const acquired: Array<{
+    url: string;
+    sessionId: string | undefined;
+    persistStorage: { projectId: string } | undefined;
+  }> = [];
   let active = 0;
   const released: string[] = [];
   const aliased: [string, string][] = [];
+  const reset: string[] = [];
   const pool = {
-    acquire(url: string, opts: { sessionId?: string } = {}): Promise<Lease> {
-      acquired.push({ url, sessionId: opts.sessionId });
+    acquire(
+      url: string,
+      opts: { sessionId?: string; persistStorage?: { projectId: string } } = {},
+    ): Promise<Lease> {
+      acquired.push({
+        url,
+        sessionId: opts.sessionId,
+        persistStorage: opts.persistStorage,
+      });
       active += 1;
       const sessionId = opts.sessionId ?? 'gen';
-      return Promise.resolve({ sessionId, url, release: () => Promise.resolve() });
+      return Promise.resolve({
+        sessionId,
+        url,
+        ...(opts.persistStorage === undefined ? {} : { storageRestored: true }),
+        release: () => Promise.resolve(),
+      });
     },
-    release(sessionId: string): Promise<void> {
+    release(sessionId: string) {
       released.push(sessionId);
       active = Math.max(0, active - 1);
-      return Promise.resolve();
+      return Promise.resolve({ released: true, storageSaved: true });
+    },
+    resetStorageProfile: (projectId: string) => {
+      reset.push(projectId);
+      return Promise.resolve(true);
     },
     activeCount: () => active,
     queuedCount: () => 0,
@@ -54,7 +80,7 @@ function fakePool(): {
       aliased.push([registeredId, leaseId]);
     },
   } as unknown as BrowserPool;
-  return { pool, acquired, aliased };
+  return { pool, acquired, aliased, reset };
 }
 
 // A sessions stub where the leased tab is already "connected", so acquire's wait-for-ready resolves
@@ -197,6 +223,34 @@ describe('reticle_lease_acquire', () => {
     expect(result.expiresInMs).toBe(300_000);
   });
 
+  it('opts into project-scoped storage and can reset it before acquiring', async () => {
+    const { pool, acquired, reset } = fakePool();
+    const result = (await tool(ReticleTool.LEASE_ACQUIRE)(
+      { ...baseDeps, pool },
+      {
+        url: 'http://localhost:3000/',
+        projectId: 'project-a',
+        persistStorage: true,
+        resetStorage: true,
+      },
+    )) as { storageRestored?: boolean; storageReset?: boolean };
+
+    expect(reset).toEqual(['project-a']);
+    expect(acquired[0]?.persistStorage).toEqual({ projectId: 'project-a' });
+    expect(result.storageRestored).toBe(true);
+    expect(result.storageReset).toBe(true);
+  });
+
+  it('refuses persistence without a projectId', async () => {
+    const { pool } = fakePool();
+    await expect(
+      tool(ReticleTool.LEASE_ACQUIRE)(
+        { ...baseDeps, pool },
+        { url: 'http://localhost:3000/', persistStorage: true },
+      ),
+    ).rejects.toThrow(/projectId/);
+  });
+
   it('throws a clear error when no pool is available', async () => {
     await expect(
       tool(ReticleTool.LEASE_ACQUIRE)(baseDeps, { url: 'http://localhost:3000/' }),
@@ -226,10 +280,11 @@ describe('reticle_lease_release', () => {
       {
         sessionId: acq.sessionId,
       },
-    )) as { released: boolean; leased: number };
+    )) as { released: boolean; leased: number; storageSaved?: boolean };
 
     expect(result.released).toBe(true);
     expect(result.leased).toBe(1);
+    expect(result.storageSaved).toBe(true);
   });
 
   it('throws when no pool is available', async () => {

--- a/packages/server/src/tools/lease-tools.ts
+++ b/packages/server/src/tools/lease-tools.ts
@@ -192,7 +192,7 @@ export async function waitForLeasedSession(
 export const LEASE_ACQUIRE_TOOL: ToolDef = {
   name: ReticleTool.LEASE_ACQUIRE,
   description:
-    'Lease a fresh isolated headless browser context from the shared pool and navigate it to the app URL (the app must already be running and embed @reticlehq/core). Returns the sessionId the leased tab registers — pass it to other tools. The pool keeps all leases in ONE browser and caps concurrency; if at capacity this waits for a free slot. Release with reticle_lease{action:"release"} when the flow is done.',
+    'Lease a fresh isolated headless browser context from the shared pool and navigate it to the app URL (the app must already be running and embed @reticlehq/core). Returns the sessionId the leased tab registers — pass it to other tools. The pool keeps all leases in ONE browser and caps concurrency; if at capacity this waits for a free slot. Set persistStorage:true with projectId to restore and save that project auth state; resetStorage:true discards it first. Release with reticle_lease{action:"release"} when the flow is done.',
   inputSchema: {
     url: z
       .string()
@@ -201,6 +201,16 @@ export const LEASE_ACQUIRE_TOOL: ToolDef = {
       .string()
       .optional()
       .describe('Stable project id to stamp on the leased tab so the agent can scope to it.'),
+    persistStorage: z
+      .boolean()
+      .optional()
+      .describe(
+        'Opt in to restoring this projectId storage profile and saving it on release. The profile contains live credentials and stays owner-readable on this machine.',
+      ),
+    resetStorage: z
+      .boolean()
+      .optional()
+      .describe('Discard this projectId storage profile before acquiring a clean context.'),
   },
   outputSchema: {
     sessionId: z.string(),
@@ -217,6 +227,8 @@ export const LEASE_ACQUIRE_TOOL: ToolDef = {
       ),
     leased: z.number().describe('How many contexts are currently leased from the pool.'),
     queued: z.number().describe('How many acquires are waiting for a free slot.'),
+    storageRestored: z.boolean().optional(),
+    storageReset: z.boolean().optional(),
     hint: z.string().optional(),
   },
   handler: async (deps: ToolDeps, args) => {
@@ -237,11 +249,26 @@ export const LEASE_ACQUIRE_TOOL: ToolDef = {
       }
     }
     const projectId = asString(args['projectId']);
+    const persistStorage = true === args['persistStorage'];
+    const resetStorage = true === args['resetStorage'];
+    if ((persistStorage || resetStorage) && projectId === undefined) {
+      throw new Error('persistStorage/resetStorage requires a projectId');
+    }
+    if (resetStorage && !persistStorage) {
+      throw new Error('resetStorage requires persistStorage:true');
+    }
+    const storageReset =
+      resetStorage && projectId !== undefined
+        ? await pool.resetStorageProfile(projectId)
+        : undefined;
     const sessionId = newLeaseId();
     const navUrl = appendReticleParams(url, sessionId, projectId);
     let lease;
     try {
-      lease = await pool.acquire(navUrl, { sessionId });
+      lease = await pool.acquire(navUrl, {
+        sessionId,
+        ...(persistStorage && projectId !== undefined ? { persistStorage: { projectId } } : {}),
+      });
     } catch (err) {
       // A raw page.goto failure is noisy and leaks the internal URL params — surface a clean,
       // actionable message instead.
@@ -267,6 +294,8 @@ export const LEASE_ACQUIRE_TOOL: ToolDef = {
       expiresInMs: pool.leaseTtlMs(),
       leased: pool.activeCount(),
       queued: pool.queuedCount(),
+      ...(lease.storageRestored === undefined ? {} : { storageRestored: lease.storageRestored }),
+      ...(storageReset === undefined ? {} : { storageReset }),
       ...(ready
         ? {}
         : (() => {
@@ -291,6 +320,8 @@ export const LEASE_RELEASE_TOOL: ToolDef = {
   outputSchema: {
     released: z.boolean(),
     leased: z.number(),
+    storageSaved: z.boolean().optional(),
+    storageError: z.string().optional(),
   },
   handler: async (deps: ToolDeps, args) => {
     const pool = deps.pool;
@@ -299,8 +330,8 @@ export const LEASE_RELEASE_TOOL: ToolDef = {
     if (sessionId === undefined || 0 === sessionId.length) {
       throw new Error('reticle_lease{action:"release"} requires a sessionId');
     }
-    await pool.release(sessionId);
-    return { released: true, leased: pool.activeCount() };
+    const result = await pool.release(sessionId);
+    return { ...result, leased: pool.activeCount() };
   },
 };
 


### PR DESCRIPTION
## Summary

- add opt-in project-scoped Playwright storage profiles to pooled leases
- save cookies/local storage atomically on release and restore them on the next acquire
- keep profile names hashed and files owner-only outside the checkout
- add explicit reset plus redacted save-failure reporting without leaking a pool slot
- verify same-project restore, cross-project isolation, reset, and real auth storage in Chromium

Closes #334

## Test plan

- pnpm format:check
- pnpm lint
- pnpm typecheck
- targeted server tests: 49 passed
- isolated browser package: 1,099 passed
- live multi-agent Chromium spec: 12 passed
- full e2e battery: storage spec passed; 34/35 total specs passed and 60/60 soak calls passed. The sole failure is an existing daemon-heartbeat harness command that does not quote this checkout path containing a space, so Node tries to load /Users/satyaphanindra/Desktop/testing.
