### PR TITLE
feat(server): reticle_context — the run's own memory, pulled when the agent's is gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ### Added
 
+- **`@reticlehq/core` + `@reticlehq/server` — `reticle_context`: what this run established, handed back when your own copy is gone.** A verification thread is multi-step, and the only thing holding it together is the agent's own context window. When that compacts, or the turn ends, or a sub-agent takes over, the thread goes with it and the work restarts: long runs of the same read-only call, an agent searching by exhaustion because it no longer remembers what it already saw.
+
+  Reticle's copy does not degrade at that moment, so `reticle_context` returns what the run OBSERVED (`established`, each with the `file:line` where one was reported), what a verdict already settled (`proven`), and what nothing has discharged (`remaining`, from the intent ledger). A forgotten proof is either re-proved, which is slow, or assumed, which is a false green, and both are the failure this exists to stop.
+
+  **Pulled, never pushed.** An earlier version rode along on every session-bound response and cost +136% on a verdict, because most of the time the agent still had the context and every call paid to duplicate what it knew. Nobody but the agent can tell when that stops being true, so the agent asks, once, at the moment it knows its memory is gone.
+
+  **It is a fold over the journal, never a second store.** `.reticle/sessions/<id>/` is already an append-only ledger of every action dispatched and every event observed; this reads it and writes nothing, so it cannot disagree with the ledger the way two counters eventually do. It supersedes rather than accumulates and is capped, so it shrinks. And every row carries the document and the edit round it was seen under: a fact from a replaced page, or from before your last source edit, is dropped rather than presented as current, because presenting it is exactly the false green this product exists to prevent.
+
+  On the extended surface rather than the default one. The default surface is a hard tool count shared with every other MCP server a user has connected, and this tool's claim is unmeasured. Its caller is also, by construction, an agent that has just lost its context and is re-reading the tool list, so the one `reticle_tools` hop it costs is a call that caller was already making.
+
 - **`@reticlehq/server` — a client that registers Reticle and never asks for the tools is now a state `status` can name.** Some MCP hosts register the server, start it, and then never send `tools/list` until the client is restarted. The agent has no Reticle tools, the user has a product that does nothing, and from our side that install is byte-identical to one somebody wired and abandoned: daemon idle, no sessions, nothing to report. Reported from the field, and the answer is always the same one nobody could have known to try.
 
   `reticle status` now carries `mcpClient`, and it distinguishes three states rather than two: nothing has ever started the MCP server on this port, a client started it and never listed the tools, or the client side is healthy. The middle one comes with the sentence that fixes it — restart your MCP client — and the healthy one comes with nothing at all, because advice printed beside a working install reads as though something is wrong.

--- a/SKILL.md
+++ b/SKILL.md
@@ -285,7 +285,7 @@ A verdict of `verified: "unknown"` is not a pass. It means Reticle drove the app
 
 Then report what you drove, what it produced, and the `file:line` for anything broken.
 
-The surface is deliberately small: `default` 18, `all` 29. Editors budget tools across every MCP server you have connected (Cursor allows 40 in total), so the count is capped rather than allowed to grow. `reticle_tools` loads the argument grammar for the rest on demand, and `reticle_run` invokes any of them by name. Nothing is unreachable; the cold tail just costs one discovery hop.
+The surface is deliberately small: `default` 18, `all` 30. Editors budget tools across every MCP server you have connected (Cursor allows 40 in total), so the count is capped rather than allowed to grow. `reticle_tools` loads the argument grammar for the rest on demand, and `reticle_run` invokes any of them by name. Nothing is unreachable; the cold tail just costs one discovery hop.
 
 - Batching, regression suites, reading a verdict: `https://docs.reticle.sh/agent-cheatsheet.md`
 - Every predicate and action: `https://docs.reticle.sh/predicates.md`, `https://docs.reticle.sh/actions.md`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,7 @@ export * from './browser-misdirect.js';
 export * from './daemon-registry.js'; // daemon discovery, used by the vite plugin + server
 export * from './project-registry.js'; // projectId -> directory, so a cross-repo daemon can still resolve
 export * from './intent.js'; // what a change was supposed to make true, captured while somebody knows
+export * from './run-context.js'; // what a run established, folded and capped, for the agent to pull back
 export * from './instrumentation-gap.js'; // what Reticle could not see, and the change that would let it
 export * from './security.js'; // sanitize/serialize helpers shared by browser + server
 export * from './redaction.js'; // isSensitiveKey / scrubKnownSecrets — the shared redaction rules

--- a/packages/core/src/journal.ts
+++ b/packages/core/src/journal.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { TRANSPORT_LIMITS } from './constants.js';
+import { Verified } from './verified-constants.js';
 
 /**
  * The durable causal journal. Each session gets an append-only pair on disk:
@@ -39,3 +40,24 @@ export const JournalActionSchema = z.object({
   at: z.number().int().min(0),
 });
 export type JournalAction = z.infer<typeof JournalActionSchema>;
+
+/**
+ * The bounded verdict summary a verification tool writes into a journal action's `effect`.
+ *
+ * `effect` is deliberately open (`unknown`) and narrowed by its writer; this is that narrowing for
+ * the one writer whose record has to be READ back later. Without it a verdict lives only in the tool
+ * response, which is exactly the place that disappears when an agent compacts, so "what did this run
+ * already prove" would have no ledger to fold and the answer would be silently empty.
+ *
+ * Three fields and no more: the claim the verdict was about, how it came out, and where in the
+ * source it pointed. A transcript here would grow the journal without making the answer better.
+ */
+export const JournalVerdictEffectSchema = z.object({
+  /** What was claimed, in the caller's own words — the subject a later proof supersedes. */
+  claim: z.string().min(1).max(TRANSPORT_LIMITS.MAX_STRING_LENGTH),
+  /** The verdict, as the one field an agent reads. The enum, never a re-typed copy of it. */
+  verified: z.nativeEnum(Verified),
+  /** `file:line` for the element driven, when the page told us one. */
+  source: z.string().max(TRANSPORT_LIMITS.MAX_URL_LENGTH).optional(),
+});
+export type JournalVerdictEffect = z.infer<typeof JournalVerdictEffectSchema>;

