### PR TITLE
fix(server): a gap said the app was unverifiable and named no file to open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ### Fixed
 
+- **`@reticlehq/server` — an instrumentation gap told the agent an app was unverifiable and gave it nowhere to go.** A gap exists to be acted on: it names an absence in the app, the cost that absence imposed on the verdict just returned, and the one change that closes it. What it never carried was a location. The type declared an optional `file:line` and no producer had ever set one, so every gap went out with a `ref` and nothing else.
+
+  A `ref` is a handle to a DOM node, and gaps are read late. `reticle_verify { action: "coverage" }` is the "am I done?" call, made long after the verdict that recorded the gap, by which time the page has re-rendered and the handle very likely resolves to nothing. So the surface aimed squarely at a build-and-verify loop was handing that loop a remedy with no address.
+
+  A gap about a control that changed the DOM and signalled nothing now carries the `file:line` of that control, taken from what the build plugin already stamped and the act path already had in hand. It survives into the coverage answer intact, which is the point: `source` is a fact about the code and stays true while the `ref` beside it rots.
+
+  **The other gaps stay unlocated, deliberately.** A store is registered once at app setup and a router adapter is wired app-wide; neither lives at the control that was driven, and lending them its line would send the agent to a file that cannot hold the fix — worse than silence, because it costs the trip as well. An absent pointer here means Reticle does not know, and it is not filled in with a guess.
+
 - **`@reticlehq/server` — the predicate grammar was reachable from nothing, and an agent that cannot find a grammar writes a weaker check.** A predicate parameter is advertised compactly on purpose: the union is recursive, and inlining it costs thousands of characters per parameter, re-sent every turn, to describe a grammar most calls use one variant of. The compact form carries the kind list and points at `reticle_tools` for the fields — but `reticle_tools` answered with the parameter's own prose, which for `reticle_act_and_wait { until }` reads "same shape as `reticle_assert`". So the one pointer the surface offered led to another pointer, and the fields of a kind could be learned only by guessing at them one rejected call at a time.
 
   **The cost that matters is not the round trips.** An agent that could not find `route`'s fields fell back to a `text` check where a route check was meant — a presence assertion standing in for a navigation assertion, which is precisely the false green this product exists to prevent. A grammar that is hard to discover pushes the caller toward the weakest oracle on the surface.

