### PR TITLE
fix(build): the unit gate could replay a green recorded against different Rust

### DIFF
--- a/packages/server/src/tools/guards-are-cache-invalidated.test.ts
+++ b/packages/server/src/tools/guards-are-cache-invalidated.test.ts
@@ -1,11 +1,11 @@
 /**
  * A guard that reads another package's files must be invalidated by them.
  *
- * Eleven tests in this package scan the repo outside their own directory: browser sources, the docs
- * site, `apps/`, `bench/`, the skills, the plugin manifests. Turbo's cache key for
- * `@reticlehq/server#test:unit` is, by default, this package plus its dependency graph — and
- * `@reticlehq/server` does not depend on `@reticlehq/browser` at all. So a change anywhere in those
- * trees left the key untouched and the guards replayed a pass recorded against different files.
+ * Tests across this repo scan trees outside their own package: browser sources, the docs site,
+ * `apps/`, `bench/`, the skills, the plugin manifests, the Rust crate. Turbo's cache key for a
+ * `#test:unit` task is, by default, that package plus its dependency graph. So a change anywhere in
+ * those other trees left the key untouched and the guards replayed a pass recorded against
+ * different files.
  *
  * Reproduced before this was written: edit `packages/browser/src/dom/refs.ts`, run `pnpm test:unit`,
  * and `@reticlehq/server:test:unit` reports `cache hit, replaying logs`. The guard did not run.
@@ -13,44 +13,89 @@
  * That is a false green in the gate itself, which is worse than the defects these guards catch: the
  * whole value of a source-scanning guard is that it fails locally, before CI. It surfaced when a
  * heavy browser test was added, the full local gate went green, and CI then failed on macos, windows
- * and verify at once — the signature of a real failure rather than a flake. The person running it
- * did nothing wrong; `pnpm test:unit` said success, and the guard is what is supposed to stop that.
+ * and verify at once, the signature of a real failure rather than a flake. The person running it did
+ * nothing wrong; `pnpm test:unit` said success, and the guard is what is supposed to stop that.
  *
- * The fix is `inputs` on that one task using `$TURBO_ROOT$`, which turbo 2.x supports and which
+ * The fix is `inputs` on the task using `$TURBO_ROOT$`, which turbo 2.x supports and which
  * [#282](https://github.com/reticlehq/reticle/issues/282) doubted would work. It does; it was
- * measured. That beats `globalDependencies` (busts every task's cache on any browser change) and
- * beats moving the guards to a new tooling package (a bigger change for the same result).
+ * measured. That beats `globalDependencies` (busts every task's cache on any change) and beats
+ * moving the guards to a new tooling package (a bigger change for the same result).
+ *
+ * ## Why this checks every package and not one
+ *
+ * It used to check `@reticlehq/server` alone, and that is how the same hole reopened in
+ * `@reticlehq/core`: `desktop-contract.test.ts` reads the Rust crate's `capture.rs` and `lib.rs` to
+ * hold the daemon and the crate to one contract, core's task declared no `inputs`, and so breaking
+ * that agreement replayed a green recorded against Rust the suite never opened.
+ *
+ * Fixing that one package the way the first was fixed would leave the rule exactly as findable as it
+ * was the first time, which is to say not at all. A guard scoped to the package that happened to be
+ * caught is a guard that catches each package once. So the scan is over every package that has a
+ * `src`, and a new cross-package guard is covered on the day it lands rather than on the day
+ * somebody notices.
  *
  * This test exists because the fix is a config file nobody reads. The next cross-package guard will
  * be written by someone who does not know turbo.json is load-bearing, and it would be silently
- * uncached from the day it lands — indistinguishable from working.
+ * uncached from the day it lands, indistinguishable from working.
  */
 
 import { describe, expect, it } from 'vitest';
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-const SERVER_SRC = join(HERE, '..');
 const REPO = join(HERE, '..', '..', '..', '..');
