### PR TITLE
feat(server): a client that never lists the tools is a state status can name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
+### Added
+
+- **`@reticlehq/server` — a client that registers Reticle and never asks for the tools is now a state `status` can name.** Some MCP hosts register the server, start it, and then never send `tools/list` until the client is restarted. The agent has no Reticle tools, the user has a product that does nothing, and from our side that install is byte-identical to one somebody wired and abandoned: daemon idle, no sessions, nothing to report. Reported from the field, and the answer is always the same one nobody could have known to try.
+
+  `reticle status` now carries `mcpClient`, and it distinguishes three states rather than two: nothing has ever started the MCP server on this port, a client started it and never listed the tools, or the client side is healthy. The middle one comes with the sentence that fixes it — restart your MCP client — and the healthy one comes with nothing at all, because advice printed beside a working install reads as though something is wrong.
+
+  **Both bits are records of something that happened, not readings of a config file.** A registration entry proves somebody wrote a line of JSON; it does not prove any client ever read it, which is the whole question here. So the proxy records that it was started and that a `tools/list` arrived, durably per port, and the diagnosis says out loud what it cannot see: which client asked, and anything that happened before the record existed. An honest "here is what I can see, here is what to check" beats a confident wrong no.
+
+  The minimal attach contract a harness author has to meet is now written down in [`docs/platform-integration.md`](docs/platform-integration.md), including `reticle_tools` + `reticle_run` as the way a host with a tool-count cap still reaches the whole surface.
+
 ### Fixed
 
 - **`@reticlehq/server` — a cloud call that stalls no longer hangs the tool call waiting on it.** Node's `fetch` has no default timeout: a connection that opens and then goes quiet never settles, and every cloud request in the server was awaited without one. The worst of them sat inside `reticle_flow_verify` on the `verify: 'server'` path, where a stalled hosted runner meant an MCP call that simply never returned — the failure mode this product treats as its worst, because an agent waiting on a tool has no way to notice, retry, or report. The same absence made every `reticle cloud …` subcommand able to sit at a blank terminal indefinitely.

--- a/docs/platform-integration.md
+++ b/docs/platform-integration.md
@@ -93,6 +93,23 @@ Live, clickable demo of each: `apps/vibe-builder-demo/` (set `BUG_MODE=…`). Pr
 
 ---
 
+## The minimal attach contract (for a harness or MCP host)
+
+Reticle is a stdio MCP server. A host that wires it correctly does four things, and each one is a step Reticle can see:
+
+1. **Spawn it.** `npx @reticlehq/server mcp`, over stdio, one process per host. That process is the proxy: it starts the local daemon on demand, reconnects on its own when the stream drops, and answers from cache while a daemon comes back.
+2. **Complete `initialize`.** Reticle answers the handshake itself when the daemon is slow, so a host that waits for a reply gets one either way.
+3. **Send `tools/list`, and send it again on `notifications/tools/list_changed`.** This is the step hosts skip. Registering a server is not the same as enumerating it: a host can register Reticle and never ask for the tool list until the client is restarted, and the model then has no Reticle tools at all while the install looks healthy from every other angle. Reticle declares `tools.listChanged` so a host that honours the notification recovers without a restart.
+4. **Call the tools.** `tools/call`, with the tool name and its arguments.
+
+`reticle status` reports how far a host has got. `mcpClient: "never-attached"` means no client has started the server on this port. `mcpClient: "never-enumerated"` means one started it and never asked for the tool list, which is the state a client restart fixes. `mcpClient: "enumerated"` means the client side is done, and anything still missing is the app rather than the host. The record is per port rather than per client, and it begins the first time a client starts a Reticle version that keeps it, so `status` says both of those out loud instead of naming a client it cannot see.
+
+### Hosts that cap the number of tools
+
+Some editors cap the total tool count across every MCP server, which is why Reticle advertises a small surface instead of everything it can do. Nothing is out of reach: `reticle_tools { names: [...] }` lists the tools and returns the full argument grammar for the ones you name, and `reticle_run { tool, args }` invokes any of them, advertised or not. A host that is short on tool slots pays for the advertised handful and still reaches the whole surface through that pair. See [`reticle_tools` and `reticle_run`](/tools-tools-and-run).
+
+---
+
 ## Exact steps per platform
 
 The shape is identical (in-app SDK in the template → verify in the sandbox → act on the verdict); the specifics differ by where each platform runs the preview.

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { stateDirProblem } from './daemon/state-dir.js';
 import { statusNextAction } from './cli/status-next-action.js';
 import { hasConnectedBefore } from './session/connection-memory.js';
