### PR TITLE
feat: reticle_intent — capture what a change was meant to do, while somebody still knows

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -285,7 +285,7 @@ A verdict of `verified: "unknown"` is not a pass. It means Reticle drove the app
 
 Then report what you drove, what it produced, and the `file:line` for anything broken.
 
-The surface is deliberately small: `default` 18, `all` 28. Editors budget tools across every MCP server you have connected (Cursor allows 40 in total), so the count is capped rather than allowed to grow. `reticle_tools` loads the argument grammar for the rest on demand, and `reticle_run` invokes any of them by name. Nothing is unreachable; the cold tail just costs one discovery hop.
+The surface is deliberately small: `default` 18, `all` 29. Editors budget tools across every MCP server you have connected (Cursor allows 40 in total), so the count is capped rather than allowed to grow. `reticle_tools` loads the argument grammar for the rest on demand, and `reticle_run` invokes any of them by name. Nothing is unreachable; the cold tail just costs one discovery hop.
 
 - Batching, regression suites, reading a verdict: `https://docs.reticle.sh/agent-cheatsheet.md`
 - Every predicate and action: `https://docs.reticle.sh/predicates.md`, `https://docs.reticle.sh/actions.md`

--- a/apps/e2e/specs/tool-surface-sweep-test.mjs
+++ b/apps/e2e/specs/tool-surface-sweep-test.mjs
@@ -23,7 +23,7 @@
 //   - no response tells the agent its own bad call may be a Reticle bug;
 //   - the tools that require a driven browser actually work when one is driven.
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { McpStdioClient } from '../../../bench/harness/mcp-client.mjs';
 import { waitForSession } from '../wait-for-session.mjs';
 
@@ -52,11 +52,19 @@ const RUN_TOOL = 'reticle_run';
  * floor of 40 here outlived that change by a whole release and failed the battery on the cap
  * working as designed.
  */
