### PR TITLE
feat(server): reticle_assert journals its verdict, without opening an attribution window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ### Added
 
+- **`@reticlehq/server` — a `reticle_assert` verdict is now written to the journal, so a later turn can read what it proved.** `reticle_context` answers "what has this run already established" by folding the action ledger, and `reticle_assert` was not in it: it produced a verdict and journalled nothing, because it never opened an action at all. An agent that proved something with the tool most used for pure assertion, and then compacted, was told nothing had been proven — which leaves it to re-prove the claim, or to assume it. Assuming it is a false green, and preventing that is the whole reason the run context exists.
+
+  **Recorded without opening an attribution window.** While a window is open, every observed event is stamped with that action's id. An assertion drives nothing, so the events arriving during it are ambient, and stamping them would manufacture a causal link that never existed — the one claim `attribution: "window"` is carefully worded not to make. So the record is appended directly: an `act_and_wait` window open across an assert keeps attributing to itself, unchanged.
+
+  **No range is invented for a window that never existed.** The record carries no `seqRange`, because no event was attributed to it, and no settle outcome, because nothing was dispatched. Omitting both is the truthful answer, and the run fold already skips an action that states none rather than writing an empty one down as a fact.
+
+  The verdict itself is the same three fields `act_and_wait` writes — the claim, how it came out, and the `file:line` when one was known — so the journal holds one verdict shape rather than two, and everything that reads it needed no change.
+
 - **`@reticlehq/core` + `@reticlehq/server` — a verdict drawn over a change nothing declared now says so.** Declaring intent has been entirely opt-in and entirely invisible: `reticle_intent` exists, flows can carry a business intent, and nothing ever noticed that a code change landed and nobody said what it was for. A change with no declared intent can only be checked against itself, so a green means "nothing visibly broke" and gets read as "the change worked" — which is the definition of a false green, and the one absence no amount of instrumentation can close.
 
   Reticle already knows the moment. The edit epoch advances when the page applies a hot update, and the intent ledger already models what is still outstanding. So when a verdict is the first one taken since code changed, and the ledger holds nothing undischarged, `act_and_wait` and `reticle_assert` report an `undeclared-change` instrumentation gap — in the same block, on the same rule, with the same shape as every other gap: what is missing, what it cost this verdict, and the one call that closes it. `reticle_verify { action: "coverage" }` picks it up unchanged, because it reads the gap ledger.

--- a/packages/server/src/journal/journal-recorder.test.ts
+++ b/packages/server/src/journal/journal-recorder.test.ts
@@ -109,3 +109,67 @@ describe('JournalRecorder', () => {
     expect(sink.actions[0]?.seqRange).toBeUndefined();
   });
 });
+
+/**
+ * A verdict tool that drives nothing still has to leave a record, or a later turn is told nothing was
+ * proven and re-proves it — or, worse, assumes it. The constraint is that recording must not open an
+ * attribution window: an assertion causes no events, so stamping the ones that arrive during it would
+ * invent a causal link that never existed.
+ */
+describe('JournalRecorder.recordAction (a verdict with no window)', () => {
+  it('writes the action record with its effect', async () => {
+    const sink = fakeSink();
+    const rec = new JournalRecorder(sink, { now: () => 7, flushAt: 100 });
+    rec.recordAction('a4', 'reticle_assert', { predicate: {} }, { claim: 'the row is gone' });
+    await rec.flush();
+    const action = sink.actions[0];
+    expect(action?.actionId).toBe('a4');
+    expect(action?.tool).toBe('reticle_assert');
+    expect(action?.effect).toEqual({ claim: 'the row is gone' });
+    expect(action?.at).toBe(7);
+  });
+
+  it('omits seqRange and records an empty tRange — no window, so nothing was attributed', async () => {
+    const sink = fakeSink();
+    const rec = new JournalRecorder(sink, { now: () => 7, flushAt: 100 });
+    rec.recordAction('a4', 'reticle_assert', {}, {});
+    await rec.flush();
+    expect(sink.actions[0]?.seqRange).toBeUndefined();
+    expect(sink.actions[0]?.tRange).toEqual({ from: 7, to: 7 });
+    expect(sink.actions[0]?.settled).toBeUndefined();
+  });
+
+  it('does NOT open a window — a later event stays unattributed', () => {
+    const sink = fakeSink();
+    const rec = new JournalRecorder(sink, { now: () => 0, flushAt: 100 });
+    rec.recordAction('a4', 'reticle_assert', {}, {});
+    const after = rec.observe(evt(9));
+    expect(after.actionId).toBeUndefined();
+    expect(after.attribution).toBeUndefined();
+  });
+
+  it('leaves an in-flight action window untouched', async () => {
+    const sink = fakeSink();
+    const rec = new JournalRecorder(sink, { now: stepClock([10, 20, 42]), flushAt: 100 });
+    rec.beginAction('c1', 'reticle_act_and_wait', {});
+    const before = rec.observe(evt(3));
+    rec.recordAction('a2', 'reticle_assert', {}, {});
+    const after = rec.observe(evt(5));
+    rec.finishAction({ claim: 'the toast is visible' }, true);
+    await rec.flush();
+    expect(before.actionId).toBe('c1');
+    expect(after.actionId).toBe('c1');
+    expect(after.attribution).toBe(EventAttribution.WINDOW);
+    const window = sink.actions.find((a) => 'c1' === a.actionId);
+    expect(window?.seqRange).toEqual({ from: 3, to: 5 });
+  });
+
+  it('flushes buffered events before the record, so ordering holds', async () => {
+    const sink = fakeSink();
+    const rec = new JournalRecorder(sink, { now: () => 0, flushAt: 100 });
+    rec.observe(evt(0));
+    rec.recordAction('a1', 'reticle_assert', {}, {});
+    await rec.flush();
+    expect(sink.log).toEqual(['events:1', 'action:a1']);
+  });
+});

