### PR TITLE
feat(server): report sibling Reticle daemons in no-session diagnosis

### DIFF
--- a/packages/server/src/daemon/daemon.ts
+++ b/packages/server/src/daemon/daemon.ts
@@ -222,6 +222,40 @@ export function reclaimStaleDaemons(
   return reclaimed;
 }
 
+/**
+ * Find all live Reticle daemons OTHER than `ownPort` by scanning the pid file registry.
+ *
+ * Injectable `home` and `pidAlive` follow `reclaimStaleDaemons`'s pattern for testability.
+ */
+export function discoverSiblingDaemons(
+  ownPort: number,
+  home: string = reticleStateHome(),
+  pidAlive: (pid: number) => boolean = isAlive,
+): readonly number[] {
+  const siblings: number[] = [];
+  let files: string[];
+  try {
+    files = readdirSync(home);
+  } catch {
+    return siblings;
+  }
+  for (const file of files) {
+    const m = /^daemon-(\d+)\.pid$/.exec(file);
+    if (null === m) continue;
+    const port = Number(m[1]);
+    if (port === ownPort) continue;
+    let pid: number | null = null;
+    try {
+      pid = parseInt(readFileSync(join(home, file), 'utf8').trim(), 10);
+      if (isNaN(pid)) pid = null;
+    } catch {
+      pid = null;
+    }
+    if (null !== pid && pidAlive(pid)) siblings.push(port);
+  }
+  return siblings;
+}
+
 /** The minimal shape of a spawned child that spawnDaemon uses. */
 export interface SpawnedChild {
   readonly pid?: number | undefined;

--- a/packages/server/src/daemon/discover-sibling-daemons.test.ts
+++ b/packages/server/src/daemon/discover-sibling-daemons.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { discoverSiblingDaemons } from './daemon.js';
+
+const TEST_HOME = join(tmpdir(), `reticle-sibling-test-${process.pid}`);
+
+function writePid(port: number, pid: number): void {
+  writeFileSync(join(TEST_HOME, `daemon-${String(port)}.pid`), String(pid));
+}
+
+afterEach(() => {
+  try {
+    rmSync(TEST_HOME, { recursive: true });
+  } catch {
+    // already gone
+  }
+});
+
+describe('discoverSiblingDaemons', () => {
+  it('returns live ports other than ownPort', () => {
+    mkdirSync(TEST_HOME, { recursive: true });
+    writePid(4400, 1001);
+    writePid(4460, 1002);
+    writePid(4480, 1003);
+    const aliveSet = new Set([1001, 1002, 1003]);
+    const siblings = discoverSiblingDaemons(4400, TEST_HOME, (pid) => aliveSet.has(pid));
+    expect(siblings).toContain(4460);
+    expect(siblings).toContain(4480);
+    expect(siblings).not.toContain(4400);
+  });
+
+  it('excludes dead daemons', () => {
+    mkdirSync(TEST_HOME, { recursive: true });
+    writePid(4400, 1001);
+    writePid(4460, 1002);
+    writePid(4480, 9999);
+    const siblings = discoverSiblingDaemons(4400, TEST_HOME, (pid) => pid !== 9999);
+    expect(siblings).toContain(4460);
+    expect(siblings).not.toContain(4480);
+  });
+
+  it('returns empty when no state directory exists', () => {
+    const siblings = discoverSiblingDaemons(4400, '/nonexistent-path-xyz', () => true);
+    expect(siblings).toEqual([]);
+  });
+
+  it('returns empty when only ownPort is live', () => {
+    mkdirSync(TEST_HOME, { recursive: true });
+    writePid(4400, 1001);
+    const siblings = discoverSiblingDaemons(4400, TEST_HOME, () => true);
+    expect(siblings).toEqual([]);
+  });
+
+  it('ignores non-pidfile entries', () => {
+    mkdirSync(TEST_HOME, { recursive: true });
+    writePid(4460, 1002);
+    writeFileSync(join(TEST_HOME, 'pairing-token'), 'abc');
+    writeFileSync(join(TEST_HOME, 'not-a-daemon.pid'), '9999');
+    const siblings = discoverSiblingDaemons(4400, TEST_HOME, () => true);
+    expect(siblings).toEqual([4460]);
+  });
+});

--- a/packages/server/src/session/no-session-diagnosis.test.ts
+++ b/packages/server/src/session/no-session-diagnosis.test.ts
@@ -630,3 +630,77 @@ describe('a stalled install is surfaced in the diagnosis', () => {
     expect(msg).not.toMatch(/\d+ minutes.*no.+app/i);
   });
 });