--- a/packages/core/src/run-context.test.ts
+++ b/packages/core/src/run-context.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RUN_ESTABLISHED_CAP,
+  buildRunContext,
+  foldEstablished,
+  foldProven,
+  remainingFor,
+} from './run-context.js';
+import { NO_EDITS_OBSERVED } from './edit-epoch.js';
+import { Verified } from './verified-constants.js';
+import { IntentState, type Intent } from './intent.js';
+
+/**
+ * What this run has established, so an agent whose own copy is gone does not rediscover it.
+ *
+ * Verification is multi-step and the only thing holding the thread together is the agent's context
+ * window. When that compacts, or the turn ends, or a sub-agent takes over, the thread is gone and
+ * the work restarts. Reticle's copy does not degrade at the same moment, which is the entire reason
+ * it can answer: it is not a competing memory, it is the ground truth compaction destroyed.
+ *
+ * Two rules keep it from becoming the thing it prevents:
+ *
+ * **It must shrink, not grow.** Re-establishing a subject REPLACES rather than appends, and both
+ * blocks are capped by a stated number.
+ *
+ * **Memory that can be wrong is worse than no memory.** A fact from a replaced document, or from
+ * before the last source edit, is precisely the false-green mechanism this product exists to
+ * prevent, so it is dropped rather than presented as current.
+ */
+
+const fact = (key: string, text: string, doc?: string, epoch?: number) => ({
+  key,
+  fact: text,
+  doc,
+  epoch,
+});
+
+describe('foldEstablished', () => {
+  it('keeps a fact that is still current', () => {
+    const out = foldEstablished([], [fact('e12', 'e12 is the Send button', 'd3')], 'd3', undefined);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.fact).toBe('e12 is the Send button');
+  });
+
+  it('SUPERSEDES rather than appends when the same subject is re-established', () => {
+    const first = foldEstablished(
+      [],
+      [fact('e12', 'e12 is the Send button', 'd3')],
+      'd3',
+      undefined,
+    );
+    const out = foldEstablished(
+      first,
+      [fact('e12', 'e12 is the Submit button', 'd3')],
+      'd3',
+      undefined,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]?.fact).toBe('e12 is the Submit button');
+  });
+
+  /**
+   * The rule that makes this safe to trust at all. A fact established under a document that has
+   * since been replaced is not stale-ish or probably-fine: it describes a page that no longer
+   * exists, and citing it is the false green this product exists to catch.
+   */
+  it('DROPS every fact established under a replaced document', () => {
+    const before = foldEstablished([], [fact('e12', 'e12 is the Send button', 'd3')], 'd3', 1);
+    expect(foldEstablished(before, [], 'd4', 1)).toEqual([]);
+  });
+
+  /**
+   * Same argument one layer in. A hot update swaps modules inside the SAME document, so the document
+   * id never moves, and every fact about the code that was replaced survives unless the epoch is
+   * checked too.
+   */
+  it('DROPS every fact established under a pre-edit epoch', () => {
+    const before = foldEstablished([], [fact('e12', 'e12 is the Send button', 'd3', 1)], 'd3', 1);
+    expect(foldEstablished(before, [], 'd3', 2)).toEqual([]);
+  });
+
+  it('keeps facts from the current document while dropping the superseded ones', () => {
+    const mixed = [fact('a', 'a is old', 'd3'), fact('b', 'b is current', 'd4')];
+    const out = foldEstablished(mixed, [], 'd4', undefined);
+    expect(out.map((f) => f.key)).toEqual(['b']);
+  });
+
+  it('caps the set at a stated number, keeping the most recent', () => {
+    const many = Array.from({ length: RUN_ESTABLISHED_CAP + 5 }, (_, i) =>
+      fact(`k${String(i)}`, `fact ${String(i)}`, 'd3'),
+    );
+    const out = foldEstablished([], many, 'd3', undefined);
+    expect(out).toHaveLength(RUN_ESTABLISHED_CAP);
+    expect(out.at(-1)?.key).toBe(`k${String(RUN_ESTABLISHED_CAP + 4)}`);
+  });
+
+  /**
+   * An unstamped fact predates document identity. It is kept for the same reason unstamped EVIDENCE
+   * is treated as current: an older SDK stamps nothing, and dropping its facts would make the answer
+   * silently empty rather than honestly smaller.
+   */
+  it('keeps an unstamped fact rather than dropping it as foreign', () => {
+    expect(foldEstablished([], [fact('e1', 'no document known')], 'd3', 4)).toHaveLength(1);
+  });
+
+  it('keeps a fact from a page where no edit was ever observed', () => {
+    const kept = foldEstablished(
+      [],
+      [fact('e1', 'e1 is the Send button', 'd3', NO_EDITS_OBSERVED)],
+      'd3',
+      NO_EDITS_OBSERVED,
+    );
+    expect(kept).toHaveLength(1);
+  });
+});
+
+describe('foldProven', () => {
+  const proof = (claim: string, doc?: string, epoch?: number) => ({
+    claim,
+    verified: Verified.YES,
+    doc,
+    epoch,
+  });
+
+  it('keeps what a verdict proved, so a forgotten proof is not re-proved or assumed', () => {
+    const out = foldProven([], [proof('badge reads checked in', 'd3')], 'd3', undefined);
+    expect(out).toEqual([
+      { claim: 'badge reads checked in', verified: Verified.YES, doc: 'd3', epoch: undefined },
+    ]);
+  });
+
+  it('supersedes when the same claim is proved twice', () => {
+    const first = foldProven([], [proof('badge reads checked in', 'd3')], 'd3', undefined);
+    const out = foldProven(
+      first,
+      [{ claim: 'badge reads checked in', verified: Verified.NO, doc: 'd3' }],
+      'd3',
+      undefined,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]?.verified).toBe(Verified.NO);
+  });
+
+  it('drops a proof taken under a replaced document or a pre-edit epoch', () => {
+    const before = foldProven([], [proof('checkout works', 'd3', 1)], 'd3', 1);
+    expect(foldProven(before, [], 'd4', 1)).toEqual([]);
+    expect(foldProven(before, [], 'd3', 2)).toEqual([]);
+  });
+});
+
+describe('remainingFor', () => {
+  const intent = (id: string, state: Intent['state'], statement: string): Intent => ({
+    id,
+    statement,
+    state,
+    declaredAt: 0,
+  });
+
+  it('lists what no verdict has discharged yet', () => {
+    const out = remainingFor([
+      intent('i1', IntentState.BOUND, 'the badge should read checked in'),
+      intent('i2', IntentState.PROVED, 'the form submits'),
+    ]);
+    expect(out).toEqual(['the badge should read checked in']);
+  });
+
+  it('includes a declared intent, which is undischarged by definition', () => {
+    expect(remainingFor([intent('i1', IntentState.DECLARED, 'checkout works')])).toEqual([
+      'checkout works',
+    ]);
+  });
+
+  /**
+   * `remaining` is DERIVED, never inferred. It reports which declared bindings are undischarged, a
+   * fact about the ledger, and never a guess at what the agent means to do next. A tool that
+   * predicts intent is inventing evidence, which is the one thing this must not do.
+   */
+  it('is empty when everything declared has been proved', () => {
+    expect(remainingFor([intent('i1', IntentState.PROVED, 'done')])).toEqual([]);
+    expect(remainingFor([])).toEqual([]);
+  });
+});
+
+describe('buildRunContext', () => {
+  it('reports the step, what is established, what is proven, and what is outstanding', () => {
+    const context = buildRunContext({
+      step: 6,
+      intents: [
+        { id: 'i1', statement: 'badge reads checked in', state: IntentState.BOUND, declaredAt: 0 },
+      ],
+      established: [fact('e12', 'e12 is the Send button', 'd3')],
+      proven: [{ claim: 'the row disappears', verified: Verified.YES, doc: 'd3' }],
+      currentDocumentId: 'd3',
+      currentEditEpoch: undefined,
+    });
+    expect(context.step).toBe(6);
+    expect(context.established).toHaveLength(1);
+    expect(context.proven).toHaveLength(1);
+    expect(context.remaining).toEqual(['badge reads checked in']);
+  });
+
+  /**
+   * An empty answer is the honest one for a run that has established nothing. The push version of
+   * this returned `undefined` so an empty block would not ride on every response; a PULL is asked
+   * for, and "nothing yet" is the answer the asker needs rather than silence.
+   */
+  it('answers a fresh run with an honest empty context rather than inventing one', () => {
+    const context = buildRunContext({
+      step: 0,
+      intents: [],
+      established: [],
+      proven: [],
+      currentDocumentId: 'd1',
+      currentEditEpoch: undefined,
+    });
+    expect(context).toEqual({ step: 0, established: [], proven: [], remaining: [] });
+  });
+});

