### PR TITLE
fix(core): reticle_context returned the same subject more than once

### DIFF
--- a/packages/core/src/run-context.test.ts
+++ b/packages/core/src/run-context.test.ts
@@ -148,6 +148,51 @@ describe('foldProven', () => {
   });
 });
 
+describe('the fold supersedes within one batch, not only against a prior one', () => {
+  /**
+   * `buildRunContext` folds against an EMPTY prior set, so if superseding only ever applied to the
+   * existing rows it would never apply at all — and the contract this envelope advertises is that
+   * `key` is the subject and re-observing it replaces rather than appends.
+   *
+   * Observed on a real driven session before this was fixed: the same ref twice, the same proven
+   * claim three times. Duplicates in the one payload whose entire purpose is a CHEAP context
+   * restore, and a report that contradicts its own declared schema.
+   */
+  it('keeps one row per subject when a batch observes the same subject twice', () => {
+    const out = foldEstablished(
+      [],
+      [fact('e4', 'e4 is the Save button', 'd1'), fact('e4', 'e4 is the Submit button', 'd1')],
+      'd1',
+      undefined,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]?.fact).toBe('e4 is the Submit button');
+  });
+
+  it('keeps the LAST reading, because the newest observation is the true one', () => {
+    const out = foldEstablished(
+      [],
+      [fact('a', 'first', 'd1'), fact('b', 'other', 'd1'), fact('a', 'second', 'd1')],
+      'd1',
+      undefined,
+    );
+    expect(out.map((f) => f.key)).toEqual(['b', 'a']);
+    expect(out.find((f) => 'a' === f.key)?.fact).toBe('second');
+  });
+
+  it('still supersedes an existing row, which is what it already did', () => {
+    // The behaviour that worked stays working — this is a fold that gained a case, not a rewrite.
+    const out = foldEstablished(
+      [fact('e4', 'old', 'd1')],
+      [fact('e4', 'new', 'd1')],
+      'd1',
+      undefined,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]?.fact).toBe('new');
+  });
+});
+
 describe('remainingFor', () => {
   const intent = (id: string, state: Intent['state'], statement: string): Intent => ({
     id,

--- a/packages/core/src/run-context.ts
+++ b/packages/core/src/run-context.ts
@@ -135,11 +135,28 @@ function foldScoped<T extends ScopedEvidence>(
   currentEditEpoch: number | undefined,
 ): T[] {
   const current = (row: T): boolean => isCurrent(row, currentDocumentId, currentEditEpoch);
-  const superseded = new Set(incoming.map(keyOf));
+
+  // Supersede WITHIN the batch as well as against the prior set. `buildRunContext` folds against an
+  // empty prior set, so a rule that only ever applied to `existing` never applied at all there — and
+  // the envelope's whole contract is that `key` is the subject and re-observing it replaces rather
+  // than appends. A driven session showed the same ref twice and the same claim three times:
+  // duplicates in the one payload whose entire purpose is a cheap context restore.
+  //
+  // Last wins, because the newest reading is the true one. Insertion order is preserved from the
+  // LAST occurrence, so a re-observed subject moves to the recent end where the cap protects it.
+  const fresh = new Map<string, T>();
+  for (const row of incoming) {
+    if (!current(row)) continue;
+    const key = keyOf(row);
+    fresh.delete(key);
+    fresh.set(key, row);
+  }
+
+  const superseded = new Set(fresh.keys());
   const kept = existing.filter((row) => current(row) && !superseded.has(keyOf(row)));
   // Oldest first, so trimming from the front drops the least recent. `slice` on the tail keeps the
   // newest, which is the half a next step is most likely to need.
-  return [...kept, ...incoming.filter(current)].slice(-RUN_ESTABLISHED_CAP);
+  return [...kept, ...fresh.values()].slice(-RUN_ESTABLISHED_CAP);
 }
 
 /** Fold new observations into the established set. See `foldScoped`. */


### PR DESCRIPTION
Found by **driving the packaged 2.11.1 artifact**, not by reading the code — a real session returned the same ref twice and the same proven claim three times.

## The defect

`foldScoped` computed its superseded set from `incoming` and applied it only to `existing`. `buildRunContext` folds against an **empty** prior set:

```ts
established: foldEstablished([], input.established, …)
proven:      foldProven([], input.proven, …)
```

So the rule never applied there at all. And the envelope's entire contract is that `key` is the subject — re-observing it replaces rather than appends. The tool was contradicting its own declared output schema, and doing it in the one payload whose whole purpose is a **cheap** context restore.

## The fix

Superseding now happens within the batch as well as against the prior set. Last wins, because the newest reading is the true one, and insertion order comes from the last occurrence so a re-observed subject moves to the recent end where the cap protects it.

Fixed inside `foldScoped` rather than at the call site, so the established and proven folds both get it and neither can drift from the other.

## Not a rewrite

A third test pins the behaviour that already worked — superseding an older row against a prior set is unchanged. This is a fold that gained a case.

## Verification

Two tests red first, reproducing the live symptom exactly (`expected length 1, got 2` and `['a','b','a']` instead of `['b','a']`). `format:check`, `lint`, `typecheck`, `test:unit --force` (17/17) green.

Worth noting for the release: everything else in the packaged-artifact drive passed — `reticle_context` populated `proven` after both an `act_and_wait` and a bare `reticle_assert` verdict, gaps carried `source` file:line, coverage ended `unproven`, a signal count caught a real double-fire, and a real Vite hot update produced the edit-aware stale-ref message. **No source-vs-artifact discrepancy at all.** This was the one defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)