+
+/**
+ * Sibling Reticle daemons — another daemon is running on a port this one is not on.
+ *
+ * Issue #261: "the version worth building reports the observation without the conclusion:
+ * 'something is listening on :4460, which this daemon is not; that may or may not be related.'"
+ *
+ * The diagnosis must be NEUTRAL — report what was observed, never assert causation.
+ */
+describe('sibling daemon observation', () => {
+  it('names the sibling port when no session has connected and a sibling is live', () => {
+    const msg = diagnoseNoSession({
+      everConnected: false,
+      initialized: true,
+      listening: [5173],
+      port: 4400,
+      siblingDaemons: [4460],
+    });
+    expect(msg).toContain('4460');
+    expect(msg).toMatch(/Reticle daemon/i);
+  });
+
+  it('names multiple siblings when more than one exists', () => {
+    const msg = diagnoseNoSession({
+      everConnected: false,
+      initialized: true,
+      listening: [5173],
+      port: 4400,
+      siblingDaemons: [4460, 4480],
+    });
+    expect(msg).toContain('4460');
+    expect(msg).toContain('4480');
+  });
+
+  it('does NOT mention siblings when a session has connected — the wiring already proved itself', () => {
+    const msg = diagnoseNoSession({
+      everConnected: true,
+      initialized: true,
+      listening: [5173],
+      port: 4400,
+      siblingDaemons: [4460],
+    });
+    expect(msg).not.toContain('4460');
+  });
+
+  it('says nothing when siblingDaemons is empty', () => {
+    const withSiblings = diagnoseNoSession({
+      everConnected: false,
+      initialized: true,
+      listening: [5173],
+      port: 4400,
+      siblingDaemons: [],
+    });
+    const without = diagnoseNoSession({
+      everConnected: false,
+      initialized: true,
+      listening: [5173],
+      port: 4400,
+    });
+    expect(withSiblings).toBe(without);
+  });
+
+  it('uses neutral wording — observation, not conclusion', () => {
+    const msg = diagnoseNoSession({
+      everConnected: false,
+      initialized: true,
+      listening: [5173],
+      port: 4400,
+      siblingDaemons: [4460],
+    });
+    expect(msg).toMatch(/may or may not/i);
+    expect(msg).not.toMatch(/this is why|this is the cause|the problem is/i);
+  });
+});

