### PR TITLE
feat(flows): a flow carries the business intent it discharges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
   **Absence means unknown, never "no edits happened".** A page with no hot-update channel — Next, Electron, Tauri, a plain script tag, an older SDK — stamps nothing, nothing is labelled, and nothing behaves differently than before. Reticle does not watch files, read your repo, or know what your build does; it only records what the running page told it.
 
+- **`@reticlehq/core` + `@reticlehq/server` — a saved flow now carries the business intent it discharges, so a failure reports what stopped being true.** A replay reported in the language of the DOM: step 3 drifted, the success oracle did not fire, this testid is gone. All true, all actionable, and none of it says what the flow was FOR — so whoever read it had to reconstruct the stakes before they could judge whether to care. A regression suite whose failures need reconstructing is a suite people learn to skim.
+
+  A flow file gains one optional field, `intentId`, pointing at a row in the intent ledger that already exists — the one in `.reticle/intent.json` that models declared → bound → proved and records which verdict discharged what. **Not a second notion of intent.** The prose a recorder already captured is promoted into that ledger at save time and the flow keeps the id, so there is one vocabulary and one file a reviewer reads; a flow can also be pointed by hand at an intent somebody declared long before it, and prove that instead.
+
+  A failure now leads with the outcome and keeps the mechanism underneath it — the intent is what makes the report legible, the step and the file:line are what make it fixable, and dropping either one costs something. A passing replay discharges the intent it was bound to, stamped with the verdict that did it and with the flow's assertion grade, which is what makes a later weakening visible in review rather than invisible in a green suite. An intent is bound only when the flow asserts an observable consequence, so a flow that cannot go red can never prove anything.
+
+  **A flow with no declared intent says so, and nothing is derived from its step names.** A guessed goal reads as the product owner's words and an agent will act on them, which is strictly worse than the honest absence — the same rule the source pointer follows. Older flow files parse, replay, and report exactly as they did, and the on-disk flow version does not move.
+
 ### Fixed
 
 - **`@reticlehq/server` — an instrumentation gap told the agent an app was unverifiable and gave it nowhere to go.** A gap exists to be acted on: it names an absence in the app, the cost that absence imposed on the verdict just returned, and the one change that closes it. What it never carried was a location. The type declared an optional `file:line` and no producer had ever set one, so every gap went out with a `ref` and nothing else.