--- a/packages/core/src/run-context.ts
+++ b/packages/core/src/run-context.ts
@@ -1,0 +1,195 @@
+/**
+ * What a run has established, held so the agent can ASK for it back.
+ *
+ * Verification is multi-step, and the only thing holding the thread together is the agent's own
+ * context window. When that compacts, or the turn ends, or a sub-agent takes over, the thread is
+ * gone and the work restarts. The shape of that shows in the field without needing the theory: long
+ * runs of the same read-only call, an agent searching by exhaustion because it no longer remembers
+ * what it already saw.
+ *
+ * ## Pulled, never pushed
+ *
+ * An earlier version of this rode along on every tool response. It cost +136% on a verdict and was
+ * cut, because the agent still had most of that context most of the time: we paid on every call to
+ * duplicate what it already knew. The asymmetry that makes the feature work is not that Reticle
+ * remembers MORE, it is that Reticle's copy does not degrade at the moment the agent's does. So the
+ * agent asks, at the moment it knows its own memory is gone, and pays once.
+ *
+ * That inversion is why nothing here returns `undefined` for an empty run. A push had to stay silent
+ * when it had nothing to say; a pull was asked a question, and "nothing established yet" is the
+ * answer the asker needs.
+ *
+ * ## Two rules stop it becoming the thing it prevents
+ *
+ * **It must shrink, not grow.** Superseding facts REPLACE rather than append, and both blocks are
+ * capped. A context object that accumulates is a token bomb, and read-only payloads are already the
+ * largest thing this product emits.
+ *
+ * **Memory that can be wrong is worse than no memory.** A stale established fact is precisely the
+ * false-green mechanism this product exists to prevent, and stale refs are already the most common
+ * error an agent sees from us. So every fact carries the document AND the edit epoch it was observed
+ * under, and is dropped the moment either moves: no grace period, no probably-fine. The comparison
+ * is `isSameDocument`/`isSameEditEpoch` rather than a third rule written beside them.
+ *
+ * ## What may never go in
+ *
+ * Only what Reticle OBSERVED. Never what the agent intends, plans, or believes: that is not ours to
+ * hold, it is unbounded, and a verification tool that remembers what an agent was thinking is
+ * inventing evidence. `remaining` is the one forward-looking field and it is derived mechanically
+ * from declared bindings, so it remains a report of a fact — which bindings are undischarged — and
+ * not a prediction.
+ */
+
+import { isSameDocument } from './document-identity.js';
+import { isSameEditEpoch } from './edit-epoch.js';
+import { IntentState, type Intent } from './intent.js';
+import type { Verified } from './verified-constants.js';
+
+/**
+ * How many rows either block may carry.
+ *
+ * A decision written down in one place, because the whole feature is a bet that this answer costs
+ * fewer tokens than the re-derivation it prevents, and a cap that drifts makes that bet
+ * unmeasurable. Twelve is enough to hold the refs, routes and verdicts a single verification thread
+ * works with, and small enough that the answer stays a briefing rather than a second payload.
+ *
+ * One number for both blocks on purpose: two caps is two things to keep in step, and nothing has
+ * ever suggested proofs and observations deserve different budgets.
+ */
+export const RUN_ESTABLISHED_CAP = 12;
+
+/**
+ * Evidence scoped to the page and the source revision it was taken under.
+ *
+ * Both fields are optional and absence means "current", exactly as `isSameDocument` and
+ * `isSameEditEpoch` already rule: an SDK predating either stamps nothing, and a page with no
+ * hot-update channel never stamps an epoch at all.
+ */
+interface ScopedEvidence {
+  /** The document this was seen under. Absent only from evidence predating document identity. */
+  readonly doc?: string | undefined;
+  /** The edit epoch this was seen under. Absent where no hot update could ever be observed. */
+  readonly epoch?: number | undefined;
+}
+
+/**
+ * One thing this run established, with the page state it was true under.
+ *
+ * `key` is the SUBJECT — re-establishing the same subject supersedes rather than appends. `fact` is
+ * the conclusion in prose, never the transcript it came from: "e12 is the Submit button", not the
+ * snapshot that revealed it.
+ */
+export interface EstablishedFact extends ScopedEvidence {
+  readonly key: string;
+  readonly fact: string;
+  /** Where in the source this was about, `file:line`, when the run observed one. */
+  readonly source?: string | undefined;
+}
+
+/**
+ * One claim a verdict already settled.
+ *
+ * The claim IS the subject: proving the same thing twice is one row, the newer one. An agent that
+ * has forgotten it proved something either re-proves it, which is slow, or assumes it, which is a
+ * false green — and both are the failure this block exists to stop, so `verified` travels with the
+ * claim rather than being flattened to a boolean.
+ */
+export interface ProvenClaim extends ScopedEvidence {
+  readonly claim: string;
+  readonly verified: Verified;
+  readonly source?: string | undefined;
+}
+
+/** What this run has established, what it has proved, and what nothing has discharged. */
+export interface RunContext {
+  readonly step: number;
+  readonly established: readonly EstablishedFact[];
+  readonly proven: readonly ProvenClaim[];
+  readonly remaining: readonly string[];
+}
+
+/** Is this evidence still describing the page and the source revision in force? */
+function isCurrent(
+  evidence: ScopedEvidence,
+  currentDocumentId: string | undefined,
+  currentEditEpoch: number | undefined,
+): boolean {
+  return (
+    isSameDocument(evidence.doc, currentDocumentId) &&
+    isSameEditEpoch(evidence.epoch, currentEditEpoch)
+  );
+}
+
+/**
+ * Drop what a navigation or an edit invalidated, supersede what was re-observed, keep the most
+ * recent within the cap.
+ *
+ * One fold with a key function rather than two, because `established` and `proven` obey the same
+ * three rules and a second copy is a second place for them to drift apart.
+ */
+function foldScoped<T extends ScopedEvidence>(
+  existing: readonly T[],
+  incoming: readonly T[],
+  keyOf: (row: T) => string,
+  currentDocumentId: string | undefined,
+  currentEditEpoch: number | undefined,
+): T[] {
+  const current = (row: T): boolean => isCurrent(row, currentDocumentId, currentEditEpoch);
+  const superseded = new Set(incoming.map(keyOf));
+  const kept = existing.filter((row) => current(row) && !superseded.has(keyOf(row)));
+  // Oldest first, so trimming from the front drops the least recent. `slice` on the tail keeps the
+  // newest, which is the half a next step is most likely to need.
+  return [...kept, ...incoming.filter(current)].slice(-RUN_ESTABLISHED_CAP);
+}
+
+/** Fold new observations into the established set. See `foldScoped`. */
+export function foldEstablished(
+  existing: readonly EstablishedFact[],
+  incoming: readonly EstablishedFact[],
+  currentDocumentId: string | undefined,
+  currentEditEpoch: number | undefined,
+): EstablishedFact[] {
+  return foldScoped(existing, incoming, (f) => f.key, currentDocumentId, currentEditEpoch);
+}
+
+/** Fold new verdicts into the proven set, keyed on the claim. See `foldScoped`. */
+export function foldProven(
+  existing: readonly ProvenClaim[],
+  incoming: readonly ProvenClaim[],
+  currentDocumentId: string | undefined,
+  currentEditEpoch: number | undefined,
+): ProvenClaim[] {
+  return foldScoped(existing, incoming, (p) => p.claim, currentDocumentId, currentEditEpoch);
+}
+
+/**
+ * The declared intents no verdict has discharged yet.
+ *
+ * Derived, never inferred. This reports a property of the ledger — which bindings remain unproved —
+ * and says nothing about what the agent means to do next.
+ */
+export function remainingFor(intents: readonly Intent[]): string[] {
+  return intents.filter((i) => IntentState.PROVED !== i.state).map((i) => i.statement);
+}
+
+/** Assemble the answer. Always answers: an empty run has an empty context, and that is the truth. */
+export function buildRunContext(input: {
+  step: number;
+  intents: readonly Intent[];
+  established: readonly EstablishedFact[];
+  proven: readonly ProvenClaim[];
+  currentDocumentId: string | undefined;
+  currentEditEpoch: number | undefined;
+}): RunContext {
+  return {
+    step: input.step,
+    established: foldEstablished(
+      [],
+      input.established,
+      input.currentDocumentId,
+      input.currentEditEpoch,
+    ),
+    proven: foldProven([], input.proven, input.currentDocumentId, input.currentEditEpoch),
+    remaining: remainingFor(input.intents),
+  };
+}

