### PR TITLE
presenter-shell: one AbortController instead of nine hand-rolled removals

### DIFF
--- a/packages/browser/src/presenter/presenter-shell.test.ts
+++ b/packages/browser/src/presenter/presenter-shell.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { Presenter } from './presenter.js';
+import { HudShell } from './presenter-shell.js';
 import { asSyntheticInput } from '../actions/synthetic-input.js';
 import { Annotator } from '../review/annotator.js';
 import { LOG_KIND } from './presenter-log.js';
@@ -352,5 +353,106 @@ describe('the activity feed opens at the newest row', () => {
     await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(() => r(null))));
     expect(log.scrollTop, 'a feed that grew after layout still ends at the bottom').toBe(1400);
     p.destroy();
+  });
+});
+
+/**
+ * Teardown has to actually remove what mount added.
+ *
+ * Every click handler in the shell is an anonymous closure over `this`, so there was no reference
+ * to hand `removeEventListener` and none of them was ever removed.
+ *
+ * Asserting the MECHANISM rather than a side effect, deliberately. The obvious test — destroy, then
+ * dispatch, then check nothing happened — passes whether or not the listeners were removed, because
+ * `destroy()` also removes the HUD from the DOM, so the handlers are unreachable either way. I wrote
+ * that version first and it stayed green with the `abort()` deleted, which is the vacuous-guard
+ * shape #455 is about. Recording every registration and checking its signal is aborted is the thing
+ * that actually goes red.
+ */
+describe('presenter HUD shell teardown', () => {
+  interface Registration {
+    type: string;
+    signal: AbortSignal | undefined;
+  }
+
+  /** Record every document-level registration and the signal (if any) it was given. */
+  const recordDocumentListeners = (): { seen: Registration[]; restore: () => void } => {
+    const seen: Registration[] = [];
+    const real = document.addEventListener.bind(document);
+    document.addEventListener = ((
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions,
+    ): void => {
+      const signal = 'object' === typeof options && null !== options ? options.signal : undefined;
+      seen.push({ type, signal });
+      real(type, listener, options);
+    }) as typeof document.addEventListener;
+    return { seen, restore: () => (document.addEventListener = real) };
+  };
+
+  it('registers its document listeners with a signal, and aborts it on teardown', () => {
+    // HudShell directly, not through Presenter: the settings, report and drag components register
+    // pointerdown/keydown on `document` too, and this change is scoped to one file. Driving the
+    // shell alone means the assertion is about the listeners this PR converted and nothing else.
+    document.body.innerHTML = '<div id="root"></div>';
+    const root = document.querySelector<HTMLElement>('#root');
+    if (null === root) throw new Error('no root');
+
+    const { seen, restore } = recordDocumentListeners();
+    const shell = new HudShell({});
+    shell.mount(root);
+    restore();
+
+    // Guards the guard: if the shell stops registering these, the loop below passes for free.
+    expect(seen.length, 'the shell should install its document listeners').toBe(2);
+    expect(seen.map((r) => r.type).sort()).toEqual(['keydown', 'pointerdown']);
+    for (const registration of seen) {
+      expect(
+        registration.signal,
+        `${registration.type} was registered with no signal`,
+      ).toBeDefined();
+      expect(registration.signal?.aborted, `${registration.type} aborted before teardown`).toBe(
+        false,
+      );
+    }
+
+    shell.teardown();
+
+    for (const registration of seen) {
+      expect(
+        registration.signal?.aborted,
+        `${registration.type} outlived teardown() — its signal was never aborted`,
+      ).toBe(true);
+    }
+  });
+
+  it('disconnects the toolbar MutationObserver on teardown', () => {
+    // A MutationObserver takes no signal, so it is not covered by the abort — and this disconnect
+    // was missing entirely, leaving the observer holding `root` after teardown.
+    document.body.innerHTML = '';
+    const disconnected: string[] = [];
+    const RealObserver = globalThis.MutationObserver;
+    class SpyObserver extends RealObserver {
+      override disconnect(): void {
+        disconnected.push('disconnect');
+        super.disconnect();
+      }
+    }
+    globalThis.MutationObserver = SpyObserver;
+    try {
+      document.body.innerHTML = '<div id="root"></div>';
+      const root = document.querySelector<HTMLElement>('#root');
+      if (null === root) throw new Error('no root');
+      const shell = new HudShell({});
+      shell.mount(root);
+      const before = disconnected.length;
+      shell.teardown();
+      expect(disconnected.length, 'teardown() disconnected no MutationObserver').toBeGreaterThan(
+        before,
+      );
+    } finally {
+      globalThis.MutationObserver = RealObserver;
+    }
   });
 });

