### PR TITLE
feat(server): the run envelope, folded out of the journal and flagged off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
+### Added
+
+- **`@reticlehq/server` — a run can carry what it already established, behind a flag that is OFF and unproven.** Verification is multi-step, and the only thing holding the thread together is the agent's own context window; when that compacts the thread is gone and the work restarts. `RETICLE_RUN_ENVELOPE=1` attaches a bounded `run` block to session-bound tool results: what this run has established, folded and capped, plus the declared intents no verdict has discharged yet.
+
+  **It is a fold over the journal, never a second store.** `.reticle/sessions/<id>/` already holds an append-only record of every action dispatched and every event observed, and the run is derived from it on every call — the step count is the journal's action count, the facts are its settle outcomes and route changes, and the document each was seen under comes off the events themselves so a full navigation drops them rather than carrying them forward. Run state written independently would drift from that ledger, and the day it drifted the disagreement would land inside a verdict.
+
+  Only what Reticle OBSERVED goes in. An action that settled is a fact. A route change is a fact. What the agent intends is not, and cannot enter.
+
+  **Flagged off because the claim is not proven.** The bet is that the block costs fewer tokens than the re-queries it prevents. Measured on the deterministic replay benchmark, the cost side is real and the saving side is invisible — that pass has no model in the loop, so nothing there can re-query and nothing can be saved. It does not become the default until an agent-loop measurement says the trade is positive, and it comes out if it says otherwise.
+
 ### Fixed
 
 - **`@reticlehq/server` — a cloud call that stalls no longer hangs the tool call waiting on it.** Node's `fetch` has no default timeout: a connection that opens and then goes quiet never settles, and every cloud request in the server was awaited without one. The worst of them sat inside `reticle_flow_verify` on the `verify: 'server'` path, where a stalled hosted runner meant an MCP call that simply never returned — the failure mode this product treats as its worst, because an agent waiting on a tool has no way to notice, retry, or report. The same absence made every `reticle cloud …` subcommand able to sit at a blank terminal indefinitely.

