### PR TITLE
presenter-controls: one AbortController instead of eight unremoved listeners

### DIFF
--- a/packages/browser/src/presenter/presenter-controls.test.ts
+++ b/packages/browser/src/presenter/presenter-controls.test.ts
@@ -377,3 +377,42 @@ describe('presenter-controls / live-control panel', () => {
     expect(snap.tree).not.toContain('secret guidance text');
   });
 });
+
+/**
+ * Teardown has to remove what mount added.
+ *
+ * All eight of this panel's listeners are anonymous closures over `this`, so there was no reference
+ * to hand `removeEventListener` and teardown removed none of them.
+ *
+ * Asserting the MECHANISM rather than a side effect: a test that tears down, clicks, and checks
+ * nothing happened passes either way once the HUD has left the DOM, so it measures the removal
+ * rather than the fix. Recording each registration and checking its signal is what goes red.
+ */
+describe('control panel teardown', () => {
+  it('registers its listeners with a signal, and aborts it on teardown', () => {
+    document.body.innerHTML = '';
+    const add = vi.spyOn(EventTarget.prototype, 'addEventListener');
+
+    const p = new Presenter({});
+    p.mount();
+    p.sessionStart();
+
+    const signals = add.mock.calls
+      .map(([, , options]) =>
+        'object' === typeof options && null !== options ? options.signal : undefined,
+      )
+      .filter((s): s is AbortSignal => s !== undefined);
+    add.mockRestore();
+
+    // Guards the guard: if nothing registers with a signal, the loop below passes for free.
+    expect(signals.length, 'the HUD should register listeners with a signal').toBeGreaterThan(0);
+    expect(signals.some((s) => s.aborted)).toBe(false);
+
+    p.destroy();
+
+    expect(
+      signals.every((s) => s.aborted),
+      'a signalled listener outlived destroy()',
+    ).toBe(true);
+  });
+});

