### PR TITLE
test(next): cover the source-stamp loader

### DIFF
--- a/packages/next/index.test.mjs
+++ b/packages/next/index.test.mjs
@@ -1,0 +1,66 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const { withReticle, readPairingToken } = require('./index.cjs');
+
+const TOKEN_ENV = 'RETICLE_PAIRING_TOKEN_DIR';
+
+describe('readPairingToken', () => {
+  const previous = process.env[TOKEN_ENV];
+  /** @type {string | undefined} */
+  let dir;
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env[TOKEN_ENV];
+    else process.env[TOKEN_ENV] = previous;
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  it('reads the token from RETICLE_PAIRING_TOKEN_DIR when the daemon has written one', () => {
+    dir = mkdtempSync(join(tmpdir(), 'reticle-next-token-'));
+    writeFileSync(join(dir, 'pairing-token'), 'tok-from-daemon\n');
+    process.env[TOKEN_ENV] = dir;
+    expect(readPairingToken()).toBe('tok-from-daemon');
+  });
+
+  it('returns undefined when the file is missing, so connect proceeds without a token', () => {
+    dir = mkdtempSync(join(tmpdir(), 'reticle-next-token-'));
+    process.env[TOKEN_ENV] = dir;
+    expect(readPairingToken()).toBeUndefined();
+  });
+});
+
+describe('withReticle', () => {
+  const previousEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = previousEnv;
+  });
+
+  it('is a no-op in production, so a production Next config is byte-identical', () => {
+    process.env.NODE_ENV = 'production';
+    const input = { reactStrictMode: true };
+    expect(withReticle(input)).toBe(input);
+  });
+
+  it('installs the stamping loader as a webpack pre-loader in development', () => {
+    process.env.NODE_ENV = 'development';
+    const config = withReticle({});
+    expect(typeof config.webpack).toBe('function');
+    const webpackConfig = { module: { rules: [] } };
+    const out = config.webpack(webpackConfig, { dev: true });
+    const rule = out.module.rules.find(
+      (entry) =>
+        entry.enforce === 'pre' && String(entry.use?.[0]?.loader ?? '').endsWith('loader.cjs'),
+    );
+    expect(rule).toBeDefined();
+    expect(rule.test.test('src/Foo.tsx')).toBe(true);
+    expect(rule.test.test('src/Foo.jsx')).toBe(true);
+    expect(rule.test.test('src/util.ts')).toBe(false);
+  });
+});

--- a/packages/next/loader.test.mjs
+++ b/packages/next/loader.test.mjs
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const loader = require('./loader.cjs');
+
+// Mirrors DATA_RETICLE_SOURCE_ATTR in @reticlehq/core. This package is plain CJS and does not
+// depend on core; the babel plugin it calls stamps this name. #456 is the job that makes the
+// name come from core rather than a literal.
+const SOURCE_ATTR = 'data-reticle-source';
+
+/**
+ * Drive the webpack loader the way webpack does: `this.async()` plus `this.resourcePath`.
+ * @param {string} source
+ * @param {string} resourcePath
+ */
+function runLoader(source, resourcePath) {
+  return new Promise((resolve, reject) => {
+    const ctx = {
+      resourcePath,
+      async() {
+        return (err, code, map) => {
+          if (err) reject(err);
+          else resolve({ code, map });
+        };
+      },
+    };
+    loader.call(ctx, source, undefined);
+  });
+}
+
+describe('reticle next loader', () => {
+  it('stamps host elements with data-reticle-source (file:line:col)', async () => {
+    const { code } = await runLoader('const x = <button>Hi</button>;', 'src/Foo.tsx');
+    expect(code).toContain(SOURCE_ATTR);
+    expect(code).toMatch(/src\/Foo\.tsx:1:\d+/);
+  });
+
+  it('emits forward slashes on every OS, so a pointer is the same string everywhere', async () => {
+    const { code } = await runLoader('const x = <span>Hi</span>;', 'src/deep/Bar.tsx');
+    expect(code).toContain('src/deep/Bar.tsx:1:');
+    expect(code).not.toContain('\\');
+  });
+
+  it('does not stamp components', async () => {
+    const { code } = await runLoader('const x = <App />;', 'src/Foo.tsx');
+    expect(code).not.toContain(SOURCE_ATTR);
+  });
+
+  it('leaves non-JSX files untouched, so SWC still owns the real compile', async () => {
+    const source = 'export const n = 1;';
+    const { code } = await runLoader(source, 'src/util.ts');
+    expect(code).toBe(source);
+  });
+
+  it('skips node_modules, even when the file is TSX', async () => {
+    const source = 'const x = <button>Hi</button>;';
+    const { code } = await runLoader(source, '/app/node_modules/ui/Button.tsx');
+    expect(code).toBe(source);
+    expect(code).not.toContain(SOURCE_ATTR);
+  });
+});

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -40,6 +40,9 @@
     "@babel/core": "^7.26.0",
     "@reticlehq/babel-plugin": "workspace:*"
   },
+  "scripts": {
+    "test:unit": "vitest run loader.test.mjs index.test.mjs"
+  },
   "peerDependencies": {
     "next": ">=13"
   },


### PR DESCRIPTION
## What & why

Refs #459

`@reticlehq/next` had no `scripts` key, so `pnpm test:unit` never entered the package. This is the Next half of that issue: a `test:unit` script plus tests for the webpack loader (string → stamped JSX) and `withReticle` (production no-op, pre-loader in dev, pairing token).

The Electron half is a follow-up PR. Full coverage is not the goal; the package is no longer invisible to the fast gate.

## How it was verified

- `pnpm --filter @reticlehq/next test:unit` — 9 passed
- `pnpm exec turbo run test:unit --filter=@reticlehq/next` — `@reticlehq/next#test:unit` appears in turbo output

## Gates run

- [x] `pnpm lint && pnpm typecheck && pnpm test:unit`
- [x] `pnpm test:e2e`
- [x] `pnpm gate:install` — tests only; loader / `init` unchanged
- [ ] `pnpm test:e2e:desktop`
- [ ] None of the above tiers apply to this change

## Checklist

- [x] Every commit is signed off (`git commit -s`)
- [x] Tests added (the new script would fail if the loader stopped stamping)
- [x] No `any`, no free wire strings, no non-null `!`
- [x] No `console.log` or tracking codes
- [x] Each changed file is under the 1000-line cap
- [ ] Docs and CHANGELOG — not user-facing
- [ ] Security-affecting? no


Made with [Cursor](https://cursor.com)