+import { attachStatusFields } from './mcp/attach-memory.js';
 import { reticleStateHome } from './daemon/daemon.js';
 import {
   handleWatch,
@@ -330,6 +331,10 @@ function handleStatus(port: number): void {
   // path does the first without the second — so this is the commonest reason `status` has nothing to
   // report, and it was not among the facts this command could state.
   const initialized = projectId !== undefined;
+  // The OTHER half of the install, and the half this command could not see. A host that registers
+  // Reticle and never lists its tools looks exactly like an abandoned install from here — same idle
+  // daemon, same zero sessions — and the user sees a tool that does nothing. See attach-memory.ts.
+  const client = attachStatusFields(reticleStateHome(), port);
   if (null === pid || !isAlive(pid)) {
     // `running: false` on its own has been reported about a port that was demonstrably occupied,
     // because the pid file is not the port. Ask the port before answering.
@@ -344,6 +349,7 @@ function handleStatus(port: number): void {
         // `running: false` and nothing else, which reads as "Reticle is broken" for what is usually
         // just a daemon that has not been asked to do anything yet.
         ...withNextAction({ running, sessionCount: 0, previouslyConnected, initialized }),
+        ...client,
       });
     });
     return;
@@ -362,6 +368,7 @@ function handleStatus(port: number): void {
         pid,
         ...nudge,
         ...withNextAction({ running: true, sessionCount: 0, previouslyConnected, initialized }),
+        ...client,
       });
       return;
     }
@@ -373,7 +380,7 @@ function handleStatus(port: number): void {
       summary.why === undefined
         ? withNextAction({ running: true, ...summary, previouslyConnected, initialized })
         : {};
-    log('reticle_status', { port, running: true, pid, ...summary, ...next, ...nudge });
+    log('reticle_status', { port, running: true, pid, ...summary, ...next, ...client, ...nudge });
   });
 }
 

