### PR TITLE
fix(server): the enterprise gate refused every valid licence on a real release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,15 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
   The group key is the licence id and nothing else. **A customer's machine still never transmits their name**, so an event carries no identity and the analytics side holds no customer list unless we deliberately upload one from the issuance ledger, which is the only place that mapping exists. Absent entirely on an unlicensed build: an empty group key would mint a phantom bucket that every OSS install falls into, and it would be the largest group on the dashboard.
 
+### Changed
+
+- **`@reticlehq/server` — `reticle license` stopped naming gated features to customers whose licence already works.** `gated` exists to close a dead end for somebody who has NOT bought: being told to set an environment variable with no idea what it unlocks. An `active` licence is the one reader that question is already answered for, so listing feature names at them revealed the product surface and answered nothing they asked. Every unlicensed status still reports it, and so does the one active case that cannot be explained without it, a key covering nothing the running build gates. `contact` remains on every status, because a stuck reader always needs somebody to write to.
+
 ### Fixed
 
 - **`@reticlehq/server` — the telemetry client ignored its own injected environment when resolving a licence.** `createTelemetry` takes an `env` for injection, and licence resolution read the ambient `process.env` instead. Identical in production, which is why it went unnoticed, and wrong everywhere the seam is actually used: an embedder or a test that injects an environment got attribution from the process it happened to be running in rather than the one it asked for. Found while asserting the group payload against the file sink, where the two environments differ for the first time.
