### PR TITLE
test(mcp): the no-example fallback test now asserts the fallback message

### DIFF
--- a/packages/server/src/mcp/mcp.test.ts
+++ b/packages/server/src/mcp/mcp.test.ts
@@ -254,13 +254,18 @@ describe('a wrong-shaped call is answered with a correct one', () => {
       .join(' ');
   };
 
-  const openServer = async (): Promise<{
+  const openServer = async (
+    examples?: Map<string, string>,
+  ): Promise<{
     client: import('@modelcontextprotocol/sdk/client/index.js').Client;
     close: () => Promise<void>;
   }> => {
     const { InMemoryTransport } = await import('@modelcontextprotocol/sdk/inMemory.js');
     const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
     const server = createMcpServer(toolDepsForTest(), TOOL_SURFACE.DEFAULT);
+    // Passing an empty example map re-wraps the validator so every failure answers with the
+    // no-example fallback, which is what tools without an advertised example serve today.
+    if (examples !== undefined) installFriendlyArgErrors(server, examples);
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await server.connect(serverTransport);
     const client = new Client({ name: 'c', version: '0' });
@@ -340,11 +345,22 @@ describe('a wrong-shaped call is answered with a correct one', () => {
     await close();
   });
 
-  it('points at reticle_tools when the tool carries no example', () => {
-    const server = createMcpServer(toolDepsForTest(), TOOL_SURFACE.DEFAULT);
-    // Installed with an empty example map: the fallback must still be actionable, never a bare dump.
-    installFriendlyArgErrors(server, new Map());
-    expect(typeof server).toBe('object');
+  it('points at reticle_tools when the tool carries no example', async () => {
+    // An empty example map stands in for every tool that advertises none: the failure must still
+    // navigate the agent to reticle_tools, never hand back a bare validator dump.
+    const { client, close } = await openServer(new Map());
+    const result = await client.callTool({
+      name: ReticleTool.ACT,
+      arguments: { action: 'click', testid: 'break' },
+    });
+    const failure = errorText(result);
+
+    expect(result.isError, 'the call must still be rejected').toBe(true);
+    expect(failure, 'with no example to show, the reply must navigate instead').toContain(
+      'Call reticle_tools',
+    );
+    expect(failure).toContain(ReticleTool.ACT);
+    await close();
   });
 });
 


### PR DESCRIPTION
Closes #457.

## What changed

`points at reticle_tools when the tool carries no example` (`packages/server/src/mcp/mcp.test.ts`) claimed to check the no-example fallback message but only asserted `typeof server === 'object'`. It passed whether the fallback was actionable, empty, or missing entirely.

The test now follows the recipe from the issue and its own sibling tests in the same describe block:

- `openServer` gains an optional `examples` map; passing an empty one re-wraps the validator via `installFriendlyArgErrors(server, new Map())`, so failures answer with the no-example fallback.
- The test drives a real `Client` + `InMemoryTransport`, calls `reticle_act` with a validation failure, and asserts:
  - the call is rejected (`isError === true`),
  - the error text navigates with `Call reticle_tools`,
  - the error names the tool (`reticle_act`).

Sibling tests are untouched (the parameter is optional and defaults to the previous behavior).

## Can this test fail? Yes, checked

Per the issue's verification note I confirmed the rewritten test actually fails when the fallback breaks: renaming `reticle_tools` to `reticle_toolz` in the fallback string in `mcp.ts` makes exactly this test fail (51/52 others still pass). Reverted the mutation afterwards.

## Verification

- `pnpm --filter @reticlehq/server exec vitest run src/mcp/mcp.test.ts`: 52 passed.
- Full server suite: 466 test files / 4516 tests passing.
- `pnpm format:check`: clean. `eslint src` (server package): clean.

Keeping the two sibling shape-mismatches out of this PR as the issue requested.