-// 28 since change/flows/affected/coverage/crawl merged into `reticle_verify` — three of those five
-// were advertised here, so one name stands where three did. Kept in step with
-// `surface-sizes.test.ts`, which asserts the same number in the fast gate; this is the check that it
-// is true over a REAL MCP connection rather than over an in-process list.
-const EXTENDED_SURFACE_SIZE = 28;
+// Derived, not restated. This was a hardcoded 28 with a comment promising it was "kept in step
+// with surface-sizes.test.ts", which is the same promise that file makes about every other copy of
+// the number: it is the single source and everything else points at it. A fifth copy living out
+// here could only be kept in step by remembering, and adding `reticle_intent` is exactly the moment
+// nobody does. The unit gate cannot see this file, so the drift surfaced eight minutes into the
+// battery instead of in the fast gate.
+//
+// Reading it from the built server keeps the check meaningful: the assertion below is still that a
+// REAL MCP connection advertises the surface, and it is now impossible for it to disagree with the
+// surface for the boring reason.
+const { TOOL_SURFACE } = await import(pathToFileURL(path.join(ROOT, 'packages/server/dist/tools/tool-surface.js')).href);
+const { advertisedTools } = await import(pathToFileURL(path.join(ROOT, 'packages/server/dist/mcp/mcp.js')).href);
+const EXTENDED_SURFACE_SIZE = advertisedTools(TOOL_SURFACE.ALL).length;
 
 const client = new McpStdioClient(
   'node',

--- a/bench/harness/gate.mjs
+++ b/bench/harness/gate.mjs
@@ -12,9 +12,10 @@
 //   - selector detection not full, or consequence detection not full (REPLAY)
 //   - per-run replay tokens rise > TOKEN_TOL vs the last row (REPLAY)
 import { readFileSync, existsSync } from 'node:fs';
+import { TOKEN_TOL, declaredBudgetOf, tokenVerdict } from './token-budget.mjs';
+import { parityVerdict } from './playwright-parity.mjs';
 
 const VE_TOL = 0.03; // VE may dip at most 3% vs last (noise) before it's a regression
-const TOKEN_TOL = 0.05; // per-run replay tokens may rise at most 5% vs last
 
 function readRaw(path) {
   return existsSync(path) ? JSON.parse(readFileSync(path, 'utf8')) : null;
@@ -130,6 +131,21 @@ if (analysis !== null) {
 
   if (rcr === null || rcr < 1.0) failures.push(`RCR floor: reticle RCR=${rcr} (must be 1.0)`);
   if (fp > 0) failures.push(`false positives: reticle FP=${fp} (must be 0)`);
+
+  // The claim the product is SOLD on, and until now the only one nothing defended: every other
+  // dimension here compares us against ourselves, so none would notice the day we drift past
+  // Playwright. See playwright-parity.mjs for why the two halves are not symmetric.
+  const parity = parityVerdict({
+    reticle,
+    playwright: analysis.per_tool?.playwright ?? {},
+    declaredCostlier: analysis.cost?.playwright_parity?.costlier_because,
+  });
+  if (!parity.ok) failures.push(parity.reason);
+  scorecard.push([
+    'Observe · vs Playwright',
+    `${analysis.per_tool?.playwright?.avg_tokens_o200k ?? '—'} tok @ ${analysis.per_tool?.playwright?.detection_accuracy ?? '—'}`,
+    `${reticle.avg_tokens_o200k ?? '—'} tok @ ${reticle.detection_accuracy ?? '—'}`,
+  ]);
   const lastVe = prev?.per_tool?.reticle?.ve ?? null;
   if (lastVe !== null && ve !== null && ve < lastVe * (1 - VE_TOL)) {
     failures.push(
@@ -208,13 +224,17 @@ if (stateOracle !== null) {
 if (cost !== null) {
   const now = cost.per_run?.reticle_replay_mean_tokens ?? null;
   const last = lastC?.replay_mean_tokens ?? null;
-  if (last !== null && now !== null && now > last * (1 + TOKEN_TOL)) {
-    failures.push(
-      `replay tokens rose: ${now} > ${last} (+${(((now - last) / last) * 100).toFixed(1)}%)`,
-    );
-  }
+  // A rise is either chosen or unnoticed, and the gate cannot tell those apart on its own. A run
+  // that MEANT to spend more declares it; anything else is drift. See token-budget.mjs.
+  const budget = declaredBudgetOf(cost);
+  const tokens = tokenVerdict({ now, last, budget });
+  if (!tokens.ok) failures.push(tokens.reason);
   note('Replay · tokens/run', last, now);
-  scorecard.push(['Replay · tokens/run', last ?? '—', now]);
+  scorecard.push([
+    'Replay · tokens/run',
+    last ?? '—',
+    budget > 0 ? `${now} (+${budget} declared)` : now,
+  ]);
 }
 
 // ---- Report ----

--- a/bench/harness/playwright-parity.mjs
+++ b/bench/harness/playwright-parity.mjs
@@ -1,0 +1,96 @@
+/**
+ * Does Reticle still catch more than Playwright, and still cost less to do it?
+ *
+ * Every other gated dimension compares us against OURSELVES — catch-rate, efficiency and replay
+ * tokens are all measured against the previous row. Those catch a regression, and none of them would
+ * notice the day our numbers drift past Playwright's, because the two are never compared. The most
+ * quotable claim this product makes is the one nothing defends.
+ *
+ * ## The two halves are deliberately not symmetric
+ *
+ * **Detection below Playwright's is a hard failure.** It is the thesis, not a metric: a verification
+ * layer that catches less than the tool it claims to beat has no argument left, and no amount of
+ * token saving redeems it. There is no declared override for this half, on purpose — a budget buys
+ * bytes, it does not buy the claim.
+ *
+ * **Costing more than Playwright is a positioning change.** That may genuinely be the right trade
+ * for context that earns it — intent, gaps, observability all cost bytes deliberately. So it can be
+ * declared. What it cannot be is drifted into silently across three releases until somebody notices
+ * the headline no longer holds.
+ *
+ * Absent measurements FAIL rather than pass. A green that means "we did not measure" is the worst
+ * outcome available here, because it reads exactly like a green that means "we checked".
+ */
+
+/** Run-to-run noise on a 12-scenario sample; below this a token difference is not a signal. */
+const NOISE_TOL = 0.02;
+
+function measured(value) {
+  return 'number' === typeof value && Number.isFinite(value);
+}
+
+/**
+ * Compare the two columns of the observation pass.
+ *
+ * `declaredCostlier` is the prose reason a run is allowed to cost more than Playwright — supplied by
+ * the caller from the fresh row, so the justification lives with the measurement it justifies rather
+ * than in a commit message nobody reads next year.
+ */
+export function parityVerdict({ reticle, playwright, declaredCostlier } = {}) {
+  const ourTokens = reticle?.avg_tokens_o200k;
+  const theirTokens = playwright?.avg_tokens_o200k;
+  const ourDetection = reticle?.detection_accuracy;
+  const theirDetection = playwright?.detection_accuracy;
+
+  if (
+    !measured(ourTokens) ||
+    !measured(theirTokens) ||
+    !measured(ourDetection) ||
+    !measured(theirDetection)
+  ) {
+    return {
+      ok: false,
+      reason:
+        'Reticle vs Playwright was not measured on this run, so parity is unknown. Treating that as a ' +
+        'pass would be a green that means "we did not look", which reads identically to one that means ' +
+        '"we checked". Run the observation pass (`bench-all --full`) before gating.',
+    };
+  }
+
+  if (ourDetection < theirDetection) {
+    return {
+      ok: false,
+      reason:
+        `Reticle catches less than Playwright: ${String(ourDetection)} vs ${String(theirDetection)} ` +
+        `detection accuracy. This is the product's central claim, not a metric, and there is no ` +
+        `declared override for it — a token budget buys bytes, not the thesis.`,
+    };
+  }
+
+  if (ourTokens > theirTokens * (1 + NOISE_TOL)) {
+    if ('string' === typeof declaredCostlier && declaredCostlier.length > 0) {
+      return {
+        ok: true,
+        reason:
+          `Reticle costs more than Playwright (${String(ourTokens)} vs ${String(theirTokens)}) and ` +
+          `that was declared: ${declaredCostlier}`,
+      };
+    }
+    return {
+      ok: false,
+      reason:
+        `Reticle costs more than Playwright and nobody said it would: ${String(ourTokens)} vs ` +
+        `${String(theirTokens)} average tokens. Catching more while costing less is the claim this ` +
+        `product is sold on, so losing half of it is a positioning change and should be a decision. ` +
+        `If the extra bytes buy something, declare it as ` +
+        `{ cost: { playwright_parity: { costlier_because } } } on this run's row.`,
+    };
+  }
+
+  return {
+    ok: true,
+    reason:
+      `Reticle ${String(ourTokens)} tokens at ${String(ourDetection)} detection vs Playwright ` +
+      `${String(theirTokens)} at ${String(theirDetection)} — cheaper and at least as complete.`,
+  };
+}

--- a/bench/harness/playwright-parity.test.mjs
+++ b/bench/harness/playwright-parity.test.mjs
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { parityVerdict } from './playwright-parity.mjs';
+
+/**
+ * The claim this product is sold on is that Reticle catches more than Playwright and costs less to
+ * do it. Nothing in the repo defends it.
+ *
+ * Every existing gated dimension compares us against OURSELVES — catch-rate, efficiency, replay
+ * tokens, all against the last row. Those catch a regression. None of them would notice the day
+ * Playwright's numbers move, or the day ours drift past theirs, because neither is measured against
+ * the other. The most quotable claim we make is the one with no test behind it.
+ *
+ * Both halves are gated, and they are not symmetric. Detection falling below Playwright's is a
+ * failure with no honest excuse — it is the whole thesis. Costing more than Playwright is a
+ * POSITIONING CHANGE, which may sometimes be the right trade for context that earns it, so it can be
+ * declared. It cannot be drifted into silently.
+ */
+
+const at = (tokens, accuracy) => ({ avg_tokens_o200k: tokens, detection_accuracy: accuracy });
+
+describe('parityVerdict', () => {
+  it('passes when Reticle is cheaper and catches more', () => {
+    expect(parityVerdict({ reticle: at(1106, 1), playwright: at(1209, 0.909) }).ok).toBe(true);
+  });
+
+  it('passes when Reticle catches the same and costs the same', () => {
+    expect(parityVerdict({ reticle: at(1000, 0.9), playwright: at(1000, 0.9) }).ok).toBe(true);
+  });
+
+  /**
+   * The half with no excuse. If Reticle catches less than the tool it claims to beat, the product's
+   * central sentence is false and no amount of token saving redeems it.
+   */
+  it('FAILS when Reticle catches less, however cheap it got', () => {
+    const v = parityVerdict({ reticle: at(10, 0.8), playwright: at(1209, 0.909) });
+    expect(v.ok).toBe(false);
+    expect(v.reason).toContain('catches less');
+  });
+
+  it('fails on a detection drop even with a declared token budget', () => {
+    // A budget buys tokens. It does not buy the thesis.
+    const v = parityVerdict({
+      reticle: at(1106, 0.8),
+      playwright: at(1209, 0.909),
+      declaredCostlier: 'intent capture',
+    });
+    expect(v.ok).toBe(false);
+  });
+
+  it('fails when Reticle costs more and nobody said it would', () => {
+    const v = parityVerdict({ reticle: at(1400, 1), playwright: at(1209, 0.909) });
+    expect(v.ok).toBe(false);
+    expect(v.reason).toContain('costs more');
+  });
+
+  /**
+   * The deliberate case: context that earns its bytes. Allowed, but only when somebody wrote down
+   * that they meant it — a positioning change should be a decision, not a drift.
+   */
+  it('passes a costlier run when it is declared, and echoes the stated reason', () => {
+    const v = parityVerdict({
+      reticle: at(1400, 1),
+      playwright: at(1209, 0.909),
+      declaredCostlier: 'intent + gap context, measured worth it',
+    });
+    expect(v.ok).toBe(true);
+    expect(v.reason).toContain('intent + gap context');
+  });
+
+  it('tolerates run-to-run noise rather than firing on a rounding difference', () => {
+    expect(parityVerdict({ reticle: at(1215, 1), playwright: at(1209, 0.909) }).ok).toBe(true);
+  });
+
+  /**
+   * Absent evidence is not evidence of parity. A pass here would be the worst possible failure —
+   * a green that means "we did not measure".
+   */
+  it('does not pass when either side was not measured', () => {
+    const missing = parityVerdict({ reticle: at(null, null), playwright: at(1209, 0.909) });
+    expect(missing.ok).toBe(false);
+    expect(missing.reason).toContain('not measured');
+    expect(parityVerdict({ reticle: at(1106, 1), playwright: at(null, null) }).ok).toBe(false);
+    expect(parityVerdict({}).ok).toBe(false);
+  });
+});

--- a/bench/harness/token-budget.mjs
+++ b/bench/harness/token-budget.mjs
@@ -1,0 +1,69 @@
+/**
+ * Whether a rise in per-run replay tokens was chosen or merely happened.
+ *
+ * The gate cannot tell those apart on its own, and they need opposite responses. Reticle is adding
+ * context deliberately — instrumentation gaps, observability, intent — and each costs bytes on
+ * purpose. But loosening the tolerance to make room for that would remove the only thing that
+ * catches the other kind, and the other kind is real: read-only calls are roughly half the tool
+ * surface and the two largest payloads we emit are both reads. That is slack, not intent, and
+ * nothing else in the repo would notice it growing.
+ *
+ * So: a deliberate rise is DECLARED, not absorbed. The 2.9.0 history row already does this in prose
+ * — it documents a +16% rise, names the feature that caused it, and verifies it against the pre-merge
+ * build. This turns that paragraph into a field the gate can read.
+ *
+ * ## Two properties that keep it honest
+ *
+ * **A budget is spent, not standing.** It is measured against the LAST row, so declaring +50 once
+ * does not license +50 again on every release after it. Otherwise the ceiling ratchets and the gate
+ * quietly stops meaning anything, which is worse than not having it.
+ *
+ * **An unreadable budget is zero, never unlimited.** A corrupt or half-written row must not turn
+ * into a permanently open gate — the failure that costs the most is the one that looks like a pass.
+ *
+ * Separate from `gate.mjs` so this logic is unit-tested. The gate itself has no test harness, which
+ * is exactly why the rule it enforces should not live inside it.
+ */
+
+/** Per-run replay tokens may rise this much against the last row before it counts as drift. */
+export const TOKEN_TOL = 0.05;
+
+/**
+ * The extra tokens a row declared it intends to spend, in absolute terms.
+ *
+ * Absolute rather than a percentage on purpose: "this feature adds about forty tokens to a reply" is
+ * a claim somebody can check against the diff, and "+15%" is not.
+ */
+export function declaredBudgetOf(row) {
+  const declared = row?.cost?.token_budget?.extra_tokens;
+  if ('number' !== typeof declared || !Number.isFinite(declared) || declared <= 0) return 0;
+  return declared;
+}
+
+/**
+ * Did per-run tokens move more than was allowed for?
+ *
+ * Returns `{ ok, reason }` rather than throwing, so the caller decides whether a failure is fatal —
+ * the gate collects several and reports them together rather than dying on the first.
+ */
+export function tokenVerdict({ now, last, budget }) {
+  if (null === last || undefined === last || null === now || undefined === now) {
+    return { ok: true, reason: 'no baseline to compare against' };
+  }
+  const allowed = last * (1 + TOKEN_TOL) + (budget ?? 0);
+  if (now <= allowed) return { ok: true, reason: 'within tolerance and declared budget' };
+
+  const overrun = Math.round(now - allowed);
+  const declared =
+    0 === (budget ?? 0)
+      ? 'undeclared — no `cost.token_budget` on the fresh row'
+      : `over its declared budget of +${String(budget)}`;
+  return {
+    ok: false,
+    reason:
+      `per-run replay tokens ${String(now)} vs ${String(last)} is ${declared}, by ${String(overrun)} ` +
+      `tokens beyond the 5% noise tolerance. A rise somebody CHOSE is not a regression — declare it ` +
+      `as { cost: { token_budget: { extra_tokens, reason } } } on this run's row and say what buys ` +
+      `it. A rise nobody chose is the thing this gate exists for.`,
+  };
+}

--- a/bench/harness/token-budget.test.mjs
+++ b/bench/harness/token-budget.test.mjs
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { TOKEN_TOL, declaredBudgetOf, tokenVerdict } from './token-budget.mjs';
+
+/**
+ * A rise in tokens is either something we chose or something we did not notice, and the gate cannot
+ * tell those apart on its own.
+ *
+ * Reticle is adding context deliberately — intent, gaps, observability — and each of those costs
+ * bytes on purpose. Absorbing that by loosening the tolerance would remove the only thing that
+ * catches the OTHER kind, and the other kind is real: read-only calls are about half the tool
+ * surface, and the two largest payloads we emit are both reads. That is slack, not intent.
+ *
+ * So a deliberate rise must be DECLARED, not absorbed. The repo already does this in prose — the
+ * 2.9.0 row documents a +16% rise, names the feature that caused it, and verifies it against the
+ * pre-merge build. This makes that a field the gate reads instead of a paragraph it cannot.
+ */
+
+const row = (tokens, budget) => ({
+  cost: { replay_mean_tokens: tokens, ...(budget === undefined ? {} : { token_budget: budget }) },
+});
+
+describe('declaredBudgetOf', () => {
+  it('is zero when a row declares no budget — the honest default', () => {
+    expect(declaredBudgetOf(row(278))).toBe(0);
+  });
+
+  it('reads a declared budget', () => {
+    expect(declaredBudgetOf(row(278, { extra_tokens: 40, reason: 'intent ledger' }))).toBe(40);
+  });
+
+  it('is zero for a malformed or missing row rather than an excuse', () => {
+    // A budget that cannot be read must never read as "unlimited" — that would turn a corrupt file
+    // into a permanently open gate.
+    expect(declaredBudgetOf(null)).toBe(0);
+    expect(declaredBudgetOf({})).toBe(0);
+    expect(declaredBudgetOf(row(278, { reason: 'no number' }))).toBe(0);
+    expect(declaredBudgetOf(row(278, { extra_tokens: -50, reason: 'negative' }))).toBe(0);
+  });
+});
+
+describe('tokenVerdict', () => {
+  it('passes when tokens did not move', () => {
+    expect(tokenVerdict({ now: 278, last: 278, budget: 0 }).ok).toBe(true);
+  });
+
+  it('passes a rise inside the noise tolerance', () => {
+    expect(tokenVerdict({ now: 285, last: 278, budget: 0 }).ok).toBe(true);
+  });
+
+  it('fails an undeclared rise past the tolerance', () => {
+    const v = tokenVerdict({ now: 320, last: 278, budget: 0 });
+    expect(v.ok).toBe(false);
+    expect(v.reason).toContain('undeclared');
+  });
+
+  /**
+   * The point of the whole mechanism: a rise somebody chose, and said so, is not a regression.
+   */
+  it('passes a rise that fits inside a declared budget', () => {
+    expect(tokenVerdict({ now: 320, last: 278, budget: 50 }).ok).toBe(true);
+  });
+
+  it('fails a rise that OVERRUNS its declared budget, and says by how much', () => {
+    const v = tokenVerdict({ now: 400, last: 278, budget: 50 });
+    expect(v.ok).toBe(false);
+    expect(v.reason).toContain('400');
+    expect(v.reason).toContain('50');
+  });
+
+  /**
+   * A budget is spent, not standing. Declaring +50 once must not license +50 on every release after
+   * it, or the ceiling ratchets forever and the gate quietly stops meaning anything.
+   */
+  it('measures the budget against the LAST row, so it cannot be reused release after release', () => {
+    // Release A declared +50 and landed at 328. Release B declares nothing and stays at 328: fine.
+    expect(tokenVerdict({ now: 328, last: 328, budget: 0 }).ok).toBe(true);
+    // Release B tries to spend A's budget again.
+    expect(tokenVerdict({ now: 378, last: 328, budget: 0 }).ok).toBe(false);
+  });
+
+  it('always passes when there is no baseline to compare against', () => {
+    expect(tokenVerdict({ now: 278, last: null, budget: 0 }).ok).toBe(true);
+    expect(tokenVerdict({ now: 278, last: undefined, budget: 0 }).ok).toBe(true);
+  });
+
+  it('always passes when this run measured nothing', () => {
+    expect(tokenVerdict({ now: null, last: 278, budget: 0 }).ok).toBe(true);
+  });
+
+  it('never fails a DROP, however large', () => {
+    expect(tokenVerdict({ now: 100, last: 278, budget: 0 }).ok).toBe(true);
+  });
+
+  it('states the tolerance it used, so the number is checkable', () => {
+    expect(TOKEN_TOL).toBe(0.05);
+    expect(tokenVerdict({ now: 320, last: 278, budget: 0 }).reason).toContain('5%');
+  });
+});

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -223,6 +223,8 @@ export const ReticleDir = {
    * questions about the product; this answers the user's question about their own work.
    */
   IMPACT_FILE: 'impact.json',
+  /** what changes were SUPPOSED to make true —.reticle/intent.json (git-checked, reviewed) */
+  INTENT_FILE: 'intent.json',
   /** opt-in pixel baselines —.reticle/visual/<name>.png + <name>.diff.png. */
   VISUAL_SUBDIR: 'visual',
   /** verification-run artifacts —.reticle/runs/<runId>.json (the OEM/CI-consumable verdict). */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export * from './browser-misdirect.js';
 // ── INTERNAL cross-package plumbing (shared impl; not a stable outside API — may change in a minor) ─
 export * from './daemon-registry.js'; // daemon discovery, used by the vite plugin + server
 export * from './project-registry.js'; // projectId -> directory, so a cross-repo daemon can still resolve
+export * from './intent.js'; // what a change was supposed to make true, captured while somebody knows
 export * from './instrumentation-gap.js'; // what Reticle could not see, and the change that would let it
 export * from './security.js'; // sanitize/serialize helpers shared by browser + server
 export * from './redaction.js'; // isSensitiveKey / scrubKnownSecrets — the shared redaction rules

--- a/packages/core/src/intent.test.ts
+++ b/packages/core/src/intent.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest';
+import {
+  IntentState,
+  INTENT_FILE_VERSION,
+  IntentFileSchema,
+  bindIntent,
+  declareIntent,
+  dischargeIntent,
+  emptyIntentFile,
+  openIntents,
+  upsertIntent,
+} from './intent.js';
+
+/**
+ * An agent building a feature knows what it is for. That knowledge is in its context, and then the
+ * turn ends and the context goes. Later — a different turn, a different session, a different model —
+ * something drives the app and has to decide whether the feature works, with the DOM, the diff, and
+ * no intent. So it asserts what it can SEE rather than what was MEANT, and what it can see is
+ * weaker.
+ *
+ * The prose is captured EARLY, where fidelity is highest and bindability is zero. The predicate is
+ * bound LATE, where bindability is highest and fidelity has decayed. Capturing at either end alone
+ * loses one of the two.
+ */
+
+const NOW = 1_000;
+
+describe('declareIntent', () => {
+  it('captures the prose without demanding a predicate', () => {
+    const intent = declareIntent({
+      id: 'itn_checkin',
+      statement: 'A user who clicks Send check-in sees the trip badge read "checked in"',
+      now: NOW,
+    });
+    expect(intent.statement).toContain('checked in');
+    expect(intent.state).toBe(IntentState.DECLARED);
+    expect(intent.binding).toBeUndefined();
+  });
+
+  /**
+   * The whole reason the prose is mandatory and the predicate is not. At declare time there is no
+   * route, no ref and often no code — demanding a predicate there would collect mechanisms, which is
+   * what we already have.
+   */
+  it('is DECLARED, not bound, until something says how it would be proved', () => {
+    const intent = declareIntent({ id: 'i1', statement: 'users can recover a password', now: NOW });
+    expect(intent.state).toBe(IntentState.DECLARED);
+  });
+
+  it('records when and against what it was declared', () => {
+    const intent = declareIntent({
+      id: 'i1',
+      statement: 's',
+      now: NOW,
+      surface: { route: '/trips', files: ['TripCard.tsx'] },
+    });
+    expect(intent.declaredAt).toBe(NOW);
+    expect(intent.surface?.route).toBe('/trips');
+  });
+});
+
+describe('bindIntent', () => {
+  it('moves a declared intent to BOUND once a predicate exists', () => {
+    const bound = bindIntent(declareIntent({ id: 'i1', statement: 's', now: NOW }), {
+      kind: 'text',
+      value: 'checked in',
+    });
+    expect(bound.state).toBe(IntentState.BOUND);
+    expect(bound.binding).toEqual({ kind: 'text', value: 'checked in' });
+  });
+
+  it('leaves the prose exactly as declared', () => {
+    const declared = declareIntent({ id: 'i1', statement: 'the original words', now: NOW });
+    expect(bindIntent(declared, { kind: 'text' }).statement).toBe('the original words');
+  });
+
+  it('does not mutate what it was given', () => {
+    const declared = declareIntent({ id: 'i1', statement: 's', now: NOW });
+    bindIntent(declared, { kind: 'text' });
+    expect(declared.state).toBe(IntentState.DECLARED);
+    expect(declared.binding).toBeUndefined();
+  });
+});
+
+describe('dischargeIntent', () => {
+  /**
+   * A verdict discharges an intent. Deliberately not a separate call an agent has to remember —
+   * that would be the same forgetting problem one layer up.
+   */
+  it('records WHICH verdict proved it, and at what grade', () => {
+    const bound = bindIntent(declareIntent({ id: 'i1', statement: 's', now: NOW }), {
+      kind: 'net',
+    });
+    const proved = dischargeIntent(bound, { verdictId: 'v_7', grade: 'signal', at: 2_000 });
+    expect(proved.state).toBe(IntentState.PROVED);
+    expect(proved.provenBy).toEqual({ verdictId: 'v_7', grade: 'signal', at: 2_000 });
+  });
+
+  /**
+   * The grade is kept because a downgrade is the thing worth noticing later: an intent once proved
+   * at signal grade and later only at DOM-text grade is a weakening, and without the grade recorded
+   * there is nothing to compare against.
+   */
+  it('keeps the grade so a later weakening is detectable', () => {
+    const bound = bindIntent(declareIntent({ id: 'i1', statement: 's', now: NOW }), {
+      kind: 'net',
+    });
+    expect(dischargeIntent(bound, { verdictId: 'v', grade: 'dom', at: 1 }).provenBy?.grade).toBe(
+      'dom',
+    );
+  });
+
+  it('refuses to discharge an intent nothing could have proved', () => {
+    // No binding means no predicate was ever satisfied, so a discharge would be a claim with no
+    // evidence behind it — exactly the shape this whole feature exists to stop.
+    const declared = declareIntent({ id: 'i1', statement: 's', now: NOW });
+    expect(dischargeIntent(declared, { verdictId: 'v', grade: 'dom', at: 1 })).toBe(declared);
+  });
+});
+
+describe('upsertIntent — amendments are append-only', () => {
+  /**
+   * A long build changes its mind. The ledger keeps the history rather than overwriting, so a
+   * NARROWING amendment shows up in the git diff — which is the only real defence against an agent
+   * quietly rewriting intent to match what it can already prove.
+   */
+  it('keeps the previous statement when an intent is amended', () => {
+    let file = upsertIntent(
+      emptyIntentFile(),
+      declareIntent({ id: 'i1', statement: 'first', now: 1 }),
+    );
+    file = upsertIntent(file, declareIntent({ id: 'i1', statement: 'second', now: 2 }));
+    const entry = file.intents['i1'];
+    expect(entry?.statement).toBe('second');
+    expect(entry?.amended).toEqual([{ statement: 'first', at: 1 }]);
+  });
+
+  it('does not record an amendment when nothing changed', () => {
+    let file = upsertIntent(
+      emptyIntentFile(),
+      declareIntent({ id: 'i1', statement: 'same', now: 1 }),
+    );
+    file = upsertIntent(file, declareIntent({ id: 'i1', statement: 'same', now: 2 }));
+    expect(file.intents['i1']?.amended).toBeUndefined();
+  });
+
+  it('keeps other intents untouched', () => {
+    let file = upsertIntent(emptyIntentFile(), declareIntent({ id: 'a', statement: 'A', now: 1 }));
+    file = upsertIntent(file, declareIntent({ id: 'b', statement: 'B', now: 2 }));
+    expect(Object.keys(file.intents).sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('openIntents', () => {
+  it('is everything not yet proved', () => {
+    let file = emptyIntentFile();
+    file = upsertIntent(file, declareIntent({ id: 'a', statement: 'A', now: 1 }));
+    file = upsertIntent(
+      file,
+      bindIntent(declareIntent({ id: 'b', statement: 'B', now: 1 }), { kind: 'text' }),
+    );
+    file = upsertIntent(
+      file,
+      dischargeIntent(
+        bindIntent(declareIntent({ id: 'c', statement: 'C', now: 1 }), { kind: 'net' }),
+        {
+          verdictId: 'v',
+          grade: 'net',
+          at: 2,
+        },
+      ),
+    );
+    expect(
+      openIntents(file)
+        .map((i) => i.id)
+        .sort(),
+    ).toEqual(['a', 'b']);
+  });
+
+  /**
+   * An intent that stays DECLARED and never becomes BOUND is not a failure of the agent — it is the
+   * most interesting row in the ledger. Something was meant that nothing can currently prove.
+   */
+  it('includes a declared-but-unbound intent, because that is the interesting one', () => {
+    const file = upsertIntent(
+      emptyIntentFile(),
+      declareIntent({ id: 'a', statement: 'A', now: 1 }),
+    );
+    expect(openIntents(file)).toHaveLength(1);
+    expect(openIntents(file)[0]?.state).toBe(IntentState.DECLARED);
+  });
+
+  it('is empty for an empty ledger', () => {
+    expect(openIntents(emptyIntentFile())).toEqual([]);
+  });
+});
+
+describe('the on-disk file', () => {
+  it('is versioned, so a later shape change is not a silent misread', () => {
+    expect(emptyIntentFile().version).toBe(INTENT_FILE_VERSION);
+  });
+
+  it('parses a well-formed file', () => {
+    const file = upsertIntent(
+      emptyIntentFile(),
+      declareIntent({ id: 'a', statement: 'A', now: 1 }),
+    );
+    expect(IntentFileSchema.safeParse(file).success).toBe(true);
+  });
+
+  it('rejects a malformed one rather than half-reading it', () => {
+    expect(IntentFileSchema.safeParse({ version: 1, intents: { a: {} } }).success).toBe(false);
+    expect(IntentFileSchema.safeParse({ intents: {} }).success).toBe(false);
+    expect(IntentFileSchema.safeParse('nonsense').success).toBe(false);
+  });
+});

--- a/packages/core/src/intent.ts
+++ b/packages/core/src/intent.ts
@@ -1,0 +1,158 @@
+import { z } from 'zod';
+
+/**
+ * What a change was supposed to make true, captured while somebody still knows.
+ *
+ * An agent building a feature knows what it is for — which user does what, what should become true,
+ * what the failure looks like. That knowledge lives in its context, and then the turn ends. Later, a
+ * different turn or a different model drives the app and has to decide whether the feature works,
+ * holding the DOM, the diff, and no intent. So it asserts what it can SEE rather than what was
+ * MEANT, and what it can see is almost always weaker. That gap is where a false green comes from.
+ *
+ * ## Why the prose is captured early and the predicate late
+ *
+ * Intent has two properties that move in opposite directions over the life of a task.
+ *
+ * **Fidelity** is highest the moment the human asks and decays from there; every later restatement
+ * is a lossy re-derivation. **Bindability** — whether it can be written as something checkable — is
+ * near zero then, because there is no route, no ref and often no code, and rises as the code
+ * appears.
+ *
+ * Capture at either end alone loses one of them. Demanding a predicate at declare time collects
+ * MECHANISMS, which is what assertions already are. Waiting until drive time collects a
+ * RE-DERIVATION, which is the weak artifact this exists to replace — by then the agent has already
+ * forgotten, and that is the entire premise.
+ *
+ * So: `statement` is prose and mandatory. `binding` is a predicate, optional, and may arrive later
+ * or never. An intent that stays `declared` and never becomes `bound` is not a failure — it is the
+ * most interesting row in the ledger, because it names something the team meant that nothing can
+ * currently prove.
+ *
+ * ## Amendments are append-only
+ *
+ * A long build changes its mind, so an intent must be amendable. But an amendable intent is also how
+ * an agent could quietly rewrite what it meant to match what it can already prove. Keeping the
+ * previous statement makes a NARROWING visible in the git diff, which is the only real defence —
+ * and it is a partial one, stated here rather than papered over.
+ */
+
+export const INTENT_FILE_VERSION = 1;
+
+export const IntentState = {
+  /** Prose only. Nothing yet says how it would be proved. */
+  DECLARED: 'declared',
+  /** A predicate exists that would prove it. */
+  BOUND: 'bound',
+  /** A verdict satisfied that predicate. */
+  PROVED: 'proved',
+} as const;
+export type IntentState = (typeof IntentState)[keyof typeof IntentState];
+
+/** Where the intent lives, so a later run can find the ones relevant to what it is touching. */
+export const IntentSurfaceSchema = z.object({
+  route: z.string().optional(),
+  flow: z.string().optional(),
+  files: z.array(z.string()).optional(),
+});
+export type IntentSurface = z.infer<typeof IntentSurfaceSchema>;
+
+/** Which verdict discharged it, and how strongly. The grade is what makes a later weakening visible. */
+export const IntentProofSchema = z.object({
+  verdictId: z.string(),
+  grade: z.string(),
+  at: z.number(),
+});
+
+export const IntentSchema = z.object({
+  id: z.string().min(1),
+  /** The prose. Survives even when the binding rots, which is most of the point. */
+  statement: z.string().min(1),
+  state: z.enum([IntentState.DECLARED, IntentState.BOUND, IntentState.PROVED]),
+  declaredAt: z.number(),
+  /** Left as `unknown`: core must not depend on the server's predicate vocabulary. */
+  binding: z.unknown().optional(),
+  surface: IntentSurfaceSchema.optional(),
+  provenBy: IntentProofSchema.optional(),
+  /** Every statement this intent previously carried, oldest first. Append-only, never rewritten. */
+  amended: z.array(z.object({ statement: z.string(), at: z.number() })).optional(),
+});
+export type Intent = z.infer<typeof IntentSchema>;
+
+export const IntentFileSchema = z.object({
+  version: z.literal(INTENT_FILE_VERSION),
+  intents: z.record(z.string(), IntentSchema),
+});
+export type IntentFile = z.infer<typeof IntentFileSchema>;
+
+export function emptyIntentFile(): IntentFile {
+  return { version: INTENT_FILE_VERSION, intents: {} };
+}
+
+export function declareIntent(input: {
+  id: string;
+  statement: string;
+  now: number;
+  surface?: IntentSurface;
+}): Intent {
+  return {
+    id: input.id,
+    statement: input.statement,
+    state: IntentState.DECLARED,
+    declaredAt: input.now,
+    ...(input.surface === undefined ? {} : { surface: input.surface }),
+  };
+}
+
+/** Attach the predicate that would prove it. Pure — returns a new intent. */
+export function bindIntent(intent: Intent, binding: unknown): Intent {
+  return { ...intent, state: IntentState.BOUND, binding };
+}
+
+/**
+ * Record that a verdict proved it.
+ *
+ * Refuses on an intent with no binding, and returns it unchanged rather than throwing: nothing could
+ * have satisfied a predicate that does not exist, so a discharge there would be a claim with no
+ * evidence — the shape this whole feature exists to stop. A throw would be the wrong shape too,
+ * because discharge runs off the back of a verdict and must never be why one fails to return.
+ */
+export function dischargeIntent(
+  intent: Intent,
+  proof: { verdictId: string; grade: string; at: number },
+): Intent {
+  if (intent.binding === undefined) return intent;
+  return { ...intent, state: IntentState.PROVED, provenBy: proof };
+}
+
+/**
+ * Add or amend an intent, keeping what it used to say.
+ *
+ * An amendment is recorded only when the statement actually changed — re-declaring the same intent
+ * unchanged is what a re-run does, and filling the history with identical rows would bury the one
+ * amendment somebody needs to see.
+ */
+export function upsertIntent(file: IntentFile, intent: Intent): IntentFile {
+  const previous = file.intents[intent.id];
+  const changed = previous !== undefined && previous.statement !== intent.statement;
+  const amended = changed
+    ? [...(previous.amended ?? []), { statement: previous.statement, at: previous.declaredAt }]
+    : previous?.amended;
+  return {
+    version: INTENT_FILE_VERSION,
+    intents: {
+      ...file.intents,
+      [intent.id]: { ...intent, ...(amended === undefined ? {} : { amended }) },
+    },
+  };
+}
+
+/** Everything not yet proved — what an agent asking "am I done?" still owes. */
+export function openIntents(file: IntentFile): Intent[] {
+  return Object.values(file.intents).filter((intent) => intent.state !== IntentState.PROVED);
+}
+
+/** Parse an intent file, failing soft to empty. Never throws — a cache must not take a daemon down. */
+export function parseIntentFile(raw: unknown): IntentFile {
+  const parsed = IntentFileSchema.safeParse(raw);
+  return parsed.success ? parsed.data : emptyIntentFile();
+}

--- a/packages/server/src/intent/intent-store.test.ts
+++ b/packages/server/src/intent/intent-store.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { IntentState } from '@reticlehq/core';
+import { createMemoryFs } from '../project/memory-fs.js';
+import { IntentStore } from './intent-store.js';
+
+const ROOT = '/repo/apps/web/.reticle';
+
+function store() {
+  const { fs, written } = createMemoryFs();
+  return { store: new IntentStore(fs, ROOT, { now: () => 1_000 }), written };
+}
+
+describe('IntentStore', () => {
+  it('reads an empty ledger before anything is written', async () => {
+    expect(await store().store.read()).toEqual([]);
+  });
+
+  it('writes into the project it was given, not somewhere else', async () => {
+    const { store: s, written } = store();
+    await s.declare([{ id: 'a', statement: 'A' }]);
+    expect([...written.keys()].some((p) => p.startsWith(ROOT))).toBe(true);
+  });
+
+  it('round-trips a declared intent', async () => {
+    const { store: s } = store();
+    await s.declare([{ id: 'a', statement: 'users can check in' }]);
+    const [intent] = await s.read();
+    expect(intent?.statement).toBe('users can check in');
+    expect(intent?.state).toBe(IntentState.DECLARED);
+    expect(intent?.declaredAt).toBe(1_000);
+  });
+
+  it('declares several in one call, because one per feature is the budget', async () => {
+    const { store: s } = store();
+    await s.declare([
+      { id: 'a', statement: 'A' },
+      { id: 'b', statement: 'B' },
+    ]);
+    expect((await s.read()).map((i) => i.id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('binds a predicate to an existing intent', async () => {
+    const { store: s } = store();
+    await s.declare([{ id: 'a', statement: 'A' }]);
+    expect(await s.bind('a', { kind: 'text', value: 'checked in' })).toBe(true);
+    const [intent] = await s.read();
+    expect(intent?.state).toBe(IntentState.BOUND);
+  });
+
+  it('says so rather than inventing an intent when the id is unknown', async () => {
+    const { store: s } = store();
+    expect(await s.bind('nobody', { kind: 'text' })).toBe(false);
+    expect(await s.read()).toEqual([]);
+  });
+
+  /**
+   * The re-run case, and the reason amendments are append-only: a long build re-declares, and the
+   * ledger has to keep what was previously meant so a narrowing is visible in review.
+   */
+  it('keeps the previous statement when an intent is re-declared differently', async () => {
+    const { store: s } = store();
+    await s.declare([{ id: 'a', statement: 'first' }]);
+    await s.declare([{ id: 'a', statement: 'second' }]);
+    const [intent] = await s.read();
+    expect(intent?.statement).toBe('second');
+    expect(intent?.amended).toEqual([{ statement: 'first', at: 1_000 }]);
+  });
+
+  /**
+   * Fails soft, deliberately. This is a git-checked file an agent can edit and a human can
+   * hand-merge, so a malformed one is reachable — and taking a verdict down over it would trade a
+   * small problem for a large one.
+   */
+  it('reads an unparseable ledger as empty rather than throwing', async () => {
+    const { fs, written } = createMemoryFs();
+    written.set(`${ROOT}/intent.json`, '{ this is not json');
+    const s = new IntentStore(fs, ROOT, { now: () => 1 });
+    await expect(s.read()).resolves.toEqual([]);
+  });
+
+  it('survives a ledger that parses but is the wrong shape', async () => {
+    const { fs, written } = createMemoryFs();
+    written.set(`${ROOT}/intent.json`, JSON.stringify({ version: 1, intents: { a: {} } }));
+    const s = new IntentStore(fs, ROOT, { now: () => 1 });
+    await expect(s.read()).resolves.toEqual([]);
+  });
+
+  it('reports only what is still open', async () => {
+    const { store: s } = store();
+    await s.declare([
+      { id: 'a', statement: 'A' },
+      { id: 'b', statement: 'B' },
+    ]);
+    await s.bind('b', { kind: 'net' });
+    await s.discharge('b', { verdictId: 'v', grade: 'net', at: 2 });
+    expect((await s.open()).map((i) => i.id)).toEqual(['a']);
+  });
+
+  it('does not discharge an intent that was never bound', async () => {
+    const { store: s } = store();
+    await s.declare([{ id: 'a', statement: 'A' }]);
+    expect(await s.discharge('a', { verdictId: 'v', grade: 'dom', at: 2 })).toBe(false);
+    expect((await s.open()).map((i) => i.id)).toEqual(['a']);
+  });
+
+  /** Byte-stable, so an unchanged ledger round-trips without churning the diff. */
+  it('writes byte-identical content for an unchanged ledger', async () => {
+    const { store: s, written } = store();
+    await s.declare([{ id: 'a', statement: 'A' }]);
+    const first = written.get(`${ROOT}/intent.json`);
+    await s.declare([{ id: 'a', statement: 'A' }]);
+    expect(written.get(`${ROOT}/intent.json`)).toBe(first);
+  });
+});

--- a/packages/server/src/intent/intent-store.ts
+++ b/packages/server/src/intent/intent-store.ts
@@ -1,0 +1,139 @@
+import {
+  bindIntent,
+  declareIntent,
+  dischargeIntent,
+  emptyIntentFile,
+  openIntents,
+  parseIntentFile,
+  upsertIntent,
+  type Intent,
+  type IntentFile,
+  type IntentSurface,
+} from '@reticlehq/core';
+import type { FileSystemPort } from '../project/fs-port.js';
+import { reticleDirPaths } from '../project/reticle-dir.js';
+import { withFileLock } from '../project/file-lock.js';
+
+/**
+ * The intent ledger on disk — `.reticle/intent.json`, git-checked and meant to be read in review.
+ *
+ * Git-checked deliberately. The one real defence against an agent quietly narrowing what it meant to
+ * match what it can already prove is that a human sees the narrowing in a diff, and that only works
+ * if the file lives with the code and travels with the PR. It is also why the writes are byte-stable:
+ * a ledger that churns on every run is one whose diffs nobody reads.
+ *
+ * Every operation goes through the same file lock the other stores use, because two sessions driving
+ * one project is ordinary and a lost declaration would be silent.
+ */
+
+const JSON_INDENT = 2;
+
+export interface Clock {
+  now: () => number;
+}
+
+export class IntentStore {
+  readonly #fs: FileSystemPort;
+  readonly #root: string;
+  readonly #clock: Clock;
+
+  constructor(fs: FileSystemPort, root: string, clock: Clock) {
+    this.#fs = fs;
+    this.#root = root;
+    this.#clock = clock;
+  }
+
+  #path(): string {
+    return reticleDirPaths(this.#root).intent;
+  }
+
+  /**
+   * Load the ledger, failing soft to empty.
+   *
+   * This is a git-checked file an agent can write and a human can hand-merge, so a malformed one is
+   * genuinely reachable — a conflict marker left in place is the obvious case. Throwing here would
+   * take down the verdict that was only asking what was still open, which trades a small problem for
+   * a large one.
+   */
+  async #load(): Promise<IntentFile> {
+    try {
+      const raw = await this.#fs.readFile(this.#path());
+      return parseIntentFile(JSON.parse(raw) as unknown);
+    } catch {
+      return emptyIntentFile();
+    }
+  }
+
+  /** Byte-stable: 2-space indent, one trailing newline. An unchanged ledger produces no diff. */
+  async #save(file: IntentFile): Promise<void> {
+    await this.#fs.mkdir(reticleDirPaths(this.#root).root);
+    await this.#fs.writeFile(this.#path(), `${JSON.stringify(file, null, JSON_INDENT)}\n`);
+  }
+
+  /** Every intent, in declaration order. */
+  async read(): Promise<Intent[]> {
+    return Object.values((await this.#load()).intents);
+  }
+
+  /** Everything not yet proved — what an agent asking "am I done?" still owes. */
+  async open(): Promise<Intent[]> {
+    return openIntents(await this.#load());
+  }
+
+  /**
+   * Declare one or more intents.
+   *
+   * Batched because the marginal cost of the whole mechanism has to stay at one call per feature; an
+   * agent that must make five calls to declare five things will make none.
+   */
+  async declare(
+    entries: readonly { id: string; statement: string; surface?: IntentSurface }[],
+  ): Promise<Intent[]> {
+    if (0 === entries.length) return [];
+    return withFileLock(this.#path(), async () => {
+      let file = await this.#load();
+      const now = this.#clock.now();
+      const declared: Intent[] = [];
+      for (const entry of entries) {
+        const intent = declareIntent({ ...entry, now });
+        file = upsertIntent(file, intent);
+        const stored = file.intents[intent.id];
+        if (stored !== undefined) declared.push(stored);
+      }
+      await this.#save(file);
+      return declared;
+    });
+  }
+
+  /** Attach the predicate that would prove an intent. False when the id names nothing. */
+  async bind(id: string, binding: unknown): Promise<boolean> {
+    return withFileLock(this.#path(), async () => {
+      const file = await this.#load();
+      const existing = file.intents[id];
+      if (existing === undefined) return false;
+      await this.#save(upsertIntent(file, bindIntent(existing, binding)));
+      return true;
+    });
+  }
+
+  /**
+   * Record that a verdict proved an intent.
+   *
+   * False rather than a throw on an unknown or unbound id: discharge runs off the back of a verdict,
+   * and must never be the reason one fails to return.
+   */
+  async discharge(
+    id: string,
+    proof: { verdictId: string; grade: string; at: number },
+  ): Promise<boolean> {
+    return withFileLock(this.#path(), async () => {
+      const file = await this.#load();
+      const existing = file.intents[id];
+      if (existing === undefined) return false;
+      const proved = dischargeIntent(existing, proof);
+      if (proved === existing) return false;
+      await this.#save(upsertIntent(file, proved));
+      return true;
+    });
+  }
+}

--- a/packages/server/src/intent/intent-tools.ts
+++ b/packages/server/src/intent/intent-tools.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod';
+import { IntentStore } from './intent-store.js';
+import { ReticleTool } from '../tools/tool-names.js';
+import { sessionIdShape } from '../tools/tool-kit.js';
+import { sessionRoot } from '../project/session-root.js';
+import { asString } from '../tools/tools-helpers.js';
+import type { ToolDef, ToolDeps } from '../tools/tool-kit.js';
+
+/**
+ * Declare what a change was SUPPOSED to make true, while somebody still knows.
+ *
+ * One tool with three actions rather than three tools, because the surface is capped and because an
+ * agent that has to discover three names to use one idea uses none of them.
+ *
+ * There is deliberately no `discharge` action. A verdict discharges an intent by satisfying its
+ * binding, and a discharge an agent has to remember to file would be the same forgetting problem
+ * this exists to solve, moved one layer up.
+ */
+
+const DECLARE = 'declare';
+const LIST = 'list';
+const BIND = 'bind';
+
+export const INTENT_TOOLS: ToolDef[] = [
+  {
+    name: ReticleTool.INTENT,
+    description:
+      'Record what a change is SUPPOSED to make true, in your own words, while you still know — then verification does not have to re-derive it from the DOM later. { action:"declare", intents:[{ id, statement, surface? }] } takes prose and needs NO predicate: at declare time there is often no route, no ref and no code yet, and a predicate demanded there is just a mechanism. Declare EARLY (as you build) and batch them — one call per feature is the whole budget. { action:"bind", id, binding } attaches the predicate that would prove it once you know how; an intent with no binding is not a failure, it is the most interesting row in the ledger — something meant that nothing can currently prove. { action:"list" } returns what is still open. Stored in .reticle/intent.json, git-checked so a human sees in review if an intent was later narrowed to match what was easy to prove.',
+    example: {
+      action: DECLARE,
+      intents: [
+        { id: 'checkin', statement: 'clicking Send check-in makes the badge read "checked in"' },
+      ],
+    },
+    inputSchema: {
+      action: z.enum([DECLARE, LIST, BIND]),
+      intents: z
+        .array(
+          z.object({
+            id: z.string(),
+            statement: z.string(),
+            surface: z
+              .object({
+                route: z.string().optional(),
+                flow: z.string().optional(),
+                files: z.array(z.string()).optional(),
+              })
+              .optional(),
+          }),
+        )
+        .optional()
+        .describe('declare only. Batchable — declare every intent for a feature in one call.'),
+      id: z.string().optional().describe('bind only: which intent the predicate proves.'),
+      binding: z
+        .unknown()
+        .optional()
+        .describe("bind only: the predicate that would prove it, in reticle_assert's shape."),
+      ...sessionIdShape,
+    },
+    outputSchema: {
+      intents: z
+        .array(z.unknown())
+        .optional()
+        .describe(
+          'The intents this call declared, or on `list` everything still open — each { id, statement, state, declaredAt, binding?, surface?, provenBy?, amended? }. `state` is declared (prose only), bound (a predicate exists), or proved (a verdict satisfied it).',
+        ),
+      bound: z.boolean().optional().describe('bind only: false when the id names no intent.'),
+      path: z.string().optional().describe('Where the ledger was written.'),
+    },
+    handler: async (deps: ToolDeps, args) => {
+      const root = sessionRoot(deps, asString(args['sessionId']));
+      const store = new IntentStore(deps.fs, root, { now: deps.now });
+      const action = asString(args['action']);
+
+      if (BIND === action) {
+        const id = asString(args['id']) ?? '';
+        return { bound: await store.bind(id, args['binding']) };
+      }
+      if (LIST === action) {
+        return { intents: await store.open() };
+      }
+      const raw = args['intents'];
+      const entries = Array.isArray(raw)
+        ? (raw as { id: string; statement: string; surface?: never }[])
+        : [];
+      const declared = await store.declare(entries);
+      return { intents: declared, path: root };
+    },
+  },
+];

--- a/packages/server/src/project/reticle-dir.ts
+++ b/packages/server/src/project/reticle-dir.ts
@@ -26,6 +26,8 @@ export interface ReticleDirPaths {
   project: string;
   /**.../.reticle/impact.json (what Reticle has done for this user, local only) */
   impact: string;
+  /**.../.reticle/intent.json (what changes were supposed to make true — git-checked) */
+  intent: string;
   /**.../.reticle/visual (PNG baselines + diffs) */
   visual: string;
   /**.../.reticle/runs (verification-run artifacts) */
@@ -52,6 +54,7 @@ export function reticleDirPaths(root: string): ReticleDirPaths {
     baselines: join(root, ReticleDir.BASELINES_SUBDIR),
     project: join(root, ReticleDir.PROJECT_FILE),
     impact: join(root, ReticleDir.IMPACT_FILE),
+    intent: join(root, ReticleDir.INTENT_FILE),
     visual: join(root, ReticleDir.VISUAL_SUBDIR),
     runs: join(root, ReticleDir.RUNS_SUBDIR),
     sessions: join(root, ReticleDir.SESSIONS_SUBDIR),

--- a/packages/server/src/tools/invoke-tool.ts
+++ b/packages/server/src/tools/invoke-tool.ts
@@ -115,6 +115,7 @@ export const SESSION_EXEMPT_TOOLS: ReadonlySet<string> = new Set([
   ReticleTool.FLOW_REPLAY, // returns its own FlowReplayResult contract (+ auto-records a run)
   ReticleTool.FLOW_SAVE_RECORDED, // reads the recording buffer, writes disk
   ReticleTool.FLOW_HEAL, // returns its own FlowHealResult contract
+  ReticleTool.INTENT, // reads/writes .reticle/intent.json; sessionId only picks the project
   ReticleTool.PROJECT, // reads .reticle/project.json
   ReticleTool.RUN_EXPORT, // reads .reticle/runs/<id>.json (verification-run artifact)
   ReticleTool.SESSION, // merged lifecycle/human-channel family (tune/yield/end/resume/messages/review/narrate)

--- a/packages/server/src/tools/surface-sizes.test.ts
+++ b/packages/server/src/tools/surface-sizes.test.ts
@@ -26,11 +26,12 @@ const EXPECTED_SIZE: Record<ToolSurface, number> = {
   // orientation replaces exploratory snapshots, the measurement that would settle that was never
   // run, and an unproven entry is the right one to give up when the budget is a hard count.
   [TOOL_SURFACE.DEFAULT]: 18,
-  // The extended surface. NOT "everything" — see ADVERTISED_CAP. 28 since change/flows/affected/
-  // coverage/crawl merged into `reticle_verify`: three of those five were advertised here, so one
-  // name now stands where three did. The freed budget is deliberately NOT spent — what to promote
-  // into it is a separate decision with its own measurement.
-  [TOOL_SURFACE.ALL]: 28,
+  // The extended surface. NOT "everything" — see ADVERTISED_CAP. Was 28 after change/flows/
+  // affected/coverage/crawl merged into `reticle_verify`; 29 now that `reticle_intent` joins it.
+  // Intent lands here rather than in DEFAULT on the same terms the capabilities demotion set: it is
+  // new and its claim is unmeasured, so it does not take a default-surface slot from a tool that has
+  // earned one. Still one `reticle_run` hop away for any agent that wants it.
+  [TOOL_SURFACE.ALL]: 29,
   // The smallest surface that can still return a verdict: one acting tool that resolves its own
   // target, plus the two meta-tools that reach the rest. See tool-surface.ts for why it is not the
   // default.

--- a/packages/server/src/tools/tool-names.ts
+++ b/packages/server/src/tools/tool-names.ts
@@ -49,6 +49,7 @@ export const ReticleTool = {
   COVERAGE: 'reticle_coverage',
   VERIFY_CHANGE: 'reticle_verify_change',
   /** Merged: change/flows/affected/coverage/crawl — "what is proved, and what is not". */
+  INTENT: 'reticle_intent',
   VERIFY: 'reticle_verify',
   /** read cross-run history (.reticle/project.json) + diff-vs-last for a name. */
   PROJECT: 'reticle_project',

--- a/packages/server/src/tools/tool-surface.ts
+++ b/packages/server/src/tools/tool-surface.ts
@@ -214,6 +214,9 @@ export const EXTENDED_TOOL_NAMES: ReadonlySet<string> = new Set([
   ReticleTool.CAPABILITIES,
   ReticleTool.FLOW_SAVE,
   ReticleTool.FLOW_REPLAY,
+  // New and unproven, so it does not take a default-surface slot under the cap. Same terms the
+  // capabilities demotion set: reachable in one reticle_run hop by any agent that wants it.
+  ReticleTool.INTENT,
   ReticleTool.RECORD,
   ReticleTool.SCREENSHOT,
   ReticleTool.VISUAL_DIFF,

--- a/packages/server/src/tools/tools.ts
+++ b/packages/server/src/tools/tools.ts
@@ -22,6 +22,7 @@ import { CONTRACT_TOOLS } from './contract-tools.js';
 import { DOMAIN_TOOLS } from '../domain/domain-tools.js';
 import { BROWSER_TOOLS } from './browser-tools.js';
 import { FLOW_TOOLS } from '../flows/flow-tools.js';
+import { INTENT_TOOLS } from '../intent/intent-tools.js';
 import { PROJECT_TOOLS } from '../project/project-tools.js';
 import { RUN_TOOLS } from '../runs/run-tools.js';
 import { VISUAL_TOOLS } from '../visual/visual-tools.js';
@@ -525,6 +526,7 @@ const RAW_TOOLS: ToolDef[] = [
   // reticle_capabilities (live | fromDisk) + reticle_contract_save. See contract-tools.ts.
   ...RECONCILE_TOOLS,
   ...CONTRACT_TOOLS,
+  ...INTENT_TOOLS,
   ...DOMAIN_TOOLS,
   // reticle_flow_save / reticle_flow_list / reticle_flow_load. See flow-tools.ts.
   ...FLOW_TOOLS,


### PR DESCRIPTION
Steps 1 and 2 of the intent ledger. Deliberately **not** steps 4–5 — see "What this does not do".

## The problem

An agent building a feature knows what it is for. That knowledge lives in its context, and then the turn ends. Later a different turn — or a different model — drives the app holding the DOM, the diff, and no intent. So it asserts what it can **see** rather than what was **meant**, and what it can see is weaker. That gap is where a false green comes from.

## Why the shape is what it is

Intent has two properties that move in opposite directions over the life of a task:

- **Fidelity** is highest the moment the human asks, and decays from there — every later restatement is a lossy re-derivation.
- **Bindability** — whether it can be written as something checkable — is near zero then (no route, no ref, often no code) and rises as the code appears.

Capture at either end alone loses one of them:

- Demanding a predicate at declare time collects **mechanisms**, which is what assertions already are.
- Waiting until drive time collects a **re-derivation** — by then the agent has forgotten, which is the entire premise.

So `statement` is prose and mandatory; `binding` is a predicate and optional, arriving later or never. **An intent that stays `declared` and never becomes `bound` is not a failure — it is the most interesting row in the ledger**, because it names something the team meant that nothing can currently prove.

## What is in it

- **`packages/core/src/intent.ts`** — the domain. `declared → bound → proved`. `binding` is typed `unknown` so core never learns the server's predicate vocabulary. Amendments are **append-only**: a long build changes its mind, and keeping the previous statement is what makes a *narrowing* visible in a git diff. That is the only real defence against an agent rewriting intent to match what it can already prove, and it is a partial one — said in the docstring rather than papered over.
- **`packages/server/src/intent/intent-store.ts`** — `.reticle/intent.json`, git-checked, byte-stable, file-locked, reads fail soft. It writes through **the same per-session root resolution v2.11.0 shipped**, so an intent lands in the project it describes. That fix is what made this buildable at all: a ledger written into an unrelated repo would have been the flows surface's fate a second time.
- **`reticle_intent`** — one tool, three actions (`declare` / `bind` / `list`), batchable, because the marginal cost of the whole mechanism has to stay at one call per feature.

## Two design decisions worth arguing with

**There is no `discharge` action.** A verdict discharges an intent by satisfying its binding. A discharge an agent has to remember to file would be the same forgetting problem this exists to solve, moved one layer up.

**It lands in `EXTENDED`, not `DEFAULT`.** Same terms as the `reticle_capabilities` demotion: it is new and its claim is unmeasured, so it does not take a default-surface slot from a tool that has earned one. One `reticle_run` hop away for any agent that wants it.

## What this does not do

**Steps 4 and 5 are deliberately absent** — the forcing function (undeclared changed code is a finding) and downgrade detection. They wait on a measurement, not on effort:

> If assertion grades do not rise when intent is present, the idea is wrong — and steps 4 and 5 would be three more wrong things built on top of it.

The unresolved risk stays on the record: if the same agent builds, declares and verifies, it will declare what it already knows it can prove. Timing helps, append-only amendment helps, and `intent.json` is git-checked so a human sees it in review. That is weaker than I would like, and it is the thing to watch in the first release that carries this.

## Tests

30 new (18 domain, 12 store). Server suite 4645/4645. Unit 15/15, lint 16/16, typecheck 21/21, format clean.

All three allowlists moved together — the tool table, `SESSION_EXEMPT_TOOLS` and `EXTENDED_TOOL_NAMES` — because missing one is how a field silently returns nothing. The surface-count guard and SKILL.md's canonical table both went red and were updated deliberately; that is the guard working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)