--- a/packages/server/src/journal/journal-recorder.ts
+++ b/packages/server/src/journal/journal-recorder.ts
@@ -14,6 +14,11 @@ export interface JournalSink {
 /** Read side of the durable journal — the fall-through source when the ring buffer has evicted. */
 export interface JournalReader {
   readEvents(): Promise<ReticleEvent[]>;
+  /**
+   * The action ledger. Optional because a test double is a partial reader, and nothing that only
+   * needs events should be forced to grow a second method to satisfy the type.
+   */
+  readActions?(): Promise<JournalAction[]>;
 }
 
 interface JournalRecorderOptions {

--- a/packages/server/src/mcp/context-over-transport.test.ts
+++ b/packages/server/src/mcp/context-over-transport.test.ts
@@ -1,0 +1,72 @@
+/**
+ * `reticle_context` answered over a real transport, the way an agent actually reaches it.
+ *
+ * The handler tests construct the tool directly, which cannot tell whether the name was registered,
+ * whether the surface advertises it, or whether the session-exempt classification lets the call
+ * through. A tool that is built and unreachable is indistinguishable from one that was never built,
+ * and this repo has shipped that exact shape before: a channel wired end to end and dropped by the
+ * layer nobody tested.
+ *
+ * Follows the in-memory-transport pattern of `unadvertised-tool-over-transport.test.ts`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createMcpServer } from './mcp.js';
+import { TOOL_SURFACE } from '../tools/tool-surface.js';
+import { ReticleTool } from '../tools/tool-names.js';
+import { createMemoryFs } from '../project/memory-fs.js';
+import type { ToolDeps } from '../tools/tools.js';
+
+/** No session connected, which is the state the honest-empty answer is about. */
+const toolDepsForTest = (): ToolDeps =>
+  ({
+    sessions: {
+      resolve: () => {
+        throw new Error('no session is connected');
+      },
+    },
+    fs: createMemoryFs().fs,
+    reticleRoot: '/repo/.reticle',
+    now: () => 1_000,
+  }) as unknown as ToolDeps;
+
+const openServer = async (): Promise<{
+  client: import('@modelcontextprotocol/sdk/client/index.js').Client;
+  close: () => Promise<void>;
+}> => {
+  const { InMemoryTransport } = await import('@modelcontextprotocol/sdk/inMemory.js');
+  const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+  const server = createMcpServer(toolDepsForTest(), TOOL_SURFACE.ALL);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: 'c', version: '0' });
+  await client.connect(clientTransport);
+  return {
+    client,
+    close: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+};
+
+describe('reticle_context over a real MCP transport', () => {
+  it('is advertised on the extended surface and answers an honest empty context', async () => {
+    const { client, close } = await openServer();
+    try {
+      const advertised = await client.listTools();
+      expect(advertised.tools.map((tool) => tool.name)).toContain(ReticleTool.CONTEXT);
+
+      const result = await client.callTool({ name: ReticleTool.CONTEXT, arguments: {} });
+      expect(result.isError, JSON.stringify(result.content)).toBeFalsy();
+      expect(result.structuredContent).toMatchObject({
+        step: 0,
+        established: [],
+        proven: [],
+        remaining: [],
+      });
+    } finally {
+      await close();
+    }
+  }, 20_000);
+});

--- a/packages/server/src/runs/context-tools.test.ts
+++ b/packages/server/src/runs/context-tools.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EventType,
+  JOURNAL_FILE_VERSION,
+  RUN_ESTABLISHED_CAP,
+  Verified,
+  type JournalAction,
+  type ReticleEvent,
+  type RunContext,
+} from '@reticlehq/core';
+import { createMemoryFs } from '../project/memory-fs.js';
+import { IntentStore } from '../intent/intent-store.js';
+import { CONTEXT_TOOLS } from './context-tools.js';
+import { ReticleTool } from '../tools/tool-names.js';
+import type { FileSystemPort } from '../project/fs-port.js';
+import type { ToolDeps } from '../tools/tool-kit.js';
+
+const ROOT = '/repo/.reticle';
+
+const tool = () => {
+  const found = CONTEXT_TOOLS.find((t) => ReticleTool.CONTEXT === t.name);
+  if (undefined === found) throw new Error('reticle_context must be in CONTEXT_TOOLS');
+  return found;
+};
+
+function action(over: Partial<JournalAction> = {}): JournalAction {
+  return {
+    v: JOURNAL_FILE_VERSION,
+    actionId: 'c1',
+    tool: 'reticle_act_and_wait',
+    args: { ref: 'e12', action: 'click' },
+    tRange: { from: 0, to: 10 },
+    at: 0,
+    ...over,
+  };
+}
+
+function event(over: Partial<ReticleEvent> = {}): ReticleEvent {
+  return { t: 0, type: EventType.DOM_ADDED, data: {}, ...over } as ReticleEvent;
+}
+
+interface Fake {
+  actions?: JournalAction[];
+  events?: ReticleEvent[];
+  documentId?: string;
+  editEpoch?: number;
+  connected?: boolean;
+}
+
+function deps(fs: FileSystemPort, fake: Fake = {}): ToolDeps {
+  const session = {
+    readJournalActions: (): Promise<JournalAction[]> => Promise.resolve(fake.actions ?? []),
+    queryEvents: (): Promise<ReticleEvent[]> => Promise.resolve(fake.events ?? []),
+    currentDocumentId: fake.documentId,
+    currentEditEpoch: fake.editEpoch,
+  };
+  return {
+    sessions: {
+      resolve: () => {
+        if (false === fake.connected) throw new Error('no session is connected');
+        return session;
+      },
+    },
+    fs,
+    reticleRoot: ROOT,
+    now: () => 1_000,
+  } as unknown as ToolDeps;
+}
+
+const call = async (fs: FileSystemPort, fake: Fake = {}): Promise<RunContext> =>
+  (await tool().handler(deps(fs, fake), {})) as RunContext;
+
+describe('reticle_context', () => {
+  it('returns the established facts, folded and capped', async () => {
+    const { fs } = createMemoryFs();
+    const many = Array.from({ length: RUN_ESTABLISHED_CAP + 6 }, (_, i) =>
+      action({
+        actionId: `c${String(i)}`,
+        args: { ref: `e${String(i)}`, action: 'click' },
+        settled: true,
+      }),
+    );
+    const context = await call(fs, { actions: many });
+    expect(context.established.length).toBeLessThanOrEqual(RUN_ESTABLISHED_CAP);
+    expect(context.step).toBe(many.length);
+  });
+
+  it('omits a fact established under a document that has been replaced', async () => {
+    const { fs } = createMemoryFs();
+    const context = await call(fs, {
+      actions: [action({ settled: true })],
+      events: [event({ actionId: 'c1', documentId: 'doc00001' })],
+      documentId: 'doc00002',
+    });
+    expect(context.established).toEqual([]);
+  });
+
+  it('omits a fact established under a pre-edit epoch', async () => {
+    const { fs } = createMemoryFs();
+    const context = await call(fs, {
+      actions: [action({ settled: true })],
+      events: [event({ actionId: 'c1', documentId: 'doc00001', editEpoch: 1 })],
+      documentId: 'doc00001',
+      editEpoch: 2,
+    });
+    expect(context.established).toEqual([]);
+  });
+
+  it('lists the intents no verdict has discharged', async () => {
+    const { fs } = createMemoryFs();
+    await new IntentStore(fs, ROOT, { now: () => 1 }).declare([
+      { id: 'checkin', statement: 'the badge reads checked in' },
+    ]);
+    expect((await call(fs)).remaining).toEqual(['the badge reads checked in']);
+  });
+
+  it('lists what a verdict already proved, so it is neither re-proved nor assumed', async () => {
+    const { fs } = createMemoryFs();
+    const context = await call(fs, {
+      actions: [
+        action({
+          settled: true,
+          effect: { claim: 'the badge reads checked in', verified: Verified.YES },
+        }),
+      ],
+    });
+    expect(context.proven).toEqual([
+      {
+        claim: 'the badge reads checked in',
+        verified: Verified.YES,
+        source: undefined,
+        doc: undefined,
+        epoch: undefined,
+      },
+    ]);
+  });
+
+  it('answers a fresh session honestly empty rather than inventing a run', async () => {
+    const { fs } = createMemoryFs();
+    expect(await call(fs, { connected: false })).toEqual({
+      step: 0,
+      established: [],
+      proven: [],
+      remaining: [],
+    });
+  });
+});

