### PR TITLE
Name the shape of the nested field a predicate got wrong

### DIFF
--- a/packages/server/src/events/predicate-parse.test.ts
+++ b/packages/server/src/events/predicate-parse.test.ts
@@ -59,3 +59,38 @@ describe('parsePredicate turns a zod rejection into a sentence', () => {
     });
   });
 });
+
+describe('the error describes a nested field, not just its name', () => {
+  /*
+   * The three calls from the field report on #445, in order. Each was correctly rejected and none
+   * of them said what `query` wanted, so the agent guessed three times and produced no verdict.
+   */
+  const WRONG_FLAT = { kind: 'element', selector: '#journeyScreen.active iframe' };
+  const WRONG_STRING = { kind: 'element', query: '#journeyScreen.active iframe' };
+  const WRONG_NESTED_KEY = { kind: 'element', query: { css: '#journeyScreen.active iframe' } };
+
+  it.each([
+    ['a flat selector', WRONG_FLAT],
+    ['a string where an object goes', WRONG_STRING],
+    ['a key that is nobody spelling of a query field', WRONG_NESTED_KEY],
+  ])('names the shape of query when the mistake is %s', (_label, input) => {
+    const message = messageOf(input);
+    expect(message, `no query shape in: ${message}`).toContain('query accepts:');
+    // `role` and `testid` are the two an agent reaches for first; if the expansion ever silently
+    // returns [] the sentence still reads fine, so assert on contents rather than the phrase alone.
+    expect(message).toContain('role');
+    expect(message).toContain('testid');
+  });
+
+  it('still names the top-level fields it always did', () => {
+    expect(messageOf(WRONG_STRING)).toContain('element accepts:');
+  });
+
+  it('does not drag in a nested shape the caller did not get wrong', () => {
+    // `net` has no object-valued field, so nothing should be expanded for it. Guards against a
+    // version that expands every field of every kind and buries the answer in noise.
+    const message = messageOf({ kind: 'net', urlContainz: '/api/save' });
+    expect(message).toContain('net accepts:');
+    expect(message).not.toContain('accepts: by,');
+  });
+});

--- a/packages/server/src/events/predicate-parse.ts
+++ b/packages/server/src/events/predicate-parse.ts
@@ -15,7 +15,7 @@
 
 import { z } from 'zod';
 import { PredicateKind } from '@reticlehq/core';
-import { PredicateSchema, predicateFieldsFor } from './predicate-eval.js';
+import { PredicateSchema, predicateFieldsFor, predicateNestedFieldsFor } from './predicate-eval.js';
 
 /**
  * One valid call PER KIND, because an example of another kind answers a question nobody asked.
@@ -88,7 +88,7 @@ export function parsePredicate(input: unknown): z.infer<typeof PredicateSchema> 
   const issues = parsed.error.issues.slice(0, 3).map(describeIssue).join('; ');
   throw new Error(
     `that predicate did not parse (kind "${kind}"): ${issues}. Nothing ran — the predicate was ` +
-      `not evaluated, so no verdict was produced. ${accepted(kind)} ` +
+      `not evaluated, so no verdict was produced. ${accepted(kind, parsed.error.issues)} ` +
       `A valid ${kind} predicate looks like: ${exampleFor(kind)}`,
   );
 }
@@ -100,8 +100,30 @@ export function parsePredicate(input: unknown): z.infer<typeof PredicateSchema> 
  * round trip on the one call path that produces verdicts. Naming the accepted fields — or, when the
  * kind itself is the mistake, the accepted kinds — makes the retry informed instead.
  */
