### PR TITLE
feat(telemetry): a licensed event belongs to an organisation, not just a machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
+### Added
+
+- **`@reticlehq/server` — a licensed event says which organisation it belongs to, so PostHog can aggregate a customer instead of a machine.** Attribution already carried `licenseId`, but as a flat property, which means every per-customer question is a filter typed by hand against a UUID and there is no such thing as a company in the data. Events now also carry `$groups: { organization: <licenseId> }`, which is the shape PostHog aggregates natively: per-company retention, one row per customer rather than one per machine, and a view of which organisations have gone quiet.
+
+  The group key is the licence id and nothing else. **A customer's machine still never transmits their name**, so an event carries no identity and the analytics side holds no customer list unless we deliberately upload one from the issuance ledger, which is the only place that mapping exists. Absent entirely on an unlicensed build: an empty group key would mint a phantom bucket that every OSS install falls into, and it would be the largest group on the dashboard.
+
+### Fixed
+
+- **`@reticlehq/server` — the telemetry client ignored its own injected environment when resolving a licence.** `createTelemetry` takes an `env` for injection, and licence resolution read the ambient `process.env` instead. Identical in production, which is why it went unnoticed, and wrong everywhere the seam is actually used: an embedder or a test that injects an environment got attribution from the process it happened to be running in rather than the one it asked for. Found while asserting the group payload against the file sink, where the two environments differ for the first time.
+
 ### Removed
 
 - **`@reticlehq/server` — the `instrumentation_stalled` event.** Its founding argument was that a missing `app_instrumented` is an uninterpretable absence, unable to separate "never wired" from "the process died before it could say so". The event did not solve that: it emitted only on a flush tick or a graceful shutdown, so a killed daemon still sent `daemon_started` and nothing else and landed in the absence anyway. Everything it carried is derivable from `daemon_started` minus `app_instrumented`, joined on `sessionId`, and that set difference is strictly MORE complete because it does catch the killed daemons. A second way to compute the same number that disagrees with the first is worse than not having it.

--- a/packages/server/src/telemetry/license-activation.test.ts
+++ b/packages/server/src/telemetry/license-activation.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { generateKeyPairSync } from 'node:crypto';
 import { LicenseActivation } from '@reticlehq/core';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { TelemetryEventKind } from '@reticlehq/core';
 import { licenseFacts } from './license-activation.js';
+import { createTelemetry, POSTHOG_GROUP_ORGANIZATION } from './telemetry.js';
 import { LICENSE_KEY_ENV, LICENSE_PUBLIC_KEY_ENV, signLicenseKey } from '../license/license.js';
 
 const NOW = 1_700_000_000_000;
@@ -71,5 +76,53 @@ describe('licenseFacts', () => {
     const env = licensed({ [LICENSE_KEY_ENV]: key(NOW + 1_000) });
     expect(licenseFacts(NOW, env).licenseStatus).toBe(LicenseActivation.ACTIVE);
     expect(licenseFacts(NOW + 2_000, env).licenseStatus).toBe(LicenseActivation.EXPIRED);
+  });
+});
+
+/**
+ * The group that lets PostHog aggregate a customer instead of a machine. Written against the FILE
+ * SINK rather than a mocked sender, because the sink is built by the same code path as the wire
+ * payload: what this asserts is literally what would have been sent.
+ */
+describe('a licensed event belongs to an organisation group', () => {
+  const PUBKEY_PEM = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+
+  const captureFor = async (env: NodeJS.ProcessEnv): Promise<Record<string, unknown>> => {
+    const dir = mkdtempSync(join(tmpdir(), 'reticle-groups-'));
+    const file = join(dir, 'events.jsonl');
+    const telemetry = createTelemetry({
+      version: '0.0.0-test',
+      // Outside the checkout: in a Reticle source tree the emitter carries feedback and nothing
+      // else, so a cli_command_run here would be suppressed and the file would stay empty.
+      cwd: dir,
+      // Same literals the sibling local-sink test uses; Env is module-private on purpose.
+      env: { ...env, RETICLE_TELEMETRY_FILE: file, RETICLE_TELEMETRY_KEY: 'k' },
+    });
+    // Awaited: the write happens inside emit, so reading the file first races it.
+    await telemetry.emit(TelemetryEventKind.CLI_COMMAND_RUN, { command: 'license' });
+    const raw = readFileSync(file, 'utf8').trim();
+    if (raw === '') throw new Error('nothing was written to the sink');
+    const line = raw.split('\n').pop() ?? '{}';
+    rmSync(dir, { recursive: true, force: true });
+    return JSON.parse(line) as Record<string, unknown>;
+  };
+
+  it('sends $groups keyed on the licence id, and never the org name', async () => {
+    const capture = await captureFor({
+      [LICENSE_PUBLIC_KEY_ENV]: PUBKEY_PEM,
+      [LICENSE_KEY_ENV]: key(NOW + 100_000, 'Northwind Bank'),
+    });
+    const props = capture['properties'] as Record<string, unknown>;
+    expect(props['$groups']).toEqual({ [POSTHOG_GROUP_ORGANIZATION]: LID });
+    // The name reaches PostHog only if WE push it from the ledger, never from a customer's machine.
+    expect(JSON.stringify(capture)).not.toContain('Northwind');
+  });
+
+  it('sends no group at all when there is no licence', async () => {
+    // An empty or placeholder key would mint a phantom "no org" bucket that every OSS install falls
+    // into, and it would be the largest group on the dashboard.
+    const capture = await captureFor({});
+    const props = capture['properties'] as Record<string, unknown>;
+    expect(props['$groups']).toBeUndefined();
   });
 });