--- a/packages/server/src/runs/context-tools.ts
+++ b/packages/server/src/runs/context-tools.ts
@@ -1,0 +1,116 @@
+import { z } from 'zod';
+import { type Intent, type JournalAction, type ReticleEvent } from '@reticlehq/core';
+import { runContextFor } from './run-context.js';
+import { IntentStore } from '../intent/intent-store.js';
+import { ReticleTool } from '../tools/tool-names.js';
+import { sessionIdShape } from '../tools/tool-kit.js';
+import { sessionRoot } from '../project/session-root.js';
+import { asString } from '../tools/tools-helpers.js';
+import type { ToolDef, ToolDeps } from '../tools/tool-kit.js';
+
+/**
+ * What this run has established, asked for by the one party that knows when it is needed.
+ *
+ * Reticle holds the trajectory: the journal, the verdicts, the intent ledger. The agent holds a copy
+ * in its context window, and that copy is the one that disappears — at a compaction, at the end of a
+ * turn, at the handover to a sub-agent. Reticle's does not disappear at the same moment. So this is
+ * not a competing memory; it is the ground truth compaction destroyed, handed back on request.
+ *
+ * ## Why it is PULLED
+ *
+ * The same content was once pushed onto every session-bound tool response. It cost +136% on a
+ * verdict and was cut, because most of the time the agent still had the context and we were paying
+ * on every call to duplicate what it knew. Nobody but the agent can tell when that stops being true.
+ * So the agent asks, once, at the moment it knows its own memory is gone, and pays once.
+ *
+ * ## Why it is on the EXTENDED surface rather than the default
+ *
+ * The default surface is a hard COUNT — editors budget tools across every connected MCP server, so a
+ * slot taken here is taken from a tool that has already earned it, and nothing on that list has been
+ * demoted for this. The claim behind this tool is unmeasured, which is the same test `reticle_intent`
+ * and the `reticle_capabilities` demotion were held to, and it fails that test today.
+ *
+ * The reachability argument is also stronger here than for most of the cold tail. The caller is,
+ * by construction, an agent that has just lost its context and is re-reading the tool list it was
+ * handed this turn — so `reticle_tools` (advertised on every surface) is exactly the call it is
+ * already going to make, and this tool is one `reticle_run` hop behind it. A tool that is only useful
+ * after a discovery step, to a caller who is already performing a discovery step, is the cheapest
+ * possible thing to leave off the hot list. It moves to the default surface when a measurement says
+ * the pull happens often enough to be worth a permanent slot, and not before.
+ */
+
+/** What the run has established, and where each part of it came from. */
+const CONTEXT_OUTPUT_SCHEMA = {
+  step: z
+    .number()
+    .describe(
+      'How many actions this run has dispatched. Counted off the journal, not a counter of its own.',
+    ),
+  established: z
+    .array(z.unknown())
+    .describe(
+      'What Reticle OBSERVED, folded and capped, each `{ key, fact, source?, doc?, epoch? }`. `key` is the subject, so re-observing it supersedes rather than appends. Anything seen under a replaced document or a pre-edit epoch is already gone from this list.',
+    ),
+  proven: z
+    .array(z.unknown())
+    .describe(
+      'Claims a verdict already settled, each `{ claim, verified, source?, doc?, epoch? }`. Read this before re-driving something: re-proving it is slow, and assuming it is a false green.',
+    ),
+  remaining: z
+    .array(z.string())
+    .describe(
+      'The intents from .reticle/intent.json that no verdict has discharged. Derived from the ledger, never a guess at what you meant to do next.',
+    ),
+};
+
+/** The ledger and the live page state this run is folded out of. `[]`/undefined when nothing is connected. */
+async function evidenceFor(
+  deps: ToolDeps,
+  sessionId: string | undefined,
+): Promise<{
+  actions: JournalAction[];
+  events: ReticleEvent[];
+  currentDocumentId: string | undefined;
+  currentEditEpoch: number | undefined;
+}> {
+  try {
+    const session = deps.sessions.resolve(sessionId);
+    return {
+      actions: await session.readJournalActions(),
+      events: await session.queryEvents({}),
+      currentDocumentId: session.currentDocumentId,
+      currentEditEpoch: session.currentEditEpoch,
+    };
+  } catch {
+    // `resolve` throws when nothing is connected, when the id names no session, and when several are
+    // connected and none was named. All three mean the same thing here: there is no run to report,
+    // and an empty context is the honest answer rather than a reason to fail the call.
+    return {
+      actions: [],
+      events: [],
+      currentDocumentId: undefined,
+      currentEditEpoch: undefined,
+    };
+  }
+}
+
+/** The intent ledger, or nothing. A ledger that cannot be read reports nothing outstanding. */
+async function openIntentsFor(deps: ToolDeps, sessionId: string | undefined): Promise<Intent[]> {
+  return new IntentStore(deps.fs, sessionRoot(deps, sessionId), { now: deps.now }).open();
+}
+
+export const CONTEXT_TOOLS: ToolDef[] = [
+  {
+    name: ReticleTool.CONTEXT,
+    description:
+      'What THIS run has already established, so you do not rediscover it. Call it when your own copy is gone: right after a compaction, at the top of a fresh sub-agent, or at the start of a turn you did not begin. Returns `established` (what Reticle OBSERVED, with the source file:line where one was reported), `proven` (claims a verdict already settled, so you neither re-prove them nor assume them) and `remaining` (the intents from .reticle/intent.json that nothing has discharged). It is a FOLD over the journal, never a second store, so it cannot disagree with the ledger. Bounded and superseding rather than accumulating, and anything observed under a replaced document or before your last source edit is already dropped rather than presented as current. Only what Reticle observed goes in: it never reports what you intended or believed.',
+    example: {},
+    inputSchema: { ...sessionIdShape },
+    outputSchema: CONTEXT_OUTPUT_SCHEMA,
+    handler: async (deps: ToolDeps, args) => {
+      const sessionId = asString(args['sessionId']);
+      const evidence = await evidenceFor(deps, sessionId);
+      return runContextFor({ ...evidence, intents: await openIntentsFor(deps, sessionId) });
+    },
+  },
+];

