### PR TITLE
test(mcp): make the two SDK monkey-patches fail loudly instead of silently

### DIFF
--- a/packages/server/src/mcp/mcp.ts
+++ b/packages/server/src/mcp/mcp.ts
@@ -22,7 +22,20 @@ import { buildServerInstructions } from './server-instructions.js';
 import { unadvertisedToolHelp } from '../tools/unadvertised-help.js';
 
 /** The JSON-RPC method the SDK registers its tool dispatcher under. */
-const CALL_TOOL_METHOD = 'tools/call';
+export const CALL_TOOL_METHOD = 'tools/call';
+
+/**
+ * What we say when an SDK internal these patches ride on is no longer there.
+ *
+ * LOG rather than THROW, deliberately. Both patches improve an ERROR MESSAGE; neither is load
+ * bearing for a single tool call, and a throw here runs at server construction, so a renamed
+ * internal in a minor SDK bump would take the whole MCP server down for every user rather than
+ * degrade one message. That trade is backwards. The place a shape change must fail is the gate —
+ * `sdk-private-shape.test.ts` asserts both shapes and reddens CI on the bump — and this line is the
+ * backstop for the one case the gate cannot see: a user whose installed SDK is not the one CI
+ * resolved. The old behaviour, a bare `return`, gave neither.
+ */
+const SDK_SHAPE_MISSING = 'sdk_internal_missing';
 import { log } from '../log.js';
 import { SERVER_VERSION } from '../version/server-version.js';
 import { setMcpClientNameHook } from '../telemetry/feedback-context.js';