--- a/packages/server/src/mcp/attach-memory.test.ts
+++ b/packages/server/src/mcp/attach-memory.test.ts
@@ -1,0 +1,117 @@
+/**
+ * "Registered" and "usable" are two different states, and `status` could only report one of them.
+ *
+ * Some MCP hosts register the Reticle server, start it, and never send `tools/list` until the client
+ * is restarted. From our side that user is indistinguishable from somebody who installed Reticle and
+ * lost interest; from theirs, Reticle is a tool that does nothing and says nothing about why.
+ *
+ * Two durable bits tell those apart, and both are records of something that HAPPENED rather than an
+ * inference: a client started the MCP server on this port, and a client asked it for the tool list.
+ * These tests pin the three states those bits produce, and pin that the healthy one stays silent —
+ * advice printed beside a working install reads as though something is wrong.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  AttachState,
+  attachState,
+  attachStatusFields,
+  describeAttachState,
+  rememberEnumerated,
+  rememberProxyStarted,
+} from './attach-memory.js';
+
+describe('attach memory', () => {
+  let dir = '';
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'reticle-attach-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reports never attached when no client has started the MCP server on this port', () => {
+    expect(attachState(dir, 4400)).toBe(AttachState.NEVER_ATTACHED);
+  });
+
+  it('reports never enumerated when a client started the server and never asked for the tools', () => {
+    rememberProxyStarted(dir, 4400);
+    expect(attachState(dir, 4400)).toBe(AttachState.NEVER_ENUMERATED);
+  });
+
+  it('reports enumerated once a tool list was asked for', () => {
+    rememberProxyStarted(dir, 4400);
+    rememberEnumerated(dir, 4400);
+    expect(attachState(dir, 4400)).toBe(AttachState.ENUMERATED);
+  });
+
+  it('keys the record on the port, so another port is not evidence about this one', () => {
+    rememberProxyStarted(dir, 4400);
+    rememberEnumerated(dir, 4400);
+    expect(attachState(dir, 4500)).toBe(AttachState.NEVER_ATTACHED);
+  });
+
+  it('survives a restart of the process that recorded it', () => {
+    rememberEnumerated(dir, 4400);
+    // Same state home, a fresh read: the bit is on disk, not in this process.
+    expect(attachState(dir, 4400)).toBe(AttachState.ENUMERATED);
+  });
+
+  it('says nothing at all in the healthy state', () => {
+    expect(describeAttachState(AttachState.ENUMERATED)).toBeUndefined();
+  });
+
+  it('tells a client that never enumerated to restart, and names the cause', () => {
+    const message = describeAttachState(AttachState.NEVER_ENUMERATED) ?? '';
+    expect(message).toContain('tool list');
+    expect(message).toContain('restart');
+  });
+
+  it('admits it cannot see WHICH client, rather than blaming the one in front of the reader', () => {
+    // The record is per port. With two clients registered, one healthy client hides a broken one,
+    // and a confident "your client never enumerated" would be a guess wearing a diagnosis.
+    expect(describeAttachState(AttachState.NEVER_ENUMERATED) ?? '').toContain('per port');
+  });
+
+  it('admits the never-attached state can also be a gap in its own record', () => {
+    // The record starts empty on the version that introduced it, so a long-working install reads as
+    // never attached until its client next starts the server. Saying so beats a confident wrong no.
+    const message = describeAttachState(AttachState.NEVER_ATTACHED) ?? '';
+    expect(message).toContain('init');
+    expect(message).toContain('record');
+  });
+
+  it('gives `status` a state on every run, and advice only when there is any', () => {
+    // What `reticle status` spreads into its output. The healthy run carries the state and NOTHING
+    // else: the field is the answer to "is the client side wired", and a second sentence beside a
+    // working one is the noise this whole diagnosis exists to replace.
+    rememberProxyStarted(dir, 4400);
+    rememberEnumerated(dir, 4400);
+    expect(attachStatusFields(dir, 4400)).toEqual({ mcpClient: AttachState.ENUMERATED });
+  });
+
+  it('carries the restart advice for the state that has an answer', () => {
+    rememberProxyStarted(dir, 4400);
+    const fields = attachStatusFields(dir, 4400);
+    expect(fields.mcpClient).toBe(AttachState.NEVER_ENUMERATED);
+    expect(fields.mcpClientAction).toBe(describeAttachState(AttachState.NEVER_ENUMERATED));
+  });
+
+  it('carries the registration advice when nothing has ever attached', () => {
+    const fields = attachStatusFields(dir, 4400);
+    expect(fields.mcpClient).toBe(AttachState.NEVER_ATTACHED);
+    expect(fields.mcpClientAction).toBe(describeAttachState(AttachState.NEVER_ATTACHED));
+  });
+
+  it('degrades to never attached rather than throwing on an unreadable state home', () => {
+    // A diagnostic that can crash the tool it is diagnosing is worse than no diagnostic.
+    expect(attachState(join(dir, 'nope'), 4400)).toBe(AttachState.NEVER_ATTACHED);
+    expect(() => {
+      rememberProxyStarted('/dev/null/nope', 4400);
+    }).not.toThrow();
+  });
+});

--- a/packages/server/src/mcp/attach-memory.ts
+++ b/packages/server/src/mcp/attach-memory.ts
@@ -1,0 +1,163 @@
+/**
+ * Two durable bits about the CLIENT side of the install: has an MCP client ever started Reticle's
+ * MCP server on this port, and has one ever asked it for the tool list.
+ *
+ * Some hosts register the server, start it, and then never send `tools/list` until the client is
+ * restarted. The agent has no Reticle tools, the user has no message, and from our side that install
+ * is byte-identical to one somebody wired and abandoned: daemon idle, no sessions, nothing to say.
+ * `status` could report "registered" and "connected"; it could not report the state in between,
+ * which is the one with an answer ("restart your client").
+ *
+ * Both bits record something that HAPPENED — the proxy ran, a `tools/list` arrived — never an
+ * inference from a config file. A config entry proves somebody wrote a line of JSON; it does not
+ * prove a client ever read it, which is precisely the thing in question here.
+ *
+ * Deliberately the same shape as `connection-memory.ts`: one small JSON file per port under the
+ * daemon's state home, best-effort in both directions. It is a HINT, so every failure degrades to
+ * "we do not know" rather than throwing — a diagnostic that can crash the process it is diagnosing
+ * is worse than no diagnostic at all.
+ *
+ * KNOWN LIMIT, and why the messages below say so out loud: the record is per PORT, not per client.
+ * Two clients on one machine share it, so a healthy one masks a broken one, and the record itself
+ * only begins on the version that introduced it — a long-working install reads as never attached
+ * until its client next starts the server. Both limits are stated in the text the user reads,
+ * because an honest "here is what I can see, here is what to check" beats a confident wrong no.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** What the client side of this install has been observed doing on this port. */
+export const AttachState = {
+  /** No client has started Reticle's MCP server here, as far as this record goes. */
+  NEVER_ATTACHED: 'never-attached',
+  /** A client started it and never asked for the tool list — the state that needs a restart. */
+  NEVER_ENUMERATED: 'never-enumerated',
+  /** Started and enumerated. Nothing to say. */
+  ENUMERATED: 'enumerated',
+} as const;
+export type AttachState = (typeof AttachState)[keyof typeof AttachState];
+
+/**
+ * What to do about a client that started Reticle and never listed its tools.
+ *
+ * Names the cause AND the action, like the rest of the doctor/status vocabulary, and names its own
+ * blind spot: this record cannot see WHICH client asked, so it must not tell somebody running two
+ * of them that the one in front of them is the broken one.
+ */
+const NEVER_ENUMERATED_ACTION =
+  'an MCP client started Reticle on this port and never asked for the tool list, so the tools are ' +
+  'here and your client has not read them — restart your MCP client, which is what makes it list ' +
+  'them again. This record is per port, not per client, so with more than one client registered ' +
+  'the one that never listed may not be the one you are looking at.';
+
+/**
+ * What to do when nothing has ever attached.
+ *
+ * The hedge is not padding. This record begins the first time a client starts the server on a
+ * version that keeps it, so an install that has worked for months reads as never attached until its
+ * client next starts Reticle — and telling that user their server is unregistered would send them
+ * to re-run `init` over a working setup.
+ */
+const NEVER_ATTACHED_ACTION =
+  'no MCP client has started Reticle on this port, so either the server is not registered with your ' +
+  'client or nothing has attached since this record began — register it with `npx ' +
+  '@reticlehq/server init`, then restart your MCP client and run status again.';
+
+interface AttachRecord {
+  /** A client started the MCP server on this port. */
+  attached: boolean;
+  /** A client asked that server for the tool list. */
+  enumerated: boolean;
+}
+
+const EMPTY: AttachRecord = { attached: false, enumerated: false };
+
+function memoryPath(stateDir: string, port: number): string {
+  return join(stateDir, `attach-${String(port)}.json`);
+}
+
+/** The record for a port. Empty on absent, unreadable, or malformed state. */
+function read(stateDir: string, port: number): AttachRecord {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(memoryPath(stateDir, port), 'utf8'));
+    if ('object' !== typeof parsed || null === parsed) return EMPTY;
+    const record = parsed as Partial<Record<keyof AttachRecord, unknown>>;
+    return {
+      attached: true === record.attached,
+      enumerated: true === record.enumerated,
+    };
+  } catch {
+    return EMPTY;
+  }
+}
+
+/** Write the record back, best-effort. A hint must never be the reason a proxy fails to serve. */
+function write(stateDir: string, port: number, record: AttachRecord): void {
+  try {
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(memoryPath(stateDir, port), JSON.stringify(record), 'utf8');
+  } catch {
+    // An unwritable state home is already reported elsewhere; it must not break the client path.
+  }
+}
+
+/** Record that an MCP client started the proxy on this port. */
+export function rememberProxyStarted(stateDir: string, port: number): void {
+  const known = read(stateDir, port);
+  if (known.attached) return;
+  write(stateDir, port, { ...known, attached: true });
+}
+
+/**
+ * Record that a client asked for the tool list on this port.
+ *
+ * Enumeration implies attachment — a `tools/list` cannot arrive at a server nobody started — so this
+ * sets both bits, and a record written by an older proxy that only ever set one is still read
+ * correctly.
+ */
+export function rememberEnumerated(stateDir: string, port: number): void {
+  const known = read(stateDir, port);
+  if (known.enumerated) return;
+  write(stateDir, port, { attached: true, enumerated: true });
+}
+
+/** Which of the three client-side states this port is in. */
+export function attachState(stateDir: string, port: number): AttachState {
+  const known = read(stateDir, port);
+  if (known.enumerated) return AttachState.ENUMERATED;
+  return known.attached ? AttachState.NEVER_ENUMERATED : AttachState.NEVER_ATTACHED;
+}
+
+/**
+ * The sentence to print for a state, or `undefined` when there is nothing to fix.
+ *
+ * The healthy case has to stay silent: advice printed beside a working client reads as though
+ * something is still wrong, which is its own kind of lie.
+ */
+export function describeAttachState(state: AttachState): string | undefined {
+  if (state === AttachState.NEVER_ENUMERATED) return NEVER_ENUMERATED_ACTION;
+  if (state === AttachState.NEVER_ATTACHED) return NEVER_ATTACHED_ACTION;
+  return undefined;
+}
+
+/** What `reticle status` reports about the client side of the install. */
+export interface AttachStatusFields {
+  mcpClient: AttachState;
+  mcpClientAction?: string;
+}
+
+/**
+ * The client-side fields for one `status` run.
+ *
+ * The state is reported on EVERY run, healthy included — "the client has read the tools" is the
+ * fact that was missing, and reporting it only when broken leaves the reader unable to tell a
+ * healthy client from a version too old to look. The advice rides along only when there is any.
+ */
+export function attachStatusFields(stateDir: string, port: number): AttachStatusFields {
+  const state = attachState(stateDir, port);
+  const action = describeAttachState(state);
+  // OMITTED rather than undefined: `exactOptionalPropertyTypes` is on, and an absent key is also
+  // what keeps the healthy line to one fact.
+  return { mcpClient: state, ...(action === undefined ? {} : { mcpClientAction: action }) };
+}

