### PR TITLE
presenter-drag: one signal per installer, and tests that notice if it goes

### DIFF
--- a/packages/browser/src/presenter/presenter-drag.test.ts
+++ b/packages/browser/src/presenter/presenter-drag.test.ts
@@ -204,3 +204,73 @@ describe('presenter HUD drag', () => {
     teardown();
   });
 });
+
+/**
+ * Teardown has to remove what install added.
+ *
+ * Both installers were already symmetric — every addEventListener had a matching remove — so this
+ * is not a leak being fixed, it is the symmetry being made impossible to break. Which is only worth
+ * anything if something notices when it IS broken, and nothing did: deleting either `abort()` left
+ * the whole presenter suite green (187 passed).
+ */
+describe('presenter HUD drag teardown', () => {
+  it('installHudDrag stops driving the HUD after teardown', () => {
+    const hud = document.createElement('div');
+    const head = document.createElement('div');
+    document.body.append(hud, head);
+
+    let dragged = false;
+    const teardown = installHudDrag(hud, head, {
+      onDragMove: () => {
+        dragged = true;
+      },
+    });
+    teardown();
+
+    head.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: 420,
+        clientY: 320,
+        pointerId: 9,
+        button: 0,
+      }),
+    );
+    head.dispatchEvent(
+      new PointerEvent('pointermove', { bubbles: true, clientX: 500, clientY: 400, pointerId: 9 }),
+    );
+
+    expect(dragged, 'a pointer handler survived teardown').toBe(false);
+    expect(isHudDragged(hud), 'the HUD moved after teardown').toBe(false);
+  });
+
+  it('installHudPositionGuards releases its window listeners on teardown', () => {
+    const hud = document.createElement('div');
+    const overlay = document.createElement('div');
+    document.body.append(hud, overlay);
+
+    // Asserting the signal rather than a side effect: the guards react to resize by SCHEDULING a
+    // relayout, so a spy on the measurement sees nothing synchronously and the obvious behavioural
+    // test passes whether or not the listener was removed. I wrote that version first and it stayed
+    // green with the abort() deleted.
+    const add = vi.spyOn(window, 'addEventListener');
+    const teardown = installHudPositionGuards(hud, overlay);
+    const signals = add.mock.calls
+      .map(([, , options]) =>
+        'object' === typeof options && null !== options ? options.signal : undefined,
+      )
+      .filter((sig): sig is AbortSignal => sig !== undefined);
+    add.mockRestore();
+
+    // Guards the guard: no signalled registration would make the loop below pass for free.
+    expect(signals.length, 'the guards should register with a signal').toBeGreaterThan(0);
+    expect(signals.some((sig) => sig.aborted)).toBe(false);
+
+    teardown();
+
+    expect(
+      signals.every((sig) => sig.aborted),
+      'a window listener outlived teardown',
+    ).toBe(true);
+  });
+});

--- a/packages/browser/src/presenter/presenter-drag.ts
+++ b/packages/browser/src/presenter/presenter-drag.ts
@@ -106,8 +106,13 @@ export function installHudPositionGuards(hud: HTMLElement, overlay: HTMLElement)
     scheduleSyncDockLayout(hud, overlay);
   };
 
+  // One signal for all three listeners here. The observers below are NOT covered — neither
+  // ResizeObserver nor MutationObserver accepts one — so they keep their explicit disconnects.
+  const listeners = new AbortController();
+  const { signal } = listeners;
+
   const onResize = (): void => scheduleRelayout();
-  window.addEventListener('resize', onResize);
+  window.addEventListener('resize', onResize, { signal });
 
   let resizeObserver: ResizeObserver | undefined;
   if (typeof ResizeObserver !== 'undefined') {
@@ -122,13 +127,11 @@ export function installHudPositionGuards(hud: HTMLElement, overlay: HTMLElement)
   });
 
   const onVisualViewportResize = (): void => scheduleRelayout();
-  window.visualViewport?.addEventListener('resize', onVisualViewportResize);
-  window.visualViewport?.addEventListener('scroll', onVisualViewportResize);
+  window.visualViewport?.addEventListener('resize', onVisualViewportResize, { signal });
+  window.visualViewport?.addEventListener('scroll', onVisualViewportResize, { signal });
 
   return (): void => {
-    window.removeEventListener('resize', onResize);
-    window.visualViewport?.removeEventListener('resize', onVisualViewportResize);
-    window.visualViewport?.removeEventListener('scroll', onVisualViewportResize);
+    listeners.abort();
     resizeObserver?.disconnect();
     minObserver.disconnect();
   };
@@ -222,16 +225,17 @@ export function installHudDrag(
     finishDrag();
   };
 
-  head.addEventListener('pointerdown', onPointerDown);
-  head.addEventListener('pointermove', onPointerMove);
-  head.addEventListener('pointerup', onPointerUp);
-  head.addEventListener('pointercancel', onPointerCancel);
+  // All four pointer phases share one signal: they are added together and must come off
+  // together, and a partial removal would leave a half-live drag.
+  const listeners = new AbortController();
+  const { signal } = listeners;
+  head.addEventListener('pointerdown', onPointerDown, { signal });
+  head.addEventListener('pointermove', onPointerMove, { signal });
+  head.addEventListener('pointerup', onPointerUp, { signal });
+  head.addEventListener('pointercancel', onPointerCancel, { signal });
 
   return (): void => {
-    head.removeEventListener('pointerdown', onPointerDown);
-    head.removeEventListener('pointermove', onPointerMove);
-    head.removeEventListener('pointerup', onPointerUp);
-    head.removeEventListener('pointercancel', onPointerCancel);
+    listeners.abort();
     if (dragging) releaseCapture(activePointerId ?? 0);
     finishDrag();
   };


### PR DESCRIPTION
Part of #453 — `src/presenter/presenter-drag.ts`. Follows #469 and #470.

## This one had no leak, which changes what the PR is for

Unlike the other two files, this one was **already symmetric**: seven `addEventListener` calls, seven matching removals, nothing leaked. So this is not a bug fix — it is making the symmetry impossible to break.

That is only worth anything if something notices when it *is* broken, and nothing did: **deleting either `abort()` left the whole presenter suite green at 187 passed.** So both installers get a teardown test, which is the part of this PR with actual value.

## Two tests, tested two different ways, and why

- **`installHudDrag`** — behavioural, as the issue's recipe suggests: tear down, dispatch `pointerdown` + `pointermove`, require `onDragMove` never fires and the HUD did not move.
- **`installHudPositionGuards`** — asserts the signal instead. The behavioural version does not work here: the guards react to `resize` by *scheduling* a relayout, so a spy on the measurement sees nothing synchronously and the test passes whether or not the listener was removed. I wrote that first and it stayed green with the `abort()` deleted.

**Both verified to fail** on their own mutation — deleting the matching `abort()` turns exactly one test red in each case.

## Observers untouched

The `ResizeObserver` and `MutationObserver` keep their explicit `disconnect()` calls — neither takes a signal — with a comment at the controller saying so, per the issue's scope note.

## Gates

`format:check`, `lint`, `typecheck` green. Browser suite **1101 passed**.

That is the three presenter files. `observers/health.ts` (6), `observers/scroll.ts`, `focus.ts` and `animation.ts` are still open if you want me to keep going, but I would rather you look at one of these three first — if the test shape is not what you want, better to find out once than four times.