--- a/packages/server/src/runs/run-context.test.ts
+++ b/packages/server/src/runs/run-context.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EventType,
+  JOURNAL_FILE_VERSION,
+  RUN_ESTABLISHED_CAP,
+  Verified,
+  type JournalAction,
+  type ReticleEvent,
+} from '@reticlehq/core';
+import { establishedFromJournal, provenFromJournal, runContextFor } from './run-context.js';
+
+function action(over: Partial<JournalAction> = {}): JournalAction {
+  return {
+    v: JOURNAL_FILE_VERSION,
+    actionId: 'c1',
+    tool: 'reticle_act',
+    args: { ref: 'e12', action: 'click' },
+    tRange: { from: 0, to: 10 },
+    at: 0,
+    ...over,
+  };
+}
+
+function event(over: Partial<ReticleEvent> = {}): ReticleEvent {
+  return { t: 0, type: EventType.DOM_ADDED, data: {}, ...over } as ReticleEvent;
+}
+
+describe('establishedFromJournal — only what Reticle observed', () => {
+  it('keys a settled action on its ref, so re-driving it supersedes', () => {
+    const facts = establishedFromJournal([action({ settled: true })], []);
+    expect(facts[0]?.key).toBe('e12');
+    expect(facts[0]?.fact).toBe('click settled');
+  });
+
+  it('records an action that did NOT settle rather than dropping it', () => {
+    expect(establishedFromJournal([action({ settled: false })], [])[0]?.fact).toBe(
+      'click did not settle',
+    );
+  });
+
+  it('says nothing about an action whose settle outcome was never observed', () => {
+    expect(establishedFromJournal([action()], [])).toEqual([]);
+  });
+
+  it('falls back to the target text when the call named no ref', () => {
+    const facts = establishedFromJournal(
+      [action({ args: { target: 'Submit', action: 'click' }, settled: true })],
+      [],
+    );
+    expect(facts[0]?.key).toBe('Submit');
+  });
+
+  it('stamps the document and the edit epoch the action was observed under', () => {
+    const facts = establishedFromJournal(
+      [action({ settled: true })],
+      [event({ actionId: 'c1', documentId: 'doc00001', editEpoch: 3 })],
+    );
+    expect(facts[0]?.doc).toBe('doc00001');
+    expect(facts[0]?.epoch).toBe(3);
+  });
+
+  it('carries the source pointer the verdict already reported', () => {
+    const facts = establishedFromJournal(
+      [
+        action({
+          settled: true,
+          effect: {
+            claim: 'the badge reads checked in',
+            verified: Verified.YES,
+            source: 'a.tsx:9',
+          },
+        }),
+      ],
+      [],
+    );
+    expect(facts[0]?.source).toBe('a.tsx:9');
+  });
+
+  it('files the route under one stable key so only the newest survives', () => {
+    const facts = establishedFromJournal(
+      [],
+      [
+        event({ type: EventType.ROUTE_CHANGE, data: { pathname: '/a' } }),
+        event({ t: 1, type: EventType.ROUTE_CHANGE, data: { pathname: '/b' } }),
+      ],
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]?.fact).toBe('route is /b');
+  });
+
+  it('never reads further back than the fold can keep', () => {
+    const many = Array.from({ length: 40 }, (_, i) =>
+      action({
+        actionId: `c${String(i)}`,
+        args: { ref: `e${String(i)}`, action: 'click' },
+        settled: true,
+      }),
+    );
+    const facts = establishedFromJournal(many, []);
+    expect(facts.length).toBeLessThanOrEqual(RUN_ESTABLISHED_CAP);
+    expect(facts.at(-1)?.key).toBe('e39');
+  });
+});
+
+describe('provenFromJournal — what a verdict already settled', () => {
+  it('reads the claim and the verdict off the action a verification tool recorded', () => {
+    const proven = provenFromJournal(
+      [
+        action({
+          tool: 'reticle_act_and_wait',
+          effect: { claim: 'the badge reads checked in', verified: Verified.YES },
+        }),
+      ],
+      [event({ actionId: 'c1', documentId: 'doc00001', editEpoch: 2 })],
+    );
+    expect(proven).toEqual([
+      {
+        claim: 'the badge reads checked in',
+        verified: Verified.YES,
+        source: undefined,
+        doc: 'doc00001',
+        epoch: 2,
+      },
+    ]);
+  });
+
+  it('ignores an action that recorded no verdict, rather than inventing one', () => {
+    expect(provenFromJournal([action({ settled: true })], [])).toEqual([]);
+  });
+});
+
+describe('runContextFor', () => {
+  it('drops a fact from a document that has been replaced', () => {
+    const context = runContextFor({
+      actions: [action({ settled: true })],
+      events: [event({ actionId: 'c1', documentId: 'doc00001' })],
+      intents: [],
+      currentDocumentId: 'doc00002',
+      currentEditEpoch: undefined,
+    });
+    expect(context.established).toEqual([]);
+  });
+
+  it('drops a fact and a proof from a pre-edit epoch', () => {
+    const context = runContextFor({
+      actions: [
+        action({
+          settled: true,
+          effect: { claim: 'the badge reads checked in', verified: Verified.YES },
+        }),
+      ],
+      events: [event({ actionId: 'c1', documentId: 'doc00001', editEpoch: 1 })],
+      intents: [],
+      currentDocumentId: 'doc00001',
+      currentEditEpoch: 2,
+    });
+    expect(context.established).toEqual([]);
+    expect(context.proven).toEqual([]);
+  });
+
+  it('counts the step off the journal rather than a counter of its own', () => {
+    const context = runContextFor({
+      actions: [action({ settled: true }), action({ actionId: 'c2', settled: true })],
+      events: [],
+      intents: [],
+      currentDocumentId: undefined,
+      currentEditEpoch: undefined,
+    });
+    expect(context.step).toBe(2);
+  });
+
+  it('answers a fresh run with an honest empty context', () => {
+    expect(
+      runContextFor({
+        actions: [],
+        events: [],
+        intents: [],
+        currentDocumentId: undefined,
+        currentEditEpoch: undefined,
+      }),
+    ).toEqual({ step: 0, established: [], proven: [], remaining: [] });
+  });
+});