--- a/packages/server/src/mcp/mcp-proxy.ts
+++ b/packages/server/src/mcp/mcp-proxy.ts
@@ -5,7 +5,8 @@ import {
   drainLines,
   MAX_STDIN_LINE_BYTES,
 } from './proxy-handshake.js';
-import { ToolCatalogCache } from './tool-catalog-cache.js';
+import { isToolsListRequest, ToolCatalogCache } from './tool-catalog-cache.js';
+import { rememberEnumerated, rememberProxyStarted } from './attach-memory.js';
 import { toolsChangedNotification } from './proxy-handshake.js';
 import {
   LOOPBACK_HOST,
@@ -405,6 +406,11 @@ export function startMcpProxy(
   ensureDaemon?: () => Promise<void>,
 ): Promise<never> {
   return new Promise<never>((_resolve, reject) => {
+    // A client just started us, which is the only honest evidence that Reticle is registered with
+    // one at all: a config entry proves somebody wrote JSON, not that a client ever read it. Paired
+    // with the `tools/list` record below, this is what lets `status` name the state in between
+    // "never registered" and "connected" — see attach-memory.ts.
+    rememberProxyStarted(reticleStateHome(), port);
     // Declared before the SSE handler that fills it: the handler is a closure created below but
     // invoked on the first daemon frame, and a `const` referenced before its declaration executes is
     // a runtime throw, not a type error.
@@ -820,6 +826,11 @@ export function startMcpProxy(
         if ('' === trimmed) continue;
         replay.observeOutbound(trimmed);
         pending.observeOutbound(trimmed);
+        // The ARRIVAL of the request, not the delivery of an answer: "this client asked for the tool
+        // list" is the fact `status` reports on, and a request that arrived and then failed is a
+        // different problem with its own diagnosis. Recording the answer instead would let a host
+        // that never asks look identical to one that asked and was refused.
+        if (isToolsListRequest(trimmed)) rememberEnumerated(reticleStateHome(), port);
         const action = onClientRequest(postUrl !== null, dormant);
         if (action === OnRequest.SEND && postUrl !== null) {
           forward(postUrl, trimmed);

--- a/packages/server/src/mcp/tool-catalog-cache.test.ts
+++ b/packages/server/src/mcp/tool-catalog-cache.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { ToolCatalogCache } from './tool-catalog-cache.js';
+import { isToolsListRequest, ToolCatalogCache } from './tool-catalog-cache.js';
 
 const LIST_RESPONSE = JSON.stringify({
   jsonrpc: '2.0',
@@ -76,5 +76,13 @@ describe('the tool catalog the proxy has already seen', () => {
       cache.answer('{"jsonrpc":"2.0","id":1,"method":"tools/list"}') ?? '{}',
     );
     expect((parsed as { result?: { tools?: { name?: string }[] } }).result?.tools).toHaveLength(1);
+  });
+
+  it('recognises a tools/list request, so enumeration can be recorded when one arrives', () => {
+    // `reticle status` needs this fact: a client that starts Reticle and never lists its tools is a
+    // reportable state, and the request line is the only place enumeration is observable at all.
+    expect(isToolsListRequest('{"jsonrpc":"2.0","id":1,"method":"tools/list"}')).toBe(true);
+    expect(isToolsListRequest('{"jsonrpc":"2.0","id":1,"method":"tools/call"}')).toBe(false);
+    expect(isToolsListRequest('not json')).toBe(false);
   });
 });

--- a/packages/server/src/mcp/tool-catalog-cache.ts
+++ b/packages/server/src/mcp/tool-catalog-cache.ts
@@ -33,6 +33,17 @@ function parse(line: string): JsonRpcLike | null {
   }
 }
 
+/**
+ * Is this client line a request for the tool list?
+ *
+ * Lives here because this module already owns the method name and the tolerant parse. The caller is
+ * the proxy's stdin reader, which records the arrival as the one observable fact behind `reticle
+ * status`'s "registered, never enumerated" state — see attach-memory.ts.
+ */
+export function isToolsListRequest(line: string): boolean {
+  return parse(line)?.method === LIST_METHOD;
+}
+
 export class ToolCatalogCache {
   #tools: unknown[] | undefined;
 


### PR DESCRIPTION
Some MCP hosts register the Reticle server, start it, and then never send `tools/list` until the client is restarted. The agent has no Reticle tools, the user has a product that does nothing, and from our side that install is indistinguishable from one somebody wired and abandoned: daemon idle, no sessions, nothing to report. Reported from the field, and the fix is always the same one nobody could have guessed.

## What changed

**`reticle status` now carries `mcpClient`, with three states rather than two.**

- `never-attached` — no client has started the MCP server on this port.
- `never-enumerated` — a client started it and never asked for the tool list. This is the one that needs "restart your MCP client", and `mcpClientAction` says exactly that.
- `enumerated` — the client side is done, and anything still missing is the app. It carries no advice at all: a sentence printed beside a working install reads as though something is wrong.

**The record is of things that happened, not of a config file.** A registration entry proves somebody wrote a line of JSON; it does not prove any client read it, which is the question. So `mcp-proxy` records two bits durably per port (`attach-<port>.json`, same shape and same best-effort rules as `connection-memory.ts`): a client started the proxy, and a `tools/list` request arrived. The enumeration bit records the ARRIVAL of the request, not the delivery of an answer — a request that arrived and then failed is a different problem with its own diagnosis, and recording the answer would let a host that never asks look identical to one that asked and was refused.

**It states its own blind spots instead of guessing.** The record is per port, not per client, so with two clients registered a healthy one masks a broken one — the message says so rather than blaming the client in front of the reader. And the record begins the first time a client starts a version that keeps it, so `never-attached` names both possibilities (not registered, or nothing has attached since the record began) and gives the check for each.

**Docs.** `docs/platform-integration.md` gains the minimal attach contract for a harness or MCP host: spawn, complete `initialize`, send `tools/list` and honour `notifications/tools/list_changed`, call the tools — plus what `status` reports about each step, and `reticle_tools` + `reticle_run` as the route for hosts that cap the total tool count.

## Tests

Red before green in both cases. `packages/server/src/mcp/attach-memory.test.ts` covers all three states, the per-port keying, survival across processes, the `status` fields (healthy = state only, no advice), both honesty hedges, and the degrade-rather-than-throw path. `tool-catalog-cache.test.ts` gains the `tools/list` request predicate, which is reused from the module that already owned the method name and the tolerant parse.

## Gates

`pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm lint:docs` all green. `pnpm test:unit`: server 4690/4690, browser 1112/1112 (one presenter-controls test failed once under full parallel load and passes both in isolation and on a package-level re-run; it is unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
