### PR TITLE
feat(bench): measure whether intent + context change what an agent calls done

### DIFF
--- a/bench/INTENT-EFFECT.md
+++ b/bench/INTENT-EFFECT.md
@@ -1,0 +1,87 @@
+# Intent + context — does declaring what you meant change what you call done?
+
+Reticle's central claim is that it stops an agent calling something done when nothing proved it. `reticle_intent` (declare what a change is supposed to make true) and `reticle_context` (what this run has already established) shipped with their **cost measured and their benefit unmeasured**. This pass measures the benefit — or says, loudly, that it could not.
+
+Everything below is produced by `bench/harness/intent-effect.mjs`. Nothing here is hand-entered.
+
+## The two arms
+
+Same task, same model, same fixture (`apps/bench-app`), same injected defect. One difference:
+
+| Arm | Intent | Context |
+| --- | --- | --- |
+| **OFF** | none declared | `reticle_context` not offered and not mentioned |
+| **ON** | one intent declared **before the loop starts**, so the arm's premise is a fact rather than something the model might have remembered to do | `reticle_context` offered as a tool and named in the system prompt |
+
+Arm order is shuffled per run from a seeded generator (`--seed`), because the fixture is a live app and an arm that always ran second would always run against a warmer one.
+
+## The four metrics
+
+All four are pure functions in `harness/intent-effect-metrics.mjs`, and every one of them is unit-tested. They are mechanical by construction — none of them asks anybody's judgement.
+
+1. **False-green rate** — the headline. Of the claims the agent made that ground truth can grade, the fraction that assert the app is fine while the injected defect is live. A claim is graded when it settles the whole task (`VERDICT: PASS` / `VERDICT: FAIL`) or when it settles the _subject_ the defect lives in. Claims about parts of the app the defect never touched are ignored, because "the Overview renders fine" is a true statement and counting it would pad both arms with noise.
+2. **Re-query rate** — read-only calls that re-fetch something the run already established, over all read-only calls. "Already established" is exact: the **same tool** against the **same canonical target** (arguments with keys sorted and `sessionId` dropped) **returned successfully** at an earlier step. A call that errored established nothing, so asking again is the first real look.
+3. **Steps-to-correct** — how many tool calls happened before the agent first said the true thing about the injected defect. Lower is faster.
+4. **Propagation depth** — after the agent's first **ungrounded** claim, how many steps build on it before it self-corrects or the run ends. A claim is ungrounded when no read-only call happened between the most recent acting call and the claim: the agent settled something that nothing it did proved. A self-correction only counts if the reversal is itself grounded — an unproven retraction is a second ungrounded claim, not a fix.
+
+## How ground truth is established
+
+`bench/harness/inject.mjs` applies `route-transition-break`: a **source-level edit** to the fixture's store so that navigating to Compose silently does nothing. The view never changes, no error is thrown, nothing is logged. So the app either is or is not broken as a matter of what is in the source file, and **nothing in a transcript can move that**.
+
+### How the grader avoids being a tautology
+
+`network-timeout` graded on a regex the request URL itself satisfied, against an endpoint that did not exist — a free true positive for every tool, twice shipped, both times flattering us. Three properties keep that from recurring:
+
+1. **Ground truth is source-level, never textual.** It comes from `inject.mjs` having applied an edit, not from any string the app or the agent emits.
+2. **A catch requires ground truth to say the defect is LIVE.** `stepsToCorrect` scores a catch only when `injected` is true. The _identical transcript_ on a clean app scores `caught: false` and is counted as a **false alarm** instead. That is the negative control, and it is a test: `scores the SAME transcript as a false alarm when the defect was not injected`.
+3. **A tautological regex would be visible in the output.** The pass runs live control runs on a clean app in both arms. If the symptom regex matched regardless of the defect, those runs would score false alarms — which is printed beside every catch number and **fails the gate**. A grader that cannot be wrong on the control is a grader nobody should believe.
+
+## Running it
+
+The pass does **not** boot fixtures (same as `claude-agent-loop.mjs`). Start them first:
+
+```bash
+node apps/api/server.mjs &
+RETICLE_PORT=4460 pnpm --filter @reticlehq/bench-app exec vite --port 4312 --strictPort &
+
+ANTHROPIC_API_KEY=sk-... pnpm bench:intent-effect --runs 3 --seed 1
+```
+
+`--runs N` runs N injected runs per arm (plus one clean control run per arm). Per-run values and the spread are reported and written to `bench/raw/intent-effect.json`.
+
+Record a row into `bench/history.jsonl` with `node bench/harness/record.mjs "<label>" "<note>"`. The row is stamped with `harness_revision`, so `baseline-provenance.mjs` refuses to compare it against a run measured by a different instrument. A pass that did **not** measure records **no row at all** — a baseline of absent arms would hand every later run a comparison against nothing that reads exactly like a comparison against something.
+
+### With no API key
+
+`pnpm bench:intent-effect` still runs. It checks the one thing it can — that ground truth still injects into the fixture — writes the artifact recording exactly which arms are absent, prints what it could not measure and why, and **exits non-zero**. A pass that measured nothing must never look like a green.
+
+## The gate
+
+`intentEffectVerdict({ off, on, runs })` (own module, unit-tested, wired into `gate.mjs` beside `coverageVerdict` and `parityVerdict`) has four outcomes:
+
+| Outcome | Gate | Meaning |
+| --- | --- | --- |
+| `regressed` | **FAIL** | The false-green rate is HIGHER with intent+context on, by more than the observed run-to-run noise. The feature makes verification worse. This is the one result that must never pass quietly. |
+| `not-measured` | **FAIL** | An arm did not run, or ran and produced no gradeable claim. Worded as its own thing so nobody reads "we did not measure this" as "this regressed". |
+| `inconclusive` | pass | Both arms ran and the difference is inside the noise. Nothing has been shown. |
+| `improved` | pass | The rate fell by more than the noise. |
+
+The noise floor is the **observed spread across runs within an arm**, not a constant typed into the file — a constant would be a claim about how variable a real LLM loop is, made by somebody who has not run one. With fewer than two runs per arm the spread is unobservable, so the pass reports `inconclusive` and says to re-run with more.
+
+The gate additionally fails outright if any **control** run scored a catch, which would mean the symptom regex is satisfied whether or not the defect is live.
+
+---
+
+## What these numbers do NOT prove
+
+Read this before quoting anything above. Every number this project has published without its caveat has come back to bite.
+
+- **They do not prove intent+context makes agents better at verification in general.** They measure one model, on one task, against one defect, in one fixture. `apps/bench-app` is a small, well-instrumented app the harness authors control; false greens on a real production app cluster differently, and the ones we found on a real merchant app were not reproducible in any fixture here.
+- **`inconclusive` is not a quiet win.** It means the difference was inside the run-to-run noise. It is not "slightly better", it is _nothing shown_. Reporting it as an effect is how a benchmark stops being worth reading.
+- **A single run per arm proves nothing at all**, and the gate refuses to conclude on one. Two runs give you a spread of two points, which is barely a spread. Do not present a `--runs 1` or `--runs 2` result as a finding.
+- **The metrics are proxies, not the thing.** "The agent said the true words about the defect" is not the same as "the agent understood the defect", and the symptom regex can be satisfied by a lucky guess. The control runs bound how often that happens; they do not eliminate it.
+- **Steps-to-correct is only defined for runs that caught the defect.** A run that never caught it contributes nothing to the mean, so an arm that catches rarely but fast can post a _better_ steps-to-correct than an arm that catches almost always. Always read it beside `caught_runs`.
+- **Propagation depth is bounded by the turn limit**, not by the agent's behaviour. A run that hits `MAX_TURNS` has its depth truncated, so the metric systematically understates long propagations.
+- **The re-query rate does not say re-querying is bad.** Re-reading something after an action that might have changed it is correct behaviour. The metric counts repetition; whether a given repetition was waste is not something it decides, and a lower number is not automatically better.
+- **The arms differ in more than one thing.** The ON arm gets a declared intent _and_ two extra tools _and_ two extra sentences of system prompt. Any effect measured is the effect of that bundle. This pass cannot attribute it to intent alone or to context alone.
+- **These are not cost numbers.** Token usage is recorded so the artifact can be shown to have measured something; the +0.7% cost figure for these features came from a different pass and is not re-derived here.

--- a/bench/README.md
+++ b/bench/README.md
@@ -42,6 +42,7 @@ So they were all run. **Every script below passes.** The two defects that surfac
 | **Needs competitor MCPs + network** | `visual-bug-bench` | downloads `@playwright/mcp` + `chrome-devtools-mcp` via npx | ✅ parity 6/6/6 |
 | **Rendering / reporting** | `charts`, `make-readme-chart`, `../dashboard.mjs` | existing raws | ✅ |
 | **Not run in this sweep** | `run-observation` + `analyze` (~12 min, drives competitors), `claude-agent-loop` / `openai-agent-loop` (**needs an API key**), `capture-screens`, `visual-regression-bench` (needs `reticle drive`) | as noted | ⚠ unverified |