-
-/** The task whose cache key has to cover everything these guards read. */
-const TASK = '@reticlehq/server#test:unit';
-
-interface TurboConfig {
-  tasks?: Record<string, { inputs?: string[] }>;
-}
-
-function declaredInputs(): string[] {
-  const config = JSON.parse(readFileSync(join(REPO, 'turbo.json'), 'utf8')) as TurboConfig;
-  return config.tasks?.[TASK]?.inputs ?? [];
-}
+const PACKAGES = join(REPO, 'packages');
 
 /** This file's own name, so its example strings are not read as real reads. */
 const SELF = 'guards-are-cache-invalidated.test.ts';
 
-function sourceFiles(dir: string = SERVER_SRC): string[] {
+interface TurboConfig {
+  tasks?: Record<string, { inputs?: string[] }>;
+  globalDependencies?: string[];
+}
+
+function turbo(): TurboConfig {
+  return JSON.parse(readFileSync(join(REPO, 'turbo.json'), 'utf8')) as TurboConfig;
+}
+
+function declaredInputs(task: string): string[] {
+  return turbo().tasks?.[task]?.inputs ?? [];
+}
+
+interface Package {
+  /** The npm name, which is also the turbo task prefix. */
+  readonly name: string;
+  /** Directory name under `packages/`, which is what a relative escape spells. */
+  readonly directory: string;
+  readonly src: string;
+}
+
+/**
+ * Every package with a `src` and a `test:unit` script.
+ *
+ * Driven off the filesystem rather than a list, because a hand-maintained list of packages is the
+ * same class of thing this file exists to stop: correct when written, silently short later.
+ */
+function packages(): Package[] {
+  const out: Package[] = [];
+  for (const directory of readdirSync(PACKAGES)) {
+    const src = join(PACKAGES, directory, 'src');
+    const manifest = join(PACKAGES, directory, 'package.json');
+    if (!existsSync(src) || !existsSync(manifest)) continue;
+    const parsed = JSON.parse(readFileSync(manifest, 'utf8')) as {
+      name?: string;
+      scripts?: Record<string, string>;
+    };
+    const name = parsed.name;
+    if (undefined === name || undefined === parsed.scripts?.['test:unit']) continue;
+    out.push({ name, directory, src });
+  }
+  return out;
+}
+
+function sourceFiles(dir: string): string[] {
   const out: string[] = [];
   for (const entry of readdirSync(dir)) {
     if ('node_modules' === entry || 'dist' === entry || entry === SELF) continue;
@@ -62,20 +107,31 @@ function sourceFiles(dir: string = SERVER_SRC): string[] {
 }
 
 /**
- * Repo-root paths this package's tests read, as written.
+ * Repo-root paths a package's tests read, as written.
  *
- * Matched on `join(REPO, '<name>'` because that is the one spelling every cross-package guard here
- * uses to escape its own directory — they all derive `REPO` by walking up from `import.meta.url`.
- * A guard that reached out some other way would be missed, which is a real limit and is why the
- * message below says what to do rather than only what is wrong.
+ * Two spellings, because there are two ways a guard in this repo escapes its own directory and only
+ * one of them was ever matched:
+ *
+ * - `join(REPO, 'apps'` — walk up from `import.meta.url` to the root and back down. What every
+ *   guard in `@reticlehq/server` uses.
+ * - `join(process.cwd(), '..', 'tauri'` — step sideways from the package root into a sibling. What
+ *   `desktop-contract.test.ts` uses, and precisely the read that stayed uncached, because a matcher
+ *   that only knew the first spelling reported no gap and meant no gap it could see.
+ *
+ * A guard that reached out some other way is still missed. That is a real limit, and it is why the
+ * failure messages say what to add rather than only what is wrong.
  */
-function repoPathsRead(): Set<string> {
+function repoPathsRead(pkg: Package): Set<string> {
   const paths = new Set<string>();
-  for (const file of sourceFiles()) {
+  for (const file of sourceFiles(pkg.src)) {
     const text = readFileSync(file, 'utf8');
     for (const match of text.matchAll(/join\(\s*REPO,\s*'([^']+)'/g)) {
       const first = match[1];
       if (first !== undefined) paths.add(first);
+    }
+    for (const match of text.matchAll(/join\(\s*process\.cwd\(\),\s*'\.\.',\s*'([^']+)'/g)) {
+      const sibling = match[1];
+      if (sibling !== undefined) paths.add(`packages/${sibling}`);
     }
   }
   return paths;
@@ -92,11 +148,10 @@ function repoPathsRead(): Set<string> {
  * (Those globs are described rather than written out: a literal star-slash inside a block comment
  * ends it, which is exactly how this file first failed to parse.)
  *
- * `packages/server/...` is this package's own tree, already covered by `$TURBO_DEFAULT$`, so it is
- * never a gap.
+ * A package's own tree is already covered by `$TURBO_DEFAULT$`, so it is never a gap.
  */
-function isCovered(path: string, inputs: readonly string[]): boolean {
-  if (path.startsWith('packages/server')) return true;
+function isCovered(path: string, inputs: readonly string[], own: string): boolean {
+  if (path.startsWith(`packages/${own}`)) return true;
   const segments = (p: string): string[] => p.split('/').filter((s) => '' !== s && '**' !== s);
   const want = segments(path);
   return inputs.some((input) => {
@@ -111,33 +166,72 @@ function isCovered(path: string, inputs: readonly string[]): boolean {
   });
 }
 
+/** Packages whose tests read outside their own tree, and so need a cache key that says so. */
+const reaching = packages()
+  .map((pkg) => ({
+    pkg,
+    reads: [...repoPathsRead(pkg)].filter((p) => !p.startsWith(`packages/${pkg.directory}`)),
+  }))
+  .filter(({ reads }) => reads.length > 0);
+
 describe('cross-package guards are cache-invalidated by what they scan', () => {
-  it('declares inputs for the task at all', () => {
-    expect(
-      declaredInputs().length,
-      `${TASK} has no \`inputs\` in turbo.json, so its cache key is this package plus its ` +
-        `dependency graph — and the guards here read trees this package does not depend on. ` +
-        `Without \`$TURBO_ROOT$\` inputs they replay a pass recorded against different files.`,
-    ).toBeGreaterThan(1);
+  it('finds packages that read outside themselves (a pass over none proves nothing)', () => {
+    // The scan is filesystem-driven, so a rename or a moved guard could quietly reduce it to zero
+    // and every assertion below would pass by vacuity. That is the failure this whole file is about,
+    // so it does not get to happen here.
+    expect(reaching.length).toBeGreaterThan(1);
   });
 
-  it('keeps $TURBO_DEFAULT$, so the package’s own sources still count', () => {
-    // Listing `inputs` REPLACES the default set. Dropping this would mean a change to the server's
-    // own source no longer invalidated its own tests, which is a far bigger hole than the one this
-    // is fixing and would look identical from the outside.
-    expect(declaredInputs()).toContain('$TURBO_DEFAULT$');
+  describe.each(reaching)('$pkg.name', ({ pkg, reads }) => {
+    const task = `${pkg.name}#test:unit`;
+
+    it('declares inputs for the task at all', () => {
+      expect(
+        declaredInputs(task).length,
+        `${task} has no \`inputs\` in turbo.json, so its cache key is this package plus its ` +
+          `dependency graph, and its tests read trees this package does not depend on ` +
+          `(${reads.join(', ')}). Without \`$TURBO_ROOT$\` inputs they replay a pass recorded ` +
+          `against different files.`,
+      ).toBeGreaterThan(1);
+    });
+
+    it('keeps $TURBO_DEFAULT$, so the package’s own sources still count', () => {
+      // Listing `inputs` REPLACES the default set. Dropping this would mean a change to a package's
+      // own source no longer invalidated its own tests, which is a far bigger hole than the one this
+      // is fixing and would look identical from the outside.
+      expect(declaredInputs(task)).toContain('$TURBO_DEFAULT$');
+    });
+
+    it('covers every repo-root path these tests actually read', () => {
+      const inputs = declaredInputs(task);
+      const missing = reads.filter((path) => !isCovered(path, inputs, pkg.directory)).sort();
+
+      expect(
+        missing,
+        `These tests read repo-root paths that no declared input covers, so a change to them ` +
+          `leaves the cache key untouched and the guard replays an old pass. Add ` +
+          `"$TURBO_ROOT$/<path>/**" to the \`inputs\` of ${task} in turbo.json:\n` +
+          missing.map((p) => `  $TURBO_ROOT$/${p}`).join('\n'),
+      ).toEqual([]);
+    });
   });
+});
 
-  it('covers every repo-root path these tests actually read', () => {
-    const inputs = declaredInputs();
-    const missing = [...repoPathsRead()].filter((path) => !isCovered(path, inputs)).sort();
-
+/**
+ * Two files change the meaning of every compile and every lint in the repo, and are inputs to
+ * nothing.
+ *
+ * Tightening an eslint rule or changing a compiler option should re-run the tasks those settings
+ * govern. Today both replay green everywhere, so the run that proves a stricter rule holds is a run
+ * that never applied it. Unlike the per-task `inputs` above these genuinely are global, which is
+ * what `globalDependencies` is for.
+ */
+describe('repo-wide settings invalidate the tasks they govern', () => {
+  it.each(['tsconfig.base.json', 'eslint.config.mjs'])('%s is a global dependency', (file) => {
     expect(
-      missing,
-      `These tests read repo-root paths that no declared input covers, so a change to them leaves ` +
-        `the cache key untouched and the guard replays an old pass. Add ` +
-        `"$TURBO_ROOT$/<path>/**" to the \`inputs\` of ${TASK} in turbo.json:\n` +
-        missing.map((p) => `  $TURBO_ROOT$/${p}`).join('\n'),
-    ).toEqual([]);
+      turbo().globalDependencies ?? [],
+      `${file} changes the meaning of every compile or lint in the repo but is an input to nothing, ` +
+        `so changing it replays every task green against the old settings.`,
+    ).toContain(file);
   });
 });

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["packages/browser/src/**/*.ts"],
+  "globalDependencies": ["packages/browser/src/**/*.ts", "tsconfig.base.json", "eslint.config.mjs"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -24,6 +24,10 @@
     },
     "test:coverage": {
       "dependsOn": ["^build"]
+    },
+    "@reticlehq/core#test:unit": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/tauri/src/**"]
     },
     "@reticlehq/server#test:unit": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## The defect

`@reticlehq/core#test:unit` declared no `inputs`, so its turbo cache key was the package plus its dependency graph. `desktop-contract.test.ts` reads `packages/tauri/src/capture.rs` and `lib.rs` to hold the daemon and the Rust crate to one contract, and the crate is in neither. Break that agreement and the suite cache-hits and reports success against files it never opened.

Measured rather than argued:

```
turbo run test:unit --filter=@reticlehq/core   ->  0 cached
turbo run test:unit --filter=@reticlehq/core   ->  1 cached, FULL TURBO
echo >> packages/tauri/src/capture.rs
turbo run test:unit --filter=@reticlehq/core   ->  0 cached   (was a hit before this change)
```

## Why the existing guard did not catch it

This is #282 in a second package. `guards-are-cache-invalidated.test.ts` was written for exactly this failure and was blind to it twice over:

1. it scanned only `packages/server/src`, and
2. it matched only the `join(REPO, '...')` spelling, while core escapes its own directory as `join(process.cwd(), '..', 'tauri', ...)`.

So it reported no gap. That is not the same as there being none.

## What changed

Fixing core alone would leave the rule exactly as findable as it was the first time, which is to say not at all. So the guard now:

- scans **every** package with a `src` and a `test:unit`, deriving the task name from the manifest, so a new cross-package guard is covered the day it lands rather than the day somebody notices;
- understands both escape spellings;
- asserts first that it found more than one such package. A scan driven off the filesystem can quietly fall to zero and pass by vacuity, which is the exact failure this file exists to stop.

`tsconfig.base.json` and `eslint.config.mjs` join `globalDependencies`. Both change the meaning of every compile and every lint in the repo and were inputs to nothing, so tightening a rule replayed every task green against the settings it replaced.

## Verification

`format:check`, `lint`, `typecheck`, `test:unit` all green. The guard was confirmed RED before the turbo.json change (5 failures, naming core and both global settings) and green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)