### PR TITLE
fix(server): a lapsed customer had no name, and a scoped key looked healthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
+### Fixed
+
+- **`@reticlehq/server` — a lapsed customer could not be identified, which is most of what a lapse signal is for.** Found by running six dummy customers through a packaged release rather than the source tree: the expired one arrived UNATTRIBUTABLE. `licenseId` was reported only while a key verified AND was in date, so telemetry could say that somebody's licence had run out and never whose, and the renewal conversation still had to start with the customer noticing. An expired key is still SIGNED, so its claims are exactly as trustworthy as they were the day before and only the clock has moved; the id now rides it. The line that matters is the SIGNATURE, not the expiry, so a malformed or wrongly-signed key stays anonymous exactly as before, and that is pinned by its own test.
+
+- **`@reticlehq/server` — a paying customer could read `active` while every gated feature refused them.** From the same rehearsal: a key scoped to `sso` on a build that gates `audit-log` reported `active`, and then denied every gated call. Both halves were already on screen, `features` against `gated`, and nothing joined them, so the one word anybody actually reads said they were fine. `reticle license` now says outright when a valid key covers nothing the running build gates, and names both lists.
+
 ### Added
 
 - **`@reticlehq/server` — an agent can report that something WORKED, not only that it broke.** Every kind `reticle_feedback` offered an agent was a complaint: bug, gap, ambiguity, feature_request, improvement. So the only thing the corpus could ever become was a defect list, and the question a refactor actually needs answered, which parts are worth protecting when we change them, had no evidence behind it at all. The `experience` kind and its 1-5 `rating` already existed in the contract and were reachable only by a human at a terminal; the agent, which is the user this product is built for, could not file one. Both are now on the agent tool and on `reticle feedback --agent`, and the MCP instructions name it so an agent that was never told about it can still use it.

--- a/packages/server/src/license/license.test.ts
+++ b/packages/server/src/license/license.test.ts
@@ -257,3 +257,52 @@ describe('reticle license is not a dead end for somebody who has no key', () => 
     }
   });
 });
+
+describe('what the fleet rehearsal caught', () => {
+  const PUBKEY_PEM = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+  const env = (over: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv => ({
+    [LICENSE_PUBLIC_KEY_ENV]: PUBKEY_PEM,
+    ...over,
+  });
+
+  it('still names the customer once their key expires', () => {
+    // Found by running six dummy customers through a packaged release: the lapsed one came out
+    // UNATTRIBUTABLE. The whole point of reporting status through the failure states is to see a
+    // renewal coming, and "somebody's key expired" is not a renewal signal if it cannot say WHOSE.
+    // The signature still verifies on an expired key, so the id is as trustworthy as it ever was;
+    // only the clock has moved.
+    const report = describeLicense(NOW, env({ [LICENSE_KEY_ENV]: key({ exp: PAST }) }));
+    expect(report.status).toBe('expired');
+    expect(report.licenseId).toBe('lic_00000000-0000-4000-8000-000000000001');
+  });
+
+  it('a forged key is still anonymous, because its claims were never trustworthy', () => {
+    // The line is the SIGNATURE, not the expiry. An unverified payload must never name a customer.
+    const other = generateKeyPairSync('ed25519');
+    const forged = signLicenseKey(payload(), other.privateKey);
+    const report = describeLicense(NOW, env({ [LICENSE_KEY_ENV]: forged }));
+    expect(report.status).toBe('invalid');
+    expect(report.licenseId).toBeUndefined();
+  });
+
+  it('says so when a valid key covers nothing this build gates', () => {
+    // Also from the rehearsal: a customer who bought `sso` read `active` while every gated feature
+    // refused them. Both facts were on screen (`features` vs `gated`) and nothing joined them, so
+    // the one word they actually read said they were fine.
+    const report = describeLicense(NOW, env({ [LICENSE_KEY_ENV]: key({ features: ['sso'] }) }));
+    expect(report.status).toBe('active');
+    expect(report.coversNothingHere).toBe(true);
+    expect(report.detail).toMatch(/sso/);
+  });
+
+  it('stays quiet when the key does cover something, or covers everything', () => {
+    const scoped = describeLicense(
+      NOW,
+      env({ [LICENSE_KEY_ENV]: key({ features: ['audit-log'] }) }),
+    );
+    expect(scoped.coversNothingHere).toBeUndefined();
+    // No `features` at all means every gated feature is included, which is the common case.
+    const unscoped = describeLicense(NOW, env({ [LICENSE_KEY_ENV]: key() }));
+    expect(unscoped.coversNothingHere).toBeUndefined();
+  });
+});

--- a/packages/server/src/license/license.ts
+++ b/packages/server/src/license/license.ts
@@ -47,7 +47,16 @@ export type LicensePayload = z.infer<typeof LicensePayloadSchema>;
 
 type LicenseCheck =
   | { status: typeof LicenseStatus.VALID; payload: LicensePayload }
-  | { status: Exclude<LicenseStatus, typeof LicenseStatus.VALID> };
+  /**
+   * EXPIRED carries the payload; the other failures cannot. The line is the SIGNATURE, not the
+   * clock: an expired key was genuinely issued by us and its claims are exactly as trustworthy as
+   * they were yesterday, so the licence id is safe to use. A malformed or wrongly-signed key has no
+   * verified claims at all, and naming a customer from one would mean trusting whatever was pasted.
+   */
+  | { status: typeof LicenseStatus.EXPIRED; payload: LicensePayload }
+  | {
+      status: Exclude<LicenseStatus, typeof LicenseStatus.VALID | typeof LicenseStatus.EXPIRED>;
+    };
 
 /** A key is `base64url(payloadJson).base64url(ed25519Signature)`. */
 const KEY_SEP = '.';
@@ -99,7 +108,7 @@ export function verifyLicenseKey(
     return { status: LicenseStatus.BAD_SIGNATURE };
   }
   if (!signatureOk) return { status: LicenseStatus.BAD_SIGNATURE };
-  if (payload.exp <= now) return { status: LicenseStatus.EXPIRED };
+  if (payload.exp <= now) return { status: LicenseStatus.EXPIRED, payload };
   return { status: LicenseStatus.VALID, payload };
 }
 
