### PR TITLE
feat(server): exact cardinality on signal assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
+### Added
+
+- **`@reticlehq/core` + `@reticlehq/server` — a signal assertion can now say how many times, not just whether.** `{ kind: "signal", name: "order:placed", count: 1 }` asserts exact cardinality, the same field and the same semantics `net` has carried. It closes the one defect class no state-only oracle can reach: a handler wired twice fires the signal twice and leaves the store in exactly the right shape, so presence is green on both the working version and the broken one. The wrong-name variant is the same blind spot from the other side — the intended signal fires once beside a mistyped sibling — and only a count scoped to the matched name tells those apart.
+
+  **Omitting `count` still means presence**, unchanged for every existing caller, and `count: 0` is a claim of its own: the signal never fired. Collapsing those two onto each other would quietly turn "this must NOT fire" into "this must fire at least once", which is the failure the field exists to prevent.
+
+  One comparison, not two. `net` and `signal` now share the cardinality check, including the part that matters most in practice: an over-count is final the moment it is seen, because a window only accumulates and a count cannot come back down, so a double-fire is reported immediately instead of after the caller's whole budget. A recorded flow keeps the count as `signalCount`, gated on settle for the same reason net's is — a wait-until-true reader is satisfied by the first fire, before the duplicate arrives.
+
 ### Fixed
 
 - **`@reticlehq/server` — a cloud call that stalls no longer hangs the tool call waiting on it.** Node's `fetch` has no default timeout: a connection that opens and then goes quiet never settles, and every cloud request in the server was awaited without one. The worst of them sat inside `reticle_flow_verify` on the `verify: 'server'` path, where a stalled hosted runner meant an MCP call that simply never returned — the failure mode this product treats as its worst, because an agent waiting on a tool has no way to notice, retry, or report. The same absence made every `reticle cloud …` subcommand able to sit at a blank terminal indefinitely.

--- a/docs/predicates.mdx
+++ b/docs/predicates.mdx
@@ -115,6 +115,14 @@ A passing route verdict quotes the transition itself:
 
 The app emitted a named signal via `reticle.signal()`. `dataMatches` is shallow JSON matching, and `*` means "present, any value".
 
+`count` works here exactly as it does on `net`:
+
+```json
+{ "kind": "signal", "name": "order:placed", "count": 1 }
+```
+
+**Exactly once.** A handler wired twice fires the signal twice and leaves the store in the right shape either way, so every state-only check stays green. `count: 0` is a claim of its own (the signal never fired) and is not the same as leaving `count` out, which asserts presence.
+
 Nothing outranks this. A `200` proves the server was reachable; a rendered row proves React ran. A signal is the application itself saying the thing succeeded. See [instrumentation](/instrumentation) for how to emit them.
 
 ### state