+
+- **`@reticlehq/server` — the enterprise gate refused every valid licence on a real release.** Two entry points resolved the issuer key differently: `assertEnterpriseFromEnv` consulted the key baked at publish, while `assertEnterprise(ctx)` read only the environment. On a published build, where the key is baked and no env var is set, the same licence on the same build was ALLOWED by one and DENIED by the other with `no-issuer-key`. The only gated feature calls the ctx path, so it refused every customer, and whatever real feature got gated next would have been dead on arrival for the same reason. Both paths now resolve identically, baked first and the environment only as the dev and test hatch. Caught by driving the packaged, stamped artifact rather than the source tree, which is the only place the two can disagree.
 
 ### Removed
 

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -31,7 +31,7 @@ Enterprise (`ee/`) features ship **inside the open package**; they're source-ava
    expired   license expired. Renew with hey@reticle.sh to keep using enterprise features
    ```
 
-   Every status also reports `gated` (what a licence unlocks in the build you are running) and `contact`, so the command answers "what would this buy me, and how do I get one" without anybody having to find this page first. `gated` is derived from the features the gate actually enforces, so it lists what your build will really refuse rather than a roadmap.
+   Every status reports `contact`, so a reader who is stuck always has somebody to write to. An unlicensed status also reports `gated`, what a licence unlocks in the build you are running, so the command answers "what would this buy me, and how do I get one" without anybody having to find this page first. It is derived from the features the gate actually enforces, so it names what your build will really refuse rather than a roadmap. An `active` licence does not report it: that reader has already bought, and listing feature names at them answers nothing they asked.
 
 4. **Unlock.** Enterprise features now run in production; without a valid key they refuse to run there (a clear error, never a silent half-feature). In eval/dev they always run free.
 5. **Renew.** Keys carry an expiry; `reticle license` warns before it lapses.

--- a/packages/server/src/license/license.test.ts
+++ b/packages/server/src/license/license.test.ts
@@ -215,7 +215,7 @@ describe('reticle license is not a dead end for somebody who has no key', () => 
   // how to get one: it told an interested reader to set an environment variable and stopped there.
   const PUBKEY_PEM = publicKey.export({ type: 'spki', format: 'pem' }).toString();
 
-  it('every branch says what is gated and where to get a key, including the unlicensed ones', () => {
+  it('every branch says where to get a key, and every UNLICENSED one says what is gated', () => {
     // The branch an unlicensed reader lands on is exactly the branch that gets forgotten, so all of
     // them are checked rather than the happy path.
     const branches = [
@@ -231,8 +231,11 @@ describe('reticle license is not a dead end for somebody who has no key', () => 
       describeLicense(NOW, { NODE_ENV: 'production' }),
     ];
     for (const report of branches) {
+      // Contact is unconditional: whatever went wrong, the reader needs somebody to write to.
       expect(report.contact, `${report.status} names no contact`).toBe(LICENSE_CONTACT);
-      expect(report.gated.length, `${report.status} lists nothing as gated`).toBeGreaterThan(0);
+      // The feature list is for a reader who has NOT bought. See the active-licence tests below.
+      if ('active' === report.status) continue;
+      expect(report.gated?.length, `${report.status} lists nothing as gated`).toBeGreaterThan(0);
     }
   });
 
@@ -304,5 +307,72 @@ describe('what the fleet rehearsal caught', () => {
     // No `features` at all means every gated feature is included, which is the common case.
     const unscoped = describeLicense(NOW, env({ [LICENSE_KEY_ENV]: key() }));
     expect(unscoped.coversNothingHere).toBeUndefined();
+  });
+});
+
+describe('the two gate entry points must agree', () => {
+  const PUBKEY_PEM = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+
+  it('assertEnterprise honours a BAKED issuer key, exactly as the env-resolved gate does', () => {
+    // Found on the published 2.10.0 package: same build, same valid key, opposite answers.
+    // assertEnterpriseFromEnv ALLOWED and assertEnterprise(ctx) DENIED with `no-issuer-key`,
+    // because the ctx path read only the environment and never the key baked at release. The only
+    // gated feature calls the ctx path, so on a real release it refused every valid licence, and
+    // whatever real feature got gated next would have been dead on arrival for the same reason.
+    expect(() =>
+      assertEnterprise(
+        'audit-log',
+        { requireLicense: true, now: () => NOW, key: key() },
+        // No env public key: the baked one is the only thing that can resolve here.
+        { ...process.env, [LICENSE_PUBLIC_KEY_ENV]: undefined },
+        PUBKEY_PEM,
+      ),
+    ).not.toThrow();
+  });
+
+  it('still denies when nothing resolves an issuer key at all', () => {
+    expect(() =>
+      assertEnterprise(
+        'audit-log',
+        { requireLicense: true, now: () => NOW, key: key() },
+        { ...process.env, [LICENSE_PUBLIC_KEY_ENV]: undefined },
+        '',
+      ),
+    ).toThrow(/no-issuer-key/);
+  });
+});
+
+describe('what an ACTIVE licence is told about gating', () => {
+  const PUBKEY_PEM = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+  const env = (over: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv => ({
+    [LICENSE_PUBLIC_KEY_ENV]: PUBKEY_PEM,
+    ...over,
+  });
+
+  it('does not list gated features to a customer whose licence already works', () => {
+    // `gated` exists so an UNLICENSED reader is not told to set a variable with no idea what it
+    // unlocks. A paying customer has already bought; listing feature names at them reveals the
+    // product surface for no benefit they need.
+    const report = describeLicense(NOW, env({ [LICENSE_KEY_ENV]: key() }));
+    expect(report.status).toBe('active');
+    expect(report.gated).toBeUndefined();
+    expect(report.contact).toBe(LICENSE_CONTACT);
+  });
+
+  it('still lists them when the key covers nothing this build gates, because that needs explaining', () => {
+    const report = describeLicense(NOW, env({ [LICENSE_KEY_ENV]: key({ features: ['sso'] }) }));
+    expect(report.coversNothingHere).toBe(true);
+    expect(report.gated).toEqual(Object.values(EnterpriseFeature));
+  });
+
+  it('still lists them on every branch a prospective customer lands on', () => {
+    for (const report of [
+      describeLicense(NOW, {}),
+      describeLicense(NOW, env()),
+      describeLicense(NOW, env({ [LICENSE_KEY_ENV]: key({ exp: PAST }) })),
+      describeLicense(NOW, env({ [LICENSE_KEY_ENV]: 'garbage' })),
+    ]) {
+      expect(report.gated, `${report.status} lists nothing as gated`).toBeDefined();
+    }
   });
 });

--- a/packages/server/src/license/license.ts
+++ b/packages/server/src/license/license.ts
@@ -157,25 +157,23 @@ export interface GateContext {
   publicKey?: KeyObject;
 }
 
-/** The issuer public key from the environment (set at release / by the operator); undefined if unset. */
-function issuerPublicKey(): KeyObject | undefined {
-  const pem = process.env[LICENSE_PUBLIC_KEY_ENV];
-  if (pem === undefined || 0 === pem.length) return undefined;
-  try {
-    return createPublicKey(pem);
-  } catch {
-    return undefined;
-  }
-}
-
 /**
  * Gate an enterprise feature. No-op in dev/eval (requireLicense:false). In production it throws
  * EnterpriseLicenseError unless a valid, unexpired key that covers `feature` is present.
  */
-export function assertEnterprise(feature: string, ctx: GateContext): void {
+export function assertEnterprise(
+  feature: string,
+  ctx: GateContext,
+  env: NodeJS.ProcessEnv = process.env,
+  baked?: string,
+): void {
   if (!ctx.requireLicense) return;
 
-  const publicKey = ctx.publicKey ?? issuerPublicKey();
+  // Resolved exactly as the env-entry point resolves it: BAKED first, env only as the dev/test
+  // hatch. This path used to read the environment alone, so on a real release, where the key is
+  // baked and no env var is set, it denied every valid licence with `no-issuer-key` while
+  // assertEnterpriseFromEnv allowed the same key on the same build. Two gates, one truth.
+  const publicKey = ctx.publicKey ?? loadPublicKey(resolveIssuerPublicKeyPem(env, baked));
   if (publicKey === undefined) throw new EnterpriseLicenseError(feature, 'no-issuer-key');
 
   const check = verifyLicenseKey(ctx.key, publicKey, ctx.now());
@@ -230,7 +228,13 @@ export interface LicenseReport {
    * neither, so it told an interested reader to set a variable without saying what it would unlock or
    * how to obtain it. A dead end at exactly the moment somebody is asking.
    */
-  gated: readonly string[];
+  /**
+   * What a licence unlocks in this build. Present on every branch a PROSPECTIVE customer lands on,
+   * because being told to set a variable with no idea what it unlocks is the dead end this exists to
+   * close. Absent once a licence is `active`: that reader has already bought, so naming features at
+   * them reveals the product surface and answers nothing they asked.
+   */
+  gated?: readonly string[];
   contact: string;
   /**
    * The key is valid, and scoped to features this build does not gate, so it unlocks nothing here.
@@ -310,7 +314,10 @@ export function describeLicense(
       ? `licensed to ${org} (${plan}), expires ${new Date(exp).toISOString()}. This key covers ${features?.join(', ')}, and nothing this build gates (${LICENSE_OFFER.gated.join(', ')}) is included. Contact ${LICENSE_CONTACT}`
       : `licensed to ${org} (${plan}), expires ${new Date(exp).toISOString()}`;
     return {
-      ...LICENSE_OFFER,
+      contact: LICENSE_CONTACT,
+      // The one active case that still needs the list: a key covering nothing this build gates is
+      // reported here, and the sentence explaining it is unreadable without both sides named.
+      ...(coversNothingHere ? { gated: LICENSE_OFFER.gated } : {}),
       status: LicenseActivation.ACTIVE,
       licenseId: lid,
       org,


### PR DESCRIPTION
## The bug

Two gate entry points resolved the issuer key differently:

- `assertEnterpriseFromEnv` consulted the key **baked at publish**
- `assertEnterprise(ctx)` read **only the environment**

On a published build — where the key is baked and no env var is set — the same licence on the same build got opposite answers:

```
Same published 2.10.0, same valid customer key:
  assertEnterpriseFromEnv   ALLOWED
  assertEnterprise(ctx)     DENIED (no-issuer-key)
