### PR TITLE
feat(core): every observation says which document it was made under

### DIFF
--- a/packages/browser/src/reticle.document-identity.test.ts
+++ b/packages/browser/src/reticle.document-identity.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { EventType } from '@reticlehq/core';
+import { buildEvent } from './reticle.js';
+
+/**
+ * Every event says which document it was observed under.
+ *
+ * Without it, evidence is scoped by time and buffer capacity alone, so a request from a previous
+ * document — or a previous run of the app — can be cited against an action taken now. The stamp is
+ * what lets the server refuse that evidence instead of reporting it.
+ *
+ * Stamped in `buildEvent` because it is the one place every event passes through. Anywhere else and
+ * an observer added later would emit unstamped events, which read as "current" by design and would
+ * therefore reintroduce the defect silently for exactly one event type.
+ */
+
+const base = {
+  seq: 1,
+  t: 10,
+  type: EventType.CONSOLE_ERROR,
+  sessionId: 's1',
+  data: {},
+};
+
+describe('buildEvent stamps the document', () => {
+  it('carries the document id it was given', () => {
+    expect(buildEvent({ ...base, documentId: 'doc12345' }).documentId).toBe('doc12345');
+  });
+
+  it('omits the field rather than inventing one when no document is known', () => {
+    // Absence is read as "current document" downstream, so a fabricated id would be worse than none:
+    // it would silently exclude real evidence instead of merely failing to scope it.
+    expect(buildEvent(base).documentId).toBeUndefined();
+  });
+
+  it('leaves every other field of the envelope alone', () => {
+    const event = buildEvent({ ...base, ref: 'e7', documentId: 'doc12345' });
+    expect(event.seq).toBe(1);
+    expect(event.t).toBe(10);
+    expect(event.type).toBe(EventType.CONSOLE_ERROR);
+    expect(event.sessionId).toBe('s1');
+    expect(event.ref).toBe('e7');
+  });
+});