--- a/packages/core/src/flow-types.ts
+++ b/packages/core/src/flow-types.ts
@@ -67,6 +67,14 @@ export const FlowExpectSchema = z.object({
    * bare `signal` still parses, and the on-disk version stays FLOW_FILE_VERSION 1.
    */
   signalData: z.record(z.unknown()).optional(),
+  /**
+   * Exact number of times the signal must have fired — the signal-side twin of `net.count`, and the
+   * only way a saved flow can keep a cardinality the agent actually asserted. Without it a
+   * `count: 1` drive would be recorded as bare presence, which is a strictly WEAKER claim than the
+   * one made: the replayed flow then goes green on the double-fire it was recorded to catch.
+   * Additive/optional — a flow file with a bare `signal` still parses, and FLOW_FILE_VERSION stays 1.
+   */
+  signalCount: z.number().int().nonnegative().optional(),
   net: z
     .object({
       method: z.string().optional(),

--- a/packages/server/src/events/predicate-eval.ts
+++ b/packages/server/src/events/predicate-eval.ts
@@ -223,6 +223,44 @@ function describeNetFilter(p: Extract<Predicate, { kind: typeof PredicateKind.NE
   return JSON.stringify(filter);
 }
 
+/** Same, for a signal: the matcher as applied, with the cardinality and the floor taken out. */
+function describeSignalFilter(
+  p: Extract<Predicate, { kind: typeof PredicateKind.SIGNAL }>,
+): string {
+  const { kind: _kind, count: _count, since: _since, ...filter } = p;
+  return JSON.stringify(filter);
+}
+
+/**
+ * Exact cardinality, once, for every channel that can count its matches.
+ *
+ * `net` and `signal` are the same assertion over different evidence — "this happened EXACTLY n
+ * times" — and the interesting half is the same on both: an over-count is `decided`, because a
+ * window only accumulates and a count cannot come back down, so waiting out the rest of the budget
+ * to report a double-fire buys nothing but latency.
+ *
+ * `noun` names the population in prose ("network call(s)", "signal(s)"), `filter` is the matcher as
+ * applied, and `assertion` is the oracle that judged it.
+ */
+function evalExactCount(args: {
+  matched: number;
+  want: number;
+  noun: string;
+  filter: string;
+  assertion: string;
+}): EvalResult {
+  const { matched, want, noun, filter, assertion } = args;
+  if (matched === want) return { pass: true, evidence: { matched } };
+  return {
+    pass: false,
+    ...(matched > want ? { decided: true } : {}),
+    failureReason: `expected ${String(want)} ${noun} matching ${filter}, saw ${String(matched)}`,
+    observed: `${String(matched)} matching ${noun}`,
+    expected: `exactly ${String(want)} matching ${filter}`,
+    assertion,
+  };
+}
+
 /**
  * URL suffixes only the DOCUMENT fetches, which the network observer therefore never records.
  *
@@ -435,26 +473,26 @@ export function evalNet(
   // useEffect-double-fire / retry-storm regression class, where the request DID fire (presence passes)
   // but fired the WRONG number of times. Without `count`, the matcher is presence-only (≥1).
   if (p.count !== undefined) {
-    return matches.length === p.count
-      ? { pass: true, evidence: { matched: matches.length } }
-      : 0 === matches.length && targetsUnobservedChannel(p) && !sawSubresources
-        ? {
-            pass: false,
-            failureReason: unobservedChannelReason(p),
-            inconclusive: unobservedChannelReason(p),
-            assertion: 'net.count',
-          }
-        : {
-            pass: false,
-            // Monotonic: more matches than asked for can never become exactly the number asked for.
-            // This is the double-submit — two writes 59ms apart — so the finding that matters most was
-            // also the one that took the caller's whole budget to report.
-            ...(matches.length > p.count ? { decided: true } : {}),
-            failureReason: `expected ${String(p.count)} network call(s) matching ${describeNetFilter(p)}, saw ${String(matches.length)}`,
-            observed: `${String(matches.length)} matching network call(s)`,
-            expected: `exactly ${String(p.count)} matching ${describeNetFilter(p)}`,
-            assertion: 'net.count',
-          };
+    if (
+      matches.length !== p.count &&
+      0 === matches.length &&
+      targetsUnobservedChannel(p) &&
+      !sawSubresources
+    ) {
+      return {
+        pass: false,
+        failureReason: unobservedChannelReason(p),
+        inconclusive: unobservedChannelReason(p),
+        assertion: 'net.count',
+      };
+    }
+    return evalExactCount({
+      matched: matches.length,
+      want: p.count,
+      noun: 'network call(s)',
+      filter: describeNetFilter(p),
+      assertion: 'net.count',
+    });
   }
   const hit = matches[0];
   if (hit === undefined && targetsUnobservedChannel(p) && !sawSubresources) {
@@ -620,7 +658,7 @@ export function evalSignal(
   events: ReticleEvent[],
   p: Extract<Predicate, { kind: typeof PredicateKind.SIGNAL }>,
 ): EvalResult {
-  const hit = events.find((e) => {
+  const isMatch = (e: ReticleEvent): boolean => {
     if (e.type !== EventType.SIGNAL) return false;
     if (p.name !== undefined && str(e.data['name']) !== p.name) return false;
     if (p.dataMatches !== undefined) {
@@ -628,7 +666,24 @@ export function evalSignal(
       if (!dataMatches(payload, p.dataMatches)) return false;
     }
     return true;
-  });
+  };
+
+  // `count` (exact) turns presence into a cardinality assertion, exactly as it does on `net`. The
+  // double-fire is invisible to every state-only oracle — a handler wired twice leaves the store in
+  // the right shape and fires the signal twice — and so is the wrong-name fire, where the intended
+  // signal fires once beside a mistyped sibling and a presence check cannot say which is which.
+  // Counting only what the MATCHER matched is what separates them. Omit = presence (≥1).
+  if (p.count !== undefined) {
+    return evalExactCount({
+      matched: events.filter(isMatch).length,
+      want: p.count,
+      noun: 'signal(s)',
+      filter: describeSignalFilter(p),
+      assertion: 'signal.count',
+    });
+  }
+
+  const hit = events.find(isMatch);
   if (hit !== undefined) return { pass: true, evidence: hit.data };
 
   // Near-miss: show signals that fired with the same name (so the agent sees the real data).

--- a/packages/server/src/events/predicate-schema.ts
+++ b/packages/server/src/events/predicate-schema.ts
@@ -66,6 +66,11 @@ export type Predicate =
       kind: typeof PredicateKind.SIGNAL;
       name?: string;
       dataMatches?: Record<string, unknown>;
+      /**
+       * Exact number of matching signals in the window — the same cardinality assertion `net`
+       * carries, on the channel the app itself speaks. Omit for presence (≥1).
+       */
+      count?: number;
       since?: number;
     }
   | { kind: typeof PredicateKind.STATE; store?: string; path: string; equals?: unknown }
@@ -353,6 +358,17 @@ function predicateUnion() {
         kind: z.literal(PredicateKind.SIGNAL),
         name: z.string().optional(),
         dataMatches: z.record(z.unknown()).optional(),
+        /**
+         * Exact number of matching signals since the action — presence becomes cardinality.
+         *
+         * The double-fire is the defect no state-only oracle can see: a handler wired twice fires
+         * the signal twice, the store ends up in the right shape either way, and a presence check
+         * is green on both. The wrong-name variant is the same blind spot from the other side — the
+         * intended signal fires once while a mistyped sibling fires alongside it, and only a count
+         * scoped to the matched name tells the two apart. Omit = presence (≥1); `0` asserts the
+         * signal never fired, which is a claim in its own right and NOT the same as omitting it.
+         */
+        count: z.number().int().nonnegative().optional(),
         since: z.number().optional(),
       })
       .strict(),

--- a/packages/server/src/events/predicate-strict.test.ts
+++ b/packages/server/src/events/predicate-strict.test.ts
@@ -54,6 +54,14 @@ describe('a predicate key that is not real is refused, never dropped', () => {
     ).toMatchObject({ kind: 'signal', name: 'order:placed', dataMatches: { id: 1 } });
   });
 
+  it('signal { count } survives the parse instead of being rejected as an unknown key', () => {
+    // The strict union drops nothing silently, so a field the evaluator reads has to be declared
+    // here too — otherwise the cardinality assertion never reaches it and the call returns nothing.
+    expect(PredicateSchema.parse({ kind: 'signal', name: 'order:placed', count: 1 })).toMatchObject(
+      { kind: 'signal', name: 'order:placed', count: 1 },
+    );
+  });
+
   /**
    * Reported from the field, and the reasoning behind the mistake is sound:
    *

--- a/packages/server/src/events/predicate.test.ts
+++ b/packages/server/src/events/predicate.test.ts
@@ -448,6 +448,82 @@ describe('predicate engine', () => {
     expect(r.evidence).toMatchObject({ nearMiss: [{ label: '' }] });
   });
 
+  /**
+   * The defect class no state-only oracle can reach: the signal FIRED, so presence is green, but it
+   * fired the wrong NUMBER of times. The same cardinality assertion `net` already carries — a
+   * double-fired handler and a double-submitted request are one bug seen from two channels.
+   */
+  it('signal count: exactly-once passes on one fire, and a double-fire is caught', async () => {
+    const predicate = { kind: 'signal' as const, name: 'order:placed', count: 1 };
+    const once = new FakeSession([ev(EventType.SIGNAL, { name: 'order:placed', data: {} })]);
+    expect((await evaluatePredicate(once, predicate)).pass).toBe(true);
+
+    const twice = new FakeSession([
+      ev(EventType.SIGNAL, { name: 'order:placed', data: {} }),
+      ev(EventType.SIGNAL, { name: 'order:placed', data: {} }),
+    ]);
+    const r = await evaluatePredicate(twice, predicate);
+    expect(r.pass).toBe(false);
+    expect(r.assertion).toBe('signal.count');
+    expect(r.failureReason).toContain('2');
+    // Monotonic, exactly as on net: a window only accumulates, so an over-count is final.
+    expect(r.decided).toBe(true);
+  });
+
+  it('signal count: a fire under a different name is not counted', async () => {
+    // The wrong-name half of the defect class: the right signal fires once while a near-miss name
+    // fires alongside it. Counting both would report a double-fire that never happened.
+    const session = new FakeSession([
+      ev(EventType.SIGNAL, { name: 'order:placed', data: {} }),
+      ev(EventType.SIGNAL, { name: 'order:place', data: {} }),
+    ]);
+    expect(
+      (await evaluatePredicate(session, { kind: 'signal', name: 'order:placed', count: 1 })).pass,
+    ).toBe(true);
+  });
+
+  it('signal count omitted stays presence-only, so a double-fire still passes', async () => {
+    // The existing contract, pinned: adding the field must change nothing for callers who omit it.
+    const session = new FakeSession([
+      ev(EventType.SIGNAL, { name: 'order:placed', data: {} }),
+      ev(EventType.SIGNAL, { name: 'order:placed', data: {} }),
+    ]);
+    expect((await evaluatePredicate(session, { kind: 'signal', name: 'order:placed' })).pass).toBe(
+      true,
+    );
+  });
+
+  it('signal count: 0 asserts the signal never fired', async () => {
+    // `count: 0` is an assertion, not an omitted field — the two must not collapse onto each other,
+    // or "this handler must NOT fire" would silently become "it must fire at least once".
+    const quiet = new FakeSession([ev(EventType.SIGNAL, { name: 'other:thing', data: {} })]);
+    expect(
+      (await evaluatePredicate(quiet, { kind: 'signal', name: 'order:placed', count: 0 })).pass,
+    ).toBe(true);
+
+    const fired = new FakeSession([ev(EventType.SIGNAL, { name: 'order:placed', data: {} })]);
+    const r = await evaluatePredicate(fired, { kind: 'signal', name: 'order:placed', count: 0 });
+    expect(r.pass).toBe(false);
+    expect(r.assertion).toBe('signal.count');
+  });
+
+  it('signal count: dataMatches narrows what is counted', async () => {
+    const session = new FakeSession([
+      ev(EventType.SIGNAL, { name: 'save:done', data: { id: 'a' } }),
+      ev(EventType.SIGNAL, { name: 'save:done', data: { id: 'b' } }),
+    ]);
+    expect(
+      (
+        await evaluatePredicate(session, {
+          kind: 'signal',
+          name: 'save:done',
+          dataMatches: { id: 'a' },
+          count: 1,
+        })
+      ).pass,
+    ).toBe(true);
+  });
+
   it('element predicate reports a near-miss when the name is wrong', async () => {
     const session = new FakeSession([], (query) => {
       // Only a button named "Cancel" exists.

--- a/packages/server/src/flows/flow-success.test.ts
+++ b/packages/server/src/flows/flow-success.test.ts
@@ -69,6 +69,16 @@ describe('successToPredicate', () => {
     });
   });
 
+  it('signalCount gates on `settled` so a double-fire cannot pass on the first transient match', () => {
+    // Identical reasoning to net.count: a wait-until-true waiter sees exactly one fire the instant
+    // the FIRST one lands, and resolves before the duplicate arrives. The count is only true after
+    // the app goes quiet, so the settle gate is what makes the assertion mean what it says.
+    expect(successToPredicate({ signal: 'order:placed', signalCount: 1 }, NONE)).toEqual({
+      kind: 'allOf',
+      predicates: [{ kind: 'settled' }, { kind: 'signal', name: 'order:placed', count: 1 }],
+    });
+  });
+
   it('console.absent gates on `settled` (a clean-console assertion is post-settle)', () => {
     // Same post-settle reasoning as net.count: an absent assertion is satisfied at the first poll
     // (no error yet) before the action's error fires, so it must be read only after the page quiets.

--- a/packages/server/src/flows/flow-success.ts
+++ b/packages/server/src/flows/flow-success.ts
@@ -48,11 +48,20 @@ export function successToPredicate(
   const parts: Predicate[] = [];
 
   if (success.signal !== undefined) {
-    parts.push(
-      success.signalData !== undefined
-        ? { kind: PredicateKind.SIGNAL, name: success.signal, dataMatches: success.signalData }
-        : { kind: PredicateKind.SIGNAL, name: success.signal },
-    );
+    const signal: Extract<Predicate, { kind: typeof PredicateKind.SIGNAL }> = {
+      kind: PredicateKind.SIGNAL,
+      name: success.signal,
+    };
+    if (success.signalData !== undefined) signal.dataMatches = success.signalData;
+    if (success.signalCount !== undefined) {
+      signal.count = success.signalCount;
+      // Same post-settle reasoning as net.count: the success waiter is wait-until-true, so an exact
+      // count is transiently satisfied the instant the FIRST matching signal fires — before a
+      // double-fire's duplicate arrives. Gating on `settled` forces the count to be read only after
+      // the app goes quiet, by which point the duplicate IS counted and the over-count fails.
+      parts.push({ kind: PredicateKind.SETTLED });
+    }
+    parts.push(signal);
   }
 
   if (success.net !== undefined) {

--- a/packages/server/src/flows/predicate-to-expect.test.ts
+++ b/packages/server/src/flows/predicate-to-expect.test.ts
@@ -30,6 +30,16 @@ describe('predicateToExpect', () => {
     ).toEqual({ signal: 'deploy:shipped', signalData: { id: '*' } });
   });
 
+  it('carries a signal count, so a saved flow keeps the cardinality the agent asserted', () => {
+    // Dropping it would save a strictly WEAKER claim than the one made — presence where the agent
+    // said "exactly once" — and the replayed flow would then go green on the double-fire it exists
+    // to catch. Same reason net's count is carried.
+    expect(predicateToExpect({ kind: 'signal', name: 'order:placed', count: 1 })).toEqual({
+      signal: 'order:placed',
+      signalCount: 1,
+    });
+  });
+
   it('carries a net assertion including the count that catches double-submit', () => {
     expect(
       predicateToExpect({ kind: 'net', method: 'POST', urlContains: '/refund', count: 1 }),

--- a/packages/server/src/flows/predicate-to-expect.ts
+++ b/packages/server/src/flows/predicate-to-expect.ts
@@ -28,9 +28,10 @@ export function predicateToExpect(predicate: Predicate): FlowExpect | undefined 
   switch (predicate.kind) {
     case PredicateKind.SIGNAL: {
       if (predicate.name === undefined) return undefined;
-      return predicate.dataMatches === undefined
-        ? { signal: predicate.name }
-        : { signal: predicate.name, signalData: predicate.dataMatches };
+      const signal: FlowExpect = { signal: predicate.name };
+      if (predicate.dataMatches !== undefined) signal.signalData = predicate.dataMatches;
+      if (predicate.count !== undefined) signal.signalCount = predicate.count;
+      return signal;
     }
     case PredicateKind.NET: {
       const net: NonNullable<FlowExpect['net']> = {};

--- a/packages/server/src/tools/observe-tools.ts
+++ b/packages/server/src/tools/observe-tools.ts
@@ -336,7 +336,8 @@ export const OBSERVE_TOOLS: ToolDef[] = [
         // undocumented here, including `route` — and "did submitting the login form navigate away"
         // is the most common thing an agent wants to assert. A field report reached us from an agent
         // that guessed `urlContains` on route (net's spelling) and got unrecognized_keys.
-        'Predicate to evaluate. Kinds: { signal, name } { net, urlContains|method|status|count|bodyContains } ' +
+        'Predicate to evaluate. Kinds: { signal, name|dataMatches|count } ' +
+          '{ net, urlContains|method|status|count|bodyContains } ' +
           '{ state, path|equals } { route, pathname (exact) | contains (path+query+hash) } ' +
           '{ element, testid|role|text } { text } { console, level|contains|absent } { animation, name } ' +
           '{ settled } — combine with { allOf | anyOf | not }. Prefer a signal/net/state consequence ' +


### PR DESCRIPTION
`evalNet` has carried exact request counts for a while. `evalSignal` was still `events.find()` — presence only — and the predicate schema had no `count` field at all.

That leaves open the one defect class no state-only oracle can reach. A handler wired twice fires the signal twice and leaves the store in exactly the right shape, so a presence check is green on the working version and the broken one alike. The wrong-name variant is the same blind spot from the other side: the intended signal fires once beside a mistyped sibling, and only a count scoped to the matched name separates them.

## What changed

- `{ kind: 'signal', name, count }` — the same field, shape and comparison semantics `net` already uses.
- `evalExactCount` is now the single implementation both channels call, keeping the part that matters most in practice: an over-count is `decided` the moment it is seen, because a window only accumulates and a count cannot come back down, so a double-fire is reported immediately rather than after the caller's whole budget.
- A recorded flow keeps the count as `FlowExpect.signalCount`, gated on `settled` for the same reason net's count is — a wait-until-true reader is satisfied by the first fire, before the duplicate arrives. Dropping it would have saved a strictly weaker claim than the agent made, and the replayed flow would go green on the very bug it was recorded to catch.
- `reticle_assert`'s predicate description and `docs/predicates.mdx` now name the field, so an agent can find it without a `reticle_tools` round trip.

Omitting `count` still means presence, unchanged for every existing caller. `count: 0` is a claim of its own (the signal never fired) and deliberately does not collapse onto the omitted case, which would turn "this must NOT fire" into "this must fire at least once".

## Tests (written red first)

- `signal count: exactly-once passes on one fire, and a double-fire is caught` — the motivating case, including `decided` on the over-count
- `signal count: a fire under a different name is not counted`
- `signal count omitted stays presence-only, so a double-fire still passes`
- `signal count: 0 asserts the signal never fired`
- `signal count: dataMatches narrows what is counted`
- `signal { count } survives the parse instead of being rejected as an unknown key`
- `carries a signal count, so a saved flow keeps the cardinality the agent asserted`
- `signalCount gates on settled so a double-fire cannot pass on the first transient match`

## Gates

`pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test:unit --force` — all green (479 server test files, 1112 browser tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