--- a/packages/browser/src/presenter/presenter-shell.ts
+++ b/packages/browser/src/presenter/presenter-shell.ts
@@ -82,6 +82,15 @@ export class HudShell {
    */
   #annotateOn = false;
   #toggleSync: MutationObserver | undefined;
+  /**
+   * One signal for every listener this shell registers, so teardown cannot drift from mount.
+   *
+   * The click handlers below are anonymous closures over `this`: there is no reference to hand to
+   * `removeEventListener`, so before this they were never removed at all. Mounting twice onto the
+   * same root therefore stacked a second set, and every handler kept the shell reachable for as
+   * long as its element lived.
+   */
+  #listeners: AbortController | undefined;
   readonly #report = new PresenterReport({
     onBeforeOpen: () => {
       // One panel at a time in the slot above the toolbar. The chat, the settings and the report
@@ -196,6 +205,8 @@ export class HudShell {
     this.#annotateBtn?.setAttribute('data-active', on ? '1' : '0');
   }
   mount(root: HTMLElement): void {
+    this.#listeners = new AbortController();
+    const { signal } = this.#listeners;
     this.#root = root;
     this.#dock = root.querySelector<HTMLElement>(`[${DOCK_ATTR}]`) ?? undefined;
     const fabEl = root.querySelector(`[${FAB_ATTR}]`);
@@ -206,24 +217,36 @@ export class HudShell {
     this.#chatToggle = chatToggleEl instanceof HTMLElement ? chatToggleEl : undefined;
     const annotateEl = root.querySelector(`[${ANNOTATE_BTN_ATTR}]`);
     this.#annotateBtn = annotateEl instanceof HTMLButtonElement ? annotateEl : undefined;
-    this.#annotateBtn?.addEventListener('click', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      this.setAnnotateOn(!this.#annotateOn);
-      this.#callbacks.onAnnotateToggle?.(this.#annotateOn);
-    });
+    this.#annotateBtn?.addEventListener(
+      'click',
+      (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        this.setAnnotateOn(!this.#annotateOn);
+        this.#callbacks.onAnnotateToggle?.(this.#annotateOn);
+      },
+      { signal },
+    );
     const pillEl = root.querySelector(`[${CHAT_PILL_ATTR}]`);
-    pillEl?.addEventListener('click', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      this.showChat();
-    });
+    pillEl?.addEventListener(
+      'click',
+      (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        this.showChat();
+      },
+      { signal },
+    );
     const chatMinEl = root.querySelector(`[${CHAT_MIN_ATTR}]`);
-    chatMinEl?.addEventListener('click', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      this.closeChat();
-    });
+    chatMinEl?.addEventListener(
+      'click',
+      (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        this.closeChat();
+      },
+      { signal },
+    );
     const collapseEl = root.querySelector('[data-reticle-min-btn]');
     this.#collapseBtn = collapseEl instanceof HTMLButtonElement ? collapseEl : undefined;
     root.setAttribute(MIN_ATTR, '1');
@@ -241,27 +264,43 @@ export class HudShell {
       attributeFilter: [CHAT_ATTR, SETTINGS_ATTR, REPORT_ATTR],
     });
     this.#syncToolbarToggles();