--- a/packages/server/src/runs/run-context.ts
+++ b/packages/server/src/runs/run-context.ts
@@ -1,0 +1,181 @@
+import {
+  EventType,
+  JournalVerdictEffectSchema,
+  RUN_ESTABLISHED_CAP,
+  buildRunContext,
+  type EstablishedFact,
+  type Intent,
+  type JournalAction,
+  type JournalVerdictEffect,
+  type ProvenClaim,
+  type ReticleEvent,
+  type RunContext,
+} from '@reticlehq/core';
+
+/**
+ * The run, derived from the journal that is already there.
+ *
+ * `.reticle/sessions/<id>/` already holds an append-only causal ledger of every action dispatched
+ * and every event observed. The run is a FOLD over that, never a second store — the same argument
+ * that deleted `instrumentation_stalled` from this codebase applies without modification: two ways
+ * to compute one number is worse than one way, because the day they disagree the disagreement lands
+ * inside a verdict and a user finds it before we do. So nothing here writes: it reads the ledger and
+ * folds it, and if the fold is wrong the ledger is still the single authority.
+ *
+ * **One run per session, for now.** Nothing here assumes it: the fold is pure and takes its evidence
+ * as arguments, so a later multi-run or multi-agent model is a change of caller, not a rewrite. It
+ * is not built today because nobody has hit the case, and a coordination model invented ahead of its
+ * first user is a guess.
+ *
+ * Only what Reticle OBSERVED goes in. A settle outcome is an observation. A route change is an
+ * observation. A verdict a verification tool recorded is an observation. What the agent meant to do
+ * next is not, and never enters here.
+ */
+
+/**
+ * The one key the route is filed under.
+ *
+ * The subject of "the app is on /checkout" is the route itself, so a later route change SUPERSEDES
+ * rather than appends. Filing it per-path would accumulate every page ever visited, which is the
+ * token bomb the cap exists to prevent.
+ */
+const ROUTE_KEY = 'route';
+
+/** The conclusions this fold is allowed to state, as prose rather than transcript. */
+const Fact = {
+  route: (to: string): string => `route is ${to}`,
+  settled: (verb: string): string => `${verb} settled`,
+  unsettled: (verb: string): string => `${verb} did not settle`,
+} as const;
+
+/** The SUBJECT a journal action was about: the ref it spent, else the target it resolved from. */
+function subjectOf(action: JournalAction): string | undefined {
+  const ref = action.args['ref'];
+  if ('string' === typeof ref && ref.length > 0) return ref;
+  const target = action.args['target'];
+  if ('string' === typeof target && target.length > 0) return target;
+  return undefined;
+}
+
+/** What the action did, in the caller's own vocabulary — 'click', 'fill', else the tool's name. */
+function verbOf(action: JournalAction): string {
+  const named = action.args['action'];
+  return 'string' === typeof named && named.length > 0 ? named : action.tool;
+}
+
+/** The verdict a verification tool recorded on this action, if it recorded one. */
+function verdictOf(action: JournalAction): JournalVerdictEffect | undefined {
+  const parsed = JournalVerdictEffectSchema.safeParse(action.effect);
+  return parsed.success ? parsed.data : undefined;
+}
+
+/** Which document and edit epoch each action was observed under, read off its attributed events. */
+function scopeByAction(
+  events: readonly ReticleEvent[],
+): Map<string, { doc?: string | undefined; epoch?: number | undefined }> {
+  const out = new Map<string, { doc?: string | undefined; epoch?: number | undefined }>();
+  for (const event of events) {
+    if (event.actionId === undefined) continue;
+    if (event.documentId === undefined && event.editEpoch === undefined) continue;
+    const existing = out.get(event.actionId) ?? {};
+    out.set(event.actionId, {
+      doc: event.documentId ?? existing.doc,
+      epoch: event.editEpoch ?? existing.epoch,
+    });
+  }
+  return out;
+}
+
+/**
+ * Fold the journal into candidate facts, newest last.
+ *
+ * Only the last `RUN_ESTABLISHED_CAP` actions are read: anything older cannot survive the fold, so
+ * parsing it would be work done to throw away. An action with no observed settle outcome states
+ * nothing and is skipped — "we drove it and cannot say what happened" is not an established fact,
+ * and writing it down as one is how a memory starts lying.
+ */
+export function establishedFromJournal(
+  actions: readonly JournalAction[],
+  events: readonly ReticleEvent[],
+): EstablishedFact[] {
+  const scope = scopeByAction(events);
+  let route: EstablishedFact | undefined;
+  for (const event of events) {
+    if (EventType.ROUTE_CHANGE !== event.type) continue;
+    const pathname = event.data['pathname'];
+    const to = 'string' === typeof pathname ? pathname : event.data['to'];
+    if ('string' !== typeof to) continue;
+    route = { key: ROUTE_KEY, fact: Fact.route(to), doc: event.documentId, epoch: event.editEpoch };
+  }
+
+  const out: EstablishedFact[] = [];
+  for (const action of actions.slice(-RUN_ESTABLISHED_CAP)) {
+    const settled = action.settled;
+    if (undefined === settled) continue;
+    const key = subjectOf(action);
+    if (undefined === key) continue;
+    const verb = verbOf(action);
+    out.push({
+      key,
+      fact: settled ? Fact.settled(verb) : Fact.unsettled(verb),
+      // The source pointer the verdict already reported. Read off the ledger rather than looked up
+      // again: a second lookup could disagree with the one the agent was shown.
+      source: verdictOf(action)?.source,
+      ...(scope.get(action.actionId) ?? {}),
+    });
+  }
+  if (route !== undefined) out.push(route);
+  return out;
+}
+
+/**
+ * What a verdict already settled, newest last.
+ *
+ * ponytail: `reticle_act_and_wait` is the only writer today, because it is the only verdict tool
+ * that opens a journal action at all. `reticle_assert` proves things and journals nothing, so its
+ * verdicts are absent here; giving it a record needs a journal append that does NOT open an
+ * attribution window, which is a change to the recorder rather than to this fold.
+ */
+export function provenFromJournal(
+  actions: readonly JournalAction[],
+  events: readonly ReticleEvent[],
+): ProvenClaim[] {
+  const scope = scopeByAction(events);
+  const out: ProvenClaim[] = [];
+  for (const action of actions.slice(-RUN_ESTABLISHED_CAP)) {
+    const verdict = verdictOf(action);
+    if (undefined === verdict) continue;
+    out.push({
+      claim: verdict.claim,
+      verified: verdict.verified,
+      source: verdict.source,
+      ...(scope.get(action.actionId) ?? {}),
+    });
+  }
+  return out;
+}
+
+/**
+ * The context for one run.
+ *
+ * `step` is the journal's action count rather than a counter of its own, for the reason at the top
+ * of this file: a second counter is a second thing that can disagree with the ledger. The document
+ * and epoch are the session's own, so the staleness rule here is the same one every other verdict in
+ * this codebase is scoped by.
+ */
+export function runContextFor(input: {
+  actions: readonly JournalAction[];
+  events: readonly ReticleEvent[];
+  intents: readonly Intent[];
+  currentDocumentId: string | undefined;
+  currentEditEpoch: number | undefined;
+}): RunContext {
+  return buildRunContext({
+    step: input.actions.length,
+    intents: input.intents,
+    established: establishedFromJournal(input.actions, input.events),
+    proven: provenFromJournal(input.actions, input.events),
+    currentDocumentId: input.currentDocumentId,
+    currentEditEpoch: input.currentEditEpoch,
+  });
+}

