### PR TITLE
fix(tauri): unfreeze the crate — every Rust fix since 2026-08-02 has reached nobody

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -40,7 +40,10 @@ npx skills add reticlehq/reticle -l             #    the published skills are al
 
 pnpm version 2.3.0 --no-git-tag-version         # 3. bump root…
 pnpm -r exec npm version 2.3.0 --no-git-tag-version   #    …and every workspace package, in lockstep
+sed -i '' '3s/^version = .*/version = "2.3.0"/' packages/tauri/Cargo.toml  # …and the ELEVENTH artifact
 ```
+
+**The Rust crate is the eleventh artifact and it is easy to forget**, which is not hypothetical: it sat at `0.1.0` from the day it was written until 2.11.0. `publish-crate.yml` publishes only when the version is ABSENT from crates.io, so every release found `0.1.0` already there, printed "nothing to do" and exited green — a silent no-op reporting success for months, while a desktop capture-path security fix sat undelivered and the docs told users to pin the build that had it. `crate-version-lockstep.test.ts` now fails the fast unit gate if this line is forgotten, so the `sed` above is belt to its braces rather than the only thing standing between a release and nothing.
 
 ### What the gates already prove about the docs, and what they do not
 

--- a/docs/desktop.mdx
+++ b/docs/desktop.mdx
@@ -214,7 +214,7 @@ Alternatively, since an Electron renderer _is_ Chromium, `--remote-debugging-por
 
 ```toml
 [dependencies]
-reticle-tauri = "0.1"
+reticle-tauri = "2.11"
 ```
 
 ```rust

--- a/docs/install-manual.mdx
+++ b/docs/install-manual.mdx
@@ -159,7 +159,7 @@ Screenshots and headless mode need the Rust crate, which is versioned independen
 
 ```toml
 [dependencies]
-reticle-tauri = "0.1"
+reticle-tauri = "2.11"
 ```
 
 ```rust

--- a/docs/packages.mdx
+++ b/docs/packages.mdx
@@ -8,9 +8,11 @@ icon: cubes
 Reticle is eleven packages, and most people install two. This page exists so you can tell which two, and so that the ones you skip stop looking mysterious.
 
 <Note>
-  The ten npm packages ship together at one version: whatever `npm view @reticlehq/core version`
-  says, every other `@reticlehq/*` package says too. The Rust crate `reticle-tauri` is versioned
-  **independently**. That is deliberate, not drift.
+  Everything ships together at one version: whatever `npm view @reticlehq/core version` says, every
+  other `@reticlehq/*` package says too — and so does the `reticle-tauri` crate on crates.io.
+
+It was versioned independently until 2.11.0, and that turned out to mean _stuck_: the crate sat at `0.1.0` from the day it was written, the publish job skipped it every release because that version already existed, and no Rust-side fix reached anybody. Lockstep costs one line in the bump script and cannot fail that way.
+
 </Note>
 
 ## Which ones do I need?
@@ -199,13 +201,13 @@ A lint rule makes the signal layer self-enforcing, which is the only way a conve
 
 ## reticle-tauri
 
-**The Rust crate**, on crates.io. Versioned independently of the npm packages.
+**The Rust crate**, on crates.io. Versioned in lockstep with the npm packages, so `2.11` here and `2.11` there mean the same release.
 
 **Why it exists:** Tauri IPC observation needs nothing on the Rust side; an `invoke('load_todos')` already reaches Reticle as `ipc://load_todos`. You only need this crate for screenshots and headless mode.
 
 ```toml
 [dependencies]
-reticle-tauri = "0.1"
+reticle-tauri = "2.11"
 ```
 
 <Warning>

--- a/docs/packages.mdx
+++ b/docs/packages.mdx
@@ -9,7 +9,7 @@ Reticle is eleven packages, and most people install two. This page exists so you
 
 <Note>
   Everything ships together at one version: whatever `npm view @reticlehq/core version` says, every
