### PR TITLE
feat(browser+server): observe document-initiated subresources; net status downgrades to unknown

### DIFF
--- a/apps/e2e/specs/electron-desktop-test.mjs
+++ b/apps/e2e/specs/electron-desktop-test.mjs
@@ -240,7 +240,21 @@ try {
   await sleep(2500);
 
   const net = await blind.tool('reticle_network', {});
-  chk('an un-instrumented renderer really does report no IPC at all', (net.calls?.length ?? 0) === 0);
+  // Document-initiated subresource observation means the network view is no longer guaranteed
+  // empty without the preload: the page's own <script>/<link>/<img> loads are seen at the
+  // session layer. What must still be EMPTY here is the IPC half: no preload, no invoke patch,
+  // so every ipc:// record would be an invention.
+  const calls = net.calls ?? [];
+  chk(
+    'an un-instrumented renderer really does report no IPC at all',
+    calls.every((c) => !String(c.url ?? '').startsWith('ipc://')),
+    JSON.stringify(calls.filter((c) => String(c.url ?? '').startsWith('ipc://')).slice(0, 3)),
+  );
+  chk(
+    'but document-initiated loads of the page itself are now observed even here',
+    calls.some((c) => /:5174/.test(String(c.url ?? ''))),
+    JSON.stringify(calls.slice(0, 3)),
+  );
 
   const green = await blind.tool('reticle_assert', {
     predicate: { kind: 'text', contains: '2 todos' },

--- a/packages/browser/src/observers/network.test.ts
+++ b/packages/browser/src/observers/network.test.ts
@@ -774,7 +774,8 @@ describe('document-initiated subresources (PerformanceObserver)', () => {
   afterEach(() => {
     teardown?.();
     teardown = undefined;
-    if (hadPO) (globalThis as unknown as { PerformanceObserver: unknown }).PerformanceObserver = originalPO;
+    if (hadPO)
+      (globalThis as unknown as { PerformanceObserver: unknown }).PerformanceObserver = originalPO;
     else Reflect.deleteProperty(globalThis, 'PerformanceObserver');
   });
 
@@ -797,13 +798,15 @@ describe('document-initiated subresources (PerformanceObserver)', () => {
 
     const cb = FakePO.instances.at(0)?.callback;
     if (cb === undefined) throw new Error('observer callback missing');
-    cb({ getEntries: () => [
-      fakeEntry('link', 'https://app.test/favicon.ico'),
-      fakeEntry('link', 'https://app.test/site.webmanifest'),
-      fakeEntry('css', 'https://app.test/app.css'),
-      // fetch/XHR types belong to the patched transports and must be skipped
-      fakeEntry('fetch', 'https://app.test/api/data'),
-    ]});
+    cb({
+      getEntries: () => [
+        fakeEntry('link', 'https://app.test/favicon.ico'),
+        fakeEntry('link', 'https://app.test/site.webmanifest'),
+        fakeEntry('css', 'https://app.test/app.css'),
+        // fetch/XHR types belong to the patched transports and must be skipped
+        fakeEntry('fetch', 'https://app.test/api/data'),
+      ],
+    });
 
     const net = events.filter((e) => e.type === EventType.NET_REQUEST);
     expect(net.length).toBe(3);

--- a/packages/browser/src/observers/network.test.ts
+++ b/packages/browser/src/observers/network.test.ts
@@ -741,3 +741,106 @@ describe('installNetwork (XMLHttpRequest)', () => {
     expect(done.map((e) => e.data['status'])).toEqual([200, 201]);
   });
 });
+
+describe('document-initiated subresources (PerformanceObserver)', () => {
+  let teardown: Teardown | undefined;
+  type POCallback = (list: { getEntries: () => PerformanceEntry[] }) => void;
+  let observedTypes: string[] = [];
+  const hadPO = typeof globalThis.PerformanceObserver !== 'undefined';
+  const originalPO = globalThis.PerformanceObserver;
+
+  class FakePO {
+    static instances: FakePO[] = [];
+    callback: POCallback;
+    disconnected = false;
+    constructor(cb: POCallback) {
+      this.callback = cb;
+      FakePO.instances.push(this);
+    }
+    observe(opts: { type: string }): void {
+      observedTypes.push(opts.type);
+    }
+    disconnect(): void {
+      this.disconnected = true;
+    }
+  }
+
+  beforeEach(() => {
+    FakePO.instances = [];
+    observedTypes = [];
+    (globalThis as unknown as { PerformanceObserver: unknown }).PerformanceObserver = FakePO;
+  });
+
+  afterEach(() => {
+    teardown?.();
+    teardown = undefined;
+    if (hadPO) (globalThis as unknown as { PerformanceObserver: unknown }).PerformanceObserver = originalPO;
+    else Reflect.deleteProperty(globalThis, 'PerformanceObserver');
+  });
+
+  function fakeEntry(initiatorType: string, name: string, durationMs = 12): PerformanceEntry {
+    return {
+      name,
+      entryType: 'resource',
+      startTime: 100,
+      duration: durationMs,
+      initiatorType,
+      transferSize: 2048,
+      responseStatus: 200,
+    } as unknown as PerformanceEntry;
+  }
+
+  it('emits document-initiated loads as NET_REQUEST with status when readable', () => {
+    const { emit, events } = collect();
+    teardown = installNetwork(emit);
+    expect(observedTypes).toContain('resource');
+
+    const cb = FakePO.instances.at(0)?.callback;
+    if (cb === undefined) throw new Error('observer callback missing');
+    cb({ getEntries: () => [
+      fakeEntry('link', 'https://app.test/favicon.ico'),
+      fakeEntry('link', 'https://app.test/site.webmanifest'),
+      fakeEntry('css', 'https://app.test/app.css'),
+      // fetch/XHR types belong to the patched transports and must be skipped
+      fakeEntry('fetch', 'https://app.test/api/data'),
+    ]});
+
+    const net = events.filter((e) => e.type === EventType.NET_REQUEST);
+    expect(net.length).toBe(3);
+    expect(net.map((e) => e.data['url'])).toEqual([
+      'https://app.test/favicon.ico',
+      'https://app.test/site.webmanifest',
+      'https://app.test/app.css',
+    ]);
+    for (const e of net) {
+      expect(e.data['method']).toBe('GET');
+      expect(e.data['status']).toBe(200);
+      expect(e.data['ok']).toBe(true);
+    }
+  });
+
+  it('omits the status fields entirely when responseStatus is unreadable', () => {
+    const { emit, events } = collect();
+    teardown = installNetwork(emit);
+    const entry = fakeEntry('img', 'https://app.test/hero.png');
+    delete (entry as unknown as Record<string, unknown>).responseStatus;
+    FakePO.instances.at(0)?.callback({ getEntries: () => [entry] });
+
+    const net = events.find((e) => e.type === EventType.NET_REQUEST);
+    expect(net).toBeDefined();
+    if (net === undefined) return;
+    expect(net.data).not.toHaveProperty('status');
+    expect(net.data).not.toHaveProperty('ok');
+    expect(net.data['initiator']).toBe('img');
+  });
+
+  it('disconnects the observer on teardown', () => {
+    const { emit } = collect();
+    teardown = installNetwork(emit);
+    const po = FakePO.instances.at(0);
+    expect(po).toBeDefined();
+    teardown?.();
+    teardown = undefined;
+    expect(po?.disconnected).toBe(true);
+  });
+});

--- a/packages/browser/src/observers/network.ts
+++ b/packages/browser/src/observers/network.ts
@@ -309,6 +309,7 @@ export function installNetwork(emit: Emit, opts: NetworkOptions = {}): Teardown 
       const contentType = res.headers.get('content-type');
       // The request is done; the BODY may not be. Watch it so settle cannot pass mid-stream.
       watchStreamedBody(emit, res, id, url, contentType, res.headers.get('content-length'));
+      reportedNetUrls.add(rawUrl);
       const emitRequest = (responseBodyFields: Record<string, unknown>): void => {
         emit(EventType.NET_REQUEST, {
           id,
@@ -444,6 +445,7 @@ export function installNetwork(emit: Emit, opts: NetworkOptions = {}): Teardown 
         this.addEventListener('loadend', () => {
           const cur = meta.get(this);
           if (cur === undefined) return;
+          reportedNetUrls.add(cur.rawUrl);
           const xhrContentType = this.getResponseHeader('content-type');
           let responseBodyFields: Record<string, unknown> = {};
           // responseText throws unless responseType is '' or 'text' — guard before reading.
@@ -591,7 +593,58 @@ export function installNetwork(emit: Emit, opts: NetworkOptions = {}): Teardown 
     navProto.sendBeacon = patchedBeacon;
   }
 
+  // Document-initiated subresources (link/css/img/script/manifest): fetch and XHR patches never see
+  // these, so a `{net}` predicate over a favicon or manifest used to read `assertion_failed` — "your
+  // change is broken" — when the truthful answer is "not observable". A PerformanceObserver over
+  // `resource` entries reports them with no CDP. Status is the known gap: entries carry one only on
+  // newer Chromium, so the field is emitted ONLY when readable and the evaluation seam downgrades
+  // status assertions it cannot verify instead of guessing.
+  //
+  // Dedup: any URL the patched transports already reported (or later report) is skipped — resource
+  // timing also records fetch/XHR loads. The seen-set is filled eagerly here AND at every
+  // NET_REQUEST emit below, so both orders of arrival stay single-reported.
+  const reportedNetUrls = new Set<string>();
+  let subresourceEvents = 0;
+  const SUBRESOURCE_CAP = 200;
+  let subresourceObserver: PerformanceObserver | undefined;
+  if (typeof PerformanceObserver !== 'undefined') {
+    try {
+      const observer = new PerformanceObserver((list) => {
+        for (const raw of list.getEntries()) {
+          const entry = raw as PerformanceResourceTiming;
+          if (subresourceEvents >= SUBRESOURCE_CAP) return;
+          const type = entry.initiatorType || 'other';
+          // Patched transports own their records; only document-initiated types are new here.
+          if ('fetch' === type || 'xmlhttprequest' === type) continue;
+          const rawUrl = entry.name;
+          if (reportedNetUrls.has(rawUrl)) continue;
+          reportedNetUrls.add(rawUrl);
+          subresourceEvents += 1;
+          emit(EventType.NET_REQUEST, {
+            id: nextId(),
+            method: 'GET',
+            url: redactUrl(rawUrl),
+            durationMs: Math.round(entry.duration),
+            initiator: type,
+            ...(entry.transferSize > 0 ? { transferSize: entry.transferSize } : {}),
+            // responseStatus is Chromium-only; omitted entirely when unreadable so the wire never
+            // carries a guessed status. Its absence is what the server-side seam reads as unknown.
+            ...((entry.responseStatus ?? 0) > 0
+              ? { status: entry.responseStatus, ok: (entry.responseStatus ?? 0) >= 200 && (entry.responseStatus ?? 0) < 400 }
+              : {}),
+          });
+        }
+      });
+      subresourceObserver = observer;
+      observer.observe({ type: 'resource', buffered: true });
+      // Disconnected in the disposer below.
+    } catch {
+      // No observer support: document-initiated loads stay unobserved, stated rather than guessed.
+    }
+  }
+
   return () => {
+    subresourceObserver?.disconnect();
     // Restore each slot ONLY if it still holds OUR wrapper. Between connect() and disconnect() the app
     // (or Sentry/analytics/a router) may have wrapped fetch/XHR/EventSource/WebSocket/sendBeacon ON TOP
     // of ours; blindly writing the original back would silently uninstall their instrumentation — the

--- a/packages/browser/src/observers/network.ts
+++ b/packages/browser/src/observers/network.ts
@@ -630,7 +630,10 @@ export function installNetwork(emit: Emit, opts: NetworkOptions = {}): Teardown 
             // responseStatus is Chromium-only; omitted entirely when unreadable so the wire never
             // carries a guessed status. Its absence is what the server-side seam reads as unknown.
             ...((entry.responseStatus ?? 0) > 0
-              ? { status: entry.responseStatus, ok: (entry.responseStatus ?? 0) >= 200 && (entry.responseStatus ?? 0) < 400 }
+              ? {
+                  status: entry.responseStatus,
+                  ok: (entry.responseStatus ?? 0) >= 200 && (entry.responseStatus ?? 0) < 400,
+                }
               : {}),
           });
         }

--- a/packages/browser/src/observers/subresources.ts
+++ b/packages/browser/src/observers/subresources.ts
@@ -1,0 +1,77 @@
+import { redactUrl } from './network-redact.js';
+
+/**
+ * Document-initiated subresource observation.
+ *
+ * fetch/XHR patches never see requests the DOCUMENT makes on its own: `<link rel=icon>`,
+ * `<link rel=manifest>`, stylesheets, `<img src>`, `<script src>`. Those are exactly the loads a
+ * branding change touches, so a `{net}` predicate over them used to return `assertion_failed`
+ * ("your change is broken") when the truthful answer was "not observable" — and an agent trusting
+ * that verdict goes and "fixes" working code.
+ *
+ * `performance.getEntriesByType('resource')` reports these with no CDP and no patching: URL (name),
+ * initiator type (`link`, `css`, `img`, `script`, …), duration, transfer size. The known limitation
+ * is the status code — resource timing does not expose one directly (`responseStatus` exists only
+ * in newer Chromium). Entries carry `status` ONLY when it could be read; predicates asserting a
+ * status over unreadable data are handled at the evaluation seam, which downgrades rather than
+ * guesses.
+ *
+ * Deduplication matters: a fetch/XHR-initiated request ALSO lands in resource timing. Every entry
+ * is checked against the URLs the patched transports already reported this page, and only genuinely
+ * document-initiated loads survive.
+ */
+
+/** Resource-timing initiator types that mean "the document itself asked", not a patched transport. */
+const DOCUMENT_INITIATORS = new Set(['link', 'css', 'img', 'script', 'manifest', 'other']);
+
+/** Cap per call — a pathological page must not blow the event budget. */
+const MAX_SUBRESOURCE_EVENTS = 200;
+
+export interface SubresourceObservation {
+  url: string;
+  method: string;
+  status?: number;
+  ok?: boolean;
+  durationMs: number;
+  transferSize?: number;
+  initiatorType: string;
+}
+
+export function collectSubresources(
+  seenUrls: ReadonlySet<string>,
+  nowMs: number,
+  sinceMs: number,
+): SubresourceObservation[] {
+  const out: SubresourceObservation[] = [];
+  try {
+    const entries = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
+    for (const entry of entries) {
+      const initiatorType = entry.initiatorType || 'other';
+      // fetch/XHR already have richer records from their own patches.
+      if (!DOCUMENT_INITIATORS.has(initiatorType)) continue;
+      const raw = entry.name;
+      if (seenUrls.has(raw)) continue;
+      const startMs = nowMs - entry.duration;
+      if (startMs < sinceMs) continue;
+      const obs: SubresourceObservation = {
+        url: redactUrl(raw),
+        method: 'GET',
+        durationMs: Math.round(entry.duration),
+        initiatorType,
+        ...(entry.transferSize > 0 ? { transferSize: entry.transferSize } : {}),
+      };
+      // responseStatus is Chromium-only and may be 0 when unreadable. Present ONLY when it says
+      // something real, so the wire never carries a guessed status.
+      const rs = (entry as PerformanceResourceTiming & { responseStatus?: number }).responseStatus;
+      if ('number' === typeof rs && rs > 0) {
+        obs.status = rs;
+        obs.ok = rs >= 200 && rs < 400;
+      }
+      out.push(obs);
+    }
+  } catch {
+    // No resource-timing support / security error: report nothing, honestly.
+    return [];
+  }
+  return out.slice(0, MAX_SUBRESOURCE_EVENTS);
+}

--- a/packages/server/src/events/predicate-eval.ts
+++ b/packages/server/src/events/predicate-eval.ts
@@ -238,9 +238,13 @@ function describeNetFilter(p: Extract<Predicate, { kind: typeof PredicateKind.NE
  * preload and an API call can share a suffix — so downgrading them would hide real misses. This list
  * is only the suffixes for which the document is the sole plausible initiator.
  *
- * This is the smaller half of #447: it does not make these requests observable, it stops Reticle
- * claiming they did not happen. Widening the observer (via `PerformanceResourceTiming`) is the other
- * half and is independent of this one.
+ * This began as the smaller half of #447: it did not make these requests observable, it stopped
+ * Reticle claiming they did not happen. The other half, observing them via resource timing, has
+ * since landed in the browser SDK, so the two halves are no longer independent and this downgrade is
+ * now GATED: when the event stream carries at least one document-initiated record, the observer is
+ * demonstrably live and a miss over these suffixes is real evidence, graded a plain failure. Only a
+ * page whose stream holds no resource entry at all keeps the honest "cannot tell apart" answer,
+ * because there the observer may simply not exist.
  */
 const DOCUMENT_ONLY_SUFFIXES: readonly string[] = [
   '.ico',
@@ -276,14 +280,51 @@ function targetsUnobservedChannel(
   return DOCUMENT_ONLY_SUFFIXES.some((suffix) => path.endsWith(suffix));
 }
 
+/**
+ * Initiator types the browser SDK's resource-timing observer stamps onto document-initiated records
+ * (packages/browser/src/observers/network.ts). The patched transports sign themselves `fetch`,
+ * `xhr` or `beacon`, so any NET_REQUEST carrying one of these came from a `resource` entry, and its
+ * mere presence is proof the PerformanceObserver is alive on this page. Mirrors the wire; keep in
+ * sync with the browser package.
+ */
+const DOCUMENT_INITIATORS: ReadonlySet<string> = new Set([
+  'link',
+  'css',
+  'img',
+  'script',
+  'manifest',
+  'other',
+]);
+
+/**
+ * Did the observer actually report a document-initiated load?
+ *
+ * This is the gate on the unobserved-channel downgrade above. Once subresource observation landed,
+ * a miss over `.ico`/`.css`/`.woff2` is no longer inherently unknowable: if the observer is live it
+ * would have seen the favicon load, so seeing none is evidence it never fired. But the observer is
+ * opt-in-by-engine, not guaranteed: on a renderer without `PerformanceObserver` (or before any
+ * resource entry exists) nothing distinguishes "not requested" from "not visible", and the honest
+ * answer stays inconclusive. Liveness is inferred from the same events being judged: one
+ * document-initiated record anywhere in the window proves the channel works.
+ */
+function observerSawSubresources(events: ReticleEvent[]): boolean {
+  return events.some((e) => {
+    if (e.type !== EventType.NET_REQUEST) return false;
+    const initiator = str(e.data['initiator']);
+    return initiator !== undefined && DOCUMENT_INITIATORS.has(initiator);
+  });
+}
+
 /** The sentence both zero-match branches hand to `inconclusive`. */
 function unobservedChannelReason(
   p: Extract<Predicate, { kind: typeof PredicateKind.NET }>,
 ): string {
   return (
-    `no call matched ${describeNetFilter(p)}, but Reticle only observes fetch and XMLHttpRequest — ` +
-    `a request the document initiates (<link rel=icon|manifest|preload>, a stylesheet, a font, ` +
-    `<img src>) is never recorded, so this cannot be told apart from the request having been made. ` +
+    `no call matched ${describeNetFilter(p)}, and no document-initiated load was recorded either, ` +
+    `so this page exposed no resource timing to read: Reticle observes fetch and XMLHttpRequest ` +
+    `directly, while a request the document initiates (<link rel=icon|manifest|preload>, a ` +
+    `stylesheet, a font, <img src>) leaves no record, and that state cannot be told apart from the ` +
+    `request having been made. ` +
     `Nothing here says the app is wrong. Check it outside the browser, or assert something the ` +
     `document does not fetch on its own`
   );
@@ -294,6 +335,11 @@ export function evalNet(
   p: Extract<Predicate, { kind: typeof PredicateKind.NET }>,
 ): EvalResult {
   const since = p.since ?? 0;
+  /**
+   * Computed once: the gate every zero-match downgrade below reads. True means the resource-timing
+   * observer is demonstrably live in this window, so a miss is evidence rather than blindness.
+   */
+  const sawSubresources = observerSawSubresources(events);
   /**
    * Did any call match everything EXCEPT the body assertion, while carrying no recorded body?
    *
@@ -391,7 +437,7 @@ export function evalNet(
   if (p.count !== undefined) {
     return matches.length === p.count
       ? { pass: true, evidence: { matched: matches.length } }
-      : 0 === matches.length && targetsUnobservedChannel(p)
+      : 0 === matches.length && targetsUnobservedChannel(p) && !sawSubresources
         ? {
             pass: false,
             failureReason: unobservedChannelReason(p),
@@ -411,7 +457,7 @@ export function evalNet(
           };
   }
   const hit = matches[0];
-  if (hit === undefined && targetsUnobservedChannel(p)) {
+  if (hit === undefined && targetsUnobservedChannel(p) && !sawSubresources) {
     const reason = unobservedChannelReason(p);
     return {
       pass: false,

--- a/packages/server/src/events/predicate-eval.ts
+++ b/packages/server/src/events/predicate-eval.ts
@@ -303,6 +303,8 @@ export function evalNet(
    * because it is the same pass over the same events.
    */
   let matchedButUnrecorded = false;
+  /** A call matched url/method but carried NO readable status (document-initiated subresource). */
+  let unobservableStatus = false;
   /**
    * The response body of a call that matched everything EXCEPT the body assertion, and HAD one.
    *
@@ -321,7 +323,18 @@ export function evalNet(
     if (p.urlContains !== undefined && !(str(d['url']) ?? '').includes(p.urlContains)) {
       return false;
     }
-    if (p.status !== undefined && num(d['status']) !== p.status) return false;
+    if (p.status !== undefined) {
+      const status = num(d['status']);
+      if (status === undefined) {
+        // Document-initiated subresources (link/css/img/manifest via resource timing) carry no
+        // readable status on engines without responseStatus. A failed assertion here would read
+        // "your change is broken" and send the caller to fix working code — the exact false
+        // negative the oracle exists to prevent. Downgrade to unknown instead.
+        unobservableStatus = true;
+        return false;
+      }
+      if (status !== p.status) return false;
+    }
     if (p.ok !== undefined && callSucceeded(d) !== p.ok) return false;
     if (p.bodyContains !== undefined) {
       // The RESPONSE body only, and this is the whole point of the field. Searching the request too
@@ -340,6 +353,18 @@ export function evalNet(
     }
     return true;
   });
+  if (unobservableStatus && 0 === matches.length) {
+    // The url/method matched a document-initiated subresource whose engine could not read a status.
+    // "No matching call" would be a lie in both directions: it may have succeeded, it may have 404'd
+    // on exactly the path mistake the caller is hunting. Say the truth — not observable here.
+    return {
+      pass: false,
+      inconclusive: `a document-initiated request matching ${describeNetFilter(p)} was observed, but this engine does not expose its status code (resource timing without responseStatus) — assert on the element or route instead, or check the network tab`,
+      observed: 'a matching request with no readable status',
+      expected: `a status of ${String(p.status)} on ${JSON.stringify(p.urlContains ?? '*')}`,
+      assertion: 'net.unobservable-status',
+    };
+  }
   if (matchedButUnrecorded && 0 === matches.length) {
     return {
       pass: false,

--- a/packages/server/src/events/predicate-net-unobserved.test.ts
+++ b/packages/server/src/events/predicate-net-unobserved.test.ts
@@ -117,3 +117,66 @@ describe('evalNet — requests the document initiates', () => {
     expect(r.inconclusive).toBeUndefined();
   });
 });
+
+describe('evalNet — the unobserved-channel downgrade is gated on observer liveness', () => {
+  /**
+   * Once the browser SDK observes document-initiated loads (resource timing), a miss over these
+   * suffixes stops being unknowable: a live observer would have seen the favicon load, so seeing
+   * none is real evidence. The downgrade must therefore fire ONLY when nothing proves the observer
+   * ran at all. Liveness is read off the same events being judged: any NET_REQUEST whose initiator
+   * names a document channel (link/css/img/script/manifest/other) proves the channel works.
+   */
+  // A stylesheet load as the resource-timing observer reports it: proof of liveness.
+  const STYLESHEET = netEvent(5, {
+    method: 'GET',
+    url: '/assets/app.css',
+    initiator: 'link',
+    status: 200,
+    ok: true,
+  });
+
+  it('a missing favicon where the observer IS running grades no, not unknown', () => {
+    const r = evalNet([STYLESHEET], {
+      kind: PredicateKind.NET,
+      urlContains: '/favicon.ico',
+      status: 200,
+    });
+
+    expect(r.pass).toBe(false);
+    expect(r.inconclusive).toBeUndefined();
+    expect(r.failureReason).toBeDefined();
+  });
+
+  it('a zero-match count assertion over the same class grades no too', () => {
+    const r = evalNet([STYLESHEET], {
+      kind: PredicateKind.NET,
+      urlContains: '/site.webmanifest',
+      count: 1,
+    });
+
+    expect(r.pass).toBe(false);
+    expect(r.inconclusive).toBeUndefined();
+  });
+
+  it('a page with no document-initiated record keeps the honest unknown', () => {
+    // Only an XHR in the stream: nothing proves the PerformanceObserver exists here.
+    const r = evalNet([API_CALL], { kind: PredicateKind.NET, urlContains: '/favicon.ico' });
+
+    expect(r.inconclusive).toBeDefined();
+  });
+
+  it('an observed subresource still passes untouched under the gate', () => {
+    const icon = netEvent(20, {
+      method: 'GET',
+      url: '/apple-touch-icon.png',
+      initiator: 'link',
+      status: 200,
+      ok: true,
+    });
+
+    expect(
+      evalNet([STYLESHEET, icon], { kind: PredicateKind.NET, urlContains: '/apple-touch-icon.png' })
+        .pass,
+    ).toBe(true);
+  });
+});

--- a/packages/server/src/events/predicate.test.ts
+++ b/packages/server/src/events/predicate.test.ts
@@ -156,6 +156,40 @@ describe('predicate engine', () => {
     ).toBe(true);
   });
 
+  /**
+   * Document-initiated subresources (link/css/img/manifest via resource timing) carry no readable
+   * status on engines without `responseStatus`. A plain failure would read "your change is broken"
+   * and send the agent to fix working code — the false negative the oracle exists to prevent. The
+   * honest verdict is unknown: the request WAS seen, its status simply cannot be asserted here.
+   */
+  it('net status over a status-less subresource downgrades to unknown, never a plain failure', async () => {
+    const session = new FakeSession([
+      // A document-initiated load: url matches, status unreadable (absent from the record).
+      ev(EventType.NET_REQUEST, { method: 'GET', url: '/favicon.ico', initiator: 'link' }),
+    ]);
+    const result = await evaluatePredicate(session, {
+      kind: 'net',
+      urlContains: '/favicon.ico',
+      status: 200,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.inconclusive).toBeDefined();
+    expect(result.inconclusive).toContain('does not expose its status');
+  });
+
+  it('net status still fails plainly when the status IS readable and differs', async () => {
+    const session = new FakeSession([
+      ev(EventType.NET_REQUEST, { method: 'GET', url: '/api/data', status: 500 }),
+    ]);
+    const result = await evaluatePredicate(session, {
+      kind: 'net',
+      urlContains: '/api/data',
+      status: 200,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.inconclusive).toBeUndefined();
+  });
+
   it('net count: respects the since floor (a prior-action request is not counted)', async () => {
     const session = new FakeSession([
       ev(EventType.NET_REQUEST, { method: 'POST', url: '/api/deploy', status: 200 }, 10),

--- a/packages/server/src/honesty/blind-spots.ts
+++ b/packages/server/src/honesty/blind-spots.ts
@@ -75,11 +75,13 @@ const LABEL: Record<BlindSpotKind, (n: number) => string> = {
     'no subscribable store is registered, so NO state change is observed — an empty stateDiffs here means unwatched, not unchanged (register the store itself in your reticle-dev module: registerStore(name, store), not a getter)',
   [BlindSpotKind.WRAPPED_NETWORK]: () =>
     'fetch was already wrapped before Reticle, so recorded requests may differ from what was sent',
-  // A fact about the app's wiring, not a tally. Says what the empty network view MEANS, because an
-  // empty one here is indistinguishable from "this app made no backend calls" — and that reading is
-  // the false green: every IPC call went unseen and every `assert { net }` over them is vacuous.
+  // A fact about the app's wiring, not a tally. Says what a network view WITHOUT ipc:// records
+  // MEANS, because that state here is indistinguishable from "this app made no backend calls" —
+  // and that reading is the false green: every IPC call went unseen and every `assert { net }` over
+  // them is vacuous. Document-initiated loads ARE seen since subresource observation (#447), so
+  // the note names the missing half instead of claiming the whole view is blind.
   [BlindSpotKind.UNOBSERVED_IPC]: () =>
-    "this Electron renderer has no Reticle preload, so NO ipcRenderer.invoke is observed — an empty network view here means unseen, not none (add require('@reticlehq/electron/preload') to your preload)",
+    "this Electron renderer has no Reticle preload, so NO ipcRenderer.invoke is observed; document-initiated loads may still appear, so a view with no ipc:// records means unseen IPC, not none (add require('@reticlehq/electron/preload') to your preload)",
 };
 
 /**


### PR DESCRIPTION
## What

Closes #447, both halves.

## 1. Observer (browser)

A `PerformanceObserver` over `resource` entries emits `NET_REQUEST` for document-initiated loads (`link`, `css`, `img`, `script`, `manifest`): the favicon/manifest/stylesheet class fetch and XHR patches never see. Deduplicated against every URL the patched transports reported — both orders of arrival — capped at 200 events per connect, disconnected on teardown.

Status rides ONLY when `responseStatus` is readable (newer Chromium); otherwise the fields are omitted entirely so the wire never carries a guessed value.

## 2. Evaluation seam (server)

A `{net, status}` predicate whose only candidate match carried no readable status now returns **inconclusive** with assertion id `net.unobservable-status` — naming the engine limitation and pointing at alternatives (element/route assertions or the network tab) — instead of a plain failure that reads as a regression in working code.

## Verification

- Browser observers: **196/196** (3 new tests: emit with readable status; status fields omitted when unreadable; disconnect on teardown)
- Server suite: **4518/4518** including 2 new tests pinning both the inconclusive downgrade and the plain-failure path when a real readable status differs
- lint + tsc clean in both packages