--- a/packages/browser/src/presenter/presenter-controls.ts
+++ b/packages/browser/src/presenter/presenter-controls.ts
@@ -275,6 +275,14 @@ export class ControlPanel {
   /** The full replayable-flow list from the last push; re-filtered per page on route change. */
   #flowItems: FlowChip[] = [];
   #workspaceTeardown: (() => void) | undefined;
+  /**
+   * One signal for every listener this controller registers.
+   *
+   * All eight are anonymous closures over `this`, so there was no reference to hand
+   * `removeEventListener` and teardown removed none of them — each kept the controller reachable
+   * for as long as its element lived, and a second mount stacked another set on top.
+   */
+  #listeners: AbortController | undefined;
   readonly #host: ControlPanelHost;
 
   constructor(host: ControlPanelHost) {
@@ -285,6 +293,8 @@ export class ControlPanel {
   }
   /** Query control refs out of the mounted root and bind the DOM listeners, then paint active. */
   mount(root: HTMLElement, glow: HTMLElement | undefined): void {
+    this.#listeners = new AbortController();
+    const { signal } = this.#listeners;
     this.#root = root;
     this.#glow = glow;
     this.#refs = queryControlRefs(root);
@@ -292,28 +302,36 @@ export class ControlPanel {
     if (pauseBtn !== undefined) {
       paintPauseBtn(pauseBtn, this.#state === SessionState.PAUSED);
     }
-    this.#refs.pauseBtn?.addEventListener('click', () => this.#onPauseToggle());
-    this.#refs.endBtn?.addEventListener('click', () => this.#onEnd());
-    this.#refs.sendBtn?.addEventListener('click', () => this.#onSend());
-    this.#refs.input?.addEventListener('keydown', (e) => {
-      // Enter sends; Shift+Enter inserts a newline (falls through to the textarea's default).
-      if (e instanceof KeyboardEvent && 'Enter' === e.key && !e.shiftKey) {
-        e.preventDefault();
-        this.#onSend();
-      }
-    });
-    this.#refs.input?.addEventListener('input', () => this.#autosize());
+    this.#refs.pauseBtn?.addEventListener('click', () => this.#onPauseToggle(), { signal });
+    this.#refs.endBtn?.addEventListener('click', () => this.#onEnd(), { signal });
+    this.#refs.sendBtn?.addEventListener('click', () => this.#onSend(), { signal });
+    this.#refs.input?.addEventListener(
+      'keydown',
+      (e) => {
+        // Enter sends; Shift+Enter inserts a newline (falls through to the textarea's default).
+        if (e instanceof KeyboardEvent && 'Enter' === e.key && !e.shiftKey) {
+          e.preventDefault();
+          this.#onSend();
+        }
+      },
+      { signal },
+    );
+    this.#refs.input?.addEventListener('input', () => this.#autosize(), { signal });
     // Replay-a-flow: one ▶ click re-runs a saved flow (no agent). Delegated so it covers all chips.
-    this.#refs.flows?.addEventListener('click', (e) => {
-      const target = e.target;
-      if (!(target instanceof HTMLElement)) return;
-      const name = target.closest('[data-reticle-replay]')?.getAttribute('data-reticle-replay');
-      if (name !== null && name !== undefined && name.length > 0) {
-        this.#host.emit(HumanControlKind.REPLAY, name);
-      }
-    });
-    this.#refs.copyBtn?.addEventListener('click', () => this.#onCopy());
-    this.#refs.exportBtn?.addEventListener('click', () => this.#onExport());
+    this.#refs.flows?.addEventListener(
+      'click',
+      (e) => {
+        const target = e.target;
+        if (!(target instanceof HTMLElement)) return;
+        const name = target.closest('[data-reticle-replay]')?.getAttribute('data-reticle-replay');
+        if (name !== null && name !== undefined && name.length > 0) {
+          this.#host.emit(HumanControlKind.REPLAY, name);
+        }
+      },
+      { signal },
+    );
+    this.#refs.copyBtn?.addEventListener('click', () => this.#onCopy(), { signal });
+    this.#refs.exportBtn?.addEventListener('click', () => this.#onExport(), { signal });
     this.#workspaceTeardown = mountWorkspaceSelector(root);
     this.setState(SessionState.ACTIVE);
   }
@@ -349,6 +367,9 @@ export class ControlPanel {
   }
   /** Clear any pending ended-fade timer (called from Presenter.destroy). */
   teardown(): void {
+    // All eight registrations, in one call that cannot drift from mount().
+    this.#listeners?.abort();
+    this.#listeners = undefined;
     this.#workspaceTeardown?.();
     this.#workspaceTeardown = undefined;
     if (this.#fadeTimer !== undefined) nativeClearTimeout(this.#fadeTimer);


### PR DESCRIPTION
Part of #453 — `src/presenter/presenter-controls.ts`, one file. Follows #469 (`presenter-shell.ts`).

All eight registrations are anonymous closures over `this`, so there was no reference to hand `removeEventListener` and teardown removed **none** of them. `teardown()` already existed — for the workspace selector and the fade timer — so the listeners were the one thing it did not clean up. Each kept the panel reachable for as long as its element lived, and a second mount stacked another set.

All eight now take `{ signal }`; teardown aborts once.

## The test asserts the mechanism

Same reasoning as #469, and worth repeating because the obvious test is the wrong one: tearing down and then clicking passes whether or not anything was removed, since `destroy()` also takes the HUD out of the DOM. So this records the signal each registration was given and requires every one to be aborted afterwards, with a floor assertion (`toBeGreaterThan(0)`) so an empty set cannot pass for a check.

**Verified by deleting the `abort()`** — exactly one test goes red (`1 failed | 27 passed`).

Implementation note: the first version patched `EventTarget.prototype.addEventListener` by hand and tripped `@typescript-eslint/unbound-method`; `vi.spyOn` does the same job and lints clean.

## Gates

`format:check`, `lint`, `typecheck` green. Browser suite **1100 passed**.

`presenter-drag.ts` next — it is the interesting one, with 7 listeners across 3 targets including `window.visualViewport`.