--- a/packages/core/src/flow-types.ts
+++ b/packages/core/src/flow-types.ts
@@ -340,6 +340,20 @@ export const FlowFileSchema = z.object({
    */
   intent: z.string().optional(),
   /**
+   * The intent-ledger row this flow discharges — the id in `.reticle/intent.json`.
+   *
+   * `intent` above is the prose a recorder captured; this is the LINK to the ledger that already
+   * models declared → bound → proved and records which verdict discharged what. Without it there
+   * would be two ways to say what a change is for, which is the defect this codebase keeps paying
+   * for: a flow's goal and an intent's statement would drift apart with nothing to reconcile them.
+   *
+   * Set at save time from the flow's own prose, or written by hand to point a flow at an intent
+   * declared earlier via `reticle_intent` — a flow can prove something somebody else declared.
+   * Optional + back-compat: a flow without it replays exactly as before, and the on-disk version
+   * stays FLOW_FILE_VERSION 1.
+   */
+  intentId: z.string().optional(),
+  /**
    * The project the flow was recorded against (the connecting session's HELLO `projectId`), stamped at
    * save time. Scopes a flow to its app so a shared daemon's HUD lists only the current project's flows
    * instead of every project that ever saved to that daemon. Optional + back-compat: a flow with no

--- a/packages/server/src/flows/decision.test.ts
+++ b/packages/server/src/flows/decision.test.ts
@@ -308,3 +308,78 @@ describe('buildSuiteVerdict — a flow that cannot fail is not a pass', () => {
     expect(v.passed).toBe(1);
   });
 });
+
+describe('buildDecision — the business outcome first, the mechanism underneath', () => {
+  const CHECKIN = 'the trip badge reads "checked in" after the traveller checks in';
+
+  function broken(name: string): FlowReplayResult {
+    return {
+      name,
+      status: ReplayStatus.ERROR,
+      steps: [
+        {
+          step: 2,
+          tool: ReticleTool.ACT,
+          anchor: 'send-checkin',
+          ok: false,
+          error: 'flow.success not satisfied',
+        },
+      ],
+      error: { code: 'error', message: 'flow.success not satisfied' },
+    };
+  }
+
+  it('a failing flow names the business outcome that is no longer true, before the step', () => {
+    const d = buildDecision(broken('checkin'), flow({ intent: CHECKIN }));
+    expect(d.summary).toContain(CHECKIN);
+    expect(d.summary.indexOf(CHECKIN)).toBeLessThan(d.summary.indexOf('step 2'));
+    expect(d.whatChanged).toBe('flow.success not satisfied');
+  });
+
+  it('a drifting flow names the intent too — a locator miss still breaks an outcome', () => {
+    const result: FlowReplayResult = {
+      name: 'checkin',
+      status: ReplayStatus.DRIFT,
+      steps: [
+        {
+          step: 0,
+          tool: ReticleTool.ACT,
+          anchor: 'send-checkin',
+          ok: false,
+          drift: {
+            reasonKind: DriftReason.TESTID_NOT_FOUND,
+            reason: 'testid "send-checkin" not found',
+            anchor: 'send-checkin',
+            nearest: 'send-check-in',
+          },
+        },
+      ],
+    };
+    const d = buildDecision(result, flow({ intent: CHECKIN }));
+    expect(d.summary).toContain(CHECKIN);
+    expect(d.whatChanged).toBe('testid "send-checkin" not found');
+  });
+
+  it('quotes the ledger statement over the copy on the flow file, so an amendment wins', () => {
+    const d = buildDecision(broken('checkin'), flow({ intent: CHECKIN }), 'the badge reads paid');
+    expect(d.summary).toContain('the badge reads paid');
+    expect(d.summary).not.toContain(CHECKIN);
+  });
+
+  it('a flow with no intent says so plainly rather than deriving one from its steps', () => {
+    const d = buildDecision(broken('send-checkin'), flow());
+    expect(d.summary).toContain('no intent declared');
+    expect(d.summary).not.toContain('NO LONGER TRUE');
+  });
+
+  it('a passing flow with no intent says what its green does not cover', () => {
+    const result: FlowReplayResult = {
+      name: 'weak',
+      status: ReplayStatus.OK,
+      steps: [{ step: 0, tool: ReticleTool.ACT, anchor: 'btn', ok: true }],
+    };
+    const d = buildDecision(result, flow({ success: { signal: 'x:y' } }));
+    expect(d.verdict).toBe('pass');
+    expect(d.summary).toContain('no intent declared');
+  });
+});

--- a/packages/server/src/flows/decision.ts
+++ b/packages/server/src/flows/decision.ts
@@ -43,21 +43,54 @@ function whereInSource(step: FlowStepResult, flow: FlowFile | undefined): string
   return source === undefined ? undefined : `${source.file}:${String(source.line)}`;
 }
 
-export function buildDecision(result: FlowReplayResult, flow?: FlowFile): ReplayDecision {
+/**
+ * The business outcome that stopped being true, said before the mechanism that broke it.
+ *
+ * Order is the point. The intent is what makes a failure legible — a human or an agent reading
+ * "step 3 assertion failed" has to reconstruct the stakes — and the mechanical detail underneath is
+ * what makes it actionable. Dropping either one costs something, so the summary carries both.
+ */
+const INTENT_BROKEN_PREFIX = 'NO LONGER TRUE: ';
+/**
+ * What a report says when nothing declared what the flow is for.
+ *
+ * Never an intent derived from step names: a guessed goal reads as the product owner's words and an
+ * agent will act on it. The same rule as the source pointer — absence stays honest.
+ */
+const NO_INTENT_ON_PASS =
+  'no intent declared, so this proves the steps ran, not what they were for — declare one with reticle_intent.';
+const NO_INTENT_ON_FAIL = 'no intent declared, so this names the mechanism, not the stakes.';
+
+/** `<intent> — <mechanical>`, or the mechanical sentence plus the honest absence. */
+function withIntent(mechanical: string, statement: string | undefined): string {
+  return statement === undefined
+    ? `${mechanical} — ${NO_INTENT_ON_FAIL}`
+    : `${INTENT_BROKEN_PREFIX}"${statement}" — ${mechanical}`;
+}
+
+/**
+ * @param intentStatement the ledger's current wording, when the flow is bound to an intent row.
+ * Falls back to the copy on the flow file, which is what a flow saved before the link carries.
+ */
+export function buildDecision(
+  result: FlowReplayResult,
+  flow?: FlowFile,
+  intentStatement?: string,
+): ReplayDecision {
   const { name, status, steps } = result;
+  const intentSaid = intentStatement ?? flow?.intent;
 
   if (status === ReplayStatus.OK) {
     // Green — but is it green-for-the-right-reason? A flow that asserts no consequence can pass while
     // broken, so the honest next action is to add one.
     const grade = flow !== undefined ? classifyFlowAssertions(flow) : undefined;
     const verifiesOutcome = true === grade?.hasConsequenceAssertion;
-    const intent = flow?.intent;
     return {
       verdict: 'pass',
       summary:
-        intent !== undefined
-          ? `"${name}" passed — intent "${intent}" ${verifiesOutcome ? 'verified' : 'NOT asserted'}.`
-          : `"${name}" passed (${steps.length} steps).`,
+        intentSaid !== undefined
+          ? `"${name}" passed — intent "${intentSaid}" ${verifiesOutcome ? 'verified' : 'NOT asserted'}.`
+          : `"${name}" passed (${steps.length} steps) — ${NO_INTENT_ON_PASS}`,
       nextAction: verifiesOutcome
         ? 'none — the flow held and its consequence was observed.'
         : 'add a consequence assertion (assert-signal / success-state) so this flow can fail when the feature breaks.',
@@ -77,7 +110,7 @@ export function buildDecision(result: FlowReplayResult, flow?: FlowFile): Replay
           : undefined;
     return {
       verdict: 'drift',
-      summary: `"${name}" drifted at step ${step.step} (${step.anchor}).`,
+      summary: withIntent(`"${name}" drifted at step ${step.step} (${step.anchor}).`, intentSaid),
       whatChanged: drift.reason,
       ...(where !== undefined ? { whereInSource: where } : {}),
       ...(fix !== undefined ? { suggestedFix: fix } : {}),
@@ -93,7 +126,10 @@ export function buildDecision(result: FlowReplayResult, flow?: FlowFile): Replay
   const isSuccessOracle = step?.tool === SUCCESS_STEP_TOOL;
   return {
     verdict: 'fail',
-    summary: `"${name}" failed${step !== undefined ? ` at step ${step.step} (${step.anchor})` : ''}.`,
+    summary: withIntent(
+      `"${name}" failed${step !== undefined ? ` at step ${step.step} (${step.anchor})` : ''}.`,
+      intentSaid,
+    ),
     whatChanged: message,
     ...(where !== undefined ? { whereInSource: where } : {}),
     nextAction: isSuccessOracle

--- a/packages/server/src/flows/flow-intent.test.ts
+++ b/packages/server/src/flows/flow-intent.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import { FLOW_FILE_VERSION, IntentState, type FlowFile } from '@reticlehq/core';
+import { createMemoryFs } from '../project/memory-fs.js';
+import { IntentStore } from '../intent/intent-store.js';
+import { FlowStore, type FlowAnnotations } from './flows.js';
+import { ReticleTool } from '../tools/tool-names.js';
+import { dischargeFlowIntent, flowIntentId, flowIntentStatement } from './flow-intent.js';
+import type { CompiledProgram } from './recordings.js';
+
+const ROOT = '/repo/.reticle';
+const NOW = 1_000;
+
+function harness() {
+  const { fs, written } = createMemoryFs();
+  const clock = { now: () => NOW };
+  return {
+    flows: new FlowStore(fs, ROOT, clock),
+    intents: new IntentStore(fs, ROOT, clock),
+    written,
+  };
+}
+
+function program(name: string): CompiledProgram {
+  return {
+    name,
+    version: 1,
+    steps: [
+      {
+        tool: ReticleTool.ACT,
+        stable: true,
+        args: { by: 'testid', value: 'send-checkin', action: 'click', args: {} },
+      },
+    ],
+  };
+}
+
+function annotations(partial: Partial<FlowAnnotations>): FlowAnnotations {
+  return { stepExpect: new Map(), dynamic: [], ...partial };
+}
+
+const CHECKIN = 'the trip badge reads "checked in" after the traveller checks in';
+
+describe('a flow carries the business intent it discharges', () => {
+  it('saving a flow with a business goal declares it in the shared intent ledger', async () => {
+    const { flows, intents } = harness();
+    await flows.save(program('checkin'), annotations({ intent: CHECKIN }));
+
+    const [intent] = await intents.read();
+    expect(intent?.statement).toBe(CHECKIN);
+    expect(intent?.surface?.flow).toBe('checkin');
+  });
+
+  it('stamps the ledger id onto the flow file, so the link survives on disk', async () => {
+    const { flows } = harness();
+    await flows.save(program('checkin'), annotations({ intent: CHECKIN }));
+
+    const loaded = await flows.load('checkin');
+    expect(loaded.ok && loaded.value.intentId).toBe(flowIntentId('checkin'));
+  });
+
+  it('binds the intent when the flow asserts an observable outcome, so a replay can prove it', async () => {
+    const { flows, intents } = harness();
+    await flows.save(
+      program('checkin'),
+      annotations({ intent: CHECKIN, success: { signal: 'trip:checked-in' } }),
+    );
+
+    const [intent] = await intents.read();
+    expect(intent?.state).toBe(IntentState.BOUND);
+  });
+
+  it('leaves an intent unbound when the flow asserts nothing observable', async () => {
+    const { flows, intents } = harness();
+    await flows.save(program('checkin'), annotations({ intent: CHECKIN }));
+
+    const [intent] = await intents.read();
+    expect(intent?.state).toBe(IntentState.DECLARED);
+    expect(intent?.binding).toBeUndefined();
+  });
+
+  it('an older flow with no business goal writes no ledger row and no intentId', async () => {
+    const { flows, intents, written } = harness();
+    await flows.save(program('legacy'));
+
+    expect(await intents.read()).toEqual([]);
+    const loaded = await flows.load('legacy');
+    expect(loaded.ok && loaded.value.intentId).toBeUndefined();
+    expect([...written.keys()].some((path) => path.endsWith('intent.json'))).toBe(false);
+  });
+
+  it('a green replay marks the intent proved with the verdict that did it', async () => {
+    const { flows, intents } = harness();
+    await flows.save(
+      program('checkin'),
+      annotations({ intent: CHECKIN, success: { signal: 'trip:checked-in' } }),
+    );
+    const loaded = await flows.load('checkin');
+    if (!loaded.ok) throw new Error('flow did not save');
+
+    const proved = await dischargeFlowIntent(intents, loaded.value, {
+      verdictId: 'flow_replay:checkin:2000',
+      grade: 'asserted',
+      at: 2_000,
+    });
+
+    expect(proved).toBe(true);
+    const [intent] = await intents.read();
+    expect(intent?.state).toBe(IntentState.PROVED);
+    expect(intent?.provenBy).toEqual({
+      verdictId: 'flow_replay:checkin:2000',
+      grade: 'asserted',
+      at: 2_000,
+    });
+  });
+
+  it('a flow with no declared intent discharges nothing', async () => {
+    const { flows, intents } = harness();
+    await flows.save(program('legacy'));
+    const loaded = await flows.load('legacy');
+    if (!loaded.ok) throw new Error('flow did not save');
+
+    expect(
+      await dischargeFlowIntent(intents, loaded.value, {
+        verdictId: 'v',
+        grade: 'asserted',
+        at: 2_000,
+      }),
+    ).toBe(false);
+    expect(await intents.read()).toEqual([]);
+  });
+
+  it('reads the statement from the ledger, so an amendment is what a report quotes', async () => {
+    const { flows, intents } = harness();
+    await flows.save(program('checkin'), annotations({ intent: CHECKIN }));
+    await intents.declare([{ id: flowIntentId('checkin'), statement: 'the badge reads paid' }]);
+    const loaded = await flows.load('checkin');
+    if (!loaded.ok) throw new Error('flow did not save');
+
+    expect(await flowIntentStatement(intents, loaded.value)).toBe('the badge reads paid');
+  });
+
+  it('reads no statement for a flow that never declared one — never one derived from its steps', async () => {
+    const { flows, intents } = harness();
+    await flows.save(program('legacy'));
+    const loaded = await flows.load('legacy');
+    if (!loaded.ok) throw new Error('flow did not save');
+
+    expect(await flowIntentStatement(intents, loaded.value)).toBeUndefined();
+  });
+
+  it('honours an intentId already on the flow, so a flow can discharge an intent declared elsewhere', async () => {
+    const { flows, intents } = harness();
+    await intents.declare([{ id: 'checkout-works', statement: 'checkout still works' }]);
+    const flow: FlowFile = {
+      version: FLOW_FILE_VERSION,
+      name: 'pay',
+      createdAt: NOW,
+      steps: [],
+      intentId: 'checkout-works',
+      success: { signal: 'order:placed' },
+    };
+    await flows.saveFlow(flow);
+
+    const [intent] = await intents.read();
+    expect(intent?.id).toBe('checkout-works');
+    expect(intent?.statement).toBe('checkout still works');
+    expect(intent?.state).toBe(IntentState.BOUND);
+  });
+});

--- a/packages/server/src/flows/flow-intent.ts
+++ b/packages/server/src/flows/flow-intent.ts
@@ -1,0 +1,106 @@
+import type { FlowFile } from '@reticlehq/core';
+import { IntentStore } from '../intent/intent-store.js';
+import { classifyFlowAssertions } from './flow-classify.js';
+
+/**
+ * The link between a saved flow and the intent ledger — what the flow is FOR.
+ *
+ * A replay used to report only in the language of the DOM: step 3 drifted, this assertion failed.
+ * True, actionable, and illegible — the reader still had to reconstruct what stopped working. The
+ * ledger in `.reticle/intent.json` already holds the other half (prose statements, declared → bound
+ * → proved, and the verdict that discharged each one), so a flow does not need its own notion of
+ * intent. It needs an id.
+ *
+ * Nothing here derives an intent from step names. A flow that declares none reports that it declares
+ * none — a guessed intent puts words in the product owner's mouth and an agent will act on them,
+ * which is strictly worse than the honest absence.
+ */
+
+/** Namespaced so a flow-declared intent never collides with one an agent declared by hand. */
+const FLOW_INTENT_ID_PREFIX = 'flow:';
+const FLOW_VERDICT_ID_PREFIX = 'flow_replay:';
+const ID_SEPARATOR = ':';
+
+/** The ledger id a flow's own prose goal is declared under. */
+export function flowIntentId(flowName: string): string {
+  return `${FLOW_INTENT_ID_PREFIX}${flowName}`;
+}
+
+/** The verdict that a replay of this flow, at this time, constitutes — what `provenBy` records. */
+export function flowReplayVerdictId(flowName: string, at: number): string {
+  return `${FLOW_VERDICT_ID_PREFIX}${flowName}${ID_SEPARATOR}${String(at)}`;
+}
+
+/**
+ * Which ledger row this flow answers to, or nothing.
+ *
+ * An explicit `intentId` wins, so a flow can discharge an intent that was declared before it existed.
+ * Otherwise the flow's own prose implies one. A flow with neither has no intent, and says so.
+ */
+export function intentIdOf(flow: FlowFile): string | undefined {
+  if (flow.intentId !== undefined) return flow.intentId;
+  return flow.intent === undefined ? undefined : flowIntentId(flow.name);
+}
+
+/**
+ * Promote a flow's prose goal into the ledger and stamp the id back onto the flow.
+ *
+ * The binding is attached only when the flow asserts an observable consequence, because that is the
+ * only case where replaying it green proves anything. A flow that asserts nothing leaves its intent
+ * `declared` — and `dischargeIntent` refuses to prove an unbound intent, so an assertion-free flow
+ * can never discharge one. That is the whole guard, and it is the ledger's own rule, not a new one.
+ *
+ * Returns the flow unchanged (and writes nothing) when there is no intent, so a flow file saved
+ * before any of this existed keeps its exact bytes.
+ */
+export async function linkFlowIntent(store: IntentStore, flow: FlowFile): Promise<FlowFile> {
+  const id = intentIdOf(flow);
+  if (id === undefined) return flow;
+  if (flow.intent !== undefined) {
+    await store.declare([{ id, statement: flow.intent, surface: { flow: flow.name } }]);
+  }
+  if (classifyFlowAssertions(flow).hasConsequenceAssertion) {
+    await store.bind(id, { flow: flow.name });
+  }
+  return { ...flow, intentId: id };
+}
+
+/**
+ * What the ledger currently says this flow is for, or undefined when nothing declared it.
+ *
+ * Read from the ledger rather than from the flow file's own copy: the ledger is where an amendment
+ * lands, and a report that quotes the stale copy would be the two-vocabularies problem all over
+ * again — one sentence in review, a different one in the failure message.
+ */
+export async function flowIntentStatement(
+  store: IntentStore,
+  flow: FlowFile,
+): Promise<string | undefined> {
+  const id = intentIdOf(flow);
+  if (id === undefined) return undefined;
+  const found = (await store.read()).find((intent) => intent.id === id);
+  return found?.statement ?? flow.intent;
+}
+
+/**
+ * Record that this replay proved the flow's intent. False when there was nothing to prove.
+ *
+ * Best-effort by construction: `IntentStore.discharge` returns false rather than throwing on an
+ * unknown or unbound id, because discharge runs off the back of a verdict and must never be the
+ * reason one fails to return.
+ */
+export async function dischargeFlowIntent(
+  store: IntentStore,
+  flow: FlowFile,
+  proof: { verdictId: string; grade: string; at: number },
+): Promise<boolean> {
+  const id = intentIdOf(flow);
+  if (id === undefined) return false;
+  try {
+    return await store.discharge(id, proof);
+  } catch {
+    // A ledger that cannot be written is a small problem; a verdict that never returns because of
+    // one is a large problem. The replay already succeeded — the proof is simply not recorded.
+    return false;
+  }
+}

--- a/packages/server/src/flows/flow-replay-run.ts
+++ b/packages/server/src/flows/flow-replay-run.ts
@@ -15,6 +15,10 @@ import { asString } from '../tools/tools-helpers.js';
 import { replayFlow } from './flow-replay.js';
 import { assertSuccess, dynamicTestids, successLabel, SUCCESS_STEP_TOOL } from './flow-success.js';
 import { buildDecision, unverifiableReason } from './decision.js';
+import { classifyFlowAssertions } from './flow-classify.js';
+import { dischargeFlowIntent, flowIntentStatement, flowReplayVerdictId } from './flow-intent.js';
+import { IntentStore } from '../intent/intent-store.js';
+import { sessionRoot } from '../project/session-root.js';
 import { waitForPredicate } from '../events/predicate.js';
 import { computeSegments } from '../journal/rollups.js';
 import { AssertionTiersStore } from './assertion-tiers-store.js';
@@ -154,6 +158,13 @@ export async function replayNamedFlow(
       error: { code: loaded.code, message: flowErrorMessage(loaded.code) },
     };
   }
+  // What this flow is FOR, from the shared ledger — so a failure can report the business outcome
+  // that stopped being true before the step that stopped being green. Undefined when nothing
+  // declared one, which the decision then says plainly rather than inventing a goal from step names.
+  const intents = new IntentStore(deps.fs, sessionRoot(deps, asString(args['sessionId'])), {
+    now: deps.now,
+  });
+  const intentSaid = await flowIntentStatement(intents, loaded.value);
   const session = deps.sessions.resolve(asString(args['sessionId']));
   // Captured before replay: if the tab isn't on the flow's start page, a step-1 drift is a wrong-page
   // symptom, not a regression — surface that on the decision instead of a bare "a step no longer matches".
@@ -206,6 +217,18 @@ export async function replayNamedFlow(
       // Record what this flow COVERS so a later deletion can be scoped to the files that changed.
       toFlowSources([{ name, steps: loaded.value.steps }])[0]?.sources ?? [],
     );
+    // The ledger learns what this run proved. Only a flow that COULD have gone red discharges: an
+    // assertion-free flow is never bound, and `dischargeIntent` refuses an unbound intent, so the
+    // guard here is the cheap half of a rule the ledger already enforces. `grade` is what makes a
+    // later weakening visible — an intent re-proved by a weaker flow says so in the git diff.
+    if (unverifiableReason(loaded.value) === undefined) {
+      const provedAt = deps.now();
+      await dischargeFlowIntent(intents, loaded.value, {
+        verdictId: flowReplayVerdictId(name, provedAt),
+        grade: classifyFlowAssertions(loaded.value).grade,
+        at: provedAt,
+      });
+    }
   }
   // Push-default: the deviation report over this drive's segments, learned across runs. Best-effort.
   const deviation = await computeReplayDeviation(deps, session, replayFloor);
@@ -217,7 +240,7 @@ export async function replayNamedFlow(
       steps,
       error: { code: ReplayStatus.ERROR, message: failed.error ?? 'flow action failed' },
     };
-    errored.decision = buildDecision(errored, loaded.value);
+    errored.decision = buildDecision(errored, loaded.value, intentSaid);
     applyStartPathHint(errored, startPathHint);
     if (deviation !== undefined) errored.deviation = deviation;
     return errored;
@@ -229,7 +252,7 @@ export async function replayNamedFlow(
   // drift, and the sibling tools would then disagree about the same flow.
   const cannotFail = status === ReplayStatus.OK ? unverifiableReason(loaded.value) : undefined;
   if (cannotFail !== undefined) result.unverifiable = { reason: cannotFail };
-  if (status !== ReplayStatus.OK) result.decision = buildDecision(result, loaded.value);
+  if (status !== ReplayStatus.OK) result.decision = buildDecision(result, loaded.value, intentSaid);
   applyStartPathHint(result, startPathHint);
   if (deviation !== undefined) result.deviation = deviation;
   return result;

--- a/packages/server/src/flows/flows.ts
+++ b/packages/server/src/flows/flows.ts
@@ -18,6 +18,8 @@ import type {
 import { ReticleTool } from '../tools/tool-names.js';
 import { asString, asRecord } from '../tools/tools-helpers.js';
 import { applyHealChanges } from './heal.js';
+import { linkFlowIntent } from './flow-intent.js';
+import { IntentStore } from '../intent/intent-store.js';
 import type { CompiledProgram, RecordedStep } from './recordings.js';
 import type { FileSystemPort } from '../project/fs-port.js';
 import { flowDir, flowPath, reticleDirPaths, isValidFlowName } from '../project/reticle-dir.js';
@@ -228,6 +230,17 @@ export class FlowStore {
   }
 
   /**
+   * Register the flow's business goal in the intent ledger and stamp the row's id onto the flow.
+   *
+   * Both save paths route through here — the compiled-recording one and the in-page recorder one —
+   * because a flow's goal must land in the ledger whichever way the flow arrived. A flow with no
+   * goal is returned untouched and nothing is written, so an older flow keeps its exact bytes.
+   */
+  #linkIntent(flow: FlowFile): Promise<FlowFile> {
+    return linkFlowIntent(new IntentStore(this.#fs, this.#root, this.#clock), flow);
+  }
+
+  /**
    * Convert a CompiledProgram (testid-normalized) into an anchored, on-disk flow + write it.
    * Optionally fold structured annotations (per-step expect, dynamic[], success) onto
    * the flow before writing. Omitting `annotations` reproduces the same bytes.
@@ -249,7 +262,7 @@ export class FlowStore {
       createdAt: this.#clock.now(),
       steps,
     };
-    const flow = withAnnotations(base, annotations);
+    const flow = await this.#linkIntent(withAnnotations(base, annotations));
     await this.#fs.mkdir(flowDir(this.#root, pid));
     await this.#fs.writeFile(flowPath(this.#root, program.name, pid), this.#serialize(flow));
     const degraded = flow.steps.filter((s) => true === s.degraded).length;
@@ -277,7 +290,7 @@ export class FlowStore {
     const stamped = pid === undefined ? flow : { ...flow, projectId: pid };
     const parsed = FlowFileSchema.safeParse(stamped);
     if (!parsed.success) return { ok: false, code: FlowErrorCode.PARSE_FAILED };
-    const valid = parsed.data;
+    const valid = await this.#linkIntent(parsed.data);
     await this.#fs.mkdir(flowDir(this.#root, pid));
     await this.#fs.writeFile(
       flowPath(this.#root, asFlowName(valid.name), pid),

--- a/packages/server/src/flows/tools.flow-replay.test.ts
+++ b/packages/server/src/flows/tools.flow-replay.test.ts
@@ -7,7 +7,9 @@ import {
   asFlowName,
   ActionType,
   DANGEROUS_ACTION_CONFIRM_ARG,
+  EventType,
   FlowErrorCode,
+  IntentState,
   ReticleCommand,
   QueryBy,
   ReplayStatus,
@@ -15,7 +17,10 @@ import {
   RunStatus,
   type CommandResult,
   type FlowReplayResult,
+  type ReticleEvent,
 } from '@reticlehq/core';
+import { IntentStore } from '../intent/intent-store.js';
+import { FlowAssertionGrade } from './flow-classify.js';
 import { TOOLS, type ToolDeps } from '../tools/tools.js';
 import { buildSuiteVerdict } from './decision.js';
 import { ReticleTool } from '../tools/tool-names.js';
@@ -363,5 +368,101 @@ describe('reticle_flow_replay — a green that cannot go red (#341)', () => {
     // than trusted: a field the handler sets and the schema omits returns as nothing, silently.
     const schema = tool(ReticleTool.FLOW_REPLAY).outputSchema;
     expect(schema).toHaveProperty('unverifiable');
+  });
+});
+
+/**
+ * A replay reports in the language of the product, not only of the DOM.
+ *
+ * The intent ledger already models `declared → bound → proved` and records which verdict discharged
+ * an intent. A flow that carries one should therefore DISCHARGE it when it passes — otherwise the
+ * ledger stays open forever on something a suite proves on every run, and a failing flow reports a
+ * missing testid where the reader needed "checkout no longer works".
+ */
+describe('reticle_flow_replay — the business intent a flow discharges', () => {
+  let dir: string;
+  let root: string;
+  let fs: FileSystemPort;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'reticle-flow-intent-'));
+    root = join(dir, '.reticle');
+    fs = createNodeFileSystem();
+  });
+
+  afterEach(async () => {
+    await removeTempDir(dir);
+  });
+
+  const CHECKED_IN = 'the trip badge reads "checked in" after the traveller checks in';
+
+  function sessionEmitting(signal: string, options: ScriptedSessionOptions = {}): Partial<Session> {
+    const event: ReticleEvent = {
+      t: 1,
+      type: EventType.SIGNAL,
+      sessionId: 'demo',
+      data: { name: signal },
+    };
+    return {
+      ...scriptedSession((testid) => ({ elements: [{ ref: `e-${testid}` }] }), options),
+      eventsSince: () => [event],
+    };
+  }
+
+  async function save(name: string, annotations?: FlowAnnotations): Promise<void> {
+    const res = await new FlowStore(fs, root, clock).save(
+      program(name, [actStep('send-checkin')]),
+      annotations,
+    );
+    if (!res.ok) throw new Error(`save failed: ${res.code}`);
+  }
+
+  function withIntent(intent: string, signal: string): FlowAnnotations {
+    return { stepExpect: new Map(), dynamic: [], intent, success: { signal } };
+  }
+
+  it('a passing replay marks the intent proved with the verdict that did it', async () => {
+    await save('checkin', withIntent(CHECKED_IN, 'trip:checked-in'));
+    const deps = fakeDeps(fs, root, sessionEmitting('trip:checked-in'));
+
+    const res = (await tool(ReticleTool.FLOW_REPLAY).handler(deps, {
+      flowName: 'checkin',
+    })) as FlowReplayResult;
+    expect(res.status).toBe(ReplayStatus.OK);
+
+    const [intent] = await new IntentStore(fs, root, clock).read();
+    expect(intent?.statement).toBe(CHECKED_IN);
+    expect(intent?.state).toBe(IntentState.PROVED);
+    expect(intent?.provenBy?.verdictId).toContain('checkin');
+    expect(intent?.provenBy?.grade).toBe(FlowAssertionGrade.ASSERTED);
+  });
+
+  it('a failing replay names the business outcome that is no longer true, then the step', async () => {
+    await save('checkin', withIntent(CHECKED_IN, 'trip:checked-in'));
+    // The check-in button no longer does anything: the step fails, so the outcome never happens.
+    const deps = fakeDeps(fs, root, sessionEmitting('trip:checked-in', { actOk: false }));
+
+    const res = (await tool(ReticleTool.FLOW_REPLAY).handler(deps, {
+      flowName: 'checkin',
+    })) as FlowReplayResult;
+    expect(res.status).toBe(ReplayStatus.ERROR);
+    expect(res.decision?.summary).toContain(CHECKED_IN);
+    expect(res.decision?.whatChanged).toBeDefined();
+
+    // A failed replay must never discharge: the ledger stays open on an outcome nothing proved.
+    const [intent] = await new IntentStore(fs, root, clock).read();
+    expect(intent?.state).not.toBe(IntentState.PROVED);
+  });
+
+  it('an older flow file with no intent replays exactly as it does today', async () => {
+    await save('legacy');
+    const deps = fakeDeps(fs, root, sessionEmitting('irrelevant'));
+
+    const res = (await tool(ReticleTool.FLOW_REPLAY).handler(deps, {
+      flowName: 'legacy',
+    })) as FlowReplayResult;
+    expect(res.status).toBe(ReplayStatus.OK);
+    expect(res.steps).toHaveLength(1);
+    expect(await new IntentStore(fs, root, clock).read()).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

A replay reported in the language of the DOM — step 3 drifted, the success oracle did not fire, this testid is gone. All true, all actionable, and none of it says what the flow was **for**, so whoever read it had to reconstruct the stakes before they could judge whether to care.

A saved flow now carries the business intent it discharges.

## How, without a second vocabulary

The intent ledger already models this: prose statements, `declared → bound → proved`, and `provenBy` naming the verdict that discharged an intent. So a flow gets **one optional field**, `intentId`, pointing at a row in `.reticle/intent.json` — not a parallel notion of intent.

- The prose a recorder already captured (`flow.intent`) is promoted into the ledger at save time, under `flow:<name>`, with `surface.flow` set. Both save paths route through one place, so a flow's goal lands in the ledger however the flow arrived.
- An `intentId` written by hand wins, so a flow can prove an intent somebody declared long before it existed.
- The failure message quotes the **ledger's** statement, not the flow file's copy — an amendment is what a report says, which is the whole reason there is one vocabulary.

## Binding and discharge

An intent is bound only when the flow asserts an observable consequence, so a flow that cannot go red is left `declared` — and `dischargeIntent` already refuses to prove an unbound intent. A green replay discharges with `{ verdictId, grade, at }`, where `grade` is the flow's assertion grade: an intent re-proved by a weaker flow says so in the git diff. A ledger write that fails is swallowed — discharge runs off the back of a verdict and must never be why one fails to return.

## The message

Before:

```
"checkin" failed at step 2 (send-checkin).
```

After:

```
NO LONGER TRUE: "the trip badge reads 'checked in' after the traveller checks in" — "checkin" failed at step 2 (send-checkin).
```

Outcome first (legible), mechanism underneath (actionable), `whatChanged` / `whereInSource` unchanged.

## Not inventing intent

A flow with no declared intent says so — `no intent declared, so this proves the steps ran, not what they were for` — and nothing is ever derived from step names. A guessed goal reads as the product owner's words and an agent will act on them, which is worse than the honest absence. Same rule as the source pointer.

## Back-compat

`intentId` is additive and optional; `FLOW_FILE_VERSION` does not move. A flow file without intent is returned untouched by the link step, writes no ledger row, and keeps its exact bytes. Proven by tests, not asserted.

## Tests, red first

Proven red before implementing (`Cannot find module './flow-intent.js'` plus 7 assertion failures):

- a flow saved with an intent carries it through save and load
- stamps the ledger id onto the flow file, so the link survives on disk
- binds the intent when the flow asserts an observable outcome / leaves it unbound when it does not
- an older flow with no business goal writes no ledger row and no `intentId`
- an older flow file with no intent replays exactly as it does today
- a passing replay marks the intent proved with the verdict that did it
- a failing replay names the business outcome that is no longer true, then the step
- a failing replay does not discharge — the ledger stays open
- a flow with no intent says so plainly rather than deriving one from its steps
- honours an `intentId` already on the flow, so a flow can discharge an intent declared elsewhere

## Gates

`pnpm format:check` · `pnpm lint` · `pnpm typecheck` · `pnpm test:unit` (4782 tests) — all green. No new tool arguments or output fields, so the documented-argument gate is untouched.

`pnpm test:e2e` is **not** warranted: no tool surface, wire command, or observer changed. The battery is blind to this — it never replays a flow that carries an intent — and everything here is exercised by the unit gate against the real filesystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)