--- a/packages/server/src/session/session.ts
+++ b/packages/server/src/session/session.ts
@@ -28,6 +28,7 @@ import {
   SessionState,
   type BrowserBrand,
   type CommandResult,
+  type JournalAction,
   type HelloMessage,
   type HumanControlData,
   type ReticleEvent,
@@ -460,6 +461,17 @@ export class Session {
   finishAction(effect?: unknown, settled?: boolean, settledInMs?: number): void {
     this.#activeActionId = undefined;
     this.#journal?.finishAction(effect, settled, settledInMs);
+  }
+
+  /**
+   * The durable action ledger for this session — the ledger the run context is folded out of.
+   *
+   * `[]` when nothing journals this session (journaling disabled, or an id that is not a safe path
+   * segment). An absent ledger reads as an empty run, never as a missing one: the fold simply has
+   * nothing to say, which is the honest answer.
+   */
+  async readJournalActions(): Promise<JournalAction[]> {
+    return (await this.#journalReader?.readActions?.()) ?? [];
   }
 
   /** Flush any buffered journal events to disk (call on session end). */

--- a/packages/server/src/tools/act-tools.ts
+++ b/packages/server/src/tools/act-tools.ts
@@ -19,6 +19,7 @@ import {
   Verified,
   VerifiedReason,
   PredicateKind,
+  type JournalVerdictEffect,
 } from '@reticlehq/core';
 import { assertNativeInputSupported } from './act-danger.js';
 import { leanActResult, mutatedWithin } from './act-view.js';
@@ -578,6 +579,10 @@ export const ACT_TOOLS: ToolDef[] = [
       // (the whole point of act_and_wait) attribute to this action. finishAction fires after the wait.
       session.beginAction(ReticleTool.ACT_AND_WAIT, asRecord(args));
       let settledOutcome: boolean | undefined;
+      // The verdict, written into the action record so a LATER turn can read what this one proved.
+      // A verdict that lives only in the response lives only in the agent's context window, which is
+      // exactly the copy a compaction destroys — see runs/run-context.ts.
+      let verdictEffect: JournalVerdictEffect | undefined;
       // Was the declared consequence ALREADY TRUE? Only asked for predicates that read live DOM
       // state — event-based ones are floored at this act's cursor and cannot be satisfied by the
       // past, so they need no pre-check and pay nothing. One extra query, on the path where a green
@@ -803,6 +808,11 @@ export const ACT_TOOLS: ToolDef[] = [
           routeChanged: actionSummary.route !== undefined,
           routeSignalFired: actionSummary.signals.some((name) => name.startsWith('route')),
         });
+        verdictEffect = {
+          claim: describeWaitTarget(until),
+          verified: decision.verified,
+          ...(actedSourceLabel === undefined ? {} : { source: actedSourceLabel }),
+        };
         // Recorded on the session, so a later "am I done?" can answer with what is STILL missing
         // rather than with everything that was ever missing. An empty list closes a gap, which is
         // why it is noted rather than skipped.
@@ -840,7 +850,7 @@ export const ACT_TOOLS: ToolDef[] = [
         });
       } finally {
         session.finishAction(
-          undefined,
+          verdictEffect,
           settledOutcome,
           true === settledOutcome ? session.elapsed() - since : undefined,
         );

--- a/packages/server/src/tools/invoke-tool.ts
+++ b/packages/server/src/tools/invoke-tool.ts
@@ -116,6 +116,7 @@ export const SESSION_EXEMPT_TOOLS: ReadonlySet<string> = new Set([
   ReticleTool.FLOW_SAVE_RECORDED, // reads the recording buffer, writes disk
   ReticleTool.FLOW_HEAL, // returns its own FlowHealResult contract
   ReticleTool.INTENT, // reads/writes .reticle/intent.json; sessionId only picks the project
+  ReticleTool.CONTEXT, // folds the journal + intent ledger; must still answer when nothing is connected
   ReticleTool.PROJECT, // reads .reticle/project.json
   ReticleTool.RUN_EXPORT, // reads .reticle/runs/<id>.json (verification-run artifact)
   ReticleTool.SESSION, // merged lifecycle/human-channel family (tune/yield/end/resume/messages/review/narrate)

--- a/packages/server/src/tools/surface-sizes.test.ts
+++ b/packages/server/src/tools/surface-sizes.test.ts
@@ -30,8 +30,10 @@ const EXPECTED_SIZE: Record<ToolSurface, number> = {
   // affected/coverage/crawl merged into `reticle_verify`; 29 now that `reticle_intent` joins it.
   // Intent lands here rather than in DEFAULT on the same terms the capabilities demotion set: it is
   // new and its claim is unmeasured, so it does not take a default-surface slot from a tool that has
-  // earned one. Still one `reticle_run` hop away for any agent that wants it.
-  [TOOL_SURFACE.ALL]: 29,
+  // earned one. Still one `reticle_run` hop away for any agent that wants it. 30 now that
+  // `reticle_context` joins it on exactly those terms, which puts the extended surface ON the cap:
+  // the next tool added here has to displace one, and that is the budget working as designed.
+  [TOOL_SURFACE.ALL]: 30,
   // The smallest surface that can still return a verdict: one acting tool that resolves its own
   // target, plus the two meta-tools that reach the rest. See tool-surface.ts for why it is not the
   // default.

--- a/packages/server/src/tools/tool-names.ts
+++ b/packages/server/src/tools/tool-names.ts
@@ -50,6 +50,8 @@ export const ReticleTool = {
   VERIFY_CHANGE: 'reticle_verify_change',
   /** Merged: change/flows/affected/coverage/crawl — "what is proved, and what is not". */
   INTENT: 'reticle_intent',
+  /** what THIS run has established, proved, and not yet discharged — pulled when memory is gone. */
+  CONTEXT: 'reticle_context',
   VERIFY: 'reticle_verify',
   /** read cross-run history (.reticle/project.json) + diff-vs-last for a name. */
   PROJECT: 'reticle_project',

--- a/packages/server/src/tools/tool-surface.ts
+++ b/packages/server/src/tools/tool-surface.ts
@@ -217,6 +217,10 @@ export const EXTENDED_TOOL_NAMES: ReadonlySet<string> = new Set([
   // New and unproven, so it does not take a default-surface slot under the cap. Same terms the
   // capabilities demotion set: reachable in one reticle_run hop by any agent that wants it.
   ReticleTool.INTENT,
+  // Same terms again, plus one argument specific to it: its caller is BY CONSTRUCTION an agent that
+  // just lost its context and is re-reading the tool list, so the discovery hop it costs is a call
+  // that caller was already going to make. See context-tools.ts for the full argument.
+  ReticleTool.CONTEXT,
   ReticleTool.RECORD,
   ReticleTool.SCREENSHOT,
   ReticleTool.VISUAL_DIFF,

--- a/packages/server/src/tools/tools.ts
+++ b/packages/server/src/tools/tools.ts
@@ -23,6 +23,7 @@ import { DOMAIN_TOOLS } from '../domain/domain-tools.js';
 import { BROWSER_TOOLS } from './browser-tools.js';
 import { FLOW_TOOLS } from '../flows/flow-tools.js';
 import { INTENT_TOOLS } from '../intent/intent-tools.js';
+import { CONTEXT_TOOLS } from '../runs/context-tools.js';
 import { PROJECT_TOOLS } from '../project/project-tools.js';
 import { RUN_TOOLS } from '../runs/run-tools.js';
 import { VISUAL_TOOLS } from '../visual/visual-tools.js';
@@ -527,6 +528,7 @@ const RAW_TOOLS: ToolDef[] = [
   ...RECONCILE_TOOLS,
   ...CONTRACT_TOOLS,
   ...INTENT_TOOLS,
+  ...CONTEXT_TOOLS,
   ...DOMAIN_TOOLS,
   // reticle_flow_save / reticle_flow_list / reticle_flow_load. See flow-tools.ts.
   ...FLOW_TOOLS,


### PR DESCRIPTION
A verification thread is multi-step, and the only thing holding it together is the agent's own context window. When that compacts, or the turn ends, or a sub-agent takes over, the thread goes with it and the work restarts: long runs of the same read-only call, an agent searching by exhaustion because it no longer remembers what it already saw.

Reticle's copy does not degrade at that moment. That asymmetry is the whole feature: Reticle is not a competing memory, it is the ground truth compaction destroyed.

## What `reticle_context` returns

- **`established`** — what Reticle OBSERVED, folded and capped, each with the `file:line` where a verdict reported one.
- **`proven`** — claims a verdict already settled. A forgotten proof is either re-proved, which is slow, or assumed, which is a false green.
- **`remaining`** — the intents from `.reticle/intent.json` that nothing has discharged, derived mechanically from undischarged bindings.
- **`step`** — the journal's action count, not a counter of its own.

## Pulled, never pushed

The same content once rode on every session-bound response. It cost +136% on a verdict and was cut, because most of the time the agent still had the context and every call paid to duplicate what it knew. Nobody but the agent can tell when that stops being true, so the agent asks once, at the moment it knows its memory is gone.

That inversion is also why nothing here returns `undefined` for an empty run. A push had to stay silent when it had nothing to say; a pull was asked a question, and "nothing established yet" is the answer.

## A fold, never a second store

`.reticle/sessions/<id>/` is already an append-only ledger of every action dispatched and every event observed. This reads it and writes nothing, so it cannot disagree with the ledger the way two counters eventually do. It supersedes rather than accumulates and is capped by `RUN_ESTABLISHED_CAP`, so it shrinks.

## Document AND edit-epoch scoped

Through `isSameDocument` / `isSameEditEpoch` rather than a third comparison written beside them. A hot update swaps modules inside the SAME document, so the document id never moves and every fact about the replaced code would survive on the document check alone. Presenting one as current is exactly the false green this product exists to prevent.

## One writer added

`reticle_act_and_wait` now writes its verdict into the journal action's `effect` — a field the schema always allowed and nothing had ever filled. Without it a verdict lives only in the tool response, which is precisely the copy a compaction destroys. `reticle_assert` proves things and journals nothing, so its verdicts are still absent; giving it a record needs a journal append that does not open an attribution window, and that is noted in the code rather than guessed at here.

## Extended surface, not default

The default surface is a hard tool COUNT shared with every other MCP server a user has connected, so a slot taken there is taken from a tool that has already earned one. This tool's claim is unmeasured, which is the same test `reticle_intent` and the `reticle_capabilities` demotion were held to.

The reachability argument is also stronger here than for most of the cold tail: the caller is, by construction, an agent that has just lost its context and is re-reading the tool list it was handed this turn, so the `reticle_tools` hop it costs is a call that caller was already going to make. It moves to the default surface when a measurement says the pull happens often enough to be worth a permanent slot.

`all` goes 29 to 30, which puts the extended surface ON the cap: the next addition has to displace something, and that is the budget working as designed. `default` is unchanged at 18. SKILL.md's gated table updated.

## Tests, red first

`packages/core/src/run-context.test.ts`, `packages/server/src/runs/run-context.test.ts`, `packages/server/src/runs/context-tools.test.ts` and `packages/server/src/mcp/context-over-transport.test.ts` were each written and proved red before the module they cover existed. They pin: facts folded and capped, facts omitted from a replaced document, facts omitted from a pre-edit epoch, undischarged intents listed, what a verdict already proved listed, an honest empty answer for a fresh session, and reachability over a real `InMemoryTransport`.

## Gates

`pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test:unit` all green (495 files / 4787 tests in `@reticlehq/server`).

`pnpm test:e2e` is warranted and has NOT been run here: this changes the tool surface and adds a journal writer, and the unit gate cannot see cross-package drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
