### PR TITLE
feat(server): expand nested predicate fields in the parse error

### DIFF
--- a/packages/server/src/events/predicate-parse.test.ts
+++ b/packages/server/src/events/predicate-parse.test.ts
@@ -52,6 +52,27 @@ describe('parsePredicate turns a zod rejection into a sentence', () => {
     expect(messageOf({ kind: 'nope' })).toContain('kind');
   });
 
+  it('expands a nested object field, so element.query is not a second round trip', () => {
+    // The reported trap: a plain CSS string works in reticle_snapshot.scope and
+    // reticle_query.scope, so assuming it works here is the natural guess. The
+    // rejection is the only place that inconsistency can be explained.
+    const message = messageOf({ kind: 'element', query: '#journeyScreen iframe' });
+    expect(message).toContain('element accepts:');
+    expect(message).toContain('query accepts:');
+    expect(message).toContain('role');
+    expect(message).toContain('testid');
+  });
+
+  it('expands the nested shape for a wrong top-level field too', () => {
+    expect(messageOf({ kind: 'element', selector: '#app' })).toContain('query accepts:');
+  });
+
+  it('leaves a kind with no nested object field unchanged', () => {
+    const message = messageOf({ kind: 'route', pathnmae: '/x' });
+    expect(message).toContain('route accepts:');
+    expect(message).not.toContain(' accepts: by,');
+  });
+
   it('still parses a good predicate untouched, aliases included', () => {
     expect(parsePredicate({ kind: 'route', path: '/checkout' })).toMatchObject({
       kind: 'route',

--- a/packages/server/src/events/predicate-parse.ts
+++ b/packages/server/src/events/predicate-parse.ts
@@ -15,7 +15,7 @@
 
 import { z } from 'zod';
 import { PredicateKind } from '@reticlehq/core';
-import { PredicateSchema, predicateFieldsFor } from './predicate-eval.js';
+import { PredicateSchema, predicateFieldsFor, predicateNestedFieldsFor } from './predicate-eval.js';
 
 /**
  * One valid call PER KIND, because an example of another kind answers a question nobody asked.
@@ -102,6 +102,13 @@ export function parsePredicate(input: unknown): z.infer<typeof PredicateSchema> 
  */
 function accepted(kind: string): string {
   const fields = predicateFieldsFor(kind);
-  if (0 < fields.length) return `${kind} accepts: ${fields.join(', ')}.`;
+  if (0 < fields.length) {
+    // A field whose value is an object is the one an agent cannot guess from its name alone, so
+    // expand it in the same breath rather than making the shape a second round trip.
+    const nested = Object.entries(predicateNestedFieldsFor(kind))
+      .map(([field, keys]) => ` ${field} accepts: ${keys.join(', ')}.`)
+      .join('');
+    return `${kind} accepts: ${fields.join(', ')}.${nested}`;
+  }
   return `"${kind}" is not a predicate kind — use one of: ${Object.values(PredicateKind).join(', ')}.`;
 }

--- a/packages/server/src/events/predicate-schema.ts
+++ b/packages/server/src/events/predicate-schema.ts
@@ -426,7 +426,13 @@ export function predicateNestedFieldsFor(
     for (const [field, schema] of Object.entries(option.shape)) {
       if ('kind' === field) continue;
       const inner = unwrapSchema(schema as z.ZodTypeAny);
-      if (inner instanceof z.ZodObject) nested[field] = Object.keys(inner.shape);
+      // `instanceof z.ZodObject` narrows to ZodObject<any>, whose `.shape` is `any`. Name the shape
+      // type so the keys are read off something typed rather than laundering an `any` through
+      // Object.keys.
+      if (inner instanceof z.ZodObject) {
+        const shape = (inner as z.ZodObject<z.ZodRawShape>).shape;
+        nested[field] = Object.keys(shape);
+      }
     }
     return nested;
   }

--- a/packages/server/src/events/predicate-schema.ts
+++ b/packages/server/src/events/predicate-schema.ts
@@ -384,3 +384,51 @@ export function predicateFieldsFor(kind: string): readonly string[] {
   }
   return [];
 }
+
+/** Peel optional/nullable/default/effects wrappers off a field to reach the schema underneath. */
+function unwrapSchema(schema: z.ZodTypeAny): z.ZodTypeAny {
+  let current = schema;
+  for (;;) {
+    if (
+      current instanceof z.ZodOptional ||
+      current instanceof z.ZodNullable ||
+      current instanceof z.ZodDefault
+    ) {
+      current = current._def.innerType as z.ZodTypeAny;
+      continue;
+    }
+    if (current instanceof z.ZodEffects) {
+      current = current._def.schema as z.ZodTypeAny;
+      continue;
+    }
+    return current;
+  }
+}
+
+/**
+ * One level into the fields that are themselves objects — `{ query: ['by', 'value', ...] }`.
+ *
+ * Naming the top-level fields alone leaves `element` unguessable: `query` is an object with its own
+ * required shape, and a plain CSS string works in `reticle_snapshot.scope` and `reticle_query.scope`,
+ * so assuming it works here is the natural guess. The rejection is the only place that inconsistency
+ * can be explained.
+ *
+ * One level only. Derived from the schema for the same reason `predicateFieldsFor` is: a stale field
+ * list is worse than none, because the agent trusts it and retries into the same wall.
+ */
+export function predicateNestedFieldsFor(
+  kind: string,
+): Readonly<Record<string, readonly string[]>> {
+  for (const option of predicateUnion().options) {
+    const literal = option.shape['kind'];
+    if (!(literal instanceof z.ZodLiteral) || literal.value !== kind) continue;
+    const nested: Record<string, readonly string[]> = {};
+    for (const [field, schema] of Object.entries(option.shape)) {
+      if ('kind' === field) continue;
+      const inner = unwrapSchema(schema as z.ZodTypeAny);
+      if (inner instanceof z.ZodObject) nested[field] = Object.keys(inner.shape);
+    }
+    return nested;
+  }
+  return {};
+}


### PR DESCRIPTION
Closes #445.

## Problem

A predicate rejection named the kind's top-level fields but never the shape of a nested one, so `element.query` stayed unguessable. From the report in the issue — three rejections in a row, each correct and none informative:

```
{kind:"element", selector:"..."}       -> "predicates.1.query: Required; unknown field selector"
{kind:"element", query:"..."}          -> "query: Expected object, received string"
{kind:"element", query:{css:"..."}}    -> "unknown field css"
```

The agent then gave up on the predicate and asserted via `reticle_query` instead. As the issue notes, a plain CSS string works in `reticle_snapshot.scope` and `reticle_query.scope`, so assuming it works in a predicate is the natural guess — and the rejection is the only place that inconsistency can be explained.

## Change

**`predicate-schema.ts`** — `predicateNestedFieldsFor(kind)` walks one level into any object-valued field and returns its keys, read off the schema exactly the way `predicateFieldsFor` is, so the two can't drift. A small `unwrapSchema` helper peels `ZodOptional` / `ZodNullable` / `ZodDefault` / `ZodEffects` so a wrapped object field isn't missed.

**`predicate-parse.ts`** — `accepted()` appends one clause per nested field.

One level only, as the issue asks. Kinds with no object-valued field (`route`, `signal`, `text`, …) produce byte-identical messages to before.

### Before

```
... element accepts: query, state, absent. A valid element predicate looks like: ...
```

### After

```
that predicate did not parse (kind "element"): query: Expected object, received string. Nothing ran
— the predicate was not evaluated, so no verdict was produced. element accepts: query, state, absent.
query accepts: by, value, role, name, text, label, placeholder, testid, alt, component, attrs, source,
scope, self. A valid element predicate looks like: { kind: "element", query: { role: "button", name: "Save" } }
```

## Testing

Three tests added to `predicate-parse.test.ts`:

- a string `query` (the reported trap) now yields both `element accepts:` and `query accepts:`, including `role` and `testid`
- a wrong top-level field (`selector`) also gets the nested expansion
- `route` — a kind with no nested object — is unchanged, asserted negatively so the expansion can't leak into every message

Confirmed they guard the change: with both source hunks stashed, 2 of the 3 fail.

```
pnpm --filter @reticlehq/server test:unit   # 466 files, 4519 tests passed
pnpm typecheck                              # 21/21 successful
prettier --check                            # clean
```

Commit is signed off (DCO) and uses Conventional Commits per CONTRIBUTING.