--- a/packages/server/src/session/no-session-diagnosis.ts
+++ b/packages/server/src/session/no-session-diagnosis.ts
@@ -344,8 +344,8 @@ function siblingDaemonClause(facts: NoSessionFacts): string {
   const ports = siblings.map(String).join(', ');
   const subject =
     1 === siblings.length
-      ? `A Reticle daemon is also answering on :${ports}`
-      : `Reticle daemons are also answering on :${ports}`;
+      ? `Another Reticle daemon is registered on :${ports} and its process is alive`
+      : `Reticle daemons are registered on :${ports} and their processes are alive`;
   return (
     ` ${subject}, which this daemon (on :${String(facts.port)}) is not on — ` +
     'that may or may not be related to why no session has appeared here.'

--- a/packages/server/src/session/no-session-diagnosis.ts
+++ b/packages/server/src/session/no-session-diagnosis.ts
@@ -108,6 +108,13 @@ export interface NoSessionFacts {
    * install never finished" to the user-facing diagnosis rather than only to telemetry.
    */
   daemonUpMs?: number;
+  /**
+   * Ports where another live Reticle daemon was found in the pid registry.
+   *
+   * Reported as a neutral observation — the daemon that is NOT this one may or may not be related
+   * to why no session has appeared here. The message never asserts causation.
+   */
+  siblingDaemons?: readonly number[];
 }
 
 /** The one framework whose most likely cause differs from every other framework's. */
@@ -324,6 +331,28 @@ function portMismatchClause(facts: NoSessionFacts): string {
 }
 
 /**
+ * A neutral observation that another Reticle daemon exists on a different port.
+ *
+ * Never asserts causation — "may or may not be related" is the strongest claim this makes.
+ * Only appended on `!everConnected` branches: once a session has proved itself, the existence
+ * of another daemon is irrelevant to this daemon's working state.
+ */
+function siblingDaemonClause(facts: NoSessionFacts): string {
+  if (facts.everConnected) return '';
+  const siblings = facts.siblingDaemons ?? [];
+  if (0 === siblings.length) return '';
+  const ports = siblings.map(String).join(', ');
+  const subject =
+    1 === siblings.length
+      ? `A Reticle daemon is also answering on :${ports}`
+      : `Reticle daemons are also answering on :${ports}`;
+  return (
+    ` ${subject}, which this daemon (on :${String(facts.port)}) is not on — ` +
+    'that may or may not be related to why no session has appeared here.'
+  );
+}
+
+/**
  * The tail every "the app is wired and silent" branch ends with, ranked.
  *
  * One place, because the ranking is the whole fix: a hint that lists "no server", "no SDK" and
@@ -433,7 +462,7 @@ export function diagnoseNoSession(facts: NoSessionFacts): string {
         ? `${unattributedListeners(listening)} If the dev server is not running, start it first ` +
           '(the command is in `next_action`).'
         : unattributedListeners(listening);
-    return `${RESTARTED_LEAD} ${OPEN_THE_APP} ${listeners} ${rankedCauses(facts)} ${SELF_SERVE} ${RETRY}`;
+    return `${RESTARTED_LEAD} ${OPEN_THE_APP} ${listeners} ${rankedCauses(facts)}${siblingDaemonClause(facts)} ${SELF_SERVE} ${RETRY}`;
   }
 
   // A config found elsewhere outranks every "you may have no SDK" branch below: those reason from
@@ -443,7 +472,7 @@ export function diagnoseNoSession(facts: NoSessionFacts): string {
     return (
       'no browser session connected, and this daemon has never seen one. ' +
       `${configsElsewhereClause(facts)} ${unattributedListeners(listening)} ${OPEN_THE_APP} ` +
-      `${rankedCauses(facts)} ${SELF_SERVE} ${RETRY}`
+      `${rankedCauses(facts)}${siblingDaemonClause(facts)} ${SELF_SERVE} ${RETRY}`
     );
   }
 
@@ -476,7 +505,7 @@ export function diagnoseNoSession(facts: NoSessionFacts): string {
         `file ${INIT_CMD} writes, so the app may carry no Reticle SDK — but check the app's ` +
         'OWN directory before re-running `init`: in a monorepo the daemon often runs at the root ' +
         'while the app lives in a subdirectory, and an app wired by the Vite or Babel plugin ' +
-        `carries the SDK without that file at all.${searchedClause(facts)} ${URL_THEN_LEASE} ${RETRY}`
+        `carries the SDK without that file at all.${searchedClause(facts)}${siblingDaemonClause(facts)} ${URL_THEN_LEASE} ${RETRY}`
       );
     }
     return (
@@ -496,7 +525,8 @@ export function diagnoseNoSession(facts: NoSessionFacts): string {
       // Deliberately NOT offering reticle_lease here, and a test pins that: a lease opens a URL, and
       // if nothing is listening there is nothing at any URL to open. Asking for the real one is the
       // only move that can recover the :7699 case.
-      `the app IS running, ask the human for its URL rather than assuming it is down. ${URL_THEN_LEASE} ` +
+      `the app IS running, ask the human for its URL rather than assuming it is down. ${URL_THEN_LEASE}` +
+      `${siblingDaemonClause(facts)} ` +
       // Reachable only for a project that HAS been through `init` — the uninstrumented case is
       // answered above, leading with that certainty instead of behind this scan's guess.
       `${RETRY}`
@@ -512,7 +542,7 @@ export function diagnoseNoSession(facts: NoSessionFacts): string {
       "a subdirectory, or in an app wired by the Vite or Babel plugin. Check the app's OWN " +
       `directory: if it has no config, run ${INIT_CMD} there and restart the dev server; if it ` +
       `has one, the app is wired and simply has no page open — ${OPEN_CMD}. ` +
-      `${unattributedListeners(listening)}${searchedClause(facts)} ${RETRY}`
+      `${unattributedListeners(listening)}${searchedClause(facts)}${siblingDaemonClause(facts)} ${RETRY}`
     );
   }
 
@@ -520,6 +550,6 @@ export function diagnoseNoSession(facts: NoSessionFacts): string {
     `${stallClause(facts)}no browser session connected, and this daemon has never seen one for this project, which is ` +
     `wired for Reticle. ${OPEN_THE_APP} ${unattributedListeners(listening)} ` +
     'If the page IS open and still does not appear, the app is wired and the SDK is not reaching ' +
-    `this daemon (on ${String(port)}). ${rankedCauses(facts)} ${SELF_SERVE} ${RETRY}`
+    `this daemon (on ${String(port)}). ${rankedCauses(facts)}${siblingDaemonClause(facts)} ${SELF_SERVE} ${RETRY}`
   );
 }

--- a/packages/server/src/session/no-session-restart-wiring.test.ts
+++ b/packages/server/src/session/no-session-restart-wiring.test.ts
@@ -65,6 +65,7 @@ describe('the watch reads the durable bit and hands it to the diagnosis', () => 
       directory: dir,
       stateDir: dir,
       probe: () => Promise.resolve([3000]),
+      siblingProbe: () => [],
     });
     try {
       expect(sessions.noSessionHint() ?? '').not.toMatch(/never seen one/i);
@@ -82,6 +83,7 @@ describe('the watch reads the durable bit and hands it to the diagnosis', () => 
       directory: dir,
       stateDir: dir,
       probe: () => Promise.resolve([]),
+      siblingProbe: () => [],
     });
     try {
       expect(sessions.noSessionHint() ?? '').toMatch(/never seen one|no `\.reticle\.json`/i);

--- a/packages/server/src/session/no-session-watch.test.ts
+++ b/packages/server/src/session/no-session-watch.test.ts
@@ -44,6 +44,24 @@ function stubSessions(): { manager: SessionManager; hint: () => string } {
   return { manager, hint: () => installed?.() ?? '' };
 }
 
+describe('sibling daemon probe reaches the diagnosis output', () => {
+  it('a port returned by siblingProbe appears in noSessionHint', () => {
+    const dir = projectDir(undefined);
+    const { manager, hint } = stubSessions();
+    const stop = startNoSessionWatch({
+      sessions: manager,
+      port: 4400,
+      initialized: false,
+      directory: dir,
+      probe: () => Promise.resolve([]),
+      siblingProbe: () => [4460],
+    });
+    const message = hint();
+    stop();
+    expect(message).toContain('4460');
+  });
+});
+
 describe('the no-session diagnosis and a config written after boot', () => {
   it('reads `.reticle.json` when the question is asked, not when the daemon booted', async () => {
     const dir = projectDir(JSON.stringify({ framework: 'vite', projectId: 'app-1' }));

--- a/packages/server/src/session/no-session-watch.test.ts
+++ b/packages/server/src/session/no-session-watch.test.ts
@@ -73,6 +73,7 @@ describe('the no-session diagnosis and a config written after boot', () => {
       initialized: false,
       directory: dir,
       probe: () => Promise.resolve([5173]),
+      siblingProbe: () => [],
     });
     // Let the port scan settle — the dev server IS up, which is the stale-process shape.
     await Promise.resolve();
@@ -93,6 +94,7 @@ describe('the no-session diagnosis and a config written after boot', () => {
       initialized: false,
       directory: dir,
       probe: () => Promise.resolve([5173]),
+      siblingProbe: () => [],
     });
     const message = hint();
     stop();

--- a/packages/server/src/session/no-session-watch.ts
+++ b/packages/server/src/session/no-session-watch.ts
@@ -18,7 +18,7 @@ import type { NoSessionNextAction } from './no-session-next-action.js';
 import { readProjectFramework, readProjectId, readProjectPort } from '../cli/cli-port.js';
 import { discoverProjectConfigs } from '../cli/config-discovery.js';
 import { hasProjectConnectedBefore, rememberConnected } from './connection-memory.js';
-import { reticleStateHome } from '../daemon/daemon.js';
+import { discoverSiblingDaemons, reticleStateHome } from '../daemon/daemon.js';
 import { stallUptime } from './stall-clock.js';
 import type { SessionManager } from './session-manager.js';
 
@@ -75,6 +75,11 @@ interface NoSessionWatchOptions {
    * a test says otherwise.
    */
   stateDir?: string;
+  /**
+   * Returns ports of live sibling Reticle daemons (all live daemons other than this one).
+   * Injectable for testing; defaults to scanning the pid file registry.
+   */
+  siblingProbe?: () => readonly number[];
 }
 
 /**
@@ -95,6 +100,7 @@ export function startNoSessionWatch(options: NoSessionWatchOptions): () => void 
    * `options.probe` returns only the serving set, so this stays empty for injected probes.
    */
   let slowListeners: readonly number[] = [];
+  let siblingDaemons: readonly number[] = [];
   let running = false;
   /** Ports auto-attach has already spent its one attempt on. Bounded: never a loop, never a retry. */
   const attempted = new Set<number>();
@@ -159,10 +165,13 @@ export function startNoSessionWatch(options: NoSessionWatchOptions): () => void 
     }
   };
 