@@ -223,6 +232,11 @@ export interface LicenseReport {
    */
   gated: readonly string[];
   contact: string;
+  /**
+   * The key is valid, and scoped to features this build does not gate, so it unlocks nothing here.
+   * Present only when true: a `false` on every healthy licence is noise on the common case.
+   */
+  coversNothingHere?: boolean;
   org?: string;
   plan?: string;
   expiresAt?: number;
@@ -235,10 +249,10 @@ export interface LicenseReport {
  * return, because the value that must never go missing is the one on the branch nobody was thinking
  * about — and the branch an unlicensed reader lands on is exactly that branch.
  */
-const LICENSE_OFFER = {
+const LICENSE_OFFER: { readonly gated: readonly string[]; readonly contact: string } = {
   gated: Object.values(EnterpriseFeature),
   contact: LICENSE_CONTACT,
-} as const;
+};
 
 function loadPublicKey(pem: string | undefined): KeyObject | undefined {
   if (pem === undefined || 0 === pem.length) return undefined;
@@ -287,6 +301,14 @@ export function describeLicense(
   const check = verifyLicenseKey(env[LICENSE_KEY_ENV], publicKey, now);
   if (check.status === LicenseStatus.VALID) {
     const { lid, org, plan, exp, features } = check.payload;
+    // A key scoped to features this build does not gate is `active` and unlocks nothing. Both halves
+    // were already on screen (`features` against `gated`) and nothing joined them, so the one word a
+    // customer actually reads told them they were fine while every gated call refused them.
+    const coversNothingHere =
+      features !== undefined && !features.some((f) => LICENSE_OFFER.gated.includes(f));
+    const detail = coversNothingHere
+      ? `licensed to ${org} (${plan}), expires ${new Date(exp).toISOString()}. This key covers ${features?.join(', ')}, and nothing this build gates (${LICENSE_OFFER.gated.join(', ')}) is included. Contact ${LICENSE_CONTACT}`
+      : `licensed to ${org} (${plan}), expires ${new Date(exp).toISOString()}`;
     return {
       ...LICENSE_OFFER,
       status: LicenseActivation.ACTIVE,
@@ -295,7 +317,8 @@ export function describeLicense(
       plan,
       expiresAt: exp,
       ...(features !== undefined ? { features } : {}),
-      detail: `licensed to ${org} (${plan}), expires ${new Date(exp).toISOString()}`,
+      ...(coversNothingHere ? { coversNothingHere } : {}),
+      detail,
     };
   }
   if (check.status === LicenseStatus.MISSING) {
@@ -308,9 +331,14 @@ export function describeLicense(
     };
   }
   if (check.status === LicenseStatus.EXPIRED) {
+    // The id rides an expired key so a lapse can be attributed to a CUSTOMER. Without it, telemetry
+    // reports that somebody's licence ran out and cannot say whose, which is not a renewal signal.
     return {
       ...LICENSE_OFFER,
       status: LicenseActivation.EXPIRED,
+      licenseId: check.payload.lid,
+      org: check.payload.org,
+      expiresAt: check.payload.exp,
       detail: `license expired. Renew with ${LICENSE_CONTACT} to keep using enterprise features`,
     };
   }

--- a/packages/server/src/telemetry/license-activation.test.ts
+++ b/packages/server/src/telemetry/license-activation.test.ts
@@ -36,12 +36,14 @@ describe('licenseFacts', () => {
     expect(JSON.stringify(facts)).not.toContain('Northwind');
   });
 
-  it('keeps reporting status once a key lapses, which is what makes a lapse visible', () => {
-    // The renewal signal. `licenseId` drops (nothing verified), but a machine that used to report
-    // `active` now reports `expired` — on identity alone this would be indistinguishable from churn.
+  it('names the customer whose key lapsed, not merely that one did', () => {
+    // The renewal signal, and it has to carry identity to be one. A fleet rehearsal through a
+    // packaged release showed the lapsed customer arriving UNATTRIBUTABLE: the status said a licence
+    // had run out and nothing said whose. An expired key is still SIGNED, so its id is exactly as
+    // trustworthy as it was the day before; only the clock moved.
     const facts = licenseFacts(NOW, licensed({ [LICENSE_KEY_ENV]: key(NOW - 1) }));
     expect(facts.licenseStatus).toBe(LicenseActivation.EXPIRED);
-    expect(facts.licenseId).toBeUndefined();
+    expect(facts.licenseId).toBe(LID);
   });
 
   it('reports missing and invalid distinctly', () => {


### PR DESCRIPTION
## What & why

Both defects were found by running **six dummy customers through a packaged release** rather than the source tree, which is the only place either is visible.

**A lapsed customer had no name.** `licenseId` was reported only while a key both verified *and* was in date. So telemetry could say that somebody's licence had run out and never whose, and the renewal conversation still had to start with the customer noticing — which is most of what reporting status through the failure states was supposed to prevent.

An expired key is still **signed**. Its claims are exactly as trustworthy as they were the day before; only the clock has moved. So the id rides it now. The line that matters is the **signature**, not the expiry: a malformed or wrongly-signed key stays anonymous exactly as before, and that has its own test.

**A paying customer could read `active` while every gated call refused them.** A key scoped to `sso`, on a build that gates `audit-log`, reported `active` and then denied everything. Both halves were already on screen — `features` against `gated` — and nothing joined them, so the one word anybody actually reads told them they were fine.

## How it was verified

The fleet rollup before the fix, joining events to the issuance ledger:

```
ORG               MACHINES  REPORTS  PRAISE       BUGS  GAPS  STATUS
Northwind Bank    3         4        4.5★ (n=2)   1     1     active
Contoso Ltd       2         2        5.0★ (n=1)   0     0     active
Fabrikam Inc      1         1        3.0★ (n=1)   0     0     active
(UNATTRIBUTABLE)  1         1        -            ?     ?     expired
```

After, on a freshly stamped and installed release build:

```
expired names the org:   expired Initech 5adcc8a1
scoped key warns:        active coversNothingHere=true
lapsed customer's event: licenseId=5adcc8a1 status=expired plan=(absent, correct)
control, forged key:     invalid  org=(none)  lid=(none)
control, healthy key:    active   Northwind Bank  06f91b5d  coversNothingHere=false
```

## Gates run

- [x] `pnpm format:check && pnpm lint && pnpm typecheck && pnpm test:unit`
- [ ] `pnpm test:e2e` — not run on the final rebase; the licence path has no e2e spec, and the same tree passed the battery before the rebase onto #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)