--- a/packages/server/src/journal/journal-recorder.ts
+++ b/packages/server/src/journal/journal-recorder.ts
@@ -14,6 +14,11 @@ export interface JournalSink {
 /** Read side of the durable journal — the fall-through source when the ring buffer has evicted. */
 export interface JournalReader {
   readEvents(): Promise<ReticleEvent[]>;
+  /**
+   * The action ledger. Optional because a test double is a partial reader, and nothing that only
+   * needs events should be forced to grow a second method to satisfy the type.
+   */
+  readActions?(): Promise<JournalAction[]>;
 }
 
 interface JournalRecorderOptions {

--- a/packages/server/src/runs/run-envelope.test.ts
+++ b/packages/server/src/runs/run-envelope.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EventType,
+  JOURNAL_FILE_VERSION,
+  type JournalAction,
+  type ReticleEvent,
+} from '@reticlehq/core';
+import {
+  currentDocumentIdOf,
+  establishedFromJournal,
+  runEnvelopeEnabled,
+  runEnvelopeFor,
+  RUN_ENVELOPE_ENV,
+} from './run-envelope.js';
+
+function action(over: Partial<JournalAction> = {}): JournalAction {
+  return {
+    v: JOURNAL_FILE_VERSION,
+    actionId: 'c1',
+    tool: 'reticle_act',
+    args: { ref: 'e12', action: 'click' },
+    tRange: { from: 0, to: 10 },
+    at: 0,
+    ...over,
+  };
+}
+
+function event(over: Partial<ReticleEvent> = {}): ReticleEvent {
+  return { t: 0, type: EventType.DOM_ADDED, data: {}, ...over } as ReticleEvent;
+}
+
+describe('establishedFromJournal — only what Reticle observed', () => {
+  it('keys a settled action on its ref, so re-driving it supersedes', () => {
+    const facts = establishedFromJournal([action({ settled: true })], []);
+    expect(facts).toEqual([{ key: 'e12', fact: 'click settled', doc: undefined }]);
+  });
+
+  it('records an action that did NOT settle rather than dropping it', () => {
+    const facts = establishedFromJournal([action({ settled: false })], []);
+    expect(facts[0]?.fact).toBe('click did not settle');
+  });
+
+  it('says nothing about an action whose settle outcome was never observed', () => {
+    expect(establishedFromJournal([action()], [])).toEqual([]);
+  });
+
+  it('falls back to the target text when the call named no ref', () => {
+    const facts = establishedFromJournal(
+      [action({ args: { target: 'Submit', action: 'click' }, settled: true })],
+      [],
+    );
+    expect(facts[0]?.key).toBe('Submit');
+  });
+
+  it('stamps the document the action was observed under', () => {
+    const facts = establishedFromJournal(
+      [action({ settled: true })],
+      [event({ actionId: 'c1', documentId: 'doc00001' })],
+    );
+    expect(facts[0]?.doc).toBe('doc00001');
+  });
+
+  it('files the route under one stable key so only the newest survives', () => {
+    const facts = establishedFromJournal(
+      [],
+      [
+        event({ type: EventType.ROUTE_CHANGE, data: { pathname: '/a' } }),
+        event({ t: 1, type: EventType.ROUTE_CHANGE, data: { pathname: '/b' } }),
+      ],
+    );
+    expect(facts).toEqual([{ key: 'route', fact: 'route is /b', doc: undefined }]);
+  });
+
+  it('never reads further back than the fold can keep', () => {
+    const many = Array.from({ length: 40 }, (_, i) =>
+      action({
+        actionId: `c${String(i)}`,
+        args: { ref: `e${String(i)}`, action: 'click' },
+        settled: true,
+      }),
+    );
+    const facts = establishedFromJournal(many, []);
+    expect(facts.length).toBeLessThanOrEqual(12);
+    expect(facts.at(-1)?.key).toBe('e39');
+  });
+});
+
+describe('currentDocumentIdOf', () => {
+  it('is the newest stamped observation', () => {
+    const id = currentDocumentIdOf([
+      event({ documentId: 'doc00001' }),
+      event({ t: 1, documentId: 'doc00002' }),
+      event({ t: 2 }),
+    ]);
+    expect(id).toBe('doc00002');
+  });
+
+  it('is undefined when nothing stamped anything', () => {
+    expect(currentDocumentIdOf([event()])).toBeUndefined();
+  });
+});
+
+describe('runEnvelopeFor', () => {
+  it('drops a fact from a document that has been replaced', () => {
+    const envelope = runEnvelopeFor({
+      runId: 's1',
+      actions: [action({ settled: true })],
+      events: [
+        event({ actionId: 'c1', documentId: 'doc00001' }),
+        event({ t: 1, documentId: 'doc00002' }),
+      ],
+      intents: [],
+    });
+    expect(envelope).toBeUndefined();
+  });
+
+  it('counts the step off the journal rather than a counter of its own', () => {
+    const envelope = runEnvelopeFor({
+      runId: 's1',
+      actions: [action({ settled: true }), action({ actionId: 'c2', settled: true })],
+      events: [],
+      intents: [],
+    });
+    expect(envelope?.step).toBe(2);
+    expect(envelope?.id).toBe('s1');
+  });
+});
+
+describe('runEnvelopeEnabled', () => {
+  it('is off by default', () => {
+    expect(runEnvelopeEnabled({})).toBe(false);
+  });
+
+  it('is on for the truthy forms every other flag here accepts', () => {
+    expect(runEnvelopeEnabled({ [RUN_ENVELOPE_ENV]: '1' })).toBe(true);
+    expect(runEnvelopeEnabled({ [RUN_ENVELOPE_ENV]: 'true' })).toBe(true);
+    expect(runEnvelopeEnabled({ [RUN_ENVELOPE_ENV]: '0' })).toBe(false);
+  });
+});

--- a/packages/server/src/runs/run-envelope.ts
+++ b/packages/server/src/runs/run-envelope.ts
@@ -1,0 +1,154 @@
+import {
+  EventType,
+  RUN_ESTABLISHED_CAP,
+  buildRunEnvelope,
+  type EstablishedFact,
+  type Intent,
+  type JournalAction,
+  type ReticleEvent,
+  type RunEnvelope,
+} from '@reticlehq/core';
+import { envFlagOn } from '../tools/tool-surface.js';
+
+/**
+ * The run, derived from the journal that is already there.
+ *
+ * `.reticle/sessions/<id>/` already holds an append-only causal ledger of every action dispatched
+ * and every event observed. The run is a FOLD over that, never a second store — the same argument
+ * that deleted `instrumentation_stalled` from this codebase applies without modification: two ways
+ * to compute one number is worse than one way, because the day they disagree the disagreement lands
+ * inside a verdict and a user finds it before we do. So nothing here writes: it reads the ledger and
+ * folds it, and if the fold is wrong the ledger is still the single authority.
+ *
+ * **One run per session, for now.** The run id IS the session id. Nothing here assumes that — the id
+ * is a parameter, `foldEstablished` is pure, and the envelope carries its own id — so a later
+ * multi-run or multi-agent model is a change of caller, not a rewrite. It is not built today because
+ * nobody has hit the case, and a coordination model invented ahead of its first user is a guess.
+ *
+ * Only what Reticle OBSERVED goes in. A settle outcome is an observation. A route change is an
+ * observation. What the agent meant to do next is not, and never enters here.
+ */
+
+/**
+ * Turns the envelope on. Default OFF, deliberately: the feature is a bet that this block costs fewer
+ * tokens than the re-queries it prevents, and until the benchmark says so it does not get to be the
+ * default. Read like every other behaviour switch here — see `envFlagOn`.
+ */
+export const RUN_ENVELOPE_ENV = 'RETICLE_RUN_ENVELOPE';
+
+/**
+ * The one key the route is filed under.
+ *
+ * The subject of "the app is on /checkout" is the route itself, so a later route change SUPERSEDES
+ * rather than appends. Filing it per-path would accumulate every page ever visited, which is the
+ * token bomb the cap exists to prevent.
+ */
+const ROUTE_KEY = 'route';
+
+/** The conclusions this fold is allowed to state, as prose rather than transcript. */
+const Fact = {
+  route: (to: string): string => `route is ${to}`,
+  settled: (verb: string): string => `${verb} settled`,
+  unsettled: (verb: string): string => `${verb} did not settle`,
+} as const;
+
+/** The SUBJECT a journal action was about: the ref it spent, else the target it resolved from. */
+function subjectOf(action: JournalAction): string | undefined {
+  const ref = action.args['ref'];
+  if ('string' === typeof ref && ref.length > 0) return ref;
+  const target = action.args['target'];
+  if ('string' === typeof target && target.length > 0) return target;
+  return undefined;
+}
+
+/** What the action did, in the caller's own vocabulary — 'click', 'fill', else the tool's name. */
+function verbOf(action: JournalAction): string {
+  const named = action.args['action'];
+  return 'string' === typeof named && named.length > 0 ? named : action.tool;
+}
+
+/**
+ * The document currently under observation, read off the newest stamped event.
+ *
+ * `Session` carries no `currentDocumentId` on this branch — document identity is minted browser-side
+ * and crosses the wire on every event, and nothing server-side has read it until now. The newest
+ * stamped event is therefore the authority, and it is the same authority a `currentDocumentId` field
+ * would be derived from if one existed.
+ */
+export function currentDocumentIdOf(events: readonly ReticleEvent[]): string | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const id = events[i]?.documentId;
+    if (id !== undefined) return id;
+  }
+  return undefined;
+}
+
+/**
+ * Fold the journal into candidate facts, newest last.
+ *
+ * Only the last `RUN_ESTABLISHED_CAP` actions are read: anything older cannot survive the fold, so
+ * parsing it would be work done to throw away. An action with no observed settle outcome states
+ * nothing and is skipped — "we drove it and cannot say what happened" is not an established fact,
+ * and writing it down as one is how a memory starts lying.
+ */
+export function establishedFromJournal(
+  actions: readonly JournalAction[],
+  events: readonly ReticleEvent[],
+): EstablishedFact[] {
+  const docByAction = new Map<string, string>();
+  let route: EstablishedFact | undefined;
+  for (const event of events) {
+    if (event.actionId !== undefined && event.documentId !== undefined) {
+      docByAction.set(event.actionId, event.documentId);
+    }
+    if (EventType.ROUTE_CHANGE === event.type) {
+      const pathname = event.data['pathname'];
+      const to = 'string' === typeof pathname ? pathname : event.data['to'];
+      if ('string' === typeof to) {
+        route = { key: ROUTE_KEY, fact: Fact.route(to), doc: event.documentId };
+      }
+    }
+  }
+
+  const out: EstablishedFact[] = [];
+  for (const action of actions.slice(-RUN_ESTABLISHED_CAP)) {
+    const settled = action.settled;
+    if (undefined === settled) continue;
+    const key = subjectOf(action);
+    if (undefined === key) continue;
+    const verb = verbOf(action);
+    out.push({
+      key,
+      fact: settled ? Fact.settled(verb) : Fact.unsettled(verb),
+      doc: docByAction.get(action.actionId),
+    });
+  }
+  if (route !== undefined) out.push(route);
+  return out;
+}
+
+/**
+ * The envelope for one run, or nothing at all.
+ *
+ * `step` is the journal's action count rather than a counter of its own, for the reason at the top
+ * of this file: a second counter is a second thing that can disagree with the ledger.
+ */
+export function runEnvelopeFor(input: {
+  runId: string;
+  actions: readonly JournalAction[];
+  events: readonly ReticleEvent[];
+  intents: readonly Intent[];
+}): RunEnvelope | undefined {
+  return buildRunEnvelope({
+    runId: input.runId,
+    step: input.actions.length,
+    intents: input.intents,
+    established: establishedFromJournal(input.actions, input.events),
+    currentDocumentId: currentDocumentIdOf(input.events),
+  });
+}
+
+/** Is the flag on in this environment? */
+export function runEnvelopeEnabled(env: Readonly<Record<string, string | undefined>>): boolean {
+  return envFlagOn(env[RUN_ENVELOPE_ENV]);
+}