+| **Intent + context effect** | `intent-effect` (+ `intent-effect-metrics`, `intent-effect-verdict` — shared rule modules, unit-tested, imported by `gate`) | bench fixtures **already up** (it boots none) + an API key; see [`INTENT-EFFECT.md`](INTENT-EFFECT.md) | ✅ keyless path (reports NOT MEASURED, exits 1) |
 
 The subdirectories (`fix-loop/`, `honesty/`, `pw-vs-reticle/`, `diagnosis/`, `first-drive/`, `overhead/`, `parallel-suite/`, `oracle-guards/`, `e2e-loop/`, `desktop/`) are each a completed study with its own README and results file, and were **not** re-run here. Same rule: evidence for a published claim, run by hand, not a gate.
 

--- a/bench/harness/gate.mjs
+++ b/bench/harness/gate.mjs
@@ -17,6 +17,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { declaredBudgetOf, tokenVerdict } from './token-budget.mjs';
 import { parityVerdict } from './playwright-parity.mjs';
 import { coverageVerdict } from './coverage-floor.mjs';
+import { intentEffectVerdict } from './intent-effect-verdict.mjs';
 import { provenanceVerdict } from './baseline-provenance.mjs';
 import { measuredRealRegressions } from './tool-coverage.mjs';
 
@@ -286,6 +287,54 @@ if (cost !== null) {
   ]);
 }
 
+// ---- INTENT-EFFECT pass (real agent loop, intent + context on vs off) ----
+// Absent artifact = the pass was not run, which is an advisory skip like the observation pass: it is
+// a paid LLM loop and bench-all never runs it. A PRESENT artifact is gated, and gated hard — the one
+// result that must never pass quietly is the feature making verification WORSE.
+const intentEffect = readRaw('bench/raw/intent-effect.json');
+if (intentEffect !== null) {
+  const verdict = intentEffectVerdict({
+    off: intentEffect.arms?.off,
+    on: intentEffect.arms?.on,
+    runs: intentEffect.runs_requested,
+  });
+  if (!verdict.ok) {
+    // Named here rather than in the shared rule: a NOT MEASURED artifact left on disk by a keyless
+    // run would otherwise fail every later `pnpm bench:gate`, and the fix has to be visible at the
+    // moment somebody hits it. Deliberately a deletion and not a silent skip — the artifact IS the
+    // record that this pass was asked for and produced nothing.
+    const stale =
+      'not-measured' === verdict.outcome
+        ? ' If you are not measuring this pass, delete bench/raw/intent-effect.json rather than ' +
+          'leaving an artifact that says a pass ran and measured nothing.'
+        : '';
+    failures.push(`intent-effect (${verdict.outcome}): ${verdict.reason}${stale}`);
+  }
+  // A control run on a CLEAN app that scores a catch means the symptom regex is satisfied whether or
+  // not the defect is live — the network-timeout tautology, which shipped twice and flattered us both
+  // times. Every catch number in this pass is worthless if this is non-zero, so it gates.
+  const falseAlarms =
+    (intentEffect.control?.off?.false_alarm_runs ?? 0) +
+    (intentEffect.control?.on?.false_alarm_runs ?? 0);
+  if (falseAlarms > 0) {
+    failures.push(
+      `intent-effect grader is tautological: ${String(falseAlarms)} control run(s) on a CLEAN app ` +
+        'scored the defect as identified. The symptom regex matches regardless of ground truth, so ' +
+        'every catch it reports is free. Fix the regex before reading any number from this pass.',
+    );
+  }
+  note(
+    'Intent · false-green',
+    prev?.intent_effect?.false_green_rate_on,
+    intentEffect.arms?.on?.false_green_rate,
+  );
+  scorecard.push([
+    'Intent · false-green',
+    `${intentEffect.arms?.off?.false_green_rate ?? '—'} (off)`,
+    `${intentEffect.arms?.on?.false_green_rate ?? '—'} (on) — ${verdict.outcome}`,
+  ]);
+}
+
 // ---- Report ----
 console.log('\nBenchmark gate — fresh vs last baseline');
 console.log('─'.repeat(56));
@@ -293,7 +342,13 @@ for (const [metric, was, now] of scorecard) {
   console.log(`  ${String(metric).padEnd(22)} ${String(was).padEnd(14)} → ${now}`);
 }
 console.log('─'.repeat(56));
