### PR TITLE
fix(server): keep no-session action aligned with config scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ### Fixed
 
+- **`@reticlehq/server` — a config discovered in another monorepo app no longer produces a contradictory `reticle init` action.** The no-session prose already treated a `.reticle.json` found outside the daemon's directory as positive evidence of a scope problem, but `next_action` did not receive that discovery and could simultaneously claim no config was found. Both halves now consume the same live scope facts, name the discovered directory and project ID, and recommend scoping the daemon to that app or acquiring its URL with `reticle_lease` instead of reinitializing a working install.
+
 - **`@reticlehq/server` — an instrumentation gap told the agent an app was unverifiable and gave it nowhere to go.** A gap exists to be acted on: it names an absence in the app, the cost that absence imposed on the verdict just returned, and the one change that closes it. What it never carried was a location. The type declared an optional `file:line` and no producer had ever set one, so every gap went out with a `ref` and nothing else.
 
   A `ref` is a handle to a DOM node, and gaps are read late. `reticle_verify { action: "coverage" }` is the "am I done?" call, made long after the verdict that recorded the gap, by which time the page has re-rendered and the handle very likely resolves to nothing. So the surface aimed squarely at a build-and-verify loop was handing that loop a remedy with no address.

--- a/packages/server/src/session/no-session-next-action.test.ts
+++ b/packages/server/src/session/no-session-next-action.test.ts
@@ -59,6 +59,22 @@ describe('nextActionFor', () => {
     expect(next.command).not.toContain('run dev');
   });
 