-  other `@reticlehq/*` package says too — and so does the `reticle-tauri` crate on crates.io.
+  other `@reticlehq/*` package says too, and so does the `reticle-tauri` crate on crates.io.
 
 It was versioned independently until 2.11.0, and that turned out to mean _stuck_: the crate sat at `0.1.0` from the day it was written, the publish job skipped it every release because that version already existed, and no Rust-side fix reached anybody. Lockstep costs one line in the bump script and cannot fail that way.
 

--- a/packages/server/src/tools/crate-version-lockstep.test.ts
+++ b/packages/server/src/tools/crate-version-lockstep.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The Rust crate must ship the version everything else ships.
+ *
+ * `reticle-tauri` sat at `0.1.0` from the day it was written on 2026-08-02 until 2.11.0. Nothing
+ * bumped it, and `publish-crate.yml` publishes only when the version is ABSENT from crates.io — so
+ * every release in the 2.x line ran that job, found `0.1.0` already there, printed "nothing to do",
+ * and exited successfully. A silent no-op reporting green, on every release, for months.
+ *
+ * The cost was not theoretical. `d09cd5c6` moved desktop captures out of the shared OS temp
+ * directory, where they were written under a name any local process could work out — a public
+ * prefix, a readable pid, and a counter starting at zero. That fix merged on 2026-08-13 and reached
+ * nobody, because the only published crate was the one from before it, and the docs told users to
+ * pin `reticle-tauri = "0.1"`, which resolves to exactly that build.
+ *
+ * The docs called this "versioned independently — deliberate, not drift". True as written and false
+ * in effect: it was not versioned, it was stuck.
+ *
+ * So the crate moves in lockstep, and this is what makes lockstep a fact rather than an intention.
+ * A release that bumps the ten npm packages and forgets the eleventh artifact now fails here, in the
+ * fast unit gate, instead of silently shipping nothing.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SERVER_VERSION } from '../version/server-version.js';
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+const CARGO = join(REPO, 'packages', 'tauri', 'Cargo.toml');
+
+/** The `version = "x.y.z"` of the `[package]` table — the first one in the file. */
+function crateVersion(source: string): string | undefined {
+  return /^version\s*=\s*"([^"]+)"/m.exec(source)?.[1];
+}
+
+describe('the Rust crate ships the version everything else ships', () => {
+  it('reads a version out of Cargo.toml at all', () => {
+    // Guards the guard: a regex that stopped matching would make every assertion below vacuous, and
+    // this file exists precisely because a check that quietly passes is worse than no check.
+    expect(crateVersion(readFileSync(CARGO, 'utf8'))).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('is in lockstep with the npm packages', () => {
+    expect(
+      crateVersion(readFileSync(CARGO, 'utf8')),
+      'packages/tauri/Cargo.toml is behind the release. A version already on crates.io is SKIPPED by ' +
+        'publish-crate.yml, which then reports success — so forgetting this ships nothing and says ' +
+        'it worked. Bump it with the npm packages.',
+    ).toBe(SERVER_VERSION);
+  });
+
+  it('parses the package version, not a dependency pinned in the same file', () => {
+    // `[dependencies]` entries carry their own `version = "…"`. Anchoring to the first match works
+    // only while `[package]` is first; if that ever stops being true this test should say so rather
+    // than silently compare a dependency's version to ours.
+    const source = readFileSync(CARGO, 'utf8');
+    expect(source.indexOf('[package]')).toBeLessThan(source.indexOf('version'));
+  });
+});
+
+describe('the docs pin a crate version that exists', () => {
+  const pinned = (file: string): string[] => {
+    const source = readFileSync(join(REPO, 'docs', file), 'utf8');
+    return [...source.matchAll(/reticle-tauri\s*=\s*"([^"]+)"/g)].map((m) => m[1] ?? '');
+  };
+
+  it.each(['desktop.mdx', 'install-manual.mdx', 'packages.mdx'])(
+    '%s pins a version this release actually publishes',
+    (file) => {
+      const [major, minor] = SERVER_VERSION.split('.');
+      for (const pin of pinned(file)) {
+        // A caret pin of `major.minor` resolves to this release's patches. A pin naming a
+        // major.minor we do not publish resolves to whatever was last there — which is how users
+        // stayed on a build with a known capture-path defect for months.
+        expect(pin, `${file} pins reticle-tauri = "${pin}"`).toBe(`${major}.${minor}`);
+      }
+    },
+  );
+});

--- a/packages/tauri/Cargo.toml
+++ b/packages/tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reticle-tauri"
-version = "0.1.0"
+version = "2.11.0"
 edition = "2021"
 description = "Reticle screenshots and headless mode for a Tauri app"
 license = "MIT"


### PR DESCRIPTION
Found while auditing what v2.11.0 actually shipped against the plan. This is the most serious thing in that audit and it predates 2.11.0 — every release in the 2.x line has it.

## The defect

`reticle-tauri` has been `0.1.0` since the day it was written. `publish-crate.yml` publishes only when the version is **absent** from crates.io, so every release ran that job, found `0.1.0` already there, printed *"nothing to do"*, and **exited successfully**.

crates.io confirms it — exactly one published version:

```
$ curl https://crates.io/api/v1/crates/reticle-tauri
versions: ['0.1.0']
```

A silent no-op reporting green, on every release, for months.

## What it cost

Five commits have touched `packages/tauri` since. One of them is **`d09cd5c6`** — desktop captures were being written into the shared OS temp directory under a name any local process could work out: a public prefix, a readable pid, and a counter starting at zero.

That fix merged on **2026-08-13** and has reached **nobody**. The only crate on crates.io predates it, and all three docs pages tell users to pin `reticle-tauri = "0.1"` — which resolves to exactly that build.

`docs/packages.mdx` described the crate as *"versioned independently. That is deliberate, not drift."* True as written and false in effect: it was not versioned, it was **stuck**.

## The fix

- **Lockstep at `2.11.0`.** A `0.1.0 → 2.11.0` jump is legal on crates.io (append-only, monotonic) and is the honest signal that this crate is part of a 2.x product. Tauri's own model — independent versions plus a build-time compatibility checker — is defensible and costs a checker written in Rust. Lockstep costs one line.
- **All three docs pages** repinned to `"2.11"`, and the independence note rewritten to say what actually happened rather than what was intended.
- **`RELEASING.md`** gains the bump line, with the reason beside it.
- **`crate-version-lockstep.test.ts`** is what turns lockstep from an intention into a fact: the fast unit gate now fails when `Cargo.toml` falls behind, and when a docs page pins a `major.minor` this release does not publish.

## On the test

I reverted the version and watched it go red before committing — a guard nobody has watched fail proves nothing when it passes:

```
× is in lockstep with the npm packages
  AssertionError: packages/tauri/Cargo.toml is behind the release … expected '0.1.0' to be '2.11.0'
```

It also guards its own regex. A matcher that quietly stopped matching would make every assertion in the file vacuous, which is the failure mode this whole PR is about.

## What this does NOT fix

**B1 — the npm publish credential.** `publish.yml` authenticates with a granular token capped at 90 days, so publishing will fail partway through some future release at an unpredictable date, with the tag already pushed. The fix is OIDC trusted publishing and `permissions: id-token: write` is already in the workflow — **but I cannot push `.github/workflows/`**, my token has no `workflow` scope. That one needs you, and it needs doing before the next release rather than during one.

Note also that the registry side (`npm trust github --file publish.yml --allow-publish`, per package, one 2FA prompt) has no workspace support and npm/cli#8976 is open on E404 for **scoped** packages under OIDC — every `@reticlehq/*` package is scoped. Keep the granular token as a fallback for exactly one release and verify provenance before deleting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)