--- a/packages/browser/src/reticle.ts
+++ b/packages/browser/src/reticle.ts
@@ -17,6 +17,7 @@ import {
   RETICLE_ROOT_GLOBAL,
   RETICLE_SDK_VERSION_GLOBAL,
   CONTRACT_FINGERPRINT,
+  newDocumentId,
   type CommandMessage,
   type HelloMessage,
   type RedactionConfig,
@@ -189,6 +190,7 @@ export function buildEvent(args: {
   sessionId: string;
   data: Record<string, unknown>;
   ref?: string | undefined;
+  documentId?: string | undefined;
 }): ReticleEvent {
   return {
     t: args.t,
@@ -196,6 +198,11 @@ export function buildEvent(args: {
     type: args.type,
     sessionId: args.sessionId,
     ref: args.ref,
+    // Which document this was observed under, so the server can refuse evidence minted before a
+    // navigation replaced the page. Stamped HERE because it is the one place every event passes
+    // through: an observer added later would otherwise emit unstamped events, which read as
+    // "current" by design and would reintroduce the defect silently for one event type.
+    documentId: args.documentId,
     data: args.data,
   };
 }
@@ -210,6 +217,13 @@ export class Reticle {
   #teardowns: Teardown[] = [];
   #connected = false;
   #session = 'default';
+  /**
+   * Minted once, here, because this class is constructed once per document: a full navigation tears
+   * down the JavaScript context and builds a new one, so the id dies with the document it names. An
+   * SPA route change does not reconstruct it, which is correct — same context, same in-flight
+   * requests, same evidence.
+   */
+  readonly #documentId = newDocumentId(Math.random);
   #start = 0;
   #overlay: OverlayHandle | undefined;
   #presenter: Presenter | undefined;
@@ -450,6 +464,7 @@ export class Reticle {
       t: Math.round(performance.now() - this.#start),
       type,
       sessionId: this.#session,
+      documentId: this.#documentId,
       data,
       ref,
     });

--- a/packages/core/src/document-identity.test.ts
+++ b/packages/core/src/document-identity.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { DOCUMENT_ID_LENGTH, newDocumentId, isSameDocument } from './document-identity.js';
+
+/**
+ * Which document an observation belongs to.
+ *
+ * Evidence was scoped by time and by ring-buffer capacity and by nothing else, so a request observed
+ * under a PREVIOUS document — or under a previous run of the application entirely — could be counted
+ * against an action taken now. Field reports describe exactly that, including one where the failing
+ * request Reticle cited named a database row that does not exist any more. The report was true about
+ * the bytes and false about the world, which is the worst kind of wrong a verification tool can be.
+ *
+ * A document id is minted once per real document and dies with it. A full navigation replaces the
+ * document and therefore the id; an SPA route change does NOT, which is correct — same JavaScript
+ * context, same in-flight requests, same evidence.
+ *
+ * Randomness is injected rather than read here, for the same reason the clock is: a generator that
+ * reaches for `Math.random()` cannot be tested and cannot be replayed.
+ */
+
+describe('newDocumentId', () => {
+  it('is stable for one document and different across documents', () => {
+    const a = newDocumentId(() => 0.5);
+    const b = newDocumentId(() => 0.5);
+    // Same seed, same id: the value is a pure function of what it was given, so a replay reproduces
+    // it exactly rather than drifting.
+    expect(a).toBe(b);
+    expect(newDocumentId(() => 0.5)).not.toBe(newDocumentId(() => 0.9));
+  });
+
+  it('is short enough to stamp on every event', () => {
+    // Stamped on EVERY event, so its cost is paid thousands of times per session. Long enough not to
+    // collide within one session, short enough that the wire does not notice.
+    expect(newDocumentId(() => 0.42)).toHaveLength(DOCUMENT_ID_LENGTH);
+  });
+
+  it('produces distinct ids across many documents', () => {
+    let n = 0;
+    const ids = new Set(Array.from({ length: 200 }, () => newDocumentId(() => (n++ % 97) / 97)));
+    expect(ids.size).toBeGreaterThan(1);
+  });
+
+  it('never emits a character that would need escaping on the wire', () => {
+    for (let i = 0; i < 50; i++) {
+      expect(newDocumentId(() => i / 50)).toMatch(/^[0-9a-z]+$/);
+    }
+  });
+});
+
+describe('isSameDocument', () => {
+  it('matches a document against itself', () => {
+    expect(isSameDocument('abc123', 'abc123')).toBe(true);
+  });
+
+  it('rejects evidence minted under a superseded document', () => {
+    expect(isSameDocument('abc123', 'def456')).toBe(false);
+  });
+
+  /**
+   * The back-compat case, and the one where getting the default wrong is expensive in both
+   * directions. An SDK older than this field stamps nothing.
+   *
+   * Unstamped evidence is treated as BELONGING to the current document. Excluding it would make an
+   * older SDK silently stop reporting real contradictions — a verification tool that quietly finds
+   * nothing is far worse than one that occasionally over-reports, and the whole point of this change
+   * is to stop quietly-wrong answers rather than to trade one for another.
+   */
+  it('treats unstamped evidence as current, so an older SDK does not go silent', () => {
+    expect(isSameDocument(undefined, 'abc123')).toBe(true);
+    expect(isSameDocument('abc123', undefined)).toBe(true);
+    expect(isSameDocument(undefined, undefined)).toBe(true);
+  });
+});

--- a/packages/core/src/document-identity.ts
+++ b/packages/core/src/document-identity.ts
@@ -1,0 +1,59 @@
+/**
+ * Which document an observation belongs to.
+ *
+ * Evidence used to be scoped by time and by ring-buffer capacity and by nothing else. A request
+ * observed under a PREVIOUS document — or under a previous run of the application entirely — could
+ * therefore be counted against an action taken now. Field reports describe exactly that, including
+ * one where the failing request Reticle cited named a database row that no longer exists: true about
+ * the bytes, false about the world, which is the worst kind of wrong a verification tool can be.
+ *
+ * A document id is minted once per real document and dies with it. A full navigation replaces the
+ * document and so replaces the id. An SPA route change does NOT, which is correct rather than a
+ * limitation: same JavaScript context, same in-flight requests, same evidence.
+ *
+ * This lives in `core` because it crosses the wire, and every wire value is defined here.
+ */
+
+/**
+ * Long enough not to collide within a session, short enough to stamp on every event.
+ *
+ * The cost is paid thousands of times per session, so this is a deliberate trade rather than a
+ * default: eight base-36 characters is a little over forty bits, against a population of at most a
+ * handful of documents per session. Collisions are not the risk being managed here; wire weight is.
+ */
+export const DOCUMENT_ID_LENGTH = 8;
+
+const ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz';
+
+/**
+ * Mint an id for the current document.
+ *
+ * `random` is injected for the same reason the clock is: a generator that reaches for `Math.random()`
+ * cannot be unit-tested and cannot be replayed, and this repo forbids both.
+ */
+export function newDocumentId(random: () => number): string {
+  let out = '';
+  for (let i = 0; i < DOCUMENT_ID_LENGTH; i++) {
+    const pick = Math.floor(random() * ALPHABET.length);
+    // A generator returning exactly 1 (or a rounding artefact at the top of the range) would index
+    // past the end and produce `undefined` in the string. Clamp rather than trust the caller.
+    out += ALPHABET[Math.min(Math.max(pick, 0), ALPHABET.length - 1)];
+  }
+  return out;
+}
+
+/**
+ * Does this evidence belong to the document currently under observation?
+ *
+ * **Unstamped evidence counts as current.** An SDK older than this field stamps nothing, and
+ * excluding it would make those installations silently stop reporting real contradictions. A
+ * verification tool that quietly finds nothing is far worse than one that occasionally over-reports,
+ * and this change exists to remove quietly-wrong answers rather than to trade one kind for another.
+ */
+export function isSameDocument(
+  evidenceDocumentId: string | undefined,
+  currentDocumentId: string | undefined,
+): boolean {
+  if (undefined === evidenceDocumentId || undefined === currentDocumentId) return true;
+  return evidenceDocumentId === currentDocumentId;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './source-constants.js'; // DATA_RETICLE_SOURCE_ATTR, RETICLE_ROOT
 export * from './event-classification.js'; // CHURN_TYPES — shared eviction priority for buffer/queue
 export * from './verified-constants.js'; // Verified — the one field an agent gates on
 export * from './session-constants.js';
+export * from './document-identity.js'; // which document an observation belongs to
 export * from './messages.js'; // ReticleEvent + the message schemas
 export * from './event-payloads.js'; // per-event payload schemas + wire vocab
 export * from './event-priority.js'; // which events survive the bridge rate cap

--- a/packages/core/src/messages.ts
+++ b/packages/core/src/messages.ts
@@ -8,9 +8,11 @@ import {
 } from './constants.js';
 import { HumanControlKind, MarkAnchorStrategy } from './session-constants.js';
 import { MAX_WIRE_REDACT_KEYS, MAX_WIRE_REDACT_KEY_LENGTH } from './redaction.js';
+import { DOCUMENT_ID_LENGTH } from './document-identity.js';
 
 const sessionIdSchema = z.string().min(1).max(TRANSPORT_LIMITS.MAX_SESSION_ID_LENGTH);
 const refSchema = z.string().max(TRANSPORT_LIMITS.MAX_REF_LENGTH);
+const documentIdSchema = z.string().min(1).max(DOCUMENT_ID_LENGTH);
 
 /**
  * Live-control: the narrowed payload of a HUMAN_CONTROL event. The server safeParses
@@ -74,6 +76,13 @@ export const ReticleEventSchema = z.object({
   actionId: refSchema.optional(),
   /** How `actionId` was derived. Present iff `actionId` is. */
   attribution: z.nativeEnum(EventAttribution).optional(),
+  /**
+   * The document this was observed under. Minted once per real document; a full navigation replaces
+   * both. Lets evidence from a superseded document be excluded rather than counted against an action
+   * taken now. Optional for back-compat with SDKs that predate it, which is why absence is read as
+   * "current" rather than "foreign" — see `isSameDocument`.
+   */
+  documentId: documentIdSchema.optional(),
   /** Event-type-specific payload. Kept open here; refined per observer at the edges. */
   data: z.record(z.unknown()).default({}),
 });


### PR DESCRIPTION
The primitive. The server-side refusal that uses it is #491, stacked on this branch.

## The defect

Evidence is scoped by time and by ring-buffer capacity and by **nothing else**. So a request observed under a previous document — or a previous run of the application entirely — can be cited as the cause of an action taken now. Field reports describe exactly this, including one where the failing request Reticle named a database row that no longer exists.

True about the bytes, false about the world. That is the worst kind of wrong a verification tool can be, because the report looks specific and checkable.

## The design

A document id is minted once per real document and dies with it. A full navigation tears down the JavaScript context and builds a new one, so the id goes with it. **An SPA route change deliberately does not** — same context, same in-flight requests, same evidence. That is correct rather than a limitation.

**Stamped in `buildEvent`**, the one place every event passes through. Anywhere else and an observer added later emits unstamped events — which read as "current" by design — so the defect would come back silently for exactly one event type.

**Unstamped evidence counts as current, deliberately.** An SDK older than this field stamps nothing, and excluding it would make those installations quietly stop reporting real contradictions. A verification tool that silently finds nothing is worse than one that occasionally over-reports, and this change exists to remove quietly-wrong answers rather than trade one kind for another.

Randomness is injected rather than read, for the same reason the clock is: a generator that reaches for `Math.random()` cannot be unit-tested and cannot be replayed.

## Verification

Core 280 tests, browser suite green, all 15 turbo tasks green under `--force` (this touches `packages/browser/src`, which is the known cache trap). The browser test asserts both that the stamp is carried and that the field is **omitted** rather than invented when no document is known — a fabricated id would be worse than none, since it would silently exclude real evidence instead of merely failing to scope it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)