### PR TITLE
test(browser): give jsdom the headroom a loaded runner needs

### DIFF
--- a/packages/browser/vitest.config.ts
+++ b/packages/browser/vitest.config.ts
@@ -3,5 +3,19 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    /**
+     * jsdom is slow, and this package's heaviest tests mount an entire HUD into it. Under a loaded
+     * runner — CI, or a machine running several suites at once — that exceeds vitest's 5s default,
+     * and the suite fails for a reason that has nothing to do with the code. It has now been
+     * observed across several different presenter files rather than one, so it is a property of the
+     * environment and belongs in the environment's configuration.
+     *
+     * This is a BOUND, not a duration. Nothing here asserts how long anything took — the repo
+     * forbids that outright — so raising the ceiling cannot mask a regression: a broken expectation
+     * still fails immediately, and a genuine hang still fails, just with headroom for a busy
+     * machine. A test that sets its own timeout keeps it; the value below only applies where none
+     * was chosen deliberately.
+     */
+    testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
Two independent build streams hit browser test failures that vanished on re-run and pass in isolation, in different presenter files, on unrelated branches. That makes it a property of the environment rather than of any one test.

The heaviest tests in this package mount an entire HUD into jsdom, which exceeds vitest's 5s default on a loaded runner. A per-file override was already added to the shell suite; seven files in `packages/browser/src/presenter` mount a HUD, so fixing them one at a time would be finding the same bug six more times.

**A bound, not a duration.** Nothing in this package asserts how long anything took — the repo forbids that outright, and #467 removed the last two such assertions — so raising the ceiling cannot mask a regression. A broken expectation still fails immediately; a genuine hang still fails, with headroom for a busy machine.

**Deliberate timeouts are preserved.** A per-test value wins over the config default, so the `}, 5000)` bounds #467 chose explicitly (and explained: *"catches a genuine hang and is immune to how loaded the runner is"*) keep their meaning. This applies only where nobody decided.

Verified: 119 files / 1112 tests pass, and the explicit 5s timeouts are still in force.

🤖 Generated with [Claude Code](https://claude.com/claude-code)