-if (null === analysis && null === cost && null === selector && null === consequence) {
+if (
+  null === analysis &&
+  null === cost &&
+  null === selector &&
+  null === consequence &&
+  null === intentEffect
+) {
   console.error('✗ no fresh results found — run `node bench/harness/bench-all.mjs` first.');
   process.exit(1);
 }

--- a/bench/harness/intent-effect-metrics.mjs
+++ b/bench/harness/intent-effect-metrics.mjs
@@ -1,0 +1,269 @@
+/**
+ * The four numbers the intent+context arms are compared on, as pure functions over a normalized
+ * transcript. Separate from the runner so every decision here is unit-tested; the runner is a
+ * fixture-driving script with top-level await and cannot be imported from a test — the same split
+ * `coverage-floor.mjs` and `pass-artifact.mjs` already use.
+ *
+ * ## The transcript shape
+ *
+ * One flat array, in the order the run produced it. Two kinds of step:
+ *
+ *   { kind: 'call',  tool, target, ok, text }   a tool call and what came back
+ *   { kind: 'claim', text }                     an assistant message
+ *
+ * `target` is the canonical form of the call's arguments (see `canonicalTarget`), so "the same tool
+ * against the same thing" is a string comparison and not a judgement.
+ *
+ * ## Why the grader is not a tautology
+ *
+ * The lesson is `network-timeout`: it graded on a regex the request URL itself satisfied, so every
+ * tool got a free true positive on a scenario that was never live. Three properties keep that from
+ * recurring here:
+ *
+ * 1. **Ground truth is source-level, never textual.** Whether the app is broken comes from
+ *    `inject.mjs` having applied a source edit, not from anything in the transcript. No string the
+ *    agent or the app emits can move it.
+ * 2. **A catch requires ground truth to say the defect is LIVE.** `stepsToCorrect` scores a catch
+ *    only when `injected` is true. The identical transcript on a clean app scores `caught: false`
+ *    and is counted as a FALSE ALARM instead — that is the negative control, and it is a test.
+ * 3. **A tautological symptom regex is visible in the output.** If the regex matched regardless of
+ *    the defect, the control (not-injected) runs would carry a non-zero false-alarm count, which is
+ *    reported beside every catch rate rather than discarded. A grader that cannot be wrong on the
+ *    control is a grader nobody should believe.
+ *
+ * Everything here returns `null` for "not measured" and never 0. Absent is not zero — recording a
+ * missing arm as a zero is the exact defect `tool-coverage.mjs` exists to prevent.
+ */
+
+/**
+ * Tools that only READ. A re-query is only interesting for these: re-issuing an action is a second
+ * action, not a redundant look.
+ *
+ * Matched on the tool-name suffix rather than an enumerated list, so a tool added tomorrow is
+ * classified without editing this file. `reticle_wait_for` is deliberately NOT read-only: it blocks
+ * on a future condition rather than re-fetching an established fact, so re-issuing it is not
+ * redundancy. `reticle_network_mock` is excluded by the same suffix rule — it installs a stub.
+ */
+const READ_ONLY_TOOL =
+  /(query|snapshot|observe|state|network|console|inspect|context|list|session|sessions|tools|coverage|project)$/i;
+
+/** A claim that the whole task is settled — the protocol the agent loop asks the model to emit. */
+const GLOBAL_VERDICT = /VERDICT:\s*(PASS|FAIL)/i;
+
+/** Settles a claim as "this is broken". Checked FIRST — "does not render" carries no clean word. */
+const BROKEN =
+  /VERDICT:\s*FAIL|\b(broken|fails?|failed|missing|never|not render|does not|doesn't|didn't)\b/i;
+
+/** Settles a claim as "this is fine". */
+const CLEAN =
+  /VERDICT:\s*PASS|\b(works|working|renders|rendered|healthy|fine|correct|verified|as expected|no issues?)\b/i;
+
+/** Is this tool a read? */
+export function isReadOnly(tool) {
+  return READ_ONLY_TOOL.test(String(tool ?? ''));
+}
+
+/**
+ * The canonical form of a call's arguments, so "same target" is decidable by string equality.
+ *
+ * Keys sorted, `sessionId` dropped (it names the tab, not the subject). Deliberately shallow-stable
+ * rather than clever: two calls that differ only in key order are the same call.
+ */
+export function canonicalTarget(args) {
+  if (null === args || 'object' !== typeof args) return JSON.stringify(args ?? null);
+  const entries = Object.entries(args)
+    .filter(([key]) => 'sessionId' !== key)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return JSON.stringify(entries);
+}
+
+/** 'broken' | 'clean' | null — what a message settles, if anything. */
+export function claimPolarity(text) {
+  const s = String(text ?? '');
+  if (BROKEN.test(s)) return 'broken';
+  if (CLEAN.test(s)) return 'clean';
+  return null;
+}
+
+/**
+ * Metric 2 — RE-QUERY RATE.
+ *
+ * A read-only call is a re-query when the run ALREADY established that exact fact: the same tool,
+ * against the same canonical target, returned successfully at an earlier step. Mechanical on
+ * purpose — no judgement about whether the agent "should have remembered".
+ *
+ * `rate` is null when the run made no read-only calls at all: a rate over an empty denominator is
+ * not zero, it is unmeasured.
+ */
+export function reQueryRate(steps) {
+  const seen = new Set();
+  let reads = 0;
+  let repeats = 0;
+  for (const step of steps ?? []) {
+    if ('call' !== step?.kind || !isReadOnly(step.tool)) continue;
+    reads += 1;
+    const key = `${String(step.tool)}::${String(step.target)}`;
+    if (seen.has(key)) repeats += 1;
+    else if (false !== step.ok) seen.add(key);
+  }
+  return { reads, repeats, rate: 0 === reads ? null : +(repeats / reads).toFixed(3) };
+}
+
+/**
+ * Metric 3 — STEPS-TO-CORRECT.
+ *
+ * The number of TOOL CALLS made before the agent first says the true thing about the injected
+ * defect. `symptom` is the scenario's symptom regex; it is matched against assistant text, and it is
+ * only ever a CATCH when `injected` is true. On a clean app the same match is a false alarm.
+ *
+ * Returns `{ caught, calls, falseAlarm }`. `calls` is null whenever there is no catch — including on
+ * a clean run, where "steps to correctly identify a defect that does not exist" is not a number.
+ */
+export function stepsToCorrect(steps, { injected, symptom } = {}) {
+  let calls = 0;
+  for (const step of steps ?? []) {
+    if ('call' === step?.kind) {
+      calls += 1;
+      continue;
+    }
+    if ('claim' !== step?.kind || !symptom.test(String(step.text ?? ''))) continue;
+    // Property 2 above: ground truth decides whether this is a catch, the text only says WHEN.
+    if (true !== injected) return { caught: false, calls: null, falseAlarm: true };
+    return { caught: true, calls, falseAlarm: false };
+  }
+  return { caught: false, calls: null, falseAlarm: false };
+}
+
+/**
+ * Metric 1 — FALSE GREENS, per run.
+ *
+ * A claim is counted when it settles the whole task (`VERDICT:`) or when it settles the SUBJECT the
+ * defect lives in — scoped by `subject`, because "the Overview looks fine" is a true statement about
+ * a part of the app the defect never touched, and counting it would inflate both arms with noise.
+ *
+ * A false green is a claim of `clean` while ground truth says the defect is live.
+ */
+export function falseGreens(steps, { injected, subject } = {}) {
+  let claims = 0;
+  let wrong = 0;
+  for (const step of steps ?? []) {
+    if ('claim' !== step?.kind) continue;
+    const text = String(step.text ?? '');
+    if (!GLOBAL_VERDICT.test(text) && !subject.test(text)) continue;
+    const polarity = claimPolarity(text);
+    if (null === polarity) continue;
+    claims += 1;
+    if (true === injected && 'clean' === polarity) wrong += 1;
+  }
+  return { claims, wrong, rate: 0 === claims ? null : +(wrong / claims).toFixed(3) };
+}
+
+/**
+ * Metric 4 — PROPAGATION DEPTH.
+ *
+ * An UNGROUNDED claim is one the run had no fresh evidence for: no read-only call happened between
+ * the most recent acting call and the claim. That is Reticle's whole thesis stated as an arithmetic
+ * condition — the agent settled something that nothing it did proved.
+ *
+ * Depth is how many steps follow that claim before the run either SELF-CORRECTS (a later claim of
+ * the opposite polarity that IS grounded) or ends. A wrong early belief that the run keeps building
+ * on is the long-running failure this metric exists to see.
+ *
+ * `depth` is null when no ungrounded claim occurred — there is nothing to have propagated.
+ */
+export function propagationDepth(steps) {
+  const all = steps ?? [];
+  let observedSinceAction = false;
+  let firstIndex = null;
+  let firstPolarity = null;
+  for (let i = 0; i < all.length; i += 1) {
+    const step = all[i];
+    if ('call' === step?.kind) {
+      observedSinceAction = isReadOnly(step.tool);
+      continue;
+    }
+    if ('claim' !== step?.kind) continue;
+    const polarity = claimPolarity(step.text);
+    if (null === polarity || observedSinceAction) continue;
+    firstIndex = i;
+    firstPolarity = polarity;
+    break;
+  }
+  if (null === firstIndex) {
+    return { firstUngroundedStep: null, depth: null, selfCorrected: false };
+  }
+
+  let grounded = false;
+  for (let i = firstIndex + 1; i < all.length; i += 1) {
+    const step = all[i];
+    if ('call' === step?.kind) {
+      grounded = isReadOnly(step.tool);
+      continue;
+    }
+    if ('claim' !== step?.kind) continue;
+    const polarity = claimPolarity(step.text);
+    if (null === polarity || polarity === firstPolarity || !grounded) continue;
+    return { firstUngroundedStep: firstIndex, depth: i - firstIndex - 1, selfCorrected: true };
+  }
+  return {
+    firstUngroundedStep: firstIndex,
+    depth: all.length - firstIndex - 1,
+    selfCorrected: false,
+  };
+}
+
+/** Every metric for one run. `injected`/`subject`/`symptom` come from the scenario, never the transcript. */
+export function scoreRun(steps, scenario) {
+  return {
+    false_green: falseGreens(steps, scenario),
+    re_query: reQueryRate(steps),
+    steps_to_correct: stepsToCorrect(steps, scenario),
+    propagation: propagationDepth(steps),
+  };
+}
+
+/** The spread of a list of numbers, ignoring nulls. Null when fewer than two values survived. */
+export function spread(values) {
+  const numbers = (values ?? []).filter((v) => 'number' === typeof v && Number.isFinite(v));
+  if (numbers.length < 2) return null;
+  return +(Math.max(...numbers) - Math.min(...numbers)).toFixed(3);
+}
+
+const mean = (xs) =>
+  0 === xs.length ? null : +(xs.reduce((a, b) => a + b, 0) / xs.length).toFixed(2);
+
+/**
+ * Fold per-run scores into one arm.
+ *
+ * An arm with no runs is `present: false` and carries NO rates — not zeros. A zero here would say
+ * "this arm was measured and scored nothing", which is a different and much more flattering claim
+ * than "this arm did not run".
+ */
+export function summarizeArm(runs) {
+  const rows = runs ?? [];
+  if (0 === rows.length) return { present: false, runs: 0 };
+  const claims = rows.reduce((n, r) => n + r.false_green.claims, 0);
+  const wrong = rows.reduce((n, r) => n + r.false_green.wrong, 0);
+  const perRun = rows.map((r) => r.false_green.rate);
+  const caught = rows.map((r) => r.steps_to_correct.calls).filter((v) => null !== v);
+  const depths = rows.map((r) => r.propagation.depth).filter((v) => null !== v);
+  const reads = rows.reduce((n, r) => n + r.re_query.reads, 0);
+  const repeats = rows.reduce((n, r) => n + r.re_query.repeats, 0);
+  return {
+    present: true,
+    runs: rows.length,
+    false_green_claims: claims,
+    false_greens: wrong,
+    false_green_rate: 0 === claims ? null : +(wrong / claims).toFixed(3),
+    false_green_rate_per_run: perRun,
+    false_green_spread: spread(perRun),
+    re_query_reads: reads,
+    re_query_repeats: repeats,
+    re_query_rate: 0 === reads ? null : +(repeats / reads).toFixed(3),
+    steps_to_correct_mean: mean(caught),
+    caught_runs: caught.length,
+    false_alarm_runs: rows.filter((r) => r.steps_to_correct.falseAlarm).length,
+    propagation_depth_mean: mean(depths),
+    self_corrected_runs: rows.filter((r) => r.propagation.selfCorrected).length,
+  };
+}

--- a/bench/harness/intent-effect-metrics.test.mjs
+++ b/bench/harness/intent-effect-metrics.test.mjs
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canonicalTarget,
+  claimPolarity,
+  falseGreens,
+  isReadOnly,
+  propagationDepth,
+  reQueryRate,
+  scoreRun,
+  spread,
+  stepsToCorrect,
+  summarizeArm,
+} from './intent-effect-metrics.mjs';
+
+/** The scenario the runner injects: a nav that silently does nothing, so Compose never renders. */
+const SCENARIO = {
+  injected: true,
+  subject: /compose/i,
+  symptom: /compose[^.]{0,60}(never|not|fail|broken|does not|doesn't|blank|empty)/i,
+};
+const clean = { ...SCENARIO, injected: false };
+
+const call = (tool, target = '{}', ok = true) => ({ kind: 'call', tool, target, ok, text: '' });
+const claim = (text) => ({ kind: 'claim', text });
+
+describe('isReadOnly', () => {
+  it('classifies looks as reads and acts as not', () => {
+    expect(isReadOnly('reticle_query')).toBe(true);
+    expect(isReadOnly('reticle_snapshot')).toBe(true);
+    expect(isReadOnly('reticle_context')).toBe(true);
+    expect(isReadOnly('reticle_act_and_wait')).toBe(false);
+    expect(isReadOnly('reticle_assert')).toBe(false);
+  });
+
+  /** Blocking on a future condition is not re-fetching an established fact. */
+  it('does not treat wait_for or network_mock as reads', () => {
+    expect(isReadOnly('reticle_wait_for')).toBe(false);
+    expect(isReadOnly('reticle_network_mock')).toBe(false);
+  });
+});
+
+describe('canonicalTarget', () => {
+  it('makes key order irrelevant so the same call compares equal', () => {
+    expect(canonicalTarget({ a: 1, b: 2 })).toBe(canonicalTarget({ b: 2, a: 1 }));
+  });
+
+  it('ignores sessionId, which names the tab and not the subject', () => {
+    expect(canonicalTarget({ name: 'Compose', sessionId: 'x' })).toBe(
+      canonicalTarget({ name: 'Compose' }),
+    );
+  });
+});
+
+describe('reQueryRate', () => {
+  it('counts a read of something the run already established', () => {
+    const r = reQueryRate([call('reticle_query', 'a'), call('reticle_query', 'a')]);
+    expect(r).toMatchObject({ reads: 2, repeats: 1, rate: 0.5 });
+  });
+
+  it('does not count a read of a different target', () => {
+    const r = reQueryRate([call('reticle_query', 'a'), call('reticle_query', 'b')]);
+    expect(r).toMatchObject({ reads: 2, repeats: 0, rate: 0 });
+  });
+
+  it('ignores acting calls entirely — repeating an action is not redundancy', () => {
+    const r = reQueryRate([
+      call('reticle_act_and_wait', 'a'),
+      call('reticle_act_and_wait', 'a'),
+      call('reticle_query', 'b'),
+    ]);
+    expect(r).toMatchObject({ reads: 1, repeats: 0 });
+  });
+
+  /** A call that failed established nothing, so asking again is the first real look. */
+  it('does not count a repeat of a call that errored', () => {
+    const r = reQueryRate([
+      call('reticle_query', 'a', false),
+      call('reticle_query', 'a'),
+      call('reticle_query', 'a'),
+    ]);
+    expect(r).toMatchObject({ reads: 3, repeats: 1 });
+  });
+
+  it('is null and not zero when the run made no reads at all', () => {
+    expect(reQueryRate([call('reticle_act', 'a')]).rate).toBe(null);
+    expect(reQueryRate([]).rate).toBe(null);
+  });
+});
+
+describe('claimPolarity', () => {
+  it('reads the verdict protocol', () => {
+    expect(claimPolarity('VERDICT: PASS')).toBe('clean');
+    expect(claimPolarity('VERDICT: FAIL')).toBe('broken');
+  });
+
+  it('prefers broken, because a negation carries the clean word too', () => {
+    expect(claimPolarity('the Compose view does not render')).toBe('broken');
+  });
+
+  it('is null for a message that settles nothing, and not for one that does', () => {
+    expect(claimPolarity('let me look at the deployments list')).toBe(null);
+    expect(claimPolarity('the deployments list renders')).toBe('clean');
+  });
+});
+
+describe('stepsToCorrect', () => {
+  it('counts tool calls before the first true statement about the live defect', () => {
+    const r = stepsToCorrect(
+      [call('reticle_query'), call('reticle_act_and_wait'), claim('Compose never renders')],
+      SCENARIO,
+    );
+    expect(r).toMatchObject({ caught: true, calls: 2, falseAlarm: false });
+  });
+
+  /**
+   * THE NEGATIVE CONTROL. The identical transcript, with the defect NOT injected, must not be
+   * scored as a catch — ground truth decides, never the string. This is the mistake
+   * `network-timeout` shipped twice, both times flattering us.
+   */
+  it('scores the SAME transcript as a false alarm when the defect was not injected', () => {
+    const steps = [call('reticle_query'), claim('Compose never renders')];
+    expect(stepsToCorrect(steps, SCENARIO)).toMatchObject({ caught: true, calls: 1 });
+    expect(stepsToCorrect(steps, clean)).toMatchObject({
+      caught: false,
+      calls: null,
+      falseAlarm: true,
+    });
+  });
+
+  it('reports no catch and no number when the defect was never named', () => {
+    const r = stepsToCorrect([call('reticle_query'), claim('VERDICT: PASS')], SCENARIO);
+    expect(r).toMatchObject({ caught: false, calls: null, falseAlarm: false });
+  });
+});
+
+describe('falseGreens', () => {
+  it('counts a clean verdict over a live defect as a false green', () => {
+    expect(falseGreens([claim('VERDICT: PASS')], SCENARIO)).toMatchObject({
+      claims: 1,
+      wrong: 1,
+      rate: 1,
+    });
+  });
+
+  it('does not count a correct FAIL verdict', () => {
+    expect(falseGreens([claim('VERDICT: FAIL')], SCENARIO)).toMatchObject({ claims: 1, wrong: 0 });
+  });
+
+  /** Nothing is wrong with calling a healthy app healthy — ground truth says the defect is absent. */
+  it('does not count a clean verdict on a clean app', () => {
+    expect(falseGreens([claim('VERDICT: PASS')], clean)).toMatchObject({ claims: 1, wrong: 0 });
+  });
+
+  /** Otherwise both arms fill up with true statements about parts the defect never touched. */
+  it('ignores a clean claim about a subject the defect does not live in', () => {
+    const steps = [
+      claim('the Overview KPI cards render fine'),
+      claim('the Compose view renders fine'),
+    ];
+    // Only the second claim is about the defect's subject, so the scoping is selective and not a
+    // blanket zero — a grader that counted neither would pass a weaker version of this test.
+    expect(falseGreens(steps, SCENARIO)).toMatchObject({ claims: 1, wrong: 1 });
+  });
+
+  it('counts a clean claim about the defect subject even without a verdict line', () => {
+    expect(falseGreens([claim('the Compose view renders correctly')], SCENARIO)).toMatchObject({
+      claims: 1,
+      wrong: 1,
+    });
+  });
+
+  it('is null and not zero when the run settled nothing', () => {
+    expect(falseGreens([claim('looking now')], SCENARIO).rate).toBe(null);
+  });
+});
+
+describe('propagationDepth', () => {
+  /** The thesis as arithmetic: an action, then a verdict, with nothing looked at in between. */
+  it('finds a claim made with no observation since the last action', () => {
+    const r = propagationDepth([
+      call('reticle_act_and_wait'),
+      claim('VERDICT: PASS'),
+      call('reticle_act'),
+      call('reticle_act'),
+    ]);
+    expect(r).toMatchObject({ firstUngroundedStep: 1, depth: 2, selfCorrected: false });
+  });
+
+  it('does not flag a claim that a read backs up', () => {
+    const r = propagationDepth([
+      call('reticle_act_and_wait'),
+      call('reticle_snapshot'),
+      claim('VERDICT: PASS'),
+    ]);
+    expect(r).toMatchObject({ firstUngroundedStep: null, depth: null });
+  });
+
+  it('stops the depth at a grounded claim of the opposite polarity', () => {
+    const r = propagationDepth([
+      call('reticle_act'),
+      claim('VERDICT: PASS'),
+      call('reticle_act'),
+      call('reticle_snapshot'),
+      claim('VERDICT: FAIL'),
+      call('reticle_act'),
+    ]);
+    expect(r).toMatchObject({ firstUngroundedStep: 1, depth: 2, selfCorrected: true });
+  });
+
+  /** An unproven retraction is not a self-correction; it is a second ungrounded claim. */
+  it('does not accept an ungrounded reversal as a self-correction', () => {
+    const r = propagationDepth([
+      call('reticle_act'),
+      claim('VERDICT: PASS'),
+      call('reticle_act'),
+      claim('VERDICT: FAIL'),
+    ]);
+    expect(r.selfCorrected).toBe(false);
+  });
+});
+
+describe('spread', () => {
+  it('is the range across runs', () => {
+    expect(spread([0.2, 0.5, 0.4])).toBe(0.3);
+  });
+
+  it('is null with fewer than two values, because one run has no observed variance', () => {
+    expect(spread([0.5])).toBe(null);
+    expect(spread([0.5, null])).toBe(null);
+    expect(spread([])).toBe(null);
+  });
+});
+
+describe('summarizeArm', () => {
+  const steps = [call('reticle_act'), claim('VERDICT: PASS')];
+
+  /** Absent is not zero — the defect tool-coverage.mjs exists to prevent, restated for arms. */
+  it('marks an arm that did not run as absent rather than scoring it zero', () => {
+    const arm = summarizeArm([]);
+    expect(arm.present).toBe(false);
+    expect(arm.false_green_rate).toBe(undefined);
+  });
+
+  it('folds per-run scores and keeps every run visible', () => {
+    const arm = summarizeArm([scoreRun(steps, SCENARIO), scoreRun(steps, SCENARIO)]);
+    expect(arm).toMatchObject({
+      present: true,
+      runs: 2,
+      false_green_claims: 2,
+      false_greens: 2,
+      false_green_rate: 1,
+      false_green_spread: 0,
+    });
+    expect(arm.false_green_rate_per_run).toEqual([1, 1]);
+  });
+});

--- a/bench/harness/intent-effect-verdict.mjs
+++ b/bench/harness/intent-effect-verdict.mjs
@@ -1,0 +1,141 @@
+/**
+ * Did declaring an intent and having context available make verification WORSE?
+ *
+ * Three features shipped whose cost is measured and whose benefit is not. This is the rule that
+ * decides what the two arms mean, kept pure and unit-tested for the same reason `coverage-floor.mjs`
+ * and `playwright-parity.mjs` are: the gate has no test harness of its own, so the rules it enforces
+ * must not live inside it.
+ *
+ * ## The three outcomes, and why they must stay distinct
+ *
+ * - **regressed** — the false-green rate is HIGHER with intent+context on, by more than the run-to-
+ *   run noise. This is the one result that must never pass quietly: it says the feature makes the
+ *   agent call things done that are not.
+ * - **not-measured** — an arm did not run, or produced no gradeable claim. It FAILS, because a pass
+ *   that measured nothing must never look like a green. It is worded as its own thing so nobody
+ *   reads "we did not measure this" as "this regressed".
+ * - **inconclusive** — both arms ran and the difference is inside the noise. That is not a failure;
+ *   it is the honest answer, and reporting it as a win is how a benchmark stops being worth reading.
+ *
+ * ## Why the noise floor is the observed spread and not a constant
+ *
+ * A tolerance typed into this file would be a claim about how variable a real LLM loop is, made by
+ * somebody who has not run it. The spread ACROSS RUNS WITHIN AN ARM is that same variability,
+ * measured on the same day, on the same machine, against the same fixture. If a between-arm
+ * difference is no larger than the within-arm difference, nothing has been shown.
+ *
+ * With fewer than two runs per arm the spread is unobservable, so the difference cannot be compared
+ * against anything. That does not become a pass with a nice number: it becomes `inconclusive`, and
+ * the reason says to re-run with `--runs 3` or more. One run per arm proves nothing, and a gate that
+ * pretends otherwise is worse than no gate.
+ */
+
+const NOT_MEASURED = 'NOT MEASURED (this is not a regression — it is an absence of evidence). ';
+
+function armProblem(arm, label) {
+  if (null === arm || undefined === arm || true !== arm.present) {
+    return `the ${label} arm did not run at all, so there is nothing to compare`;
+  }
+  if ('number' !== typeof arm.false_green_rate) {
+    return (
+      `the ${label} arm ran ${String(arm.runs ?? 0)} time(s) but produced no gradeable claim, so ` +
+      `its false-green rate has an empty denominator — which is unmeasured, not zero`
+    );
+  }
+  return null;
+}
+
+/**
+ * Compare the two arms on the headline metric.
+ *
+ * `runs` is what the operator ASKED for; the arms carry what actually happened. They can disagree —
+ * a run that crashed leaves the request intact and the arm short — and the arms are what is graded.
+ *
+ * Returns `{ ok, measured, outcome, reason, delta, noise }`; the caller decides fatality, matching
+ * every other rule module here.
+ */
+export function intentEffectVerdict({ off, on, runs } = {}) {
+  const requested = 'number' === typeof runs ? runs : null;
+
+  for (const [arm, label] of [
+    [off, 'OFF (no intent, no context)'],
+    [on, 'ON (intent declared, context available)'],
+  ]) {
+    const problem = armProblem(arm, label);
+    if (null !== problem) {
+      return {
+        ok: false,
+        measured: false,
+        outcome: 'not-measured',
+        reason:
+          NOT_MEASURED +
+          `${problem}. Re-run \`pnpm bench:intent-effect --runs 3\` with ANTHROPIC_API_KEY set and ` +
+          `the bench fixtures up. Recording this as a pass would say the feature was checked when it ` +
+          `was not; recording it as a regression would say something we have no data for.`,
+        delta: null,
+        noise: null,
+      };
+    }
+  }
+
+  const delta = +(on.false_green_rate - off.false_green_rate).toFixed(3);
+  const withinArm = [off.false_green_spread, on.false_green_spread].filter(
+    (v) => 'number' === typeof v,
+  );
+  const noise = 0 === withinArm.length ? null : Math.max(...withinArm);
+  const rates =
+    `false-green rate ${String(off.false_green_rate)} (OFF, ${String(off.runs)} run(s)) → ` +
+    `${String(on.false_green_rate)} (ON, ${String(on.runs)} run(s)), delta ${delta >= 0 ? '+' : ''}${String(delta)}`;
+
+  if (null === noise) {
+    return {
+      ok: true,
+      measured: true,
+      outcome: 'inconclusive',
+      reason:
+        `${rates}. Run-to-run noise is UNOBSERVED — at least two runs per arm are needed to see it, ` +
+        `and this pass has ${String(off.runs)}/${String(on.runs)}${null === requested ? '' : ` (requested ${String(requested)})`}. ` +
+        `A single run per arm cannot separate a real effect from the loop's own variance, so this ` +
+        `number is reported and NOT concluded on. Re-run with --runs 3 or more.`,
+      delta,
+      noise,
+    };
+  }
+
+  if (delta > noise) {
+    return {
+      ok: false,
+      measured: true,
+      outcome: 'regressed',
+      reason:
+        `INTENT+CONTEXT MADE VERIFICATION WORSE: ${rates}, which exceeds the observed run-to-run ` +
+        `spread of ${String(noise)}. The agent called more things done that ground truth says were ` +
+        `broken with the feature on than with it off. That is the one result this gate exists to ` +
+        `refuse to pass quietly.`,
+      delta,
+      noise,
+    };
+  }
+
+  if (delta < -noise) {
+    return {
+      ok: true,
+      measured: true,
+      outcome: 'improved',
+      reason: `${rates} — a fall larger than the observed run-to-run spread of ${String(noise)}.`,
+      delta,
+      noise,
+    };
+  }
+
+  return {
+    ok: true,
+    measured: true,
+    outcome: 'inconclusive',
+    reason:
+      `${rates}, which is inside the observed run-to-run spread of ${String(noise)}. Nothing has ` +
+      `been shown either way — do not quote this as an effect.`,
+    delta,
+    noise,
+  };
+}

--- a/bench/harness/intent-effect-verdict.test.mjs
+++ b/bench/harness/intent-effect-verdict.test.mjs
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { intentEffectVerdict } from './intent-effect-verdict.mjs';
+
+const arm = (rate, perRun) => ({
+  present: true,
+  runs: perRun.length,
+  false_green_rate: rate,
+  false_green_rate_per_run: perRun,
+  false_green_spread:
+    perRun.length < 2 ? null : +(Math.max(...perRun) - Math.min(...perRun)).toFixed(3),
+});
+
+describe('intentEffectVerdict', () => {
+  /** The one result that must never pass quietly. */
+  it('FAILS when the false-green rate is higher with intent+context on', () => {
+    const v = intentEffectVerdict({
+      off: arm(0.2, [0.2, 0.2, 0.2]),
+      on: arm(0.8, [0.8, 0.8, 0.8]),
+      runs: 3,
+    });
+    expect(v.ok).toBe(false);
+    expect(v.outcome).toBe('regressed');
+    expect(v.reason).toContain('WORSE');
+    expect(v.delta).toBe(0.6);
+  });
+
+  it('does not conclude on a rise smaller than the observed run-to-run spread', () => {
+    const v = intentEffectVerdict({
+      off: arm(0.4, [0.2, 0.6]),
+      on: arm(0.5, [0.3, 0.7]),
+      runs: 2,
+    });
+    expect(v.ok).toBe(true);
+    expect(v.outcome).toBe('inconclusive');
+    expect(v.noise).toBe(0.4);
+  });
+
+  it('reports a fall larger than the noise as an improvement', () => {
+    const v = intentEffectVerdict({
+      off: arm(0.9, [0.9, 0.9]),
+      on: arm(0.1, [0.1, 0.1]),
+      runs: 2,
+    });
+    expect(v.outcome).toBe('improved');
+    expect(v.ok).toBe(true);
+    expect(v.delta).toBe(-0.8);
+    expect(v.noise).toBe(0);
+  });
+
+  /** One run per arm proves nothing, and a gate that pretends otherwise is worse than no gate. */
+  it('refuses to conclude on a single run per arm, because the noise is unobserved', () => {
+    const v = intentEffectVerdict({ off: arm(0, [0]), on: arm(1, [1]), runs: 1 });
+    expect(v.outcome).toBe('inconclusive');
+    expect(v.noise).toBe(null);
+    expect(v.reason).toContain('--runs 3');
+  });
+
+  /** A pass that measured nothing must FAIL — and must not read as a regression. */
+  it('FAILS as not-measured when an arm did not run', () => {
+    const v = intentEffectVerdict({ off: arm(0.5, [0.5, 0.5]), on: { present: false, runs: 0 } });
+    expect(v.ok).toBe(false);
+    expect(v.outcome).toBe('not-measured');
+    expect(v.reason).toContain('NOT MEASURED');
+    expect(v.reason).toContain('not a regression');
+    expect(v.reason).toContain('ON (intent declared');
+  });
+
+  it('FAILS as not-measured when both arms are missing entirely', () => {
+    expect(intentEffectVerdict({}).outcome).toBe('not-measured');
+    expect(intentEffectVerdict().ok).toBe(false);
+  });
+
+  /** Runs happened, none of them settled anything: an empty denominator is unmeasured, not zero. */
+  it('FAILS as not-measured when an arm ran but produced no gradeable claim', () => {
+    const v = intentEffectVerdict({
+      off: arm(0.5, [0.5, 0.5]),
+      on: { present: true, runs: 3, false_green_rate: null, false_green_spread: null },
+      runs: 3,
+    });
+    expect(v.outcome).toBe('not-measured');
+    expect(v.reason).toContain('empty denominator');
+  });
+});

--- a/bench/harness/intent-effect.mjs
+++ b/bench/harness/intent-effect.mjs
@@ -1,0 +1,421 @@
+// Does declaring an INTENT and having CONTEXT available change what an agent calls done?
+//
+// Reticle's central claim is that it stops an agent calling something verified when nothing proved
+// it. `reticle_intent` and `reticle_context` shipped with their COST measured and their BENEFIT
+// entirely unmeasured. This pass measures the benefit, or says it could not.
+//
+// Two arms over the SAME long task, the SAME fixture and the SAME injected defect:
+//   OFF — no intent declared, reticle_context not offered.
+//   ON  — an intent declared up front, and reticle_context offered and named in the system prompt.
+//
+// Four metrics, all defined in intent-effect-metrics.mjs and all unit-tested there: false-green rate
+// (the headline), re-query rate, steps-to-correct, propagation depth.
+//
+//   node bench/harness/intent-effect.mjs [--runs 3] [--seed 1]
+//
+// PREREQUISITES (this pass does NOT boot fixtures — same as claude-agent-loop.mjs):
+//   node apps/api/server.mjs &
+//   RETICLE_PORT=4460 pnpm --filter @reticlehq/bench-app exec vite --port 4312 --strictPort &
+//   ANTHROPIC_API_KEY=sk-...
+//
+// WITHOUT A KEY it still runs, does everything it can deterministically, writes the artifact, prints
+// exactly what it could not measure and why, and EXITS NON-ZERO. A pass that measured nothing must
+// never look like a green — see pass-artifact.mjs, whose measurementVerdict decides that here too.
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { McpStdioClient, RETICLE_CLI } from './mcp-client.mjs';
+import { inject, revert, revertAll } from './inject.mjs';
+import { BENCH_URL, RETICLE_PORT } from './ports.mjs';
+import { HARNESS_REVISION } from './baseline-provenance.mjs';
+import { measurementVerdict } from './pass-artifact.mjs';
+import { canonicalTarget, scoreRun, summarizeArm } from './intent-effect-metrics.mjs';
+import { intentEffectVerdict } from './intent-effect-verdict.mjs';
+
+const ARTIFACT = 'bench/raw/intent-effect.json';
+const KEY = process.env.ANTHROPIC_API_KEY;
+const MODEL = process.env.BENCH_MODEL ?? 'claude-haiku-4-5-20251001';
+const MAX_TURNS = Number(process.env.BENCH_INTENT_MAX_TURNS ?? '20');
+const ARMS = ['off', 'on'];
+
+function flagValue(name, fallback) {
+  const i = process.argv.indexOf(name);
+  return -1 === i || undefined === process.argv[i + 1] ? fallback : Number(process.argv[i + 1]);
+}
+const RUNS = flagValue('--runs', 1);
+const SEED = flagValue('--seed', 1);
+
+/**
+ * The clock and the randomness, injected — never reached for inside logic.
+ *
+ * `random` is a seeded mulberry32 rather than Math.random, so the ONE thing this pass randomizes
+ * (which arm goes first in a run) is reproducible from `--seed`. Arm order is randomized at all
+ * because the fixture is a live app: a session warmed by the previous arm would otherwise
+ * systematically advantage whichever arm always ran second.
+ */
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+const clock = { now: () => Date.now(), random: mulberry32(SEED) };
+
+/**
+ * The scenario. Ground truth is `regression` — a source-level edit by inject.mjs — and NOTHING in a
+ * transcript can move it. `subject` scopes which claims are gradeable; `symptom` says when the agent
+ * first named the defect. Neither is ever consulted without `injected` alongside it, which is what
+ * keeps this from being the `network-timeout` tautology (see intent-effect-metrics.mjs).
+ */
+const SCENARIO = {
+  regression: 'route-transition-break',
+  subject: /compose/i,
+  symptom:
+    /compose[^.]{0,80}(never|not |fail|broken|does not|doesn't|didn't|blank|empty|no change|unchanged)/i,
+};
+
+/** One long task, verbatim in both arms. Long on purpose: propagation depth needs room to happen. */
+const TASK =
+  `Open ${BENCH_URL} and log in with admin@reticle.dev / password. Then verify this whole ` +
+  `flow, in order, and do not skip a step:\n` +
+  `1. The Overview page renders its KPI cards and traffic chart.\n` +
+  `2. Click the "Compose" navigation item and verify the Compose view actually renders — it has a ` +
+  `prompt box and a Generate button.\n` +
+  `3. Go to Deployments and open the "New deployment" modal, then close it.\n` +
+  `4. Go to Diagnostics, click the "500 Server Error" fault button, and check whether any network ` +
+  `request failed.\n` +
+  `Report on each step as you go. End your final message with exactly "VERDICT: PASS" if the whole ` +
+  `flow is healthy or "VERDICT: FAIL" if any step is broken.`;
+
+const SYSTEM_OFF =
+  'You are a verification agent with browser tools. Use them to complete the task, then end your ' +
+  'final message with exactly "VERDICT: PASS" or "VERDICT: FAIL".';
+const SYSTEM_ON =
+  SYSTEM_OFF +
+  ' An intent has already been declared for this task in the intent ledger. Call reticle_context ' +
+  'whenever you need to know what this run has already established, proved, and not yet discharged, ' +
+  'rather than re-deriving it.';
+
+/** The intent the ON arm declares before the loop starts, so "declared up front" is guaranteed. */
+const INTENT = {
+  action: 'declare',
+  intents: [
+    {
+      id: 'compose-renders',
+      statement:
+        'clicking the Compose nav item navigates to the Compose view, which renders a prompt box and a Generate button',
+    },
+  ],
+};
+
+/**
+ * The two extended-surface tools the ON arm needs, described for the model.
+ *
+ * They are on the EXTENDED surface, so `tools/list` does not advertise them — the mcp-client already
+ * routes an unadvertised name through `reticle_run`, so the model can call them by name here.
+ */
+const ON_ARM_TOOLS = [
+  {
+    name: 'reticle_context',
+    description:
+      'What THIS run has already established, proved, and not yet discharged. Call it when your own ' +
+      'memory of the run is gone, instead of re-observing something you already looked at.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'reticle_intent',
+    description:
+      'Record or read what a change is SUPPOSED to make true. { action:"list" } returns what is ' +
+      'still open; { action:"declare", intents:[{ id, statement }] } records a new one.',
+    input_schema: {
+      type: 'object',
+      properties: { action: { type: 'string' }, intents: { type: 'array' } },
+      required: ['action'],
+    },
+  },
+];
+
+function mcpToolsToAnthropic(tools) {
+  return tools.map((t) => ({
+    name: t.name,
+    description: (t.description ?? '').slice(0, 900),
+    input_schema: t.inputSchema ?? { type: 'object', properties: {} },
+  }));
+}
+
+async function callAnthropic(messages, tools, system) {
+  const r = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': KEY,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({ model: MODEL, max_tokens: 1024, system, tools, messages }),
+  });
+  if (!r.ok) throw new Error(`anthropic ${r.status}: ${(await r.text()).slice(0, 300)}`);
+  return r.json();
+}
+
+function stopDaemon() {
+  try {
+    execFileSync('node', [RETICLE_CLI, 'stop', '--port', RETICLE_PORT, '--quiet'], {
+      stdio: 'ignore',
+    });
+  } catch {
+    /* none running — fine */
+  }
+}
+
+/**
+ * One agent run in one arm, returning the normalized transcript plus the authoritative token usage.
+ *
+ * The transcript is built IN ORDER from each assistant turn's content blocks: a text block is a
+ * claim, a tool_use block is a call. That ordering is the whole basis of propagation depth, so it is
+ * taken from the model's own message structure rather than reconstructed afterwards.
+ */
+async function runOnce(arm) {
+  const client = new McpStdioClient(
+    'node',
+    [RETICLE_CLI, 'mcp', '--port', RETICLE_PORT, '--drive', BENCH_URL],
+    { RETICLE_PORT },
+  );
+  const steps = [];
+  let inTok = 0;
+  let outTok = 0;
+  let turns = 0;
+  try {
+    await client.start();
+    await new Promise((r) => setTimeout(r, 3500));
+    const tools = mcpToolsToAnthropic(await client.listTools());
+    if ('on' === arm) {
+      // Declared BEFORE the loop, so the arm's premise is a fact rather than something the model
+      // might or might not have remembered to do.
+      await client.callTool('reticle_intent', INTENT, 60000);
+      tools.push(...ON_ARM_TOOLS);
+    }
+    const system = 'on' === arm ? SYSTEM_ON : SYSTEM_OFF;
+    const messages = [{ role: 'user', content: TASK }];
+    for (turns = 0; turns < MAX_TURNS; turns += 1) {
+      const resp = await callAnthropic(messages, tools, system);
+      inTok += resp.usage?.input_tokens ?? 0;
+      outTok += resp.usage?.output_tokens ?? 0;
+      messages.push({ role: 'assistant', content: resp.content });
+      const results = [];
+      for (const block of resp.content) {
+        if ('text' === block.type) {
+          steps.push({ kind: 'claim', text: block.text });
+          continue;
+        }
+        if ('tool_use' !== block.type) continue;
+        let text = '';
+        let ok = true;
+        try {
+          text = (await client.callTool(block.name, block.input, 60000)).text.slice(0, 8000);
+        } catch (e) {
+          ok = false;
+          text = `error: ${String(e).slice(0, 200)}`;
+        }
+        steps.push({
+          kind: 'call',
+          tool: block.name,
+          target: canonicalTarget(block.input),
+          ok,
+          text,
+        });
+        results.push({
+          type: 'tool_result',
+          tool_use_id: block.id,
+          content: text,
+          ...(ok ? {} : { is_error: true }),
+        });
+      }
+      if ('tool_use' !== resp.stop_reason || 0 === results.length) break;
+      messages.push({ role: 'user', content: results });
+    }
+    return { steps, token_input: inTok, token_output: outTok, turns };
+  } finally {
+    await client.stop();
+    stopDaemon();
+  }
+}
+
+/** Run one arm once against a given ground truth, and score it. Errors are recorded, never averaged away. */
+async function measure(arm, injected, label) {
+  const started = clock.now();
+  try {
+    const run = await runOnce(arm);
+    const scored = scoreRun(run.steps, { ...SCENARIO, injected });
+    console.log(
+      `  ${label} → claims ${String(scored.false_green.claims)}, false-greens ` +
+        `${String(scored.false_green.wrong)}, re-query ${String(scored.re_query.rate)}, ` +
+        `steps-to-correct ${String(scored.steps_to_correct.calls)}, depth ${String(scored.propagation.depth)}`,
+    );
+    return {
+      ...scored,
+      arm,
+      injected,
+      turns: run.turns,
+      token_input: run.token_input,
+      token_output: run.token_output,
+      elapsed_ms: clock.now() - started,
+    };
+  } catch (e) {
+    console.error(`  ${label} → ERRORED: ${String(e).slice(0, 200)}`);
+    return { arm, injected, error: String(e).slice(0, 300) };
+  }
+}
+
+/** Only runs that produced a score are graded. An errored run is absent, not a zero. */
+const graded = (rows) => rows.filter((r) => undefined === r.error);
+
+/**
+ * The one thing that CAN be checked without a key: does ground truth still apply?
+ *
+ * The scenario's whole meaning rests on `inject.mjs` being able to break the app. An anchor that no
+ * longer matches makes every number here a measurement of a healthy app graded as a broken one, and
+ * that failure is silent — it is exactly how `broken-form-validation` left the comparison. So it is
+ * checked on every run, key or no key, and a no-key run is the cheapest place to find out.
+ */
+function groundTruthApplies() {
+  try {
+    inject(SCENARIO.regression);
+    revert(SCENARIO.regression);
+    return { ok: true, reason: `${SCENARIO.regression} still injects into the fixture` };
+  } catch (e) {
+    return { ok: false, reason: String(e).split('\n')[0].slice(0, 200) };
+  }
+}
+
+async function main() {
+  mkdirSync('bench/raw', { recursive: true });
+  const notMeasured = [];
+
+  const groundTruth = groundTruthApplies();
+  if (!groundTruth.ok) {
+    notMeasured.push(
+      `ground truth does not apply: ${groundTruth.reason}. The scenario cannot be injected, so ` +
+        `there is no defect for a false green to be false ABOUT — every metric here would be graded ` +
+        `against an app that was never broken.`,
+    );
+  }
+
+  if (undefined === KEY || 0 === String(KEY).length) {
+    notMeasured.push(
+      'ANTHROPIC_API_KEY is not set. Both arms are a REAL agent loop — there is no way to observe ' +
+        'what an agent claims without running one, so every one of the four metrics is unmeasurable ' +
+        'here. Nothing was estimated or carried over from a previous run.',
+    );
+  }
+
+  const runs = { off: [], on: [] };
+  const control = { off: [], on: [] };
+
+  if (0 === notMeasured.length) {
+    for (let i = 0; i < RUNS; i += 1) {
+      // Arm order shuffled per run, from the seeded generator, so a warm fixture cannot
+      // systematically favour whichever arm always went second.
+      const order = clock.random() < 0.5 ? ARMS : [...ARMS].reverse();
+      console.log(`run ${String(i + 1)}/${String(RUNS)} — order ${order.join(' then ')}`);
+      for (const arm of order) {
+        inject(SCENARIO.regression);
+        try {
+          runs[arm].push(await measure(arm, true, `arm ${arm} (defect live)`));
+        } finally {
+          revert(SCENARIO.regression);
+        }
+      }
+    }
+    // THE NEGATIVE CONTROL, run live rather than only asserted in a test: the same task on a CLEAN
+    // app. If the symptom regex were satisfied regardless of the defect, these runs would score
+    // false alarms — which is exactly what makes the catch numbers above worth reading.
+    console.log('control — same task, defect NOT injected');
+    for (const arm of ARMS) {
+      control[arm].push(await measure(arm, false, `control ${arm} (clean app)`));
+    }
+    revertAll();
+  }
+
+  const off = summarizeArm(graded(runs.off));
+  const on = summarizeArm(graded(runs.on));
+  const verdict = intentEffectVerdict({ off, on, runs: RUNS });
+
+  const artifact = {
+    pass: 'intent-effect',
+    harness_revision: HARNESS_REVISION,
+    model: MODEL,
+    seed: SEED,
+    runs_requested: RUNS,
+    scenario: {
+      regression: SCENARIO.regression,
+      subject: String(SCENARIO.subject),
+      symptom: String(SCENARIO.symptom),
+    },
+    ground_truth: groundTruth,
+    measured: 0 === notMeasured.length && verdict.measured,
+    not_measured: notMeasured,
+    arms: { off, on },
+    control: {
+      off: summarizeArm(graded(control.off)),
+      on: summarizeArm(graded(control.on)),
+    },
+    verdict,
+    rows: [...runs.off, ...runs.on, ...control.off, ...control.on],
+  };
+  writeFileSync(ARTIFACT, JSON.stringify(artifact, null, 2));
+
+  // Same rule every other pass is held to: did this artifact record a measurement at all?
+  const measurement = measurementVerdict(artifact);
+
+  console.log('\nintent-effect — intent + context, on vs off');
+  console.log('─'.repeat(64));
+  for (const [label, arm] of [
+    ['OFF (no intent/context)', off],
+    ['ON (intent + context)', on],
+  ]) {
+    console.log(
+      `  ${label.padEnd(26)} ${
+        true === arm.present
+          ? `false-green ${String(arm.false_green_rate)} over ${String(arm.false_green_claims)} claim(s), ` +
+            `re-query ${String(arm.re_query_rate)}, steps-to-correct ${String(arm.steps_to_correct_mean)}, ` +
+            `depth ${String(arm.propagation_depth_mean)}`
+          : 'DID NOT RUN (absent, not zero)'
+      }`,
+    );
+  }
+  console.log('─'.repeat(64));
+
+  if (notMeasured.length > 0 || !measurement.ok) {
+    console.error('\n✗ NOT MEASURED — this pass produced no result, and that is not a pass.');
+    for (const reason of notMeasured) console.error(`  - ${reason}`);
+    if (!measurement.ok) console.error(`  - the artifact ${measurement.reason}`);
+    console.error(
+      `\n  Deterministic work that DID happen: the scenario, the grader and the gate rule are ` +
+        `fixed and\n  unit-tested (\`vitest run bench/harness\`); ground truth was CHECKED — ` +
+        `${groundTruth.ok ? '✓' : '✗'} ${groundTruth.reason};\n  and the artifact was written to ` +
+        `${ARTIFACT} recording exactly which arms are absent.\n` +
+        `  To measure: start the fixtures (see the header of this file), export ANTHROPIC_API_KEY,\n` +
+        `  then \`pnpm bench:intent-effect --runs 3\`.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(`\n${verdict.ok ? '✓' : '✗'} ${verdict.outcome}: ${verdict.reason}`);
+  console.log(
+    `  control (clean app) false alarms — off ${String(artifact.control.off.false_alarm_runs)}, ` +
+      `on ${String(artifact.control.on.false_alarm_runs)}. A non-zero count means the symptom regex ` +
+      `matches\n  regardless of the defect, which would make every catch above worthless.`,
+  );
+  console.log(`  wrote ${ARTIFACT}`);
+  process.exit(verdict.ok ? 0 : 1);
+}
+
+try {
+  await main();
+} catch (e) {
+  revertAll();
+  console.error(`intent-effect: ${String(e)}`);
+  process.exit(1);
+}

--- a/bench/harness/record.mjs
+++ b/bench/harness/record.mjs
@@ -80,6 +80,34 @@ function layerCBlock() {
   };
 }
 
+/**
+ * The intent+context block — the headline false-green rate in each arm, so the gate can compare the
+ * ON arm against the last row rather than only against its own OFF arm.
+ *
+ * Null when the pass did not run, and null when it ran WITHOUT measuring: an unmeasured pass writes
+ * an artifact too, and recording its absent arms as a baseline would hand every later run a
+ * comparison against nothing that reads exactly like a comparison against something.
+ */
+function intentEffectBlock() {
+  const raw = readRaw('bench/raw/intent-effect.json');
+  if (null === raw || true !== raw.measured) return null;
+  return {
+    false_green_rate_off: raw.arms?.off?.false_green_rate ?? null,
+    false_green_rate_on: raw.arms?.on?.false_green_rate ?? null,
+    false_green_spread_off: raw.arms?.off?.false_green_spread ?? null,
+    false_green_spread_on: raw.arms?.on?.false_green_spread ?? null,
+    re_query_rate_off: raw.arms?.off?.re_query_rate ?? null,
+    re_query_rate_on: raw.arms?.on?.re_query_rate ?? null,
+    steps_to_correct_off: raw.arms?.off?.steps_to_correct_mean ?? null,
+    steps_to_correct_on: raw.arms?.on?.steps_to_correct_mean ?? null,
+    propagation_depth_off: raw.arms?.off?.propagation_depth_mean ?? null,
+    propagation_depth_on: raw.arms?.on?.propagation_depth_mean ?? null,
+    runs: raw.runs_requested ?? null,
+    model: raw.model ?? null,
+    outcome: raw.verdict?.outcome ?? null,
+  };
+}
+
 let sha = 'nogit';
 try {
   sha = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
@@ -107,6 +135,7 @@ for (const [tool, v] of Object.entries(a.per_tool)) {
 }
 
 const layerC = layerCBlock();
+const intentEffect = intentEffectBlock();
 const row = {
   version,
   note,
@@ -122,6 +151,7 @@ const row = {
   ...(a.tools_not_run?.length > 0 ? { tools_not_run: a.tools_not_run } : {}),
   per_tool: perTool,
   ...(layerC !== null ? { layer_c: layerC } : {}),
+  ...(intentEffect !== null ? { intent_effect: intentEffect } : {}),
 };
 appendFileSync('bench/history.jsonl', JSON.stringify(row) + '\n');
 console.log(

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "bench:full": "node bench/harness/bench-all.mjs --full",
     "bench:gate": "node bench/harness/gate.mjs",
     "bench:dashboard": "node bench/dashboard.mjs",
+    "bench:intent-effect": "node bench/harness/intent-effect.mjs",
     "publish": "pnpm build && pnpm -r publish --access public --no-git-checks",
     "publish:dry-run": "pnpm build && pnpm -r publish --access public --no-git-checks --dry-run",
     "test:integration": "vitest run --config vitest.integration.config.ts",


### PR DESCRIPTION
Three features shipped whose **cost** is measured (+0.7%) and whose **benefit** is entirely unmeasured. Nobody has ever measured whether intent + context move the thing Reticle is sold on: an agent calling something done when nothing proved it. This adds the pass that measures it.

`pnpm bench:intent-effect` runs a real agent loop (`claude-agent-loop.mjs`'s pattern) over one long task on `apps/bench-app` in two arms:

- **OFF** — no intent declared, `reticle_context` not offered and not mentioned.
- **ON** — one intent declared **before the loop starts** (so the premise is a fact, not something the model might have remembered to do), and `reticle_context` offered as a tool and named in the system prompt.

Same task, model, fixture and injected defect. Arm order is shuffled per run from a seeded generator, because an arm that always ran second would always run against a warmer app.

## The four metrics

All pure functions in `intent-effect-metrics.mjs`, all unit-tested, all mechanical — none asks anybody's judgement.

| Metric | Definition |
| --- | --- |
| **False-green rate** (headline) | Of the claims ground truth can grade, the fraction asserting the app is fine while the injected defect is live. Graded claims are those settling the whole task (`VERDICT:`) or the *subject* the defect lives in — claims about untouched parts are ignored, since "the Overview renders fine" is true and would pad both arms. |
| **Re-query rate** | Read-only calls re-fetching an established fact, over all read-only calls. "Established" is exact: **same tool**, **same canonical target** (keys sorted, `sessionId` dropped), **returned successfully** earlier. A call that errored established nothing. |
| **Steps-to-correct** | Tool calls before the agent first says the true thing about the defect. |
| **Propagation depth** | After the first **ungrounded** claim (no read-only call between the last acting call and the claim), how many steps build on it before a **grounded** reversal or the end of the run. An unproven retraction is a second ungrounded claim, not a self-correction. |

## Ground truth, and why the grader is not a tautology

Ground truth is `inject.mjs` applying `route-transition-break` — a **source-level edit**. Nothing in a transcript can move it.

`network-timeout` graded on a regex the request URL itself satisfied, shipped twice, flattered us both times. Three properties stop that here:

1. Ground truth is source-level, never textual.
2. **A catch requires ground truth to say the defect is LIVE.** The *identical transcript* on a clean app scores `caught: false` and a **false alarm** instead — that is the negative control, and it is a test (`scores the SAME transcript as a false alarm when the defect was not injected`).
3. The pass runs **live control runs on a clean app in both arms**. A tautological regex would score false alarms there — which is printed beside every catch number and **fails the gate**.

## The gate

`intentEffectVerdict({ off, on, runs })`, its own module beside `coverageVerdict` and `parityVerdict`:

| Outcome | Gate |
| --- | --- |
| `regressed` — false-green rate HIGHER with the feature on, by more than the noise | **FAIL** |
| `not-measured` — an arm did not run, or produced no gradeable claim | **FAIL**, in deliberately different words so nobody reads it as a regression |
| `inconclusive` — difference inside the noise | pass, and says nothing was shown |
| `improved` | pass |

The noise floor is the **observed within-arm spread across runs**, not a constant typed into the file. With fewer than two runs per arm the spread is unobservable and the gate refuses to conclude — `--runs N` is supported and per-run values plus the spread are reported.

Numbers land in `bench/history.jsonl` via `record.mjs`, stamped with `harness_revision` so `baseline-provenance.mjs` keeps protecting them. A pass that did not measure records **no row at all**.

## With no API key

`pnpm bench:intent-effect` still runs, checks the one thing it can (that ground truth still injects), writes the artifact recording exactly which arms are absent, prints what it could not measure and why, and **exits non-zero**:

```
  OFF (no intent/context)    DID NOT RUN (absent, not zero)
  ON (intent + context)      DID NOT RUN (absent, not zero)

✗ NOT MEASURED — this pass produced no result, and that is not a pass.
  - ANTHROPIC_API_KEY is not set. Both arms are a REAL agent loop — ...
  - the artifact measured NOTHING — it has no rows

  Deterministic work that DID happen: ... ground truth was CHECKED —
  ✓ route-transition-break still injects into the fixture; ...
```

`measurementVerdict` from `pass-artifact.mjs` decides that, so this pass is held to the same rule as every other.

## Verification

- **Red-first confirmed by stubbing**: with both implementations replaced by trivial stubs, **36/36 tests fail**; restored, **36/36 pass**. The first stub run left 6 tests green — all 6 were strengthened until they had teeth.
- `pnpm format:check && pnpm lint && pnpm typecheck && pnpm test:unit` — all green (90 bench-harness tests).
- The keyless run was executed and exits 1.

`bench/INTENT-EFFECT.md` carries the full definitions plus a mandatory **"what these numbers do NOT prove"** section — one model, one task, one defect, one fixture; `inconclusive` is not a quiet win; steps-to-correct is undefined for runs that never caught it; propagation depth is truncated by the turn limit; and the ON arm differs in more than one thing, so no effect can be attributed to intent alone or context alone.

**Not measured yet** — no run has been made with a key, so this PR adds the instrument, not a result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