@@ -354,7 +367,10 @@ export function installFriendlyArgErrors(
 ): void {
   const target = server as unknown as { validateToolInput?: InputValidator };
   const original = target.validateToolInput;
-  if (typeof original !== 'function') return;
+  if (typeof original !== 'function') {
+    log(SDK_SHAPE_MISSING, { internal: 'validateToolInput', lost: 'friendly argument errors' });
+    return;
+  }
   target.validateToolInput = async (tool, args, toolName) => {
     // An UNKNOWN key is the failure zod cannot catch, because object schemas are non-strict: the key
     // is silently dropped and the tool answers as if it had not been asked. Measured live —
@@ -438,7 +454,13 @@ function installUnadvertisedToolHelp(
   };
   const handlers = inner._requestHandlers;
   const original = handlers?.get(CALL_TOOL_METHOD);
-  if (handlers === undefined || original === undefined) return;
+  if (handlers === undefined || original === undefined) {
+    log(SDK_SHAPE_MISSING, {
+      internal: handlers === undefined ? '_requestHandlers' : CALL_TOOL_METHOD,
+      lost: 'unadvertised-tool help',
+    });
+    return;
+  }
   handlers.set(CALL_TOOL_METHOD, async (request: unknown, extra: unknown) => {
     const name = toolNameOf(request);
     const help = name === undefined ? undefined : unadvertisedToolHelp(name, advertised, known);

--- a/packages/server/src/mcp/sdk-private-shape.test.ts
+++ b/packages/server/src/mcp/sdk-private-shape.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The two SDK internals `mcp.ts` monkey-patches must still be there.
+ *
+ * `@modelcontextprotocol/sdk` is pinned `^1.30.0`, so a MINOR bump installs itself without asking.
+ * Both patches reach past the public API — `validateToolInput` for readable argument errors,
+ * `_requestHandlers` for the "known but un-advertised" help — and both bail out with a bare `return`
+ * when their shape is missing. A rename upstream therefore turns two shipped features off with no
+ * error, no red test and, until now, no log line. The `_requestHandlers` one cost a user a long run
+ * of false failures the first time it was ABSENT; a silent regression to that state is the same bug.
+ *
+ * So this suite fails at the fast gate, on the version bump, in CI — not in someone's session.
+ * It asserts the shapes on a real SDK server built the way `createMcpServer` builds one, and is
+ * deliberately about the SHAPE only: whether the patches behave correctly is the business of
+ * `mcp.test.ts` and `unadvertised-tool-over-transport.test.ts`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createMcpServer, CALL_TOOL_METHOD } from './mcp.js';
+import { TOOL_SURFACE } from '../tools/tool-surface.js';
+import type { ToolDeps } from '../tools/tools.js';
+
+const toolDepsForTest = (): ToolDeps =>
+  ({ sessions: { resolve: () => ({ id: 'x' }) } }) as unknown as ToolDeps;
+
+describe('the private MCP SDK shapes both monkey-patches depend on', () => {
+  it('still exposes validateToolInput, or friendly argument errors are silently off', () => {
+    const server = createMcpServer(toolDepsForTest(), TOOL_SURFACE.DEFAULT);
+    const target = server as unknown as { validateToolInput?: unknown };
+    expect(
+      typeof target.validateToolInput,
+      'SDK renamed validateToolInput — mcp.ts installFriendlyArgErrors is now a no-op',
+    ).toBe('function');
+  });
+
+  it('still exposes _requestHandlers with a tools/call entry, or unadvertised help is silently off', () => {
+    const server = createMcpServer(toolDepsForTest(), TOOL_SURFACE.DEFAULT);
+    const inner = server.server as unknown as { _requestHandlers?: Map<string, unknown> };
+    const handlers = inner._requestHandlers;
+    expect(
+      handlers instanceof Map,
+      'SDK renamed _requestHandlers — mcp.ts unadvertised-tool help is now a no-op',
+    ).toBe(true);
+    // The dispatcher is installed lazily on the first registerTool, so its absence here means the
+    // method name moved, not that registration was skipped.
+    expect(
+      handlers?.get(CALL_TOOL_METHOD),
+      `SDK no longer dispatches '${CALL_TOOL_METHOD}' — unadvertised-tool help is now a no-op`,
+    ).toBeTypeOf('function');
+  });
+});

--- a/packages/server/src/mcp/unadvertised-tool-over-transport.test.ts
+++ b/packages/server/src/mcp/unadvertised-tool-over-transport.test.ts
@@ -1,0 +1,83 @@
+/**
+ * A known-but-unadvertised tool name, called the way an agent calls it: over a real transport.
+ *
+ * `unadvertised-help.test.ts` covers the message BUILDER, which is pure and cannot tell whether the
+ * message ever reaches the wire. It does not, unless the `tools/call` wrapper in `mcp.ts` is
+ * installed — and that wrapper reaches into an SDK-private `_requestHandlers` map and returns
+ * silently when the shape is absent. So the builder can be perfect, the patch dead, and every test
+ * green while agents get `Tool <name> not found` and abandon tools that work.
+ *
+ * This is the same in-memory-transport pattern `mcp.test.ts` uses for the sibling arg-error patch;
+ * this path just never got one.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createMcpServer } from './mcp.js';
+import { TOOL_SURFACE } from '../tools/tool-surface.js';
+import type { ToolDeps } from '../tools/tools.js';
+import { ReticleTool } from '../tools/tool-names.js';
+
+/** Enough of the dep surface to construct a server; no tool is actually executed here. */
+const toolDepsForTest = (): ToolDeps =>
+  ({ sessions: { resolve: () => ({ id: 'x' }) } }) as unknown as ToolDeps;
+
+const openServer = async (): Promise<{
+  client: import('@modelcontextprotocol/sdk/client/index.js').Client;
+  close: () => Promise<void>;
+}> => {
+  const { InMemoryTransport } = await import('@modelcontextprotocol/sdk/inMemory.js');
+  const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+  const server = createMcpServer(toolDepsForTest(), TOOL_SURFACE.DEFAULT);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: 'c', version: '0' });
+  await client.connect(clientTransport);
+  return {
+    client,
+    close: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+};
+
+/** Whatever the call produced, as text — a rejection and an isError result read the same to an agent. */
+const replyText = async (call: Promise<unknown>): Promise<string> => {
+  try {
+    const result = await call;
+    const content = (result as { content?: unknown }).content;
+    const blocks = Array.isArray(content) ? content : [];
+    return blocks
+      .map((b) =>
+        'object' === typeof b && null !== b ? String((b as { text?: unknown }).text) : '',
+      )
+      .join(' ');
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+};
+
+describe('calling a known tool the default surface does not advertise', () => {
+  it('answers with the call that works, never with "not found"', async () => {
+    const { client, close } = await openServer();
+    try {
+      const advertised = await client.listTools();
+      // The premise, asserted rather than assumed: if EXPLORE ever joins the default surface this
+      // test would pass for the wrong reason.
+      expect(
+        advertised.tools.map((tool) => tool.name),
+        'the tool under test must be un-advertised here',
+      ).not.toContain(ReticleTool.EXPLORE);
+
+      const reply = await replyText(client.callTool({ name: ReticleTool.EXPLORE, arguments: {} }));
+
+      expect(reply, 'the SDK’s "not found" is the lie this patch exists to remove').not.toMatch(
+        /not found/i,
+      );
+      expect(reply).toContain(ReticleTool.EXPLORE);
+      expect(reply, 'it must name the hatch that works').toContain(ReticleTool.RUN);
+    } finally {
+      await close();
+    }
+  });
+});


### PR DESCRIPTION
## What

`packages/server/src/mcp/mcp.ts` monkey-patches two private internals of `@modelcontextprotocol/sdk` (pinned `^1.30.0`, so a MINOR bump installs itself):

- `validateToolInput` → replaces the raw zod dump with a message naming the field and a valid example call.
- `server.server._requestHandlers` (`tools/call`) → answers a **known but un-advertised** tool name with the `reticle_run` call that works, instead of the SDK's `Tool <name> not found`.

Both bailed out with a bare `return` when the expected shape was absent: no error, no red test, no log line. An upstream rename turns both shipped features off invisibly. The `_requestHandlers` one is the fix for a real field defect — a user scored a long run of false failures on `Tool <name> not found` for tools that worked seconds later through `reticle_run`.

## Changes

**1. End-to-end test over a real transport** — `unadvertised-tool-over-transport.test.ts`. Same `InMemoryTransport` pattern `mcp.test.ts` already uses for the sibling patch; this path never got one. `unadvertised-help.test.ts` only covers the pure message builder, which cannot tell whether the message reaches the wire.

Proven red: neutering `installUnadvertisedToolHelp` with an early `return` fails it with the exact field message — `MCP error -32602: Tool reticle_explore not found`. Patch restored.

**2. A gate that reddens on an SDK shape change** — `sdk-private-shape.test.ts` asserts both internals exist on a server built the way the daemon builds one. Proven red by simulating the rename (deleting `validateToolInput` from the prototype, renaming `CALL_TOOL_METHOD`): both assertions fail, each naming the patch that just went dead.

**3. The runtime bail-outs now LOG instead of returning silently.** Deliberately not a throw, justified in the code comment: both patches only improve an *error message*, and throwing at server construction would take the whole MCP server down for every user over a renamed internal — the wrong trade. The gate is where a shape change must fail; the log is the backstop for a user whose installed SDK is not the one CI resolved.

The patches themselves are untouched — upstream offers no public hook, and replacing them is out of scope. This makes their failure visible.

## Not included

No changelog entry: no agent-visible behaviour changes, this is test and diagnostic hardening.

## Gates

`pnpm format:check && pnpm lint && pnpm typecheck && pnpm test:unit` — all green (lint: 1 pre-existing warning in `apps/bench-app`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)