-function accepted(kind: string): string {
+function accepted(kind: string, issues: readonly z.ZodIssue[]): string {
   const fields = predicateFieldsFor(kind);
-  if (0 < fields.length) return `${kind} accepts: ${fields.join(', ')}.`;
-  return `"${kind}" is not a predicate kind — use one of: ${Object.values(PredicateKind).join(', ')}.`;
+  if (0 === fields.length) {
+    return `"${kind}" is not a predicate kind — use one of: ${Object.values(PredicateKind).join(', ')}.`;
+  }
+  return [`${kind} accepts: ${fields.join(', ')}.`, ...nestedShapes(kind, issues)].join(' ');
+}
+
+/**
+ * The shape of the nested field the caller actually got wrong — nothing else.
+ *
+ * Expanding EVERY object-valued field would make the sentence long and mostly irrelevant; expanding
+ * none is the state that cost three round trips. So it follows the issues: whichever field the
+ * rejection points at gets described, and a kind whose mistake was elsewhere reads exactly as before.
+ */
+function nestedShapes(kind: string, issues: readonly z.ZodIssue[]): readonly string[] {
+  const described = new Set<string>();
+  const out: string[] = [];
+  for (const issue of issues) {
+    const field = issue.path[0];
+    if ('string' !== typeof field || described.has(field)) continue;
+    described.add(field);
+    const nested = predicateNestedFieldsFor(kind, field);
+    if (0 < nested.length) out.push(`${field} accepts: ${nested.join(', ')}.`);
+  }
+  return out;
 }

--- a/packages/server/src/events/predicate-schema.ts
+++ b/packages/server/src/events/predicate-schema.ts
@@ -376,11 +376,54 @@ export const PredicateSchema = z.lazy(() =>
  * wall. Empty for a kind that is not in the union.
  */
 export function predicateFieldsFor(kind: string): readonly string[] {
+  const shape = shapeForKind(kind);
+  if (null === shape) return [];
+  return Object.keys(shape).filter((field) => 'kind' !== field);
+}
+
+/** The option shape for `kind`, or null when the kind is not in the union. */
+function shapeForKind(kind: string): z.ZodRawShape | null {
   for (const option of predicateUnion().options) {
     const literal = option.shape['kind'];
-    if (literal instanceof z.ZodLiteral && literal.value === kind) {
-      return Object.keys(option.shape).filter((field) => 'kind' !== field);
-    }
+    if (literal instanceof z.ZodLiteral && literal.value === kind) return option.shape;
   }
-  return [];
+  return null;
+}
+
+/**
+ * The keys of `schema` if it is an object, reaching through the wrappers a field can be declared
+ * behind. Empty for anything else.
+ *
+ * `query` is a bare object today, but a field can equally be `.optional()`, `.nullable()` or carry a
+ * `.default()`. Not reaching through those returns [] and silently prints the old message — a
+ * regression with no symptom, which is the kind that ships. Exported so that behaviour is asserted
+ * against this function rather than against a copy of it in a test.
+ */
+export function nestedKeysOf(schema: z.ZodTypeAny | undefined): readonly string[] {
+  let current = schema;
+  while (
+    current instanceof z.ZodOptional ||
+    current instanceof z.ZodNullable ||
+    current instanceof z.ZodDefault
+  ) {
+    current = current._def.innerType as z.ZodTypeAny;
+  }
+  return current instanceof z.ZodObject ? Object.keys(current.shape as z.ZodRawShape) : [];
+}
+
+/**
+ * The keys of a nested object field, one level down. Empty when the field is not an object.
+ *
+ * `predicateFieldsFor` answers what a KIND accepts, which for `element` is `query, state, absent` —
+ * and `query` is itself an object whose shape was described nowhere. An agent was told the name of
+ * the field it got wrong and nothing about what would have been right, so it guessed three times in
+ * a row and produced no verdict, each rejection correct and none of them useful (issue #445).
+ *
+ * One level only. This exists to make the next call land, not to print the schema: `query.source` is
+ * an object too, and expanding transitively would bury the answer that matters.
+ */
+export function predicateNestedFieldsFor(kind: string, field: string): readonly string[] {
+  const shape = shapeForKind(kind);
+  if (null === shape) return [];
+  return nestedKeysOf(shape[field]);
 }

--- a/packages/server/src/events/predicate-shape.test.ts
+++ b/packages/server/src/events/predicate-shape.test.ts
@@ -16,9 +16,10 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 import { PredicateKind } from '@reticlehq/core';
 import { parsePredicate } from './predicate-parse.js';
-import { predicateFieldsFor } from './predicate-eval.js';
+import { nestedKeysOf, predicateFieldsFor, predicateNestedFieldsFor } from './predicate-eval.js';
 
 const messageOf = (input: unknown): string => {
   try {
@@ -135,5 +136,53 @@ describe('scoping the text predicate', () => {
 
   it('names `scope` among the fields the text predicate accepts', () => {
     expect(predicateFieldsFor(PredicateKind.TEXT)).toContain('scope');
+  });
+});
+
+describe('predicateNestedFieldsFor reaches one level into an object field', () => {
+  it('reads a bare object field off the schema', () => {
+    const fields = predicateNestedFieldsFor(PredicateKind.ELEMENT, 'query');
+    expect(fields).toContain('role');
+    expect(fields).toContain('testid');
+    expect(fields).toContain('scope');
+  });
+
+  it.each([
+    ['bare', z.object({ a: z.string() })],
+    ['optional', z.object({ a: z.string() }).optional()],
+    ['with a default', z.object({ a: z.string() }).default({ a: 'x' })],
+    ['nullable', z.object({ a: z.string() }).nullable()],
+    ['optional and nullable', z.object({ a: z.string() }).nullable().optional()],
+  ])('reaches through a %s object field', (_label, schema) => {
+    // Every top-level field on a predicate kind is bare today, so none of these wrappers is
+    // exercised by the real schema. One per shape rather than trusting one to stand for the rest:
+    // the failure mode is silent — [] comes back and the old sentence prints unchanged.
+    expect(nestedKeysOf(schema)).toEqual(['a']);
+  });
+
+  it.each([
+    ['a string', z.string()],
+    ['an array', z.array(z.string())],
+    ['undefined', undefined],
+  ])('is empty for %s', (_label, schema) => {
+    expect(nestedKeysOf(schema)).toEqual([]);
+  });
+
+  it('is empty for a field that is not an object', () => {
+    // `absent` is a boolean; expanding it would put a nonsense clause in the sentence.
+    expect(predicateNestedFieldsFor(PredicateKind.ELEMENT, 'absent')).toEqual([]);
+  });
+
+  it('is empty for a kind or field that does not exist', () => {
+    expect(predicateNestedFieldsFor('elemnt', 'query')).toEqual([]);
+    expect(predicateNestedFieldsFor(PredicateKind.ELEMENT, 'quarry')).toEqual([]);
+  });
+
+  it('does not expand transitively', () => {
+    // `query.source` is an object too. One level is the contract: the sentence exists to make the
+    // next call land, not to print the schema.
+    const fields = predicateNestedFieldsFor(PredicateKind.ELEMENT, 'query');
+    expect(fields).toContain('source');
+    expect(fields).not.toContain('file');
   });
 });


### PR DESCRIPTION
Fixes #445.

## The message now

All three calls from the report get the same added clause:

```
that predicate did not parse (kind "element"): query: Expected object, received string.
Nothing ran — the predicate was not evaluated, so no verdict was produced.
element accepts: query, state, absent.
query accepts: by, value, role, name, text, label, placeholder, testid, alt, component, attrs, source, scope, self.
A valid element predicate looks like: { kind: "element", query: { role: "button", name: "Save" } }
```

`net`, and every other kind whose mistake is not on an object field, reads exactly as before.

## Two decisions, both as flagged when I claimed it

**Expansion follows the issues, not the schema.** Only the field the rejection actually points at gets described. Expanding every object-valued field unconditionally makes `element`'s error long and mostly irrelevant, which buries the one clause that matters — the same argument the file already makes for showing one example per kind rather than a generic one. There is a test pinning that `net` does not grow a `query`-shaped clause.

**One level.** `query.source` is an object too; expanding transitively prints the schema instead of answering the question. Pinned: `source` appears in the list, `file` does not.

## The wrapper unwrapping, and why it is tested the way it is

`nestedKeysOf` reaches through `optional`, `nullable` and `default`. **No real field exercises any of those today** — every top-level field on every kind is bare, and `query` is required. That is exactly why it is worth a test each rather than one standing for the rest: the failure mode is silent, `[]` comes back and the old sentence prints unchanged, so a field declared `.optional()` later would quietly stop being described with nothing going red.

So `nestedKeysOf` is **exported** and asserted directly on synthetic schemas, rather than duplicating the unwrap logic in the test. My first draft did duplicate it, which tests a copy and would have stayed green through any change to the real one.

**Mutation check:** deleting the unwrap loop fails the four wrapper cases and leaves everything else green.

## One thing worth knowing if you reproduce locally

The issue's third case (`query: { css: ... }` → "unknown field css") appeared to *parse cleanly* for me at first. That was a stale `packages/core/dist` in my checkout — `predicate-schema.ts` imports `ElementQuerySchema` from the built `@reticlehq/core`, and mine predated `.strict()` on it, so the key was silently stripped and the predicate became `query: {}`. After `pnpm --filter @reticlehq/core build` it reproduces exactly as written.

Nothing to fix — but a stale core build turns a strict-schema rejection into a green predicate that asserts nothing, which is an unpleasant thing to hit while debugging a predicate. Mentioning it in case it is worth a line in the contributor docs.

## Gates

`pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test:unit` all green (15/15 tasks). 38 tests across the two predicate test files.

Not touching the tool surface, wire contract or observers, so no e2e battery. Left the `act_and_wait` docs line for a separate PR as agreed.