### PR TITLE
Give four guards a control, so an empty collection cannot pass for a check

### DIFF
--- a/packages/server/src/init/snippet-token.test.ts
+++ b/packages/server/src/init/snippet-token.test.ts
@@ -35,7 +35,11 @@ describe('the manual connect snippet carries the pairing token', () => {
     // Two connect calls, or a token in prose beside a tokenless call, is the same bug wearing a
     // different shape: what matters is that the call the user pastes carries it.
     const snippet = htmlManual(4400, 'demo', 'tok_abc123');
-    for (const call of snippet.match(/reticle\.connect\(\{[^)]*\}\)/g) ?? []) {
+    const calls = snippet.match(/reticle\.connect\(\{[^)]*\}\)/g) ?? [];
+    // Change how the snippet spells the call and this matches nothing, passing green
+    // without having looked at a single connect call.
+    expect(calls.length, 'no connect call found in the snippet').toBeGreaterThan(0);
+    for (const call of calls) {
       expect(call, 'a connect call without the token').toContain('tok_abc123');
     }
   });

--- a/packages/server/src/tools/error-recovery.test.ts
+++ b/packages/server/src/tools/error-recovery.test.ts
@@ -96,6 +96,20 @@ describe('every tool a recovery hint names must still be advertised', () => {
     ReticleTool.TOOLS,
   ]);
 
+  it('actually reads tool names out of the hints', () => {
+    // Two ways this group can check nothing: an empty RECOVERY registers zero cases
+    // below, and hints that name no tool at all leave every inner loop with nothing to
+    // assert. Counting mentions across the whole set covers both.
+    //
+    // Deliberately NOT a per-hint control: a recovery hint that mentions no tool is
+    // legitimate, so requiring one from each would fail on a correct hint.
+    expect(Object.keys(RECOVERY).length).toBeGreaterThan(0);
+    const mentions = Object.values(RECOVERY).flatMap(
+      (hint) => hint.match(/reticle_[a-z_]+/g) ?? [],
+    );
+    expect(mentions.length, 'no hint names a tool — the check below is vacuous').toBeGreaterThan(0);
+  });
+
   it.each(Object.entries(RECOVERY))('%s names only reachable tools', (_name, hint) => {
     for (const mentioned of hint.match(/reticle_[a-z_]+/g) ?? []) {
       expect(

--- a/packages/server/src/tools/tool-examples.test.ts
+++ b/packages/server/src/tools/tool-examples.test.ts
@@ -56,6 +56,13 @@ describe('the core surface leaves nothing to guess', () => {
     (tool) => CORE_TOOL_NAMES.has(tool.name) && Object.keys(tool.inputSchema).length > 1,
   );
 
+  // Its own it(), because an empty `it.each` registers ZERO tests and reports the file
+  // green with no warning — there is nothing to hang an assertion on. The sibling group
+  // above already has this control; this one was missed.
+  it('has a core surface to check', () => {
+    expect(needExamples.length).toBeGreaterThan(0);
+  });
+
   it.each(needExamples.map((tool) => [tool.name, tool] as const))(
     '%s carries an example call',
     (_name, tool) => {

--- a/packages/server/src/tools/tool-surface.test.ts
+++ b/packages/server/src/tools/tool-surface.test.ts
@@ -77,8 +77,12 @@ describe('tool profiles', () => {
    */
   it('4a: a tool an always-on instruction ORDERS the agent to call is advertised', () => {
     for (const block of [PAUSE_HINT, buildSessionLease('s1', 0).IMPORTANT]) {
-      for (const named of block.match(/reticle_[a-z_]+/g) ?? []) {
-        expect(CORE_TOOL_NAMES.has(named), `${named} is ordered by "${block}"`).toBe(true);
+      const named = block.match(/reticle_[a-z_]+/g) ?? [];
+      // Reword the instruction to drop the literal tool name and this loop runs zero
+      // times, forever green — which is the defect the guard was written to catch.
+      expect(named.length, `no tool name in "${block}" — nothing was checked`).toBeGreaterThan(0);
+      for (const tool of named) {
+        expect(CORE_TOOL_NAMES.has(tool), `${tool} is ordered by "${block}"`).toBe(true);
       }
     }
   });


### PR DESCRIPTION
Fixes #455.

All four now assert their collection is non-empty before looping, copying the existing `toBeGreaterThan(0)` pattern rather than inventing one.

## Each control verified to fail on its own

The issue asks for this explicitly, and it is the whole point of the change, so per guard rather than as one "verified":

| guard | collection emptied | result |
|---|---|---|
| `tool-surface.test.ts` | regex matches no tool name | **1 failed** \| 25 passed |
| `tool-examples.test.ts` | filtered array empty | **1 failed** \| 52 passed |
| `snippet-token.test.ts` | connect regex matches nothing | **1 failed** \| 4 passed |
| `error-recovery.test.ts` | no hint names a tool | **1 failed** \| 82 passed |

Exactly one test red in each case — the control, not collateral.

## Two that were not mechanical

**`tool-examples.test.ts` needed its own `it()`.** An empty `it.each` registers zero tests and reports the file green, so there is nothing to hang an assertion on. Confirmed rather than assumed: with the filter forced empty, the file still passes until the separate `it()` exists.

**`error-recovery.test.ts` is counted across the whole set, not per hint.** My first version asserted `RECOVERY` was non-empty, which guards the `it.each` but not the shape the issue actually lists — the inner `hint.match(...) ?? []`. The obvious next move is a per-hint control, and that would be wrong: a recovery hint that mentions no tool is legitimate, so requiring one from each would fail on a correct hint. Counting mentions across all hints covers both failure modes — an empty `RECOVERY`, and a set where nothing matches — without inventing a rule the code does not have.

## Gates

`pnpm --filter @reticlehq/server test:unit` — **4518 passed, 466 files**. `format:check`, `lint`, `typecheck` green.