--- a/packages/server/src/journal/journal-recorder.ts
+++ b/packages/server/src/journal/journal-recorder.ts
@@ -108,6 +108,47 @@ export class JournalRecorder {
     this.#chain = this.#chain.then(() => this.#sink.appendAction(action)).catch(() => undefined);
   }
 
+  /**
+   * Append one action record for a tool that PROVED something without driving the page.
+   *
+   * `reticle_assert` produces a verdict and moves nothing, so it must never open an attribution
+   * window: while one is open every observed event is stamped with that action's id, and stamping
+   * ambient traffic with an assertion's id would manufacture a causal link that does not exist —
+   * exactly what `EventAttribution.WINDOW` is carefully labelled to avoid claiming. So this writes
+   * the record and leaves `#active` precisely as it found it: an act window open across an assert
+   * keeps attributing to itself, which is the truth of what caused those events.
+   *
+   * `settled` is left unset for the same reason — nothing was dispatched, so there is no settle
+   * outcome to report, and the run fold skips actions that state none rather than inventing one.
+   *
+   * Ordering rides the same chain as `finishAction`: buffered events flush first, so a record is
+   * always persisted after the events that preceded it. Records land in the order verdicts were
+   * REACHED, so an assert taken mid-window is written before the act it interrupted.
+   */
+  recordAction(
+    actionId: string,
+    tool: string,
+    args: Record<string, unknown>,
+    effect?: unknown,
+  ): void {
+    const at = this.#now();
+    const action: JournalAction = {
+      v: JOURNAL_FILE_VERSION,
+      actionId,
+      tool,
+      args,
+      effect,
+      // No window was opened, so no event carries this id: `seqRange` is omitted rather than
+      // invented, because any range here would claim an attribution that never happened. `tRange` is
+      // required by the schema and the honest value is the instant the verdict was recorded — a span
+      // of zero, which is exactly how much time this action attributed events over.
+      tRange: { from: at, to: at },
+      at,
+    };
+    this.#enqueueFlush();
+    this.#chain = this.#chain.then(() => this.#sink.appendAction(action)).catch(() => undefined);
+  }
+
   /** Persist any buffered events now (call on session end). Awaits the write chain to settle. */
   async flush(): Promise<void> {
     this.#enqueueFlush();

--- a/packages/server/src/runs/run-context.ts
+++ b/packages/server/src/runs/run-context.ts
@@ -131,10 +131,9 @@ export function establishedFromJournal(
 /**
  * What a verdict already settled, newest last.
  *
- * ponytail: `reticle_act_and_wait` is the only writer today, because it is the only verdict tool
- * that opens a journal action at all. `reticle_assert` proves things and journals nothing, so its
- * verdicts are absent here; giving it a record needs a journal append that does NOT open an
- * attribution window, which is a change to the recorder rather than to this fold.
+ * Both verdict tools write here. `reticle_act_and_wait` closes its attribution window with one;
+ * `reticle_assert` drives nothing, so it appends its record WITHOUT opening a window — same effect
+ * shape, so this fold reads one kind of verdict rather than two.
  */
 export function provenFromJournal(
   actions: readonly JournalAction[],

--- a/packages/server/src/session/session.ts
+++ b/packages/server/src/session/session.ts
@@ -448,13 +448,27 @@ export class Session {
    * action id. Ids are minted independently of command correlation ids so the journal is self-contained.
    */
   beginAction(tool: string, args: Record<string, unknown>): string {
-    this.#actionSeq += 1;
-    const actionId = `${ACTION_ID_PREFIX}${String(this.#actionSeq)}`;
+    const actionId = this.#mintActionId();
     // Held here, not only in the journal: with the journal off every event was unattributed, and
     // pushEvent reads that as ambient churn the settle oracle then ignores. See action-attribution test.
     this.#activeActionId = actionId;
     this.#journal?.beginAction(actionId, tool, args);
     return actionId;
+  }
+
+  /**
+   * Record one action WITHOUT opening an attribution window — for a tool that returns a verdict but
+   * drives nothing, so no event it observes was caused by it. See `JournalRecorder.recordAction`.
+   */
+  recordAction(tool: string, args: Record<string, unknown>, effect?: unknown): string {
+    const actionId = this.#mintActionId();
+    this.#journal?.recordAction(actionId, tool, args, effect);
+    return actionId;
+  }
+
+  #mintActionId(): string {
+    this.#actionSeq += 1;
+    return `${ACTION_ID_PREFIX}${String(this.#actionSeq)}`;
   }
 
   /** Close the active action window, persisting its action record with the settle outcome. */

--- a/packages/server/src/session/tools.live-control.test.ts
+++ b/packages/server/src/session/tools.live-control.test.ts
@@ -47,6 +47,7 @@ function fakeSession(opts: { state?: SessionState; inbox?: string[] }): FakeSess
     id: 'demo',
     url: SESSION_URL,
     elapsed: () => 0,
+    recordAction: () => 'a1',
     lastAct: new LastAct(),
     beginAction: () => 'a1',
     finishAction: () => undefined,

--- a/packages/server/src/session/tools.session-health.test.ts
+++ b/packages/server/src/session/tools.session-health.test.ts
@@ -35,6 +35,7 @@ function fakeSession(throttled: boolean): Session {
     id: 'demo',
     url: SESSION_URL,
     elapsed: () => 0,
+    recordAction: () => 'a1',
     lastAct: new LastAct(),
     beginAction: () => 'a1',
     finishAction: () => undefined,

--- a/packages/server/src/tools/assert-buffer-honesty.test.ts
+++ b/packages/server/src/tools/assert-buffer-honesty.test.ts
@@ -20,6 +20,7 @@ import type { Session, SessionManager } from '../session/session.js';
 function depsWithBuffer(dropped: number, lastActSource?: string): ToolDeps {
   const session: Partial<Session> = {
     id: 'demo',
+    recordAction: () => 'a1',
     lastAct: ((): LastAct => {
       const a = new LastAct();
       a.markSource(lastActSource);

--- a/packages/server/src/tools/assert-contradiction-plumbing.test.ts
+++ b/packages/server/src/tools/assert-contradiction-plumbing.test.ts
@@ -35,6 +35,7 @@ import type { Session, SessionManager } from '../session/session.js';
 function depsWith(events: ReticleEvent[]): ToolDeps {
   const session: Partial<Session> = {
     id: 'demo',
+    recordAction: () => 'a1',
     lastAct: new LastAct(),
     bufferHealth: () => ({ total: 12, dropped: 0 }),
     blindSpots: () => ({}),

--- a/packages/server/src/tools/assert-coverage-honesty.test.ts
+++ b/packages/server/src/tools/assert-coverage-honesty.test.ts
@@ -28,6 +28,7 @@ function depsWithBlindSpots(blindSpots: Record<string, number>): ToolDeps {
   const session: Partial<Session> = {
     id: 'demo',
     bufferHealth: () => ({ total: 5, dropped: 0 }),
+    recordAction: () => 'a1',
     lastAct: new LastAct(),
     command: () =>
       Promise.resolve({
@@ -166,6 +167,7 @@ describe('reticle_assert carries the verdict, not just pass', () => {
     const session: Partial<Session> = {
       id: 'demo',
       bufferHealth: () => ({ total: 5, dropped: 0 }),
+      recordAction: () => 'a1',
       lastAct: new LastAct(),
       blindSpots: () => ({}),
       eventsSince: () => events,

--- a/packages/server/src/tools/assert-journal-verdict.test.ts
+++ b/packages/server/src/tools/assert-journal-verdict.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import type { WebSocket } from 'ws';
+import {
+  EventType,
+  MessageKind,
+  RETICLE_PROTOCOL_VERSION,
+  Verified,
+  type HelloMessage,
+  type JournalAction,
+  type ReticleEvent,
+} from '@reticlehq/core';
+import { JournalRecorder, type JournalSink } from '../journal/journal-recorder.js';
+import { provenFromJournal } from '../runs/run-context.js';
+import { Session, type SessionManager } from '../session/session.js';
+import { TOOLS, type ToolDef, type ToolDeps } from './tools.js';
+import { ReticleTool } from './tool-names.js';
+
+/**
+ * `reticle_assert` produces a verdict, and for as long as it journalled nothing that proof was
+ * invisible to `reticle_context`. An agent that proved something here and then compacted was told
+ * nothing had been proven — the exact re-prove-or-assume failure the run context exists to prevent,
+ * in the tool most used for pure assertion.
+ */
+function hello(): HelloMessage {
+  return {
+    kind: MessageKind.HELLO,
+    protocolVersion: RETICLE_PROTOCOL_VERSION,
+    sessionId: 'demo',
+    url: 'http://localhost/',
+    title: 'Demo',
+    adapters: [],
+  };
+}
+
+function fakeSink(): JournalSink & { events: ReticleEvent[]; actions: JournalAction[] } {
+  const events: ReticleEvent[] = [];
+  const actions: JournalAction[] = [];
+  return {
+    events,
+    actions,
+    appendEvents(batch) {
+      events.push(...batch);
+      return Promise.resolve();
+    },
+    appendAction(action) {
+      actions.push(action);
+      return Promise.resolve();
+    },
+  };
+}
+
+const noopSocket = { send: () => undefined, close: () => undefined } as unknown as WebSocket;
+
+const tool = (name: string): ToolDef => {
+  const found = TOOLS.find((t) => t.name === name);
+  if (found === undefined) throw new Error(`${name} is not on the surface`);
+  return found;
+};
+
+/** A live session with a journal attached, plus the deps the assert handler resolves it through. */
+function journalledSession(): {
+  session: Session;
+  deps: ToolDeps;
+  sink: ReturnType<typeof fakeSink>;
+} {
+  const session = new Session(hello(), noopSocket, () => 0);
+  const sink = fakeSink();
+  session.setJournal(new JournalRecorder(sink, { now: () => session.elapsed(), flushAt: 100 }));
+  const sessions: Partial<SessionManager> = { resolve: () => session };
+  return { session, deps: { sessions: sessions as SessionManager } as unknown as ToolDeps, sink };
+}
+
+const SIGNAL_NAME = 'todo:added';
+const assertSignal = { predicate: { kind: 'signal', name: SIGNAL_NAME }, timeout_ms: 0 };
+
+function signalEvent(): ReticleEvent {
+  return { t: 1, seq: 1, type: EventType.SIGNAL, sessionId: 'demo', data: { name: SIGNAL_NAME } };
+}
+
+describe('reticle_assert journals its verdict', () => {
+  it('lands an action record carrying the verdict effect', async () => {
+    const { session, deps, sink } = journalledSession();
+    session.pushEvent(signalEvent());
+    await tool(ReticleTool.ASSERT).handler(deps, assertSignal);
+    await session.flushJournal();
+    const action = sink.actions.find((a) => ReticleTool.ASSERT === a.tool);
+    expect(action).toBeDefined();
+    expect(
+      action?.seqRange,
+      'an assert opens no window, so it attributes no events',
+    ).toBeUndefined();
+  });
+
+  it('does not open an attribution window — a later event is not stamped with it', async () => {
+    const { session, deps, sink } = journalledSession();
+    session.pushEvent(signalEvent());
+    await tool(ReticleTool.ASSERT).handler(deps, assertSignal);
+    session.pushEvent({ t: 2, seq: 2, type: EventType.NET_REQUEST, sessionId: 'demo', data: {} });
+    await session.flushJournal();
+    const ambient = sink.events.find((e) => 2 === e.seq);
+    expect(ambient?.actionId).toBeUndefined();
+    expect(ambient?.attribution).toBeUndefined();
+  });
+
+  it('leaves an act_and_wait window in flight untouched', async () => {
+    const { session, deps, sink } = journalledSession();
+    const windowId = session.beginAction(ReticleTool.ACT_AND_WAIT, {});
+    session.pushEvent(signalEvent());
+    await tool(ReticleTool.ASSERT).handler(deps, assertSignal);
+    session.pushEvent({ t: 2, seq: 2, type: EventType.NET_REQUEST, sessionId: 'demo', data: {} });
+    session.finishAction(undefined, true);
+    await session.flushJournal();
+    expect(sink.events.find((e) => 2 === e.seq)?.actionId).toBe(windowId);
+    expect(sink.actions.find((a) => a.actionId === windowId)?.seqRange).toEqual({ from: 1, to: 2 });
+  });
+
+  it('writes the same verdict shape act_and_wait writes, so proven folds it', async () => {
+    const { session, deps, sink } = journalledSession();
+    session.pushEvent(signalEvent());
+    await tool(ReticleTool.ASSERT).handler(deps, assertSignal);
+    await session.flushJournal();
+    const proven = provenFromJournal(sink.actions, sink.events);
+    expect(proven).toHaveLength(1);
+    expect(proven[0]?.claim).toContain(SIGNAL_NAME);
+    expect(proven[0]?.verified).toBe(Verified.YES);
+  });
+});

--- a/packages/server/src/tools/assert-transport-gap.test.ts
+++ b/packages/server/src/tools/assert-transport-gap.test.ts
@@ -22,6 +22,7 @@ import type { ReticleEvent } from '@reticlehq/core';
 function depsWith(events: ReticleEvent[]): ToolDeps {
   const session: Partial<Session> = {
     id: 'demo',
+    recordAction: () => 'a1',
     lastAct: new LastAct(),
     bufferHealth: () => ({ total: 12, dropped: 0 }),
     blindSpots: () => ({}),

--- a/packages/server/src/tools/assert-verdict.ts
+++ b/packages/server/src/tools/assert-verdict.ts
@@ -3,7 +3,7 @@ import { gapsForAction } from '../honesty/instrumentation-gaps.js';
 import { noteSessionGaps } from '../honesty/gap-ledger.js';
 import { declaresState } from '../events/predicate-asks.js';
 import { isStateUnwatched } from '../honesty/blind-spots.js';
-import type { InstrumentationGap } from '@reticlehq/core';
+import type { InstrumentationGap, JournalVerdictEffect } from '@reticlehq/core';
 import type { Predicate } from '../events/predicate.js';
 import type { Session } from '../session/session.js';
 import { findContradictions, type Contradiction } from '../events/contradictions.js';
@@ -80,6 +80,12 @@ export async function assertVerdict(
   contradictions: Contradiction[];
   coverage: Record<string, unknown>;
   gaps: InstrumentationGap[];
+  /**
+   * The bounded verdict, in the SAME shape `act_and_wait` writes into its journal action — so the
+   * journal holds one verdict shape rather than two and the run fold that reads it needs no second
+   * case. Built here because this is the one place that holds the typed decision and the predicate.
+   */
+  verdictEffect: JournalVerdictEffect;
 }> {
   // Scope caveat, stated because it is a real limitation and not a bug: blind spots are tracked per
   // SESSION, not per assertion window, so a cross-origin iframe seen once marks every later verdict
@@ -180,10 +186,18 @@ export async function assertVerdict(
     routeSignalFired: false,
   });
   noteSessionGaps(session, gaps, session.currentEditEpoch);
+  // The source the act path would have written: an assertion drives nothing, so the file:line it can
+  // point at is the one the last act remembered — the same pointer this tool already reports on red.
+  const source = session.lastAct.source();
   return {
     decision: decision as unknown as Record<string, unknown>,
     contradictions,
     coverage,
     gaps,
+    verdictEffect: {
+      claim: describeWaitTarget(predicate),
+      verified: decision.verified,
+      ...(source === undefined ? {} : { source }),
+    },
   };
 }

--- a/packages/server/src/tools/observe-tools.ts
+++ b/packages/server/src/tools/observe-tools.ts
@@ -46,7 +46,7 @@ import { isChangeUndeclared } from '../honesty/undeclared-change.js';
 import { openSessionIntents } from '../intent/open-intents.js';
 import { bodiesNotCaptured } from '../honesty/uncaptured-bodies.js';
 import { withControl } from '../session/control-envelope.js';
-import { asString, asNumber } from './tools-helpers.js';
+import { asString, asNumber, asRecord } from './tools-helpers.js';
 import { type ToolDef, sessionIdShape, commandOrThrow } from './tool-kit.js';
 
 /**
@@ -449,7 +449,7 @@ export const OBSERVE_TOOLS: ToolDef[] = [
         { current: session.currentEditEpoch, atLastVerdict: session.gaps?.lastVerdictEditEpoch },
         () => openSessionIntents(deps, asString(args['sessionId'])),
       );
-      const { decision, contradictions, coverage, gaps } = await assertVerdict(
+      const { decision, contradictions, coverage, gaps, verdictEffect } = await assertVerdict(
         session,
         predicate,
         verdict.pass,
@@ -458,6 +458,11 @@ export const OBSERVE_TOOLS: ToolDef[] = [
         verdict.observationLost,
         changeUndeclared,
       );
+      // Journal the verdict so a LATER turn can read what this one proved. A verdict that lives only
+      // in the response lives only in the agent's context window, which is the copy a compaction
+      // destroys — see runs/run-context.ts. Recorded WITHOUT an attribution window: this tool drives
+      // nothing, so no event it observed was caused by it.
+      session.recordAction(ReticleTool.ASSERT, asRecord(args), verdictEffect);
       return withControl(session, {
         ...decision,
         ...verdict,

--- a/packages/server/src/tools/tools.assert-advice.test.ts
+++ b/packages/server/src/tools/tools.assert-advice.test.ts
@@ -35,6 +35,7 @@ function depsWith(opts: { matched?: boolean; events?: ReticleEvent[] }): ToolDep
     // A verdict now carries the buffer-honesty block, so the fake has to be able to report it.
     // An intact buffer keeps the block omitted, which is what these advice assertions expect.
     bufferHealth: () => ({ total: 0, dropped: 0 }),
+    recordAction: () => 'a1',
     lastAct: new LastAct(),
     queryEvents: () => Promise.resolve([]),
     blindSpots: () => ({}),


### PR DESCRIPTION
## The gap

`reticle_context` returns `proven` — what a verdict already established — by folding the journal's action `effect`. `reticle_assert` produces verdicts and journalled nothing: it never called `session.beginAction(...)`, so no action record was ever written and its proofs were invisible to the fold. An agent that proved something with the tool most used for pure assertion, then compacted, was told nothing had been proven — re-prove, or assume, which is the false green the feature exists to prevent.

## What changed

- **`JournalRecorder.recordAction(actionId, tool, args, effect)`** — appends one action record directly. It never touches `#active`, so it cannot open an attribution window and cannot disturb one in flight: an `act_and_wait` window open across an assert keeps attributing to itself, unchanged. Buffered events flush first on the same write chain `finishAction` uses, so ordering holds; records land in the order verdicts were reached.
- **`Session.recordAction(...)`** — mints an action id (extracted `#mintActionId`, shared with `beginAction`) and forwards, without setting `#activeActionId`.
- **`assertVerdict` now returns `verdictEffect`** — the same `{ claim, verified, source? }` shape `act_and_wait` writes, built where the typed decision and the predicate already are. One verdict shape in the journal rather than two, so `provenFromJournal` needed no change.
- `reticle_assert` is deliberately **not** added to `ACTION_TOOLS`, and no telemetry file was touched.

## seqRange / tRange

`seqRange` is **omitted** — no window means no event carries this id, and any range would claim an attribution that never happened. `tRange` is required by `JournalActionSchema`, so it records the instant the verdict was reached (`from === to`): a span of zero, which is exactly how much time this action attributed events over. `settled`/`settledInMs` are also left unset — nothing was dispatched, and the run fold already skips an action that states no outcome rather than inventing one.

## Tests (red first)

`packages/server/src/journal/journal-recorder.test.ts` and a new `packages/server/src/tools/assert-journal-verdict.test.ts`, both proven red (7 failures) before the implementation:

- writes the action record with its effect
- omits seqRange and records an empty tRange
- does NOT open a window — a later event stays unattributed
- leaves an in-flight action window untouched
- flushes buffered events before the record, so ordering holds
- `reticle_assert` lands an action record carrying the verdict effect
- ... does not open an attribution window
- ... leaves an act_and_wait window in flight untouched
- ... writes the same verdict shape act_and_wait writes, so `proven` folds it

Seven existing `Partial<Session>` stubs on the assert path grew `recordAction`.

## Gates

`pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test:unit` all green (4824 server tests). `pnpm test:e2e` was not run: no tool name, wire contract, or observer changed — the assert tool's response shape is byte-identical and the only new behaviour is a local journal append. It is cheap insurance if a reviewer wants it, but nothing in the battery reads the action ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)