### PR TITLE
fix(bench): enable benchmark harness on Windows

### DIFF
--- a/bench/harness/bench-all.mjs
+++ b/bench/harness/bench-all.mjs
@@ -20,13 +20,13 @@ import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 import * as PORTS from './ports.mjs';
 import { verifyAnchors } from './inject.mjs';
-
 const FULL = process.argv.includes('--full');
 const NO_BOOT = process.argv.includes('--no-boot');
 // Ports live in one module — see the note there on why disagreeing about them silently
 // invalidated the benchmark twice.
 const { RETICLE_PORT, API_PORT, DEMO_PORT, BENCH_URL } = PORTS;
 const FIXTURE_READY_MS = Number(process.env.BENCH_FIXTURE_READY_MS ?? '30000');
+const PNPM_CMD = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // Deterministic, offline, pure-Reticle detection scripts — always run (the gate's hard floor).
@@ -77,10 +77,13 @@ function spawnFixture(label, command, args, env) {
   // exits and takes every remaining pass with it. That is the whole reason bench-all has been
   // unable to complete: the passes reported "measured NOTHING" and the numbers looked like a
   // verifier regression when the fixture had simply gone away underneath them.
+  const isWindows = process.platform === 'win32';
   const child = spawn(command, args, {
     env: { ...process.env, ...env },
     stdio: 'ignore',
-    detached: true,
+    detached: !isWindows,
+    windowsHide: isWindows,
+    shell: isWindows,
   });
   child.on('error', (error) => console.error(`fixture ${label} failed to spawn: ${error.message}`));
   child.label = label;
@@ -110,7 +113,15 @@ function teardownFixtures() {
     try {
       // Kill the GROUP (negative pid), not just the direct child — see spawnFixture. Killing the
       // wrapper alone is what orphaned a dev server that then outlived the run.
-      process.kill(-child.pid, 'SIGTERM');
+      if (process.platform === 'win32') {
+        try {
+          execFileSync('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' });
+        } catch {
+          child.kill('SIGTERM');
+        }
+      } else {
+        process.kill(-child.pid, 'SIGTERM');
+      }
     } catch {
       try {
         child.kill('SIGTERM');
@@ -133,7 +144,7 @@ async function bootFixtures() {
   const pairingToken = readOrCreatePairingToken();
   spawnFixture(
     'bench-app',
-    'pnpm',
+    PNPM_CMD,
     ['--filter', '@reticlehq/bench-app', 'exec', 'vite', '--port', DEMO_PORT, '--strictPort'],
     { RETICLE_PORT, VITE_RETICLE_TOKEN: pairingToken },
   );

--- a/bench/harness/mcp-client.mjs
+++ b/bench/harness/mcp-client.mjs
@@ -3,7 +3,7 @@
 // so we can capture the exact tool-response payloads, wall-clock latency, and
 // whether a failure signal is present. This is the "observation-cost" layer and
 // needs no API key. The agent-loop layer (claude-agent-loop.mjs) is separate.
-import { spawn } from 'node:child_process';
+import { spawn, execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -26,6 +26,7 @@ export class McpStdioClient {
     this.proc = spawn(this.command, this.args, {
       env: { ...process.env, ...this.env },
       stdio: ['pipe', 'pipe', 'pipe'],
+      shell: process.platform === 'win32',
     });
     this.proc.stdout.setEncoding('utf8');
     this.proc.stdout.on('data', (chunk) => this._onData(chunk));
@@ -136,7 +137,17 @@ export class McpStdioClient {
 
   async stop() {
     try {
-      this.proc?.kill('SIGTERM');
+      if (process.platform === 'win32' && this.proc?.pid) {
+        try {
+          execFileSync('taskkill', ['/pid', String(this.proc.pid), '/T', '/F'], {
+            stdio: 'ignore',
+          });
+        } catch {
+          this.proc?.kill('SIGTERM');
+        }
+      } else {
+        this.proc?.kill('SIGTERM');
+      }
     } catch {
       /* noop */
     }


### PR DESCRIPTION
Tried running `pnpm bench` on Windows 11 and hit two infrastructure issues that blocked the harness from booting fixtures.

**Problem 1: `spawn pnpm ENOENT`**
`bench-all.mjs` spawns `pnpm` directly, but on Windows the binary is `pnpm.cmd`. Node's `child_process.spawn` doesn't resolve `.cmd` files without going through the shell.

**Problem 2: `spawn EINVAL`**
`spawnFixture` uses `detached: true` with `stdio: 'ignore'`. This is a POSIX pattern for process groups that Windows simply doesn't support — the spawn call throws `EINVAL` immediately.

**What changed**
- `bench-all.mjs`: resolve `pnpm` → `pnpm.cmd` on `win32`, disable `detached` on Windows (use `windowsHide` instead), and branch the teardown logic so we don't try `process.kill(-pid)` on Windows.
- `mcp-client.mjs`: same Windows teardown fix in `stop()`, plus `shell: true` so `npx` resolves properly on Windows too.

**Verification**
`pnpm bench` (replay pass) runs clean on my machine now — all 10 scripts pass. 

`pnpm bench --full` still has flaky cells, but that's Playwright MCP failing to launch Chromium on Windows, not the harness itself.

Machine: Windows 11, Node v25.0.0, Intel i5, 8GB RAM.

Relates to #106.

## What & why

Fixes the benchmark harness boot path on Windows so contributors on that platform can run `pnpm bench` and post results to #106.

## How it was verified

Manual repro on Windows 11:
- Before fix: `pnpm bench` failed with `spawn EINVAL` during fixture boot.
- After fix: `pnpm bench` completes with all 10 replay scripts passing.

## Gates run

- [x] `pnpm lint && pnpm typecheck` (~2 min — **always**) — PASS
- [ ] `pnpm test:e2e` (~8 min) — not applicable to bench harness changes
- [ ] `pnpm gate:install` (~15 min) — not applicable
- [ ] `pnpm test:e2e:desktop` (~3 min) — not applicable
- [x] None of the above tiers apply to this change

Note: `pnpm test:unit` has 3 pre-existing timeouts/failures in `packages/vite-plugin` and `packages/server` on Windows, unrelated to this bench harness change.

## Checklist

- [x] **Every commit is signed off** (`git commit -s`) — amended with `--signoff`
- [ ] Tests added/updated — benchmark harness infrastructure change; verified by running `pnpm bench`
- [x] No `any`, no free strings, no non-null `!`
- [x] No `console.log` left in the diff
- [x] Each changed file is under the 1000-line cap
- [ ] Docs and `CHANGELOG.md` updated — not user-facing
- [ ] Security-affecting? — no