--- a/packages/server/src/telemetry/license-activation.test.ts
+++ b/packages/server/src/telemetry/license-activation.test.ts
@@ -101,7 +101,7 @@ describe('a licensed event belongs to an organisation group', () => {
     // Awaited: the write happens inside emit, so reading the file first races it.
     await telemetry.emit(TelemetryEventKind.CLI_COMMAND_RUN, { command: 'license' });
     const raw = readFileSync(file, 'utf8').trim();
-    if (raw === '') throw new Error('nothing was written to the sink');
+    if ('' === raw) throw new Error('nothing was written to the sink');
     const line = raw.split('\n').pop() ?? '{}';
     rmSync(dir, { recursive: true, force: true });
     return JSON.parse(line) as Record<string, unknown>;

--- a/packages/server/src/telemetry/telemetry.ts
+++ b/packages/server/src/telemetry/telemetry.ts
@@ -71,6 +71,18 @@ const POSTHOG_KEY = 'phc_q4yCxKMXHfWQ43VAz4HxJXZFLqFi4nBbg5v3avemggYo';
  * still key on distinct_id.
  */
 const POSTHOG_PERSONLESS = { $process_person_profile: false } as const;
+
+/**
+ * PostHog's group type for a licensed customer. Sent as `$groups` so PostHog can aggregate a whole
+ * organisation natively: per-company retention, "which orgs went quiet", one row per customer rather
+ * than one per machine.
+ *
+ * The KEY is the licence id and nothing else. The organisation's NAME is never sent from a customer's
+ * machine, here or anywhere; the name reaches PostHog only if we push it ourselves from the issuance
+ * ledger, which is the one place that mapping lives. So an event still carries no identity, and the
+ * analytics side learns a customer list only when we deliberately upload one.
+ */
+export const POSTHOG_GROUP_ORGANIZATION = 'organization';
 const SEND_TIMEOUT_MS = 2000;
 
 /**
@@ -455,7 +467,10 @@ export const createTelemetry = (opts: {
       // `blocks` entry. Resolved per event off the event's own clock rather than once at startup — an
       // eleven-hour session must not report the status it booted with. All three are absent unless a
       // release has an issuer key baked, so an OSS payload is byte-identical to before.
-      ...licenseFacts(eventTs),
+      // The RESOLVED env, not process.env: createTelemetry takes an env for injection, and reading
+      // the ambient one here would silently ignore it. Identical in production, wrong everywhere the
+      // seam is actually used.
+      ...licenseFacts(eventTs, env),
     };
     // Map the core contract onto PostHog's capture shape: id/name/time move up, the rest are properties.
     // The feedback body is FLATTENED into `feedback_*` properties rather than sent as a nested object:
@@ -522,7 +537,15 @@ export const createTelemetry = (opts: {
       event: name,
       distinct_id: distinctId,
       timestamp: new Date(ts).toISOString(),
-      properties: { ...properties, ...POSTHOG_PERSONLESS },
+      properties: {
+        ...properties,
+        ...POSTHOG_PERSONLESS,
+        // Only on a licensed build. An unlicensed event has no organisation to belong to, and an
+        // empty group key would mint a phantom "no org" bucket that every OSS install falls into.
+        ...(event.licenseId !== undefined
+          ? { $groups: { [POSTHOG_GROUP_ORGANIZATION]: event.licenseId } }
+          : {}),
+      },
     };
     const body = JSON.stringify({ api_key: apiKey, batch: [capture] });
     const filePath = env[Env.FILE];


### PR DESCRIPTION
## What & why

Attribution already carried `licenseId`, but as a flat property. Every per-customer question was then a filter typed by hand against a UUID, and there was no such thing as a *company* in the data: 48 customers looked like N machines with a shared string on them.

Events now also carry `$groups: { organization: <licenseId> }`, the shape PostHog aggregates natively. Per-company retention, one row per customer rather than one per machine, and a view of which organisations have gone quiet all come from that one field.

**The group key is the licence id and nothing else.** A customer's machine still never transmits their name, so events remain anonymous and our analytics project holds no customer list unless we deliberately upload one from the issuance ledger — the only place that mapping lives. `vault/push-groups.mjs` does that from our side, as a `$groupidentify` per company.

Absent entirely on an unlicensed build: an empty group key would mint a phantom bucket that every OSS install falls into, and it would be the largest group on the dashboard.

## The bug this surfaced

`createTelemetry` takes an `env` for injection, and licence resolution read the ambient `process.env` instead. Identical in production, which is why nobody noticed, and wrong everywhere the seam is actually used: an embedder or a test that injects an environment got attribution from whatever process it happened to run in.

Found because the group assertions run against the **file sink**, where the injected and ambient environments differ for the first time. A test that mocked the sender would have passed and left it in place.

## How it was verified

Assertions run against the file sink rather than a mocked sender, because the sink is built by the same code path as the wire payload — what the test checks is literally what would be sent:

- licensed → `$groups` equals `{ organization: <lid> }`, and the org name appears nowhere in the serialised capture
- unlicensed → no `$groups` key at all

## Gates run

- [x] `pnpm format:check && pnpm lint && pnpm typecheck && pnpm test:unit`
- [x] `pnpm test:e2e` — touches the wire payload — **35/35 specs passed**

## Note for whoever enables this in PostHog

Group analytics may be a paid add-on depending on the plan, and these events are personless (`$process_person_profile: false`). Worth confirming groups populate as expected on the real project before relying on the dashboards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