```

`recordAuditEvent`, the only gated feature, calls the ctx path. **So on any real release the gate refused every customer we have.** It was silent, too: a stub feature nobody can reach produces no complaints, and the next *real* feature put behind the gate would have been dead on arrival for exactly the same reason.

Both paths now resolve identically: baked first, environment only as the dev and test hatch.

Only visible on the **packaged, stamped artifact** — in a source tree there is no baked key, so the two paths agree and the bug cannot appear. Pinned by a test that bakes a key and leaves the environment empty.

## Also: `gated` is no longer shown to a working licence

`gated` exists to close a dead end for somebody who has **not** bought: being told to set an environment variable with no idea what it unlocks. An `active` licence is the one reader that question is already answered for, so listing feature names there revealed the product surface and answered nothing they asked.

| Reader | Sees |
| --- | --- |
| `active` | `contact`, org, expiry. **No feature names.** |
| `missing` / `expired` / `invalid` / `eval` | `contact` **and** `gated` |
| `active` but key covers nothing this build gates | `gated`, because the explanation is unreadable without both sides named |

`contact` stays on every status: a stuck reader always needs somebody to write to.

## How it was verified

On a freshly stamped and installed package, with a real customer key:

```
a real customer key:   assertEnterpriseFromEnv ALLOWED   assertEnterprise(ctx) ALLOWED
no key at all:         assertEnterpriseFromEnv DENIED (missing)   assertEnterprise(ctx) DENIED (missing)
```

Both agree on the allow and on the deny, including the reason.

## Gates run

- [x] `format:check`, and `lint` / `typecheck` / `test:unit` **with `--force`**
- Uncached deliberately: an earlier PR in this series passed a cached `lint` locally and failed CI on a yoda rule. On a changed package an uncached run is the only run that means anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