--- a/packages/server/src/bridge/bridge.gap-source.test.ts
+++ b/packages/server/src/bridge/bridge.gap-source.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Bridge } from './bridge.js';
+import type { ToolDeps } from '../tools/tools.js';
+import { FakeBrowser, callTool, makeDeps, waitUntil } from './bridge.test-harness.js';
+
+/**
+ * A gap has to survive the trip to the "am I done?" call with a pointer at the code.
+ *
+ * `reticle_verify { action: "coverage" }` reads the gap ledger LONG after the verdict that filled
+ * it, and by then the `ref` the gap carries is very likely dead — the page re-rendered, the control
+ * was replaced or removed. An agent told the app is unverifiable, with only a handle that no longer
+ * resolves, has nowhere to go. `source` is the half that stays true: it is a fact about the code,
+ * not a handle to a DOM node.
+ *
+ * Driven over the real tools rather than the pure function, because a field can be produced
+ * correctly and still never reach the agent — the result passes through the ledger, the merged
+ * `reticle_verify` dispatch and an output schema, and any of the three can drop it silently.
+ */
+
+interface GapEntry {
+  kind: string;
+  source?: string;
+  ref?: string;
+}
+interface ActResult {
+  instrumentationGaps?: GapEntry[];
+}
+interface CoverageResult {
+  instrumentationGaps?: GapEntry[];
+  untouched: { ref: string }[];
+}
+
+const NO_SIGNAL = 'no-signal-on-mutation';
+const ACTED_FILE = 'src/checkout/PayButton.tsx';
+const ACTED_LINE = 114;
+
+describe('an instrumentation gap keeps its file:line after the ref goes stale', () => {
+  let bridge: Bridge;
+  let deps: ToolDeps;
+  let browser: FakeBrowser;
+
+  beforeAll(async () => {
+    bridge = new Bridge({ port: 0 });
+    const port = await bridge.ready;
+    deps = makeDeps(bridge);
+    browser = new FakeBrowser(port, 'demo');
+    // The app IS source-mapped — the build plugin is installed — and it moved the DOM without
+    // saying so. That is the gap worth a pointer: Reticle knows where the control is written.
+    browser.actSource = { file: ACTED_FILE, line: ACTED_LINE };
+    browser.actMutatedWithin = 3;
+    await browser.open();
+    await waitUntil(() => 1 === bridge.sessions.count());
+  });
+
+  afterAll(async () => {
+    browser.close();
+    await bridge.close();
+  });
+
+  it('reports the gap with a source on the verdict, then again on coverage', async () => {
+    const acted = (await callTool(deps, 'reticle_act_and_wait', {
+      ref: 'e7',
+      action: 'click',
+      timeout_ms: 200,
+      until: { kind: 'route', pathname: '/never-happens' },
+    })) as ActResult;
+
+    const onVerdict = acted.instrumentationGaps?.find((gap) => NO_SIGNAL === gap.kind);
+    expect(onVerdict, 'a silent mutation should be reported').toBeDefined();
+    expect(onVerdict?.source).toBe(`${ACTED_FILE}:${String(ACTED_LINE)}`);
+
+    // The page re-rendered: the ref the gap named is gone. This is the ordinary case by the time
+    // coverage is read, not an edge one.
+    browser.snapshotResult = {
+      tree: '- button "Pay" (ref=e91)',
+      status: { route: '/checkout' },
+    };
+
+    const coverage = (await callTool(deps, 'reticle_verify', {
+      action: 'coverage',
+    })) as CoverageResult;
+    expect(coverage.untouched.map((c) => c.ref)).toContain('e91');
+
+    const later = coverage.instrumentationGaps?.find((gap) => NO_SIGNAL === gap.kind);
+    expect(later, 'the ledger should still hold the gap').toBeDefined();
+    expect(later?.source).toBe(`${ACTED_FILE}:${String(ACTED_LINE)}`);
+  });
+});

