### PR TITLE
test(server): add non-emptiness controls to four vacuous guards

### DIFF
--- a/packages/server/src/init/snippet-token.test.ts
+++ b/packages/server/src/init/snippet-token.test.ts
@@ -35,7 +35,11 @@ describe('the manual connect snippet carries the pairing token', () => {
     // Two connect calls, or a token in prose beside a tokenless call, is the same bug wearing a
     // different shape: what matters is that the call the user pastes carries it.
     const snippet = htmlManual(4400, 'demo', 'tok_abc123');
-    for (const call of snippet.match(/reticle\.connect\(\{[^)]*\}\)/g) ?? []) {
+    const calls = snippet.match(/reticle\.connect\(\{[^)]*\}\)/g) ?? [];
+    // The control. If the snippet's formatting drifts past what this regex matches, the loop below
+    // runs zero times and the guard passes having checked nothing.
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
       expect(call, 'a connect call without the token').toContain('tok_abc123');
     }
   });

--- a/packages/server/src/tools/error-recovery.test.ts
+++ b/packages/server/src/tools/error-recovery.test.ts
@@ -96,6 +96,16 @@ describe('every tool a recovery hint names must still be advertised', () => {
     ReticleTool.TOOLS,
   ]);
 
+  it('the hints still name tools, so the guard below means something', () => {
+    // The control, covering both ways this can go vacuous: an empty RECOVERY registers zero
+    // `it.each` cases (vitest reports that green with no warning), and hints that stop naming tools
+    // literally leave the inner loop iterating nothing.
+    const entries = Object.entries(RECOVERY);
+    expect(entries.length).toBeGreaterThan(0);
+    const mentioned = entries.flatMap(([, hint]) => hint.match(/reticle_[a-z_]+/g) ?? []);
+    expect(mentioned.length).toBeGreaterThan(0);
+  });
+
   it.each(Object.entries(RECOVERY))('%s names only reachable tools', (_name, hint) => {
     for (const mentioned of hint.match(/reticle_[a-z_]+/g) ?? []) {
       expect(

--- a/packages/server/src/tools/tool-examples.test.ts
+++ b/packages/server/src/tools/tool-examples.test.ts
@@ -56,6 +56,14 @@ describe('the core surface leaves nothing to guess', () => {
     (tool) => CORE_TOOL_NAMES.has(tool.name) && Object.keys(tool.inputSchema).length > 1,
   );
 
+  it('has core tools to check', () => {
+    // The control, and it has to be its own `it()`: confirmed against vitest 3.2.6, `it.each([])`
+    // registers ZERO tests and reports the file green with no warning, so there is nothing to hang
+    // an assertion on. A change to CORE_TOOL_NAMES would otherwise retire this guard silently.
+    // Mirrors the sibling group's control above.
+    expect(needExamples.length).toBeGreaterThan(0);
+  });
+
   it.each(needExamples.map((tool) => [tool.name, tool] as const))(
     '%s carries an example call',
     (_name, tool) => {

--- a/packages/server/src/tools/tool-surface.test.ts
+++ b/packages/server/src/tools/tool-surface.test.ts
@@ -83,6 +83,16 @@ describe('tool profiles', () => {
     }
   });
 
+  it('4a-control: those instructions still name tools, so 4a means something', () => {
+    // The control. 4a derives what it checks from the instruction text, so rewording either block
+    // to drop the literal tool name leaves it iterating zero times and passing forever — which is
+    // exactly the defect it was written to catch.
+    const named = [PAUSE_HINT, buildSessionLease('s1', 0).IMPORTANT].flatMap(
+      (block) => block.match(/reticle_[a-z_]+/g) ?? [],
+    );
+    expect(named.length).toBeGreaterThan(0);
+  });
+
   it('4b: server-management ops are NOT on the MCP surface (CLI-only — they restart the daemon)', () => {
     const names = new Set(TOOLS.map((t) => t.name));
     for (const retired of ['reticle_version_info', 'reticle_apply_update', 'reticle_rollback'])


### PR DESCRIPTION
Closes #455.

Each of the four guards now has a non-emptiness control, copying the pattern already in `cli/doctor-rows.test.ts:112` and in the sibling group at `tool-examples.test.ts:20` rather than inventing one.

| file | control |
|---|---|
| `tools/tool-surface.test.ts` | new `4a-control` `it()` — the two always-on blocks still name tools |
| `tools/tool-examples.test.ts` | new `has core tools to check` `it()` — `needExamples.length > 0` |
| `init/snippet-token.test.ts` | inline `expect(calls.length).toBeGreaterThan(0)` before the loop |
| `tools/error-recovery.test.ts` | new `it()` covering both empties — `RECOVERY` entries, and hints naming tools |

The two `it.each` cases get their control as a **separate `it()`**, since an empty `it.each` registers nothing to hang an assertion on.

## Proving each control can fail

You asked for this explicitly, so here it is per guard — collection emptied, suite run, control confirmed red, then reverted:

| guard | how I emptied it | result |
|---|---|---|
| `tool-surface` 4a | replaced the `[PAUSE_HINT, …IMPORTANT]` source array with `[]` | **1 failed** \| 26 passed |
| `tool-examples` core surface | `TOOLS.filter(() => false)` | **1 failed** \| 52 passed |
| `snippet-token` | swapped the connect-call regex for a non-matching one | **1 failed** \| 4 passed |
| `error-recovery` | `entries` forced to `[]` | **1 failed** \| 82 passed |

The `tool-examples` run is the one worth reading twice: the file went from **68 tests to 53**. Sixteen `it.each` cases silently stopped existing, and without the new control that file would have reported green — which is the whole shape of this issue.

All four restored, then re-run together: 183 passed.

```
pnpm --filter @reticlehq/server test:unit   # 466 files, 4519 tests passed
pnpm typecheck                              # 21/21 successful
prettier --check                            # clean
```

Test-only; no production code touched. Signed off (DCO).
