### PR TITLE
fix(bench): refuse to run when an anchor file has uncommitted work

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -79,6 +79,8 @@ artifacts/                charts + diagrams (SVG + PNG) + screens/ (real PNGs + 
 
 ## Run it
 
+> [!WARNING] The benchmark **rewrites tracked files in the fixture app** and reverts them with `git checkout --`: `apps/bench-app/src/store/store.ts`, `src/components/NewDeployModal.tsx`, `src/views/Overview.tsx` and `src/views/Diagnostics.tsx`. Commit or stash any work in those four before running — the injector refuses to start if they are dirty, but nothing else protects them. If a crashed run left a regression injected, clear it with `node bench/harness/inject.mjs --revert-all`.
+
 The fast path: `pnpm bench` (the replay pass) and `pnpm bench --full` (+ observation-cost pass) now **boot the fixtures themselves** — the bench-app on `:4312` and the api on `:8787` — health-check them, and tear them down on exit. Pass `--no-boot` to use fixtures you already have running, and override ports with `BENCH_DEMO_PORT` / `BENCH_API_PORT` / `BENCH_RETICLE_PORT` (default 4460 — the same value apps/bench-app/vite.config.ts defaults to; see bench/harness/ports.mjs for why they must agree). On a slow machine raise `BENCH_FIXTURE_READY_MS` (fixture boot) or `BENCH_RETICLE_READY_MS` (driven-browser connect).
 
 To run the fixtures + harness scripts by hand instead (e.g. for the manual observation/agent-loop steps):

--- a/bench/harness/bench-all.mjs
+++ b/bench/harness/bench-all.mjs
@@ -302,7 +302,17 @@ console.log(
 // rule rewrote the fixture and the anchors were not updated with it. Checked BEFORE the pass, because
 // a drifted anchor found afterwards has already produced a number somebody may have quoted.
 if (FULL) {
-  const drifted = verifyAnchors();
+  // verifyAnchors() refuses rather than destroying uncommitted work in the fixture files it
+  // rewrites. That refusal is a message to a human, so print the sentence — an unhandled throw at
+  // module top level would wrap it in a stack trace, on the `pnpm bench --full` path that most
+  // people take. Same treatment as the CLI path in inject.mjs.
+  let drifted;
+  try {
+    drifted = verifyAnchors();
+  } catch (e) {
+    console.error(e instanceof Error ? e.message : String(e));
+    process.exit(1);
+  }
   if (drifted.length > 0) {
     for (const d of drifted) console.error(`✗ DRIFTED ${d.id}: ${d.error.split('\n')[0]}`);
     console.error(

--- a/bench/harness/inject.mjs
+++ b/bench/harness/inject.mjs
@@ -147,6 +147,55 @@ export function signaturesOf(id) {
 }
 
 /** The source files a regression touches. */
+/** Every tracked file this module rewrites — the blast radius of a `git checkout --`. */
+const ANCHOR_FILES = [...new Set(Object.values(REGRESSIONS).flatMap((r) => r.files))];
+
+function isDirty(file) {
+  for (const args of [
+    ['diff', '--quiet', '--', file],
+    ['diff', '--cached', '--quiet', '--', file],
+  ]) {
+    try {
+      execFileSync('git', ['-C', ROOT, ...args], { stdio: 'ignore' });
+    } catch {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Refuse to run if an anchor file carries uncommitted work.
+ *
+ * `revert()` restores with `git checkout --`, which HARD-DISCARDS. Anything uncommitted in these
+ * four files was silently destroyed by running the benchmark — no prompt, no stash, and nothing in
+ * the reflog to recover from, because the work was never committed. Easy to hit: edit the bench app
+ * to reproduce something, run the benchmark to measure it, lose the edit. Worse with parallel agent
+ * sessions, which share one checkout.
+ *
+ * Refuse rather than destroy. Deliberately NOT `git stash` + restore: a run killed partway through
+ * would leave the user's work somewhere they do not know to look, which is a worse failure than the
+ * one being fixed.
+ *
+ * Latched, because after the first injection these files are dirty BY DESIGN and re-checking would
+ * refuse the harness's own work. `revertAll()` is intentionally left ungated — it is the recovery
+ * path when a crashed run leaves an injection behind, and gating it would strand the user.
+ */
+let anchorsChecked = false;
+export function assertAnchorsClean() {
+  if (anchorsChecked) return;
+  anchorsChecked = true;
+  const dirty = ANCHOR_FILES.filter(isDirty).map((f) => f.slice(ROOT.length + 1));
+  if (0 === dirty.length) return;
+  throw new Error(
+    `inject: refusing to run — the benchmark reverts these files with \`git checkout --\`, which ` +
+      `would discard your uncommitted work:\n` +
+      dirty.map((f) => `  ${f}`).join('\n') +
+      `\n\nCommit or stash them first. If a previous run crashed and left a regression injected, ` +
+      `run \`node bench/harness/inject.mjs --revert-all\` to clear it.`,
+  );
+}
+
 export function filesOf(id) {
   const r = REGRESSIONS[id];
   if (!r) throw new Error(`unknown regression ${id}`);
@@ -156,6 +205,7 @@ export function filesOf(id) {
 export function inject(id) {
   const r = REGRESSIONS[id];
   if (!r) throw new Error(`unknown regression ${id}`);
+  assertAnchorsClean();
   r.apply();
   return r.files;
 }
@@ -193,6 +243,8 @@ export function revertAll() {
  * measuring anything, and it must say so LOUDLY rather than average itself over the survivors.
  */
 export function verifyAnchors() {
+  // Up front, so the preflight refuses before it touches anything rather than on the first apply().
+  assertAnchorsClean();
   const broken = [];
   for (const id of Object.keys(REGRESSIONS)) {
     try {
@@ -207,7 +259,14 @@ export function verifyAnchors() {
 }
 
 if (process.argv[2] === '--verify-anchors') {
-  const broken = verifyAnchors();
+  // A refusal is a message to a human, not a crash: print the sentence, not a stack trace.
+  let broken;
+  try {
+    broken = verifyAnchors();
+  } catch (e) {
+    console.error(e instanceof Error ? e.message : String(e));
+    process.exit(1);
+  }
   for (const b of broken) console.error(`DRIFTED ${b.id}: ${b.error.split('\n')[0]}`);
   console.log(
     0 === broken.length


### PR DESCRIPTION
Closes #461.

## Problem

`revert()` / `revertAll()` restore the four injected fixture files with `git checkout --`, which hard-discards. Any uncommitted change in them was silently destroyed — no prompt, no stash, and nothing in the reflog, because the work was never committed. `verifyAnchors()` runs as a preflight before every `pnpm bench:full`, so *measuring* something was enough to lose an edit made to reproduce it.

## Change

`assertAnchorsClean()` checks the four anchor paths — worktree and index — before the first injection, and refuses:

```
inject: refusing to run — the benchmark reverts these files with `git checkout --`, which would
discard your uncommitted work:
  apps/bench-app/src/views/Overview.tsx

Commit or stash them first. If a previous run crashed and left a regression injected, run
`node bench/harness/inject.mjs --revert-all` to clear it.
```

Called from `inject()` (so no entry point — `run-observation.mjs`, `run-fix-loop.mjs`, `e2e-loop/demo.mjs` — can bypass it) and up front in `verifyAnchors()` (so the preflight refuses before touching anything rather than on the first `apply()`).

**Not `git stash` + restore**, per your note: a run killed partway through would leave the user's work somewhere they don't know to look, which is a worse failure than the one being fixed.

Two details worth calling out:

- **Latched.** After the first injection these files are dirty *by design*, so re-checking would make the harness refuse its own work.
- **`revertAll()` is deliberately left ungated.** It's the recovery path when a crashed run leaves an injection behind; gating it would strand the user with a benchmark that refuses to run and refuses to clean up. The refusal message points at it.

The `--verify-anchors` CLI catches the refusal and prints the sentence rather than a stack trace, exiting 1.

## Also

`bench/README.md` gains a warning naming the four paths, as suggested — it previously said nothing about the benchmark mutating tracked files.

## Verifying

Per your instruction I did **not** run the full benchmark. The preflight path alone, in the order you described:

1. Clean tree → `node bench/harness/inject.mjs --verify-anchors` → `anchors ok — all 8 regressions still apply`, exit 0.
2. Appended a scratch line to `apps/bench-app/src/views/Overview.tsx` → the preflight refused, naming that file, exit 1.
3. Confirmed the scratch line **was still there** afterwards — the refusal did not touch it.
4. `git checkout --` the scratch line → preflight proceeds again, exit 0, tree clean apart from this change.

`pnpm --filter @reticlehq/server test:unit` — 466 files, 4516 tests passed. Prettier clean. Signed off (DCO).