--- a/packages/server/src/bridge/bridge.test-harness.ts
+++ b/packages/server/src/bridge/bridge.test-harness.ts
@@ -33,6 +33,8 @@ export class FakeBrowser {
   actHasTestid = true;
   /** Provenance the real browser captures alongside the anchor; undefined = app built without it. */
   actSource: { file: string; line: number } | undefined = undefined;
+  /** DOM mutations the browser counted inside the acted element; undefined = it counted none. */
+  actMutatedWithin: number | undefined = undefined;
   /** when false, ACT reports settled:false + settleReason:'timeout' (throttled-tab path). */
   actSettled = true;
   /** When false, QUERY by testid returns no match (testid not in current DOM at replay). */
@@ -115,7 +117,12 @@ export class FakeBrowser {
         dispatched: true,
         settled: this.actSettled,
         settleReason: this.actSettled ? null : 'timeout',
-        effect: { dispatched: true },
+        effect: {
+          dispatched: true,
+          ...(this.actMutatedWithin === undefined
+            ? {}
+            : { domMutatedWithin: this.actMutatedWithin }),
+        },
         ...(this.actHasTestid ? { testid: 'pay-btn' } : {}),
         ...(this.actSource === undefined ? {} : { source: this.actSource }),
       };

--- a/packages/server/src/honesty/instrumentation-gaps.test.ts
+++ b/packages/server/src/honesty/instrumentation-gaps.test.ts
@@ -4,7 +4,7 @@ import { gapsForAction, type ActionInstrumentationFacts } from './instrumentatio
 
 const clean: ActionInstrumentationFacts = {
   pass: true,
-  sourceKnown: true,
+  source: 'src/Pay.tsx:42',
   stateAsked: false,
   stateUnwatched: false,
   domMutated: false,
@@ -28,11 +28,11 @@ describe('gapsForAction', () => {
    */
   describe('only fires when the absence changed the answer', () => {
     it('says nothing about a missing source mapping on a verdict that passed', () => {
-      expect(kinds({ pass: true, sourceKnown: false })).toEqual([]);
+      expect(kinds({ pass: true, source: undefined })).toEqual([]);
     });
 
     it('reports it on a verdict that did NOT pass, where the line is what the agent wants next', () => {
-      expect(kinds({ pass: false, sourceKnown: false })).toEqual([
+      expect(kinds({ pass: false, source: undefined })).toEqual([
         InstrumentationGapKind.NO_SOURCE_MAPPING,
       ]);
     });
@@ -78,7 +78,7 @@ describe('gapsForAction', () => {
   });
 
   it('carries the ref and the remedy, so the agent can act without another call', () => {
-    const [gap] = gapsForAction({ ...clean, pass: false, sourceKnown: false, ref: 'e12' });
+    const [gap] = gapsForAction({ ...clean, pass: false, source: undefined, ref: 'e12' });
     expect(gap?.ref).toBe('e12');
     expect(gap?.fix).toContain('plugin');
     expect(gap?.cost.length ?? 0).toBeGreaterThan(0);
@@ -88,7 +88,7 @@ describe('gapsForAction', () => {
     expect(
       kinds({
         pass: false,
-        sourceKnown: false,
+        source: undefined,
         domMutated: true,
         signalsFired: 0,
         routeChanged: true,
@@ -101,5 +101,56 @@ describe('gapsForAction', () => {
         InstrumentationGapKind.NO_SOURCE_MAPPING,
       ].sort(),
     );
+  });
+
+  /**
+   * The pointer the gap surface exists to hand over.
+   *
+   * A gap is read LATER — `reticle_verify { action: "coverage" }` is the "am I done?" call, by which
+   * time the `ref` it carries is very likely dead. `source` is a fact about the CODE and stays true
+   * while the ref rots, so a gap about a specific control has to carry it whenever it is known.
+   */
+  describe('points at the code, not only at a ref that will go stale', () => {
+    it('names the driven element file:line on a mutation nothing signalled', () => {
+      const [gap] = gapsForAction({
+        ...clean,
+        pass: false,
+        domMutated: true,
+        signalsFired: 0,
+        ref: 'e7',
+      });
+      expect(gap?.kind).toBe(InstrumentationGapKind.NO_SIGNAL_ON_MUTATION);
+      expect(gap?.source).toBe('src/Pay.tsx:42');
+    });
+
+    it('omits it rather than guessing when the element carries no source', () => {
+      const gaps = gapsForAction({
+        ...clean,
+        pass: false,
+        source: undefined,
+        domMutated: true,
+        signalsFired: 0,
+        ref: 'e7',
+      });
+      const silent = gaps.find((g) => InstrumentationGapKind.NO_SIGNAL_ON_MUTATION === g.kind);
+      expect(silent).toBeDefined();
+      expect(silent?.source).toBeUndefined();
+    });
+
+    /**
+     * The gaps that are NOT about the driven element must not borrow its line. A store is registered
+     * once at app setup and a router adapter is wired app-wide; neither lives where the click does,
+     * and a pointer that sends the agent to the wrong file costs it the trip AND leaves it further
+     * from the fix than no pointer at all.
+     */
+    it('does not attach the acted line to gaps that are not about the acted element', () => {
+      const [store] = gapsForAction({ ...clean, stateAsked: true, stateUnwatched: true });
+      expect(store?.kind).toBe(InstrumentationGapKind.NO_STORE_REGISTERED);
+      expect(store?.source).toBeUndefined();
+
+      const [route] = gapsForAction({ ...clean, pass: false, routeChanged: true });
+      expect(route?.kind).toBe(InstrumentationGapKind.NO_ROUTE_SIGNAL);
+      expect(route?.source).toBeUndefined();
+    });
   });
 });

--- a/packages/server/src/honesty/instrumentation-gaps.ts
+++ b/packages/server/src/honesty/instrumentation-gaps.ts
@@ -36,14 +36,15 @@ export interface ActionInstrumentationFacts {
   /** True when the outcome was positively PROVED rather than inferred. */
   proved?: boolean;
   /**
-   * Does Reticle know a `file:line` for what this verdict is about?
+   * The `file:line` of the element this verdict is about, when the build plugin stamped one.
    *
-   * A boolean rather than the source itself, deliberately: the act path holds a `{file, line}` and
-   * the assert path holds a formatted string it remembered from the last act. The gap does not care
-   * which — only whether the agent can be pointed at code — and taking the shape would make one of
-   * the two callers convert for no reason.
+   * Was a boolean, on the reasoning that the gap only needed to know WHETHER the agent could be
+   * pointed at code. That was true while the only gap reading it was the one that fires when the
+   * pointer is missing. It stopped being true the moment a gap wanted to CARRY the pointer: a gap is
+   * read back later, out of the ledger, by which time its `ref` is very likely dead, and a boolean
+   * cannot be turned back into a location. Both callers already hold this as a formatted string.
    */
-  sourceKnown: boolean;
+  source?: string | undefined;
   /** The ref that was driven, for the report. */
   ref?: string | undefined;
   /** Did the caller's predicate ask about registered state? */
@@ -65,7 +66,7 @@ export function gapsForAction(facts: ActionInstrumentationFacts): Instrumentatio
 
   // A red verdict names the control and cannot name the line that renders it. That is the round trip
   // the agent is about to spend, and the one a build plugin removes permanently.
-  if (!facts.pass && !facts.sourceKnown) {
+  if (!facts.pass && facts.source === undefined) {
     gaps.push(
       instrumentationGap(
         InstrumentationGapKind.NO_SOURCE_MAPPING,
@@ -76,7 +77,10 @@ export function gapsForAction(facts: ActionInstrumentationFacts): Instrumentatio
     );
   }
 
-  // Asked about state, and there is no state channel to answer from.
+  // Asked about state, and there is no state channel to answer from. Deliberately UNLOCATED: a store
+  // is registered once at app setup, nowhere near the control that was driven, and nothing in this
+  // window knows where that setup lives. Borrowing the acted line would send the agent to a file
+  // that cannot hold the fix — worse than no pointer, because it costs the trip as well.
   if (facts.stateAsked && facts.stateUnwatched) {
     gaps.push(
       instrumentationGap(
@@ -94,11 +98,20 @@ export function gapsForAction(facts: ActionInstrumentationFacts): Instrumentatio
         InstrumentationGapKind.NO_SIGNAL_ON_MUTATION,
         'the DOM changed and no signal fired for it',
         'the outcome had to be inferred from the DOM instead of read from the app asserting its own success, which is the strongest evidence available',
-        { ...(facts.ref === undefined ? {} : { ref: facts.ref }) },
+        // The one gap here that can be LOCATED. It is about the element that was driven, and that
+        // element is exactly what `source` describes — so the pointer is a fact, not a guess. It
+        // also outlives the `ref` beside it, which is what makes this gap still actionable when
+        // coverage reads it back long after the page has re-rendered.
+        {
+          ...(facts.ref === undefined ? {} : { ref: facts.ref }),
+          ...(facts.source === undefined ? {} : { source: facts.source }),
+        },
       ),
     );
   }
 
+  // Also unlocated, for the same reason: the remedy is a router adapter wired app-wide, not a line
+  // at the control that happened to trigger this navigation.
   if (facts.routeChanged && !facts.routeSignalFired) {
     gaps.push(
       instrumentationGap(

--- a/packages/server/src/tools/act-tools.ts
+++ b/packages/server/src/tools/act-tools.ts
@@ -646,9 +646,9 @@ export const ACT_TOOLS: ToolDef[] = [
         const actedSource = sourceOf(r['source']);
         // Remembered on the session so a LATER assertion can name a file even when its failure has no
         // element to point at — a signal that never fired, a request that was never made.
-        session.lastAct.markSource(
-          actedSource === undefined ? undefined : `${actedSource.file}:${String(actedSource.line)}`,
-        );
+        const actedSourceLabel =
+          actedSource === undefined ? undefined : `${actedSource.file}:${String(actedSource.line)}`;
+        session.lastAct.markSource(actedSourceLabel);
         const windowEvents = session.eventsSince(since);
         const trace = summarizeReaction(
           buildReactionReport(windowEvents, session.elapsed() - since),
@@ -794,7 +794,7 @@ export const ACT_TOOLS: ToolDef[] = [
         const gaps = gapsForAction({
           pass: verdict.pass,
           proved: decision.verifiedReason === VerifiedReason.PROVED,
-          sourceKnown: actedSource !== undefined,
+          source: actedSourceLabel,
           ref: asString(args['ref']),
           stateAsked: declaresState(until),
           stateUnwatched,
@@ -814,9 +814,7 @@ export const ACT_TOOLS: ToolDef[] = [
           // Promoted out of `effect` on red only. On green nobody needs it and it is noise; on red it
           // is the first thing the agent wants, and burying a file:line inside the effect block is
           // most of the way to not reporting it at all.
-          ...(verdict.pass || actedSource === undefined
-            ? {}
-            : { source: `${actedSource.file}:${String(actedSource.line)}` }),
+          ...(verdict.pass || actedSourceLabel === undefined ? {} : { source: actedSourceLabel }),
           trace,
           ...(capsuleSaved === undefined ? {} : { capsuleSaved }),
           // The window cannot say whether anything was WATCHING state — that is a level fact the

--- a/packages/server/src/tools/assert-verdict.ts
+++ b/packages/server/src/tools/assert-verdict.ts
@@ -164,7 +164,7 @@ export async function assertVerdict(
   // state assertion against an app that registers no store.
   const gaps = gapsForAction({
     pass,
-    sourceKnown: session.lastAct.source() !== undefined,
+    source: session.lastAct.source(),
     stateAsked: declaresState(predicate),
     stateUnwatched: isStateUnwatched(spots),
     domMutated: false,


### PR DESCRIPTION
## The defect

`InstrumentationGap` has always declared an optional `source` — a `file:line` pointing at the code that would close the gap. **No producer ever set it.** Every gap went out carrying a `ref` and nothing else.

That is backwards for this surface's own reader. A gap exists to be acted on, and gaps are read LATE: `reticle_verify { action: "coverage" }` is the "am I done?" call, made long after the verdict that recorded the gap. By then the page has re-rendered and the `ref` very likely resolves to nothing. So the surface aimed squarely at an agent that builds and verifies in a loop was handing that loop a remedy with no address.

## What changed

A gap about a control that changed the DOM and signalled nothing now carries that control's `file:line`, taken from what the build plugin already stamped and the act path already had in hand. It survives the ledger into the coverage answer intact — `source` is a fact about the code and stays true while the `ref` beside it rots.

**The other gaps stay unlocated, deliberately.** A store is registered once at app setup and a router adapter is wired app-wide; neither lives at the control that was driven, and lending them its line would send the agent to a file that cannot hold the fix — worse than silence, because it costs the trip as well. `no-source-mapping` has no pointer by definition, and the assert path drives nothing, so its two reachable gap kinds are both app-wide.

`ActionInstrumentationFacts.sourceKnown` becomes `source`. The boolean was enough while the only reader was the gap that fires when the pointer is MISSING; it cannot be turned back into a location now that a gap wants to carry one. Both callers already held the string.

## Tests, red first

- `instrumentation-gaps.test.ts` — "names the driven element file:line on a mutation nothing signalled", "omits it rather than guessing when the element carries no source", "does not attach the acted line to gaps that are not about the acted element".
- `bridge.gap-source.test.ts` (new) — drives the REAL tools over a bridge: `reticle_act_and_wait` produces the gap with a source, the page then re-renders so the ref is stale, and `reticle_verify { action: "coverage" }` still reports the same `file:line`. Unit-level proof would not have covered the ledger, the merged dispatch, or the output schema, any of which can drop a field silently.

Verified red before the fix: the gap was produced and `source` came back `undefined`.

## Gates

`pnpm format:check && pnpm lint && pnpm typecheck && pnpm test:unit` — all green.

`pnpm test:e2e` is arguably warranted (this touches an act-path result field), but the change is additive on one optional field, no tool name or wire constant moved, and the new bridge spec drives the same tools end to end. Worth a battery run before release.