--- a/packages/server/src/session/session.ts
+++ b/packages/server/src/session/session.ts
@@ -28,6 +28,7 @@ import {
   SessionState,
   type BrowserBrand,
   type CommandResult,
+  type JournalAction,
   type HelloMessage,
   type HumanControlData,
   type ReticleEvent,
@@ -424,6 +425,17 @@ export class Session {
   finishAction(effect?: unknown, settled?: boolean, settledInMs?: number): void {
     this.#activeActionId = undefined;
     this.#journal?.finishAction(effect, settled, settledInMs);
+  }
+
+  /**
+   * The durable action ledger for this session — the ledger the run envelope is folded out of.
+   *
+   * `[]` when nothing journals this session (journaling disabled, or an id that is not a safe path
+   * segment). An absent ledger reads as an empty run, never as a missing one: the envelope simply
+   * has nothing to say, which is the honest answer.
+   */
+  async readJournalActions(): Promise<JournalAction[]> {
+    return (await this.#journalReader?.readActions?.()) ?? [];
   }
 
   /** Flush any buffered journal events to disk (call on session end). */

--- a/packages/server/src/tools/envelope-keys-declared.test.ts
+++ b/packages/server/src/tools/envelope-keys-declared.test.ts
@@ -88,4 +88,7 @@ const ENVELOPE_SHAPED = [
   'version',
   'control',
   'warning',
+  // The run envelope. A key this short would otherwise slip the undeclared check while still being
+  // dropped at runtime by the outputSchema gate — the exact silent failure this guard is about.
+  'run',
 ];

--- a/packages/server/src/tools/invoke-tool.ts
+++ b/packages/server/src/tools/invoke-tool.ts
@@ -32,6 +32,10 @@ import {
 } from '../impact/impact-recorder.js';
 import { type FrictionKind, frictionOf, inviteFor } from './feedback-invite.js';
 import type { ToolDef, ToolDeps } from './tools.js';
+import { IntentStore } from '../intent/intent-store.js';
+import { sessionRoot } from '../project/session-root.js';
+import { runEnvelopeEnabled, runEnvelopeFor } from '../runs/run-envelope.js';
+import type { RunEnvelope } from '@reticlehq/core';
 
 /**
  * The live-session tools whose result MUST carry the
@@ -263,6 +267,34 @@ function firstOversizedArg(args: Record<string, unknown>): string | undefined {
   return undefined;
 }
 
+/**
+ * The run envelope for this session, or nothing to say.
+ *
+ * Reads the ledger, never writes one. `remaining` comes from the intent store because an
+ * undischarged intent is a property of that ledger too, and both are read fresh rather than cached:
+ * a cache is the second copy this design exists to avoid. Never throws — a run block is a courtesy
+ * on top of an answer the caller already has, and must not be why a tool call fails.
+ */
+async function runFor(deps: ToolDeps, session: Session): Promise<RunEnvelope | undefined> {
+  try {
+    // The intent ledger belongs to the PROJECT the session is driving, not to whichever directory the
+    // daemon happens to have been started in — the same resolution every other artifact read uses.
+    const root = sessionRoot(deps, session.id);
+    const intents = await new IntentStore(deps.fs, root, { now: deps.now }).open();
+    return runEnvelopeFor({
+      runId: session.id,
+      actions: await session.readJournalActions(),
+      // The ring buffer, not the durable event log: the facts that survive the fold come from the
+      // last handful of actions, whose events are still here, and re-reading a session-long event
+      // file on every tool call would cost more than the whole envelope saves.
+      events: session.eventsSince(0),
+      intents,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
 export async function runTool<Ext>(
   tool: ToolDef<Ext>,
   deps: ToolDeps<Ext>,
@@ -476,5 +508,15 @@ export async function runTool<Ext>(
   // run, same discipline as the pool lease — a hint on every call is noise that gets tuned out.
   const unverified = getSessionMetrics().takeUnverifiedNudge();
   if (unverified !== undefined) envelope[EnvelopeKey.VERIFY_NEXT] = unverified;
+  // What this run has already established, folded out of the session journal — never a second store
+  // of its own. Spliced on the SESSION-BOUND branch on purpose: those are the tools that look at or
+  // drive the live page, they are the ones `withSessionEnvelope` declares the envelope shape for,
+  // and a disk-side tool has no run to report. Flagged OFF by default; the feature is a bet that it
+  // costs fewer tokens than the re-queries it prevents, and it does not get to be the default until
+  // the benchmark says so.
+  if (runEnvelopeEnabled(process.env)) {
+    const run = await runFor(deps, resolved);
+    if (run !== undefined) envelope[EnvelopeKey.RUN] = run;
+  }
   return Object.keys(envelope).length > 0 ? { ...result, ...envelope } : result;
 }

--- a/packages/server/src/tools/run-envelope-splice.test.ts
+++ b/packages/server/src/tools/run-envelope-splice.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  JOURNAL_FILE_VERSION,
+  SessionState,
+  type JournalAction,
+  type RunEnvelope,
+} from '@reticlehq/core';
+import type { ToolDef, ToolDeps } from './tools.js';
+import { ReticleTool } from './tool-names.js';
+import { EnvelopeKey } from './tool-kit.js';
+import { runTool } from './invoke-tool.js';
+import { RUN_ENVELOPE_ENV } from '../runs/run-envelope.js';
+import { BaselineStore } from '../project/baselines.js';
+import { RecordingStore } from '../flows/recordings.js';
+import { FlowStore } from '../flows/flows.js';
+import { ProjectStore } from '../project/project-store.js';
+import { AnnotationStore } from '../flows/annotation-store.js';
+import { createNodeFileSystem } from '../project/fs-port.js';
+import type { Session, SessionManager } from '../session/session.js';
+
+const ROOT = '/tmp/reticle-run-envelope-test/.reticle';
+const now = (): number => 0;
+
+const DRIVEN: JournalAction = {
+  v: JOURNAL_FILE_VERSION,
+  actionId: 'c1',
+  tool: ReticleTool.ACT,
+  args: { ref: 'e12', action: 'click' },
+  settled: true,
+  tRange: { from: 0, to: 10 },
+  at: 0,
+};
+
+function journaledSession(): Session {
+  const stub: Partial<Session> = {
+    id: 'demo',
+    url: 'http://localhost:5173/app',
+    command: () => Promise.resolve({ kind: 'command_result', id: 'c', ok: true, result: {} }),
+    eventsSince: () => [],
+    queryEvents: () => Promise.resolve([]),
+    readJournalActions: () => Promise.resolve([DRIVEN]),
+    bufferHealth: () => ({ total: 0, dropped: 0 }),
+    blindSpots: () => ({}),
+    health: () => ({ lastSeenMs: 1, throttled: false, focused: true }),
+    getState: () => SessionState.ACTIVE,
+    drainInbox: () => [],
+    takeSessionLease: () => undefined,
+    ageWarning: () => undefined,
+  };
+  return stub as Session;
+}
+
+function fakeDeps(): ToolDeps {
+  const sessions: Partial<SessionManager> = { resolve: () => journaledSession() };
+  const fs = createNodeFileSystem();
+  return {
+    sessions: sessions as SessionManager,
+    baselines: new BaselineStore(),
+    recordings: new RecordingStore(),
+    flows: new FlowStore(fs, ROOT, { now }),
+    project: new ProjectStore(fs, ROOT, { now }),
+    annotations: new AnnotationStore(),
+    fs,
+    reticleRoot: ROOT,
+    now,
+  };
+}
+
+function stubTool(name: string): ToolDef {
+  return { name, description: '', inputSchema: {}, handler: () => Promise.resolve({ ok: true }) };
+}
+
+afterEach(() => {
+  delete process.env[RUN_ENVELOPE_ENV];
+});
+
+describe('the run envelope rides out on a tool result, behind its flag', () => {
+  it('is absent by default — the feature has to win on the benchmark first', async () => {
+    const result = (await runTool(stubTool(ReticleTool.ACT), fakeDeps(), {})) as Record<
+      string,
+      unknown
+    >;
+    expect(result[EnvelopeKey.RUN]).toBeUndefined();
+  });
+
+  it('carries what the journal established once the flag is on', async () => {
+    process.env[RUN_ENVELOPE_ENV] = '1';
+    const result = (await runTool(stubTool(ReticleTool.ACT), fakeDeps(), {})) as Record<
+      string,
+      unknown
+    >;
+    const run = result[EnvelopeKey.RUN] as RunEnvelope | undefined;
+    expect(run?.id).toBe('demo');
+    expect(run?.step).toBe(1);
+    expect(run?.established).toEqual([{ key: 'e12', fact: 'click settled', doc: undefined }]);
+  });
+
+  it('is a declared key, so a schema-strict client keeps it', async () => {
+    const { sessionEnvelopeShape } = await import('./tool-kit.js');
+    expect(sessionEnvelopeShape[EnvelopeKey.RUN]).toBeDefined();
+  });
+});

--- a/packages/server/src/tools/tool-kit.ts
+++ b/packages/server/src/tools/tool-kit.ts
@@ -187,6 +187,12 @@ export const EnvelopeKey = {
   VERSION_SKEW: 'version_skew',
   /** A feedback report that was accepted and then failed to send. Only the reporter can act on it. */
   FEEDBACK_UNDELIVERED: 'feedback_undelivered',
+  /**
+   * What this run has already established, folded out of the session journal. Flagged OFF by
+   * default — see `RUN_ENVELOPE_ENV`. Declared here so that when it IS on, a schema-strict client
+   * keeps it rather than silently dropping the whole point of the feature.
+   */
+  RUN: 'run',
 } as const;
 export type EnvelopeKey = (typeof EnvelopeKey)[keyof typeof EnvelopeKey];
 

--- a/packages/server/src/tools/tool-surface.ts
+++ b/packages/server/src/tools/tool-surface.ts
@@ -235,7 +235,7 @@ export const EXTENDED_TOOL_NAMES: ReadonlySet<string> = new Set([
 export const VERIFY_TOOL_NAMES: ReadonlySet<string> = new Set([ReticleTool.ACT_AND_WAIT]);
 
 /** Is the truthy form of a boolean env var set? `1`, `true`, `yes` — anything else is off. */
-function envFlagOn(raw: string | undefined): boolean {
+export function envFlagOn(raw: string | undefined): boolean {
   if (raw === undefined) return false;
   const value = raw.trim().toLowerCase();
   return '1' === value || 'true' === value || 'yes' === value || 'on' === value;


### PR DESCRIPTION
Wires `RunEnvelope` (landed unwired on `feat/run-context`) onto tool results, behind `RETICLE_RUN_ENVELOPE=1`. Default OFF.

## How the run is derived

A **fold over the existing journal**, never a second store. `.reticle/sessions/<id>/actions.jsonl` + the session's event buffer are the only inputs:

- `step` — the journal's action count, not a counter of its own.
- established facts — one per journal action with an **observed** settle outcome, keyed on the subject it names (`args.ref`, else `args.target`) so re-driving the same subject supersedes rather than appends. An action whose outcome was never observed states nothing and is skipped.
- the route — the newest `route.change`, filed under one stable key so a later route supersedes.
- `doc` — the `documentId` of the events attributed to that action, so `foldEstablished` drops a fact the moment a full navigation replaces the document.
- `remaining` — `IntentStore.open()`, resolved through `sessionRoot` so it is the project's ledger and not whichever directory the daemon started in.

Only what Reticle OBSERVED. Nothing the agent intends or believes can enter.

`Session` carries no `currentDocumentId` on this base, so the current document is read off the newest stamped event — the same authority such a field would be derived from.

One run per session for v1, stated in a code comment. Nothing forecloses more: the id is a parameter and the fold is pure.

## The allowlist trap

`run` joins `EnvelopeKey`, from which `sessionEnvelopeShape` is derived, which `withSessionEnvelope` merges into every session-bound tool's `outputSchema` — so a schema-strict client keeps it. The splice is on the session-bound branch on purpose: those are the tools that look at or drive the live page, and a disk-side tool has no run to report.

`envelope-keys-declared.test.ts` gains `'run'` in its shape list. Without it a key that short slips the undeclared check while still being dropped at runtime — the exact silent failure that guard exists for.

## Measurement, and the honest read

`pnpm bench` (deterministic replay pass), flag OFF twice to establish a noise floor and once ON:

| pass | OFF (run 1) | OFF (run 2) | ON |
| --- | --- | --- | --- |
| replay-bench (mean) | 280 | 280 | 280 |
| replay-detect (mean) | 356 | 349 | 349 |
| replay-detect-consequence (mean) | 377 | 371 | 371 |
| replay-detect-state (mean) | 404 | 404 | 401 |
| network-cardinality (per run) | 417 | 403 | 406 |
| forbidden-call (per run) | 431 | 420 | 417 |
| console-clean (per run) | 364 | 353 | 353 |
| state-blast-radius (per run) | 412 | 412 | 409 |
| **suite-rre (`reticle_verify`)** | **90** | **90** | **212** |

Every replay/detection row sits inside the OFF↔OFF band — those paths run through session-**exempt** tools, so no envelope is spliced and the movement is noise. The one row that moves is the one session-bound verdict answer: **90 → 212 tokens, +122 (+136%)**, stable across both OFF runs.

**Recommendation: do not make this the default, and be prepared to cut it.** The cost is measured and large relative to the answer it rides on. The saving — fewer re-queries — is *unmeasurable on this benchmark*, because the replay pass has no model in the loop and therefore nothing that could re-query. The disproof written into the feature is a token comparison, and the only half we can currently measure is the cost half. It stays behind the flag until an agent-loop (Layer B) A/B says the trade is positive.

## Gates

`format:check`, `lint`, `typecheck`, `test:unit` all green (server 481 files / 4692 tests).

Red-first: `run-envelope.test.ts` (13) then `run-envelope-splice.test.ts` (3), both proven failing before the implementation existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