+  it('a config found in another app directory is a scope problem, never an init problem', () => {
+    const next = nextActionFor({
+      everConnected: false,
+      initialized: false,
+      listening: [5173],
+      dev: DEV,
+      configsElsewhere: [{ directory: '/repo/apps/client', projectId: 'client-1' }],
+    });
+    expect(next.action).toBe(NoSessionAction.OPEN_APP);
+    expect(next.command).not.toBe('reticle init');
+    expect(next.reason).toContain('/repo/apps/client');
+    expect(next.reason).toContain('client-1');
+    expect(next.reason).toMatch(/scope|directory/i);
+    expect(next.reason).toContain('reticle_lease');
+  });
+
   it('a wired app is listening: open it — never a second dev server', () => {
     const next = nextActionFor({
       everConnected: false,

--- a/packages/server/src/session/no-session-next-action.ts
+++ b/packages/server/src/session/no-session-next-action.ts
@@ -32,6 +32,8 @@ interface NextActionFacts {
   initialized: boolean;
   listening: readonly number[];
   dev: DevCommand | undefined;
+  /** Configs found in other workspace directories: positive evidence of a scope mismatch. */
+  configsElsewhere?: readonly { directory: string; projectId?: string }[];
   /**
    * An app for this project has connected on this port before, from durable state.
    *
@@ -57,6 +59,32 @@ export function nextActionFor(facts: NextActionFacts): NoSessionNextAction {
         'a session was connected to this daemon earlier, so the wiring is correct — the tab was ' +
         'closed, reloaded, or the lease aged out. Reopen the app, or take one you own with ' +
         'reticle_lease {action:"acquire", url}.',
+    };
+  }
+
+  const configsElsewhere = facts.configsElsewhere ?? [];
+  if (!facts.initialized && configsElsewhere.length > 0) {
+    const named = configsElsewhere
+      .map((config) =>
+        config.projectId === undefined
+          ? config.directory
+          : `${config.directory} ('${config.projectId}')`,
+      )
+      .join(', ');
+    const projectIds = configsElsewhere.flatMap((config) =>
+      config.projectId === undefined ? [] : [config.projectId],
+    );
+    const leaseAlternative =
+      0 === projectIds.length
+        ? ''
+        : ' Alternatively, acquire the app URL explicitly with reticle_lease ' +
+          '{action:"acquire", url, projectId} using the matching projectId above.';
+    return {
+      action: NoSessionAction.OPEN_APP,
+      reason:
+        `a \`.reticle.json\` was found outside this daemon's directory: ${named}. This is a ` +
+        "scope problem, not an install problem. Restart the daemon from the app's directory (or " +
+        `point it there), then open the app.${leaseAlternative}`,
     };
   }
 

--- a/packages/server/src/session/no-session-watch.test.ts
+++ b/packages/server/src/session/no-session-watch.test.ts
@@ -11,10 +11,12 @@
  * by init after this daemon started"); `initialized` simply never got it.
  */
 import { describe, expect, it, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { NoSessionAction } from '@reticlehq/core';
 import { startNoSessionWatch } from './no-session-watch.js';
+import type { NoSessionNextAction } from './no-session-next-action.js';
 import type { SessionManager } from './session-manager.js';
 
 const dirs: string[] = [];
@@ -30,18 +32,29 @@ function projectDir(config: string | undefined): string {
 }
 
 /** The few things the watch asks of a SessionManager, and nothing else. */
-function stubSessions(): { manager: SessionManager; hint: () => string } {
+function stubSessions(): {
+  manager: SessionManager;
+  hint: () => string;
+  next: () => NoSessionNextAction | undefined;
+} {
   let installed: (() => string | undefined) | undefined;
+  let nextAction: (() => NoSessionNextAction | undefined) | undefined;
   const manager = {
     count: () => 0,
     everConnected: () => false,
     setNoSessionHint: (hint: (() => string | undefined) | undefined) => {
       installed = hint;
     },
-    setNoSessionNextAction: () => undefined,
+    setNoSessionNextAction: (next: (() => NoSessionNextAction | undefined) | undefined) => {
+      nextAction = next;
+    },
     setConnectionRecorder: () => undefined,
   } as unknown as SessionManager;
-  return { manager, hint: () => installed?.() ?? '' };
+  return {
+    manager,
+    hint: () => installed?.() ?? '',
+    next: () => nextAction?.(),
+  };
 }
 
 describe('the no-session diagnosis and a config written after boot', () => {
@@ -79,5 +92,31 @@ describe('the no-session diagnosis and a config written after boot', () => {
     const message = hint();
     stop();
     expect(message).toMatch(/no `\.reticle\.json`/);
+  });
+
+  it('builds the prose and next action from the same config discovered in another app', async () => {
+    const dir = projectDir(undefined);
+    const appDir = join(dir, 'apps', 'client');
+    mkdirSync(join(dir, '.git'), { recursive: true });
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(join(appDir, '.reticle.json'), JSON.stringify({ projectId: 'client-1' }), 'utf8');
+    const { manager, hint, next } = stubSessions();
+    const stop = startNoSessionWatch({
+      sessions: manager,
+      port: 4400,
+      initialized: false,
+      directory: dir,
+      probe: () => Promise.resolve([5173]),
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    const why = hint();
+    const nextAction = next();
+    stop();
+
+    expect(why).toContain(appDir);
+    expect(nextAction?.action).not.toBe(NoSessionAction.RUN_INIT);
+    expect(nextAction?.reason).toContain(appDir);
+    expect(nextAction?.reason).not.toMatch(/no `\.reticle\.json` was found/i);
   });
 });

--- a/packages/server/src/session/no-session-watch.ts
+++ b/packages/server/src/session/no-session-watch.ts
@@ -12,6 +12,7 @@
 
 import { probeDevServers, probeDevServerStates } from './dev-server-probe.js';
 import { diagnoseNoSession } from './no-session-diagnosis.js';
+import type { NoSessionFacts } from './no-session-diagnosis.js';
 import { detectDevCommand } from './dev-command.js';
 import { nextActionFor, renderNextAction } from './no-session-next-action.js';
 import type { NoSessionNextAction } from './no-session-next-action.js';
@@ -107,6 +108,32 @@ export function startNoSessionWatch(options: NoSessionWatchOptions): () => void 
   // `initialized` comment below, which this shares.
   const isWired = (): boolean => options.initialized || readProjectId(directory) !== undefined;
 
+  type ProjectScopeFacts = Pick<
+    NoSessionFacts,
+    'initialized' | 'configsElsewhere' | 'searchedDirectories'
+  >;
+
+  /**
+   * Resolve the daemon's current project scope once for both halves of a sessions response.
+   *
+   * This remains a live read because `init` commonly writes the config after the daemon starts.
+   */
+  const projectScopeFacts = (): ProjectScopeFacts => {
+    const initialized = isWired();
+    if (initialized) return { initialized };
+    const discovery = discoverProjectConfigs(directory);
+    const elsewhere = discovery.found.filter((config) => config.directory !== directory);
+    return 0 === elsewhere.length
+      ? { initialized, searchedDirectories: discovery.searched }
+      : {
+          initialized,
+          configsElsewhere: elsewhere.map((config) => ({
+            directory: config.directory,
+            ...(config.projectId === undefined ? {} : { projectId: config.projectId }),
+          })),
+        };
+  };
+
   // Read at boot: the daemon's own identity does not change under it, and this is the key the
   // durable bit is stored under.
   const stateDir = options.stateDir ?? reticleStateHome();
@@ -187,10 +214,11 @@ export function startNoSessionWatch(options: NoSessionWatchOptions): () => void 
   const timer = setInterval(refresh, REFRESH_MS);
   timer.unref();
 
-  const nextAction = (): NoSessionNextAction =>
+  const nextAction = (scope: ProjectScopeFacts): NoSessionNextAction =>
     nextActionFor({
       everConnected: options.sessions.everConnected(),
-      initialized: isWired(),
+      initialized: scope.initialized,
+      ...(scope.configsElsewhere === undefined ? {} : { configsElsewhere: scope.configsElsewhere }),
       previouslyConnected: connectedBefore(),
       listening,
       // Read when asked, like everything else here: a `package.json` can gain a dev script, and a
@@ -198,10 +226,11 @@ export function startNoSessionWatch(options: NoSessionWatchOptions): () => void 
       dev: detectDevCommand(directory),
     });
 
-  options.sessions.setNoSessionNextAction(nextAction);
+  options.sessions.setNoSessionNextAction(() => nextAction(projectScopeFacts()));
 
-  options.sessions.setNoSessionHint(
-    () =>
+  options.sessions.setNoSessionHint(() => {
+    const scope = projectScopeFacts();
+    return (
       diagnoseNoSession({
         everConnected: options.sessions.everConnected(),
         // Read WHEN ASKED, for the same reason `projectPort` below is: `.reticle.json` is routinely
@@ -210,7 +239,7 @@ export function startNoSessionWatch(options: NoSessionWatchOptions): () => void 
         // saying the project had never been through `init` about a project whose config named its
         // framework and its projectId, and whose real problem was a dev server older than the plugin.
         // The boot value still counts: it is the one the daemon scoped its sessions with.
-        initialized: isWired(),
+        ...scope,
         listening,
         slowListeners,
         port: options.port,
@@ -218,23 +247,6 @@ export function startNoSessionWatch(options: NoSessionWatchOptions): () => void 
         // `.reticle.json`" is a claim about ONE directory, and a reader standing somewhere else
         // cannot tell whether it is a claim about their app at all.
         directory,
-        // Where the config actually is, when it is not here — and where we looked, when it is
-        // nowhere. Computed only on the branch that needs it: a wired daemon has its answer already,
-        // and a workspace scan on every hint would be a directory walk per tool refusal.
-        ...(isWired()
-          ? {}
-          : (() => {
-              const discovery = discoverProjectConfigs(directory);
-              const elsewhere = discovery.found.filter((c) => c.directory !== directory);
-              return 0 === elsewhere.length
-                ? { searchedDirectories: discovery.searched }
-                : {
-                    configsElsewhere: elsewhere.map((c) => ({
-                      directory: c.directory,
-                      ...(c.projectId === undefined ? {} : { projectId: c.projectId }),
-                    })),
-                  };
-            })()),
         // The one fact that outranks every absence below it, and the reason a fresh daemon stopped
         // claiming that an install which has demonstrably worked has never worked.
         previouslyConnected: connectedBefore(),
@@ -259,11 +271,12 @@ export function startNoSessionWatch(options: NoSessionWatchOptions): () => void 
           return configured === undefined ? {} : { projectPort: configured };
         })(),
       }) +
-      // Prose for the human, then the literal command for the agent. Appended rather than folded
-      // into the diagnosis so that file stays pure and its cases stay independently pinned.
-      ` ${renderNextAction(nextAction())}` +
-      (attachFailure ?? ''),
-  );
+      // Prose for the human, then the literal command for the agent. Both consume the same scope
+      // facts so a discovered workspace config cannot become an `init` recommendation below it.
+      ` ${renderNextAction(nextAction(scope))}` +
+      (attachFailure ?? '')
+    );
+  });
 
   return () => {
     clearInterval(timer);


### PR DESCRIPTION
## What & why

Closes #520

`reticle_sessions` could diagnose a `.reticle.json` in another monorepo app while its structured `next_action` simultaneously claimed no config existed and recommended `reticle init`.

This change resolves the live project-scope facts once for both halves of the no-session response, passes discovered configs into `nextActionFor`, and ranks that positive evidence ahead of all absence-based actions. The recommendation now names the discovered directory/project ID and tells the caller to scope the daemon there or acquire the app URL with `reticle_lease`; it never reinitializes a working install.

## How it was verified

- Added a pure-function regression test first and confirmed it failed with `run_init`.
- Added the payload-level invariant test first and confirmed the prose/structured-action contradiction.
- Confirmed both new tests pass after the implementation.
- Ran the complete unit and benchmark suite under Node 22.23.2, matching CI: server 4,827 tests; browser 1,129 tests; all other package tests; and 54 benchmark tests passed.
- No e2e tier is needed because this changes neither the tool surface nor the wire contract.

## Gates run

- [x] `pnpm format:check`
- [x] `pnpm lint && pnpm typecheck && pnpm test:unit`
- [ ] `pnpm test:e2e` — not applicable; no tool surface, core, observer, or telemetry change
- [ ] `pnpm gate:install` — not applicable
- [ ] `pnpm test:e2e:desktop` — not applicable
- [ ] None of the above tiers apply to this change

## Checklist

- [x] **Every commit is signed off** (`git commit -s`)
- [x] Tests added/updated (RED → GREEN); the change is covered by a test that would fail without it
- [x] No `any`, no free wire strings, no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed source file is under the 1000-line cap
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Security-affecting: not applicable; no auth, redaction, or trust-boundary behavior changed

AI disclosure: I used Codex while developing this change and reviewed and validated the resulting diff and test results.