+  const probeSiblings = options.siblingProbe ?? (() => discoverSiblingDaemons(options.port));
+
   const refresh = (): void => {
     // Nothing to diagnose while a session is live, and no reason to scan.
     if (running || options.sessions.count() > 0) return;
     running = true;
+    siblingDaemons = probeSiblings();
     void (
       options.probe === undefined
         ? probeDevServerStates().then((states) => {
@@ -258,6 +267,7 @@ export function startNoSessionWatch(options: NoSessionWatchOptions): () => void 
           const configured = readProjectPort(directory);
           return configured === undefined ? {} : { projectPort: configured };
         })(),
+        ...(0 === siblingDaemons.length ? {} : { siblingDaemons }),
       }) +
       // Prose for the human, then the literal command for the agent. Appended rather than folded
       // into the diagnosis so that file stays pure and its cases stay independently pinned.


### PR DESCRIPTION
## Summary

Completes item (1) of #261 — sibling Reticle port detection.

- Adds `discoverSiblingDaemons(ownPort, home?, pidAlive?)` to `daemon.ts` — scans the pid file registry for live daemons other than self
- Adds `siblingDaemons?: readonly number[]` to `NoSessionFacts`
- Adds `siblingDaemonClause(facts)` — neutral observation appended to all `!everConnected` branches: *"A Reticle daemon is also answering on :4460, which this daemon is not on — that may or may not be related"*
- Wires the probe into `no-session-watch.ts` with an injectable `siblingProbe` option (synchronous pid scan on the 15s refresh interval)

Wording follows the maintainer's explicit constraint from #261: report the observation without asserting causation.

## Test plan

- [x] 5 unit tests for `discoverSiblingDaemons` (live ports, dead exclusion, missing dir, self-exclusion, non-pidfile entries)
- [x] 5 unit tests for the sibling diagnosis clause (port named, multiple siblings, everConnected suppression, empty = no change, neutral wording)
- [x] Full suite passes (4456 tests, 0 failures)
- [x] Lint, typecheck, prettier all green on changed files

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)