-    root.querySelector(`[${REPORT_BTN_ATTR}]`)?.addEventListener('click', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      this.#report.toggle();
-    });
-    this.#fab?.addEventListener('click', (e) => {
-      e.stopPropagation();
-      if (this.#suppressFabClick) {
-        this.#suppressFabClick = false;
-        return;
-      }
-      this.expand();
-    });
-    this.#collapseBtn?.addEventListener('click', (e) => {
-      e.stopPropagation();
-      this.collapse();
-    });
-    this.#chatToggle?.addEventListener('click', (e) => {
-      e.stopPropagation();
-      this.toggleChat();
-    });
+    root.querySelector(`[${REPORT_BTN_ATTR}]`)?.addEventListener(
+      'click',
+      (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        this.#report.toggle();
+      },
+      { signal },
+    );
+    this.#fab?.addEventListener(
+      'click',
+      (e) => {
+        e.stopPropagation();
+        if (this.#suppressFabClick) {
+          this.#suppressFabClick = false;
+          return;
+        }
+        this.expand();
+      },
+      { signal },
+    );
+    this.#collapseBtn?.addEventListener(
+      'click',
+      (e) => {
+        e.stopPropagation();
+        this.collapse();
+      },
+      { signal },
+    );
+    this.#chatToggle?.addEventListener(
+      'click',
+      (e) => {
+        e.stopPropagation();
+        this.toggleChat();
+      },
+      { signal },
+    );
     const toolbarDrag = root.querySelector(`.${DRAG_HANDLE_CLASS}`);
     const dragHandles = [this.#fab, toolbarDrag].filter(
       (el): el is HTMLElement => el instanceof HTMLElement,
@@ -277,12 +316,19 @@ export class HudShell {
       });
       this.#layoutTeardown = installHudPositionGuards(this.#dock, root);
     }
-    document.addEventListener('pointerdown', this.#onDocPointerDown);
-    document.addEventListener('keydown', this.#onKeyDown);
+    document.addEventListener('pointerdown', this.#onDocPointerDown, { signal });
+    document.addEventListener('keydown', this.#onKeyDown, { signal });
   }
   teardown(): void {
-    document.removeEventListener('pointerdown', this.#onDocPointerDown);
-    document.removeEventListener('keydown', this.#onKeyDown);
+    // One call for all nine registrations. It cannot fall out of step with mount() the way a list
+    // of removeEventListener calls can, which is the whole point.
+    this.#listeners?.abort();
+    this.#listeners = undefined;
+    // NOT covered by the signal: a MutationObserver takes no `signal` option. This disconnect was
+    // missing entirely, so the observer kept `root` — and through it the shell — alive after
+    // teardown, and a re-mount left the previous one still firing.
+    this.#toggleSync?.disconnect();
+    this.#toggleSync = undefined;
     this.#dragTeardown?.();
     this.#dragTeardown = undefined;
     this.#layoutTeardown?.();


### PR DESCRIPTION
Part of #453 — `src/presenter/presenter-shell.ts`, one file as you asked.

## What was actually there

Mount registered **nine** listeners; teardown removed **two**. The other seven are anonymous closures over `this` on the toolbar buttons, so there was no reference to hand `removeEventListener` — they were never removed at all. Mounting twice onto the same root stacked a second set, and each handler kept the shell reachable for as long as its element lived.

All nine now take `{ signal }`; teardown is one `abort()`.

## One thing outside the stated scope

`#toggleSync` is a `MutationObserver`. The issue says to leave those `disconnect()` calls exactly as they are — but there was nothing to leave alone: **`teardown()` never disconnected it.** It kept observing `root`, and holding it, after teardown.

It takes no signal, so it is disconnected explicitly beside the abort with a comment saying why it is separate. Happy to split it out if you would rather keep this PR to the listener conversion.

## The tests assert the mechanism, and here is why

I wrote the obvious test first — destroy, dispatch, assert nothing happened — and **it passed with the `abort()` deleted**. `destroy()` also removes the HUD from the DOM, so the handlers are unreachable either way; the test was measuring the removal, not the fix. That is the vacuous-guard shape #455 is about, and I nearly shipped it.

What replaced it records each registration and asserts its signal is aborted after teardown. It is driven through `HudShell` directly rather than `Presenter`, because the settings, report and drag components register `pointerdown`/`keydown` on `document` too — through `Presenter` the filter caught 4 registrations, not this file's 2.

**Verified all three ways this can regress**, each turning exactly one test red:

| mutation | result |
|---|---|
| `abort()` removed from teardown | 1 failed \| 20 passed |
| `disconnect()` removed | 1 failed \| 20 passed |
| one listener registered without a signal | 1 failed \| 20 passed |

## Gates

`format:check`, `lint`, `typecheck` green. `pnpm --filter @reticlehq/browser test:unit` — **1101 passed, 118 files**.

Next I will take `presenter-controls.ts` and `presenter-drag.ts` in their own PRs, unless someone claims them first.
