### PR TITLE
fix(server): report an unobservable net assertion as inconclusive, not failed

### DIFF
--- a/packages/server/src/events/predicate-eval.ts
+++ b/packages/server/src/events/predicate-eval.ts
@@ -223,6 +223,72 @@ function describeNetFilter(p: Extract<Predicate, { kind: typeof PredicateKind.NE
   return JSON.stringify(filter);
 }
 
+/**
+ * URL suffixes only the DOCUMENT fetches, which the network observer therefore never records.
+ *
+ * `network.ts` patches `fetch` and `XMLHttpRequest` and nothing else, so `<link rel=icon>`,
+ * `<link rel=manifest>`, stylesheets, fonts and `<img src>` are invisible to it. "No matching call"
+ * and "that class of call is not observed" are then indistinguishable, and the miss graded
+ * `assertion_failed` — a false RED. Reported from the field: an assert over `/favicon.ico`,
+ * `/site.webmanifest` and `/apple-touch-icon.png` returned `verified:"no"` while curl showed all
+ * three answering 200. A false negative here is worse than an unknown, because an agent that trusts
+ * it goes and "fixes" working code.
+ *
+ * Deliberately NOT here: `.js` and `.json`. Both are routinely fetched via `fetch`/XHR — a module
+ * preload and an API call can share a suffix — so downgrading them would hide real misses. This list
+ * is only the suffixes for which the document is the sole plausible initiator.
+ *
+ * This is the smaller half of #447: it does not make these requests observable, it stops Reticle
+ * claiming they did not happen. Widening the observer (via `PerformanceResourceTiming`) is the other
+ * half and is independent of this one.
+ */
+const DOCUMENT_ONLY_SUFFIXES: readonly string[] = [
+  '.ico',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.svg',
+  '.webp',
+  '.avif',
+  '.bmp',
+  '.css',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.otf',
+  '.eot',
+  '.webmanifest',
+];
+
+/**
+ * Does this filter target a class of request the observer cannot see?
+ *
+ * Read off `urlContains` only, and only when the pattern ENDS in one of the suffixes — a filter of
+ * `/api/` that happens to contain `.css` somewhere in a query string is still an ordinary XHR
+ * target. Query strings and fragments are stripped first, since `favicon.ico?v=2` is the same asset.
+ */
+function targetsUnobservedChannel(
+  p: Extract<Predicate, { kind: typeof PredicateKind.NET }>,
+): boolean {
+  if (p.urlContains === undefined) return false;
+  const path = (p.urlContains.split('#')[0] ?? '').split('?')[0]?.toLowerCase() ?? '';
+  return DOCUMENT_ONLY_SUFFIXES.some((suffix) => path.endsWith(suffix));
+}
+
+/** The sentence both zero-match branches hand to `inconclusive`. */
+function unobservedChannelReason(
+  p: Extract<Predicate, { kind: typeof PredicateKind.NET }>,
+): string {
+  return (
+    `no call matched ${describeNetFilter(p)}, but Reticle only observes fetch and XMLHttpRequest — ` +
+    `a request the document initiates (<link rel=icon|manifest|preload>, a stylesheet, a font, ` +
+    `<img src>) is never recorded, so this cannot be told apart from the request having been made. ` +
+    `Nothing here says the app is wrong. Check it outside the browser, or assert something the ` +
+    `document does not fetch on its own`
+  );
+}
+
 export function evalNet(
   events: ReticleEvent[],
   p: Extract<Predicate, { kind: typeof PredicateKind.NET }>,
@@ -300,19 +366,40 @@ export function evalNet(
   if (p.count !== undefined) {
     return matches.length === p.count
       ? { pass: true, evidence: { matched: matches.length } }
-      : {
-          pass: false,
-          // Monotonic: more matches than asked for can never become exactly the number asked for.
-          // This is the double-submit — two writes 59ms apart — so the finding that matters most was
-          // also the one that took the caller's whole budget to report.
-          ...(matches.length > p.count ? { decided: true } : {}),
-          failureReason: `expected ${String(p.count)} network call(s) matching ${describeNetFilter(p)}, saw ${String(matches.length)}`,
-          observed: `${String(matches.length)} matching network call(s)`,
-          expected: `exactly ${String(p.count)} matching ${describeNetFilter(p)}`,
-          assertion: 'net.count',
-        };
+      : 0 === matches.length && targetsUnobservedChannel(p)
+        ? {
+            pass: false,
+            failureReason: unobservedChannelReason(p),
+            inconclusive: unobservedChannelReason(p),
+            assertion: 'net.count',
+          }
+        : {
+            pass: false,
+            // Monotonic: more matches than asked for can never become exactly the number asked for.
+            // This is the double-submit — two writes 59ms apart — so the finding that matters most was
+            // also the one that took the caller's whole budget to report.
+            ...(matches.length > p.count ? { decided: true } : {}),
+            failureReason: `expected ${String(p.count)} network call(s) matching ${describeNetFilter(p)}, saw ${String(matches.length)}`,
+            observed: `${String(matches.length)} matching network call(s)`,
+            expected: `exactly ${String(p.count)} matching ${describeNetFilter(p)}`,
+            assertion: 'net.count',
+          };
   }
   const hit = matches[0];
+  if (hit === undefined && targetsUnobservedChannel(p)) {
+    const reason = unobservedChannelReason(p);
+    return {
+      pass: false,
+      failureReason: reason,
+      inconclusive: reason,
+      observed: describeObserved(
+        'calls',
+        events.filter((e) => e.type === EventType.NET_REQUEST).map(describeCall),
+      ),
+      expected: `at least one call matching ${describeNetFilter(p)}`,
+      assertion: 'net.unobserved-channel',
+    };
+  }
   return hit !== undefined
     ? { pass: true, evidence: hit.data }
     : {

--- a/packages/server/src/events/predicate-net-unobserved.test.ts
+++ b/packages/server/src/events/predicate-net-unobserved.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { EventType } from '@reticlehq/core';
+import type { ReticleEvent } from '@reticlehq/core';
+import { evalNet } from './predicate-eval.js';
+import { PredicateKind } from './predicate.js';
+
+/**
+ * A request Reticle cannot see must not be graded as a request that did not happen.
+ *
+ * The observer patches `fetch` and `XMLHttpRequest` only, so anything the DOCUMENT initiates —
+ * `<link rel=icon>`, `<link rel=manifest>`, a stylesheet, a font, `<img src>` — is never recorded.
+ * Reported from the field (#447): after a hard reload of an app whose `index.html` declares all
+ * three, an `allOf` over `/favicon.ico`, `/site.webmanifest` and `/apple-touch-icon.png` returned
+ * `verified:"no"`, `verifiedReason:"assertion_failed"`, while curl against the same server at the
+ * same moment answered 200 for every one of them.
+ *
+ * That is a false RED from the layer whose whole job is not to produce one, and a false negative is
+ * worse than an unknown here: an agent that trusts it goes and "fixes" working code. `inconclusive`
+ * is the existing seam for exactly this — `decideVerified` handles it ahead of the failure clause,
+ * so the verdict lands on `unknown` instead of blaming the app.
+ */
+function netEvent(t: number, data: Record<string, unknown>): ReticleEvent {
+  return { type: EventType.NET_REQUEST, t, data } as ReticleEvent;
+}
+
+const API_CALL = netEvent(10, {
+  method: 'GET',
+  url: '/api/auth/get-session',
+  status: 500,
+  ok: false,
+});
+
+describe('evalNet — requests the document initiates', () => {
+  it.each([
+    '/favicon.ico',
+    '/site.webmanifest',
+    '/apple-touch-icon.png',
+    '/assets/app.css',
+    '/fonts/inter.woff2',
+  ])('reports %s as inconclusive rather than failed', (urlContains) => {
+    const r = evalNet([API_CALL], { kind: PredicateKind.NET, urlContains, status: 200 });
+
+    expect(r.pass).toBe(false);
+    expect(r.inconclusive).toBeDefined();
+    expect(r.inconclusive).toContain('fetch and XMLHttpRequest');
+  });
+
+  it('ignores a query string and a fragment, since favicon.ico?v=2 is the same asset', () => {
+    const r = evalNet([API_CALL], { kind: PredicateKind.NET, urlContains: '/favicon.ico?v=2' });
+
+    expect(r.inconclusive).toBeDefined();
+  });
+
+  it('still fails an ordinary XHR target that genuinely never fired', () => {
+    // The behaviour this must not weaken: a missing API call is a real finding.
+    const r = evalNet([API_CALL], { kind: PredicateKind.NET, urlContains: '/api/save' });
+
+    expect(r.pass).toBe(false);
+    expect(r.inconclusive).toBeUndefined();
+  });
+
+  it('does not downgrade .js or .json, which are routinely fetched', () => {
+    for (const urlContains of ['/assets/index.js', '/api/config.json']) {
+      expect(
+        evalNet([API_CALL], { kind: PredicateKind.NET, urlContains }).inconclusive,
+      ).toBeUndefined();
+    }
+  });
+
+  it('does not downgrade a filter that merely contains a suffix mid-pattern', () => {
+    // `.css` here is part of a query, not the target: still an ordinary XHR.
+    const r = evalNet([API_CALL], { kind: PredicateKind.NET, urlContains: '/api/assets.css/list' });
+
+    expect(r.inconclusive).toBeUndefined();
+  });
+
+  it('leaves a matching subresource call passing when one WAS observed', () => {
+    // An XHR to a .png is observable, and an observed match must still pass untouched.
+    const icon = netEvent(20, {
+      method: 'GET',
+      url: '/apple-touch-icon.png',
+      status: 200,
+      ok: true,
+    });
+
+    expect(
+      evalNet([icon], { kind: PredicateKind.NET, urlContains: '/apple-touch-icon.png' }).pass,
+    ).toBe(true);
+  });
+
+  it('downgrades a zero-match count assertion over the same class', () => {
+    const r = evalNet([API_CALL], {
+      kind: PredicateKind.NET,
+      urlContains: '/favicon.ico',
+      count: 1,
+    });
+
+    expect(r.pass).toBe(false);
+    expect(r.inconclusive).toBeDefined();
+  });
+
+  it('still fails a count assertion that saw the wrong number of OBSERVED calls', () => {
+    const icon = netEvent(20, {
+      method: 'GET',
+      url: '/apple-touch-icon.png',
+      status: 200,
+      ok: true,
+    });
+
+    const r = evalNet([icon, icon], {
+      kind: PredicateKind.NET,
+      urlContains: '/apple-touch-icon.png',
+      count: 1,
+    });
+
+    expect(r.pass).toBe(false);
+    expect(r.inconclusive).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Refs #447 — the second half ("separate 'no matching call' from 'this class of call is not observed'"), which the issue notes is worth doing regardless of whether the observer is widened.

## Problem

The observer patches `fetch` and `XMLHttpRequest` and nothing else, so anything the document initiates — `<link rel=icon>`, `<link rel=manifest>`, `<link rel=preload>`, stylesheets, fonts, `<img src>` — is never recorded. A `{net}` predicate over that class didn't return "I cannot see that", it returned `assertion_failed`:

```
reticle_assert allOf[ net /favicon.ico 200, net /site.webmanifest 200, net /apple-touch-icon.png 200 ]
-> verified:"no", verifiedReason:"assertion_failed"
```

…while curl answered 200 for all three. As the report frames it, a false negative here is worse than an unknown, because an agent that trusts it goes and "fixes" working code.

## Change

`evalNet` returns `inconclusive` when a **zero-match** filter targets a suffix only the document fetches. Nothing else moves: `decideVerified` already handles `inconclusive` ahead of the failure clause, and `allOf`/`anyOf` already propagate it, so the verdict lands on `unknown` with the existing `INCONCLUSIVE` reason rather than a new one.

Three deliberate narrowings, each covered by a test:

- **Only when nothing matched.** An observed call whose *status* disagreed is a real failure and still grades as one — an XHR to a `.png` is observable, so a match there passes untouched.
- **`.js` and `.json` are excluded.** Both are routinely fetched via `fetch`/XHR (a module preload and an API call can share a suffix), so downgrading them would hide real misses.
- **Suffix must END the pattern**, after stripping query and fragment. `/api/assets.css/list` stays an ordinary XHR target; `/favicon.ico?v=2` is recognised as the same asset.

The `count` branch gets the same treatment at zero matches, since a count assertion over an unobserved class had the identical false-red problem.

## What this does not do

It does not make these requests observable. Part 1 of the issue — sourcing records from `PerformanceResourceTiming` via `PerformanceObserver` — is independent, and carries the design question you flagged about what `{net, status:200}` means for an entry whose status cannot be read. I left that alone rather than guess at it. This change only stops Reticle asserting the requests did not happen.

## Testing

New `predicate-net-unobserved.test.ts`, 12 tests: the three URLs from the field report plus `.css`/`.woff2`, the query-string case, and five negative cases pinning the narrowings above so the downgrade can't leak into ordinary assertions.

Confirmed they guard the change — with the `predicate-eval.ts` hunk stashed, 7 of the 12 fail.

```
pnpm --filter @reticlehq/server test:unit   # 467 files, 4528 tests passed
pnpm typecheck                              # 21/21 successful
prettier --check                            # clean
```

Signed off (DCO), Conventional Commits per CONTRIBUTING.
