### PR TITLE
feat(server): reticle_context and reticle_intent were unmeasurable, so unkillable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ### Added
 
+- **`@reticlehq/server` — `reticle_verify { action: "coverage" }` now reports whether this session used `reticle_context` and `reticle_intent` at all.** Both features shipped with the same pre-registered disproof — _if agents never call it, cut it_ — and nothing recorded whether they were called, so the disproof could never be run. A feature whose disproof cannot be run is one nobody can kill, which is the same defect that kept the old push-based run context alive.
+
+  The new `featureUse` block answers it locally, per session: how many times `reticle_context` was called and at which step, what the intent ledger holds, and the two costs of NOT using either — verdicts drawn while the ledger was empty, and read-only calls that re-fetched a fact the run had already established. It also carries a mechanical proxy for whether calling `reticle_context` changed anything: after each call, did the agent ACT, or did it re-read a subject the context had just supplied. That proxy is proximity in a call sequence and nothing more; what it cannot see is written down beside it.
+
+  **Absent is never zero.** A session this daemon recorded nothing for reports `observed: false` and states no counts, because "we were not watching" and "it was not used" are different answers and only one of them is true. It is an instrument for deciding whether two features earn their place, not a judgement on how anybody drove.
+
 - **`@reticlehq/server` — `reticle_context` and `reticle_intent` are now named where an agent will actually read them.** Both sit on the extended surface, so neither appears in the tool list an agent is handed by default, and neither was mentioned in the MCP server instructions or the skill. Nothing an agent reads on connect said either tool existed. Two features can be perfectly built and still have an effect size of zero, because nobody can call what nobody has heard of.
 
   The instructions now carry two sentences saying what each is FOR — ask what this run established instead of re-snapshotting to rediscover it; declare what a change was meant to do so the verdict has something to check against other than itself — and `SKILL.md` carries the `reticle_run` call shape for both, beside the one it already documents for `reticle_verify`.

--- a/packages/server/src/honesty/feature-capture.test.ts
+++ b/packages/server/src/honesty/feature-capture.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import { IntentState, Verified, type Intent, type JournalAction } from '@reticlehq/core';
+import { ReticleTool } from '../tools/tool-names.js';
+import { CaptureLedger, foldFeatureCapture, type CapturedCall } from './feature-capture.js';
+
+const ACTED_REF = 'e7';
+const OTHER_REF = 'e9';
+const CLAIM = 'the badge reads checked in';
+
+function action(overrides: Partial<JournalAction> = {}): JournalAction {
+  return {
+    v: 1,
+    actionId: 'a1',
+    tool: ReticleTool.ACT_AND_WAIT,
+    args: { ref: ACTED_REF },
+    settled: true,
+    tRange: { from: 0, to: 1 },
+    at: 0,
+    ...overrides,
+  };
+}
+
+function intent(overrides: Partial<Intent> = {}): Intent {
+  return {
+    id: 'checkin',
+    statement: CLAIM,
+    state: IntentState.DECLARED,
+    declaredAt: 1,
+    ...overrides,
+  };
+}
+
+function fold(input: {
+  calls?: readonly CapturedCall[];
+  dropped?: number;
+  actions?: readonly JournalAction[];
+  intents?: readonly Intent[];
+  finalActions?: number;
+}) {
+  return foldFeatureCapture({
+    calls: input.calls ?? [],
+    dropped: input.dropped ?? 0,
+    actions: input.actions ?? [],
+    intents: input.intents ?? [],
+    finalActions: input.finalActions ?? (input.actions ?? []).length,
+  });
+}
+
+describe('CaptureLedger', () => {
+  it('counts a reticle_context call', () => {
+    const ledger = new CaptureLedger();
+    ledger.note({ tool: ReticleTool.CONTEXT, afterActions: 3 });
+
+    expect(fold({ calls: ledger.calls(), finalActions: 3 }).context?.calls).toBe(1);
+  });
+
+  it('reports the step each reticle_context call was made at', () => {
+    const ledger = new CaptureLedger();
+    ledger.note({ tool: ReticleTool.CONTEXT, afterActions: 0 });
+    ledger.note({ tool: ReticleTool.CONTEXT, afterActions: 4 });
+
+    expect(fold({ calls: ledger.calls(), finalActions: 4 }).context?.atSteps).toEqual([0, 4]);
+  });
+});
+
+describe('foldFeatureCapture', () => {
+  it('reads as not observed for a session with no journal and no recorded call', () => {
+    const report = fold({});
+
+    expect(report.observed).toBe(false);
+    expect(report.context).toBeUndefined();
+  });
+
+  it('counts verdicts drawn with no intent covering them', () => {
+    const verdict = { claim: CLAIM, verified: Verified.YES };
+    const report = fold({
+      actions: [action({ effect: verdict }), action({ actionId: 'a2', effect: verdict })],
+      intents: [],
+    });
+
+    expect(report.missed?.verdictsWithNoIntentDeclared).toBe(2);
+  });
+
+  it('counts no uncovered verdict once the ledger holds an intent', () => {
+    const report = fold({
+      actions: [action({ effect: { claim: CLAIM, verified: Verified.YES } })],
+      intents: [intent()],
+    });
+
+    expect(report.missed?.verdictsWithNoIntentDeclared).toBe(0);
+  });
+
+  it('counts a read that re-fetched an already-established fact', () => {
+    const report = fold({
+      calls: [{ tool: ReticleTool.INSPECT, subject: ACTED_REF, afterActions: 1 }],
+      actions: [action()],
+    });
+
+    expect(report.missed?.refetchedEstablished).toBe(1);
+  });
+
+  it('does not count a first look as a re-fetch', () => {
+    const report = fold({
+      calls: [{ tool: ReticleTool.INSPECT, subject: ACTED_REF, afterActions: 0 }],
+      actions: [action()],
+      finalActions: 1,
+    });
+
+    expect(report.missed?.refetchedEstablished).toBe(0);
+  });
+
+  it('does not count a read of a subject nothing established', () => {
+    const report = fold({
+      calls: [{ tool: ReticleTool.INSPECT, subject: OTHER_REF, afterActions: 1 }],
+      actions: [action()],
+    });
+
+    expect(report.missed?.refetchedEstablished).toBe(0);
+  });
+
+  it('reads `acted` when an action followed the context call', () => {
+    const report = fold({
+      calls: [
+        { tool: ReticleTool.CONTEXT, afterActions: 1 },
+        { tool: ReticleTool.QUERY, afterActions: 2 },
+      ],
+      actions: [action(), action({ actionId: 'a2' })],
+    });
+
+    expect(report.context?.acted).toBe(1);
+    expect(report.context?.refetched).toBe(0);
+  });
+
+  it('reads `refetched` when the next read asked for what the context had just supplied', () => {
+    const report = fold({
+      calls: [
+        { tool: ReticleTool.CONTEXT, afterActions: 1 },
+        { tool: ReticleTool.INSPECT, subject: ACTED_REF, afterActions: 1 },
+      ],
+      actions: [action()],
+    });
+
+    expect(report.context?.refetched).toBe(1);
+    expect(report.context?.acted).toBe(0);
+  });
+
+  it('reads `acted` when the run ended on an action after the last context call', () => {
+    const report = fold({
+      calls: [{ tool: ReticleTool.CONTEXT, afterActions: 0 }],
+      actions: [action()],
+      finalActions: 1,
+    });
+
+    expect(report.context?.acted).toBe(1);
+  });
+
+  it('reads `nothingAfter` when nothing at all followed the context call', () => {
+    const report = fold({
+      calls: [{ tool: ReticleTool.CONTEXT, afterActions: 1 }],
+      actions: [action()],
+      finalActions: 1,
+    });
+
+    expect(report.context?.nothingAfter).toBe(1);
+    expect(report.context?.acted).toBe(0);
+  });
+
+  it('reports the intent ledger as declared and still open', () => {
+    const report = fold({
+      calls: [{ tool: ReticleTool.CONTEXT, afterActions: 0 }],
+      intents: [intent(), intent({ id: 'other', state: IntentState.PROVED })],
+    });
+
+    expect(report.intents).toEqual({ declared: 2, open: 1 });
+  });
+
+  it('says so when the ledger dropped calls rather than reporting a short count as complete', () => {
+    const report = fold({
+      calls: [{ tool: ReticleTool.CONTEXT, afterActions: 0 }],
+      dropped: 3,
+    });
+
+    expect(report.truncated).toBe(true);
+  });
+});

--- a/packages/server/src/honesty/feature-capture.ts
+++ b/packages/server/src/honesty/feature-capture.ts
@@ -1,0 +1,263 @@
+import {
+  IntentState,
+  JournalVerdictEffectSchema,
+  RUN_ESTABLISHED_CAP,
+  type Intent,
+  type JournalAction,
+} from '@reticlehq/core';
+import { subjectOf } from '../runs/run-context.js';
+import { ReticleTool } from '../tools/tool-names.js';
+
+/**
+ * Were `reticle_context` and `reticle_intent` used at all — and did using them change anything?
+ *
+ * Both shipped with the same pre-registered disproof: *if agents never call it, cut it*. Nothing
+ * recorded whether they were called, so the disproof could never be run, and a feature whose
+ * disproof cannot be run is one nobody can kill. This is the smallest thing that makes the question
+ * answerable, per session, locally — an instrument, not a scold. The numbers exist so a FEATURE can
+ * be removed, never so an agent can be blamed for how it drove.
+ *
+ * ## Fold first, record only what nothing records
+ *
+ * Three of the four questions are already answerable from what is on disk. The intent ledger says
+ * what was declared; the journal says what was driven and what verdicts were drawn. Those are folded
+ * here and never re-stored, for the reason `run-context.ts` gives at length: two ways to compute one
+ * number is worse than one way.
+ *
+ * The journal does NOT record read-only calls — it holds actions and verdicts only. So "was
+ * `reticle_context` called" has no ledger to fold, and that one thing is recorded, in memory, on the
+ * session, by `CaptureLedger`. It is the whole of the new state.
+ *
+ * ## Absent is not zero
+ *
+ * A session this daemon has recorded nothing for — journaling off, a session adopted after the fact
+ * — reports `observed: false` and states no counts at all. It has not established that the features
+ * went unused; it has established that it was not watching. This repo has shipped the other bug
+ * twice.
+ */
+
+/**
+ * The calls this instrument needs and the journal does not keep.
+ *
+ * Deliberately a short explicit list rather than "everything that is not an action". Under-inclusion
+ * is the safe direction: a read tool missing from here lowers the hit side and the miss side by the
+ * same call, so the comparison the disproof turns on stays fair. Over-inclusion is not — a lifecycle
+ * or disk-side tool landing in here would be counted as a "read" the agent made of the app, which it
+ * was not.
+ */
+export const CAPTURED_TOOLS: ReadonlySet<string> = new Set([
+  ReticleTool.CONTEXT,
+  ReticleTool.SNAPSHOT,
+  ReticleTool.QUERY,
+  ReticleTool.INSPECT,
+  ReticleTool.STATE,
+  ReticleTool.STORAGE,
+  ReticleTool.NETWORK,
+  ReticleTool.CONSOLE,
+  ReticleTool.OBSERVE,
+  ReticleTool.EXPLORE,
+]);
+
+/**
+ * How many calls the ledger holds before it starts dropping the oldest.
+ *
+ * A verification loop is 50–200 calls, so this is not reached in normal use; it exists so a runaway
+ * session cannot grow a per-session array without bound. When it IS reached the report says
+ * `truncated` rather than presenting a short count as a complete one.
+ */
+const CAPTURE_CAP = 2000;
+
+/** One recorded call: which tool, what it was about, and how far into the run it happened. */
+export interface CapturedCall {
+  tool: string;
+  /** The ref or target the call named, when it named one. Absent for a whole-page read. */
+  subject?: string;
+  /**
+   * The session's dispatched-action count at the moment of the call — the same counter that mints
+   * journal action ids, so it lines up with `reticle_context`'s own `step` whenever the journal is on.
+   */
+  afterActions: number;
+}
+
+/**
+ * The one thing that is stored rather than folded: the read-only calls the journal never sees.
+ *
+ * In memory and per session, the same shape as `GapLedger`. It is not durable on purpose — the
+ * question is about one run, and a second file on disk would be a second thing to reconcile with the
+ * journal.
+ */
+export class CaptureLedger {
+  #calls: CapturedCall[] = [];
+  #dropped = 0;
+
+  note(call: CapturedCall): void {
+    this.#calls.push(call);
+    if (this.#calls.length > CAPTURE_CAP) {
+      this.#calls.shift();
+      this.#dropped += 1;
+    }
+  }
+
+  calls(): readonly CapturedCall[] {
+    return this.#calls;
+  }
+
+  /** How many calls fell off the front. Non-zero means the counts below are a floor. */
+  get dropped(): number {
+    return this.#dropped;
+  }
+}
+
+/**
+ * Record one captured call against the session that made it.
+ *
+ * Tolerates a session that carries no ledger, exactly as `noteSessionGaps` does and for the same
+ * reason: `Session` is satisfied structurally, and many specs — plus any consumer embedding this
+ * engine — build one as an object literal. Such a session is a real caller that simply keeps no
+ * ledger, and an instrument must never be the reason a tool call throws. Its calls are then absent
+ * rather than counted as zero, which is what `observed: false` exists to say.
+ */
+export function noteCapturedCall(
+  session: { capture?: CaptureLedger; actionCount?: number },
+  call: Omit<CapturedCall, 'afterActions'>,
+): void {
+  session.capture?.note({ ...call, afterActions: session.actionCount ?? 0 });
+}
+
+/** What one session's use of the two features looks like. Everything but `observed` is omitted when nothing was recorded. */
+export interface FeatureCapture {
+  /** False when this daemon recorded nothing for the session — "not watched", never "not used". */
+  observed: boolean;
+  /** The ledger dropped calls, so every count is a floor. Present only when true. */
+  truncated?: boolean;
+  context?: {
+    calls: number;
+    /** The dispatched-action count each call was made at, in order. */
+    atSteps: number[];
+    acted: number;
+    refetched: number;
+    readOther: number;
+    nothingAfter: number;
+  };
+  intents?: { declared: number; open: number };
+  missed?: { verdictsWithNoIntentDeclared: number; refetchedEstablished: number };
+}
+
+/**
+ * Every point in the run at which each subject became an established fact.
+ *
+ * "Established" is not a second definition: it is the rule `establishedFromJournal` folds by — an
+ * action with an observed settle outcome, filed under the ref or target it named — and `subjectOf`
+ * is imported from there rather than rewritten, so the two cannot drift apart.
+ */
+function establishedIndexes(actions: readonly JournalAction[]): Map<string, number[]> {
+  const out = new Map<string, number[]>();
+  actions.forEach((action, index) => {
+    if (undefined === action.settled) return;
+    const key = subjectOf(action);
+    if (undefined === key) return;
+    const at = out.get(key);
+    if (at === undefined) out.set(key, [index]);
+    else at.push(index);
+  });
+  return out;
+}
+
+/** Was this subject already an established fact by the time a call at `afterActions` was made? */
+function wasEstablished(
+  index: Map<string, number[]>,
+  subject: string | undefined,
+  afterActions: number,
+): boolean {
+  if (undefined === subject) return false;
+  const at = index.get(subject);
+  if (at === undefined) return false;
+  // Action `i` has been dispatched once the counter reads `i + 1`, so `i + 1 <= afterActions` is
+  // "already true when the call was made" — which is what keeps a FIRST look off this count. The
+  // lower bound is the run context's own window: a fact that has scrolled past RUN_ESTABLISHED_CAP
+  // is not something `reticle_context` would have handed back, so re-reading it is not a re-fetch.
+  return at.some((i) => i + 1 <= afterActions && i + 1 > afterActions - RUN_ESTABLISHED_CAP);
+}
+
+/**
+ * Did calling `reticle_context` change what happened next?
+ *
+ * The mechanical proxy, stated so it can be argued with: look at the very next recorded call. If an
+ * action was dispatched before it — the action counter moved — the agent ACTED, and the context
+ * plausibly helped. If instead the next call is a read of a subject the context had just supplied,
+ * the agent re-fetched what it had been handed, and the context did not help.
+ *
+ * ## What this proxy CANNOT see
+ *
+ *  - Whether the agent READ the response, reasoned over it, or wrote a better answer from it. There
+ *    is no signal for that anywhere, and this must not be mistaken for one.
+ *  - Anything that happens between two Reticle calls: source edits, calls to other MCP servers, a
+ *    turn ending, a human interrupting. A long gap is invisible and reads as adjacency.
+ *  - Reads that name no ref or target (a whole-page snapshot). They land in `readOther`, never in
+ *    `refetched`, so a snapshot that duplicated the context is under-counted, not over-counted.
+ *  - Causation. `acted` is proximity in a call sequence, nothing more. An agent that would have acted
+ *    anyway is indistinguishable from one the context unblocked.
+ *  - `reticle_context` called with no session connected — it answers there by design, and there is no
+ *    per-session ledger to record it against, so those calls are missing entirely.
+ *  - Two agents driving one session. Their calls interleave into one sequence and "next call" stops
+ *    meaning "next thing that agent did".
+ */
+export function foldFeatureCapture(input: {
+  calls: readonly CapturedCall[];
+  dropped: number;
+  actions: readonly JournalAction[];
+  intents: readonly Intent[];
+  /** The session's dispatched-action count now, so a run that ended on an action is not read as idle. */
+  finalActions: number;
+}): FeatureCapture {
+  const { calls, actions, intents } = input;
+  if (0 === calls.length && 0 === actions.length) return { observed: false };
+
+  const established = establishedIndexes(actions);
+  const isRefetch = (call: CapturedCall): boolean =>
+    ReticleTool.CONTEXT !== call.tool &&
+    wasEstablished(established, call.subject, call.afterActions);
+
+  let acted = 0;
+  let refetched = 0;
+  let readOther = 0;
+  let nothingAfter = 0;
+  const atSteps: number[] = [];
+  calls.forEach((call, i) => {
+    if (ReticleTool.CONTEXT !== call.tool) return;
+    atSteps.push(call.afterActions);
+    const next = calls[i + 1];
+    if (next === undefined) {
+      if (input.finalActions > call.afterActions) acted += 1;
+      else nothingAfter += 1;
+      return;
+    }
+    if (next.afterActions > call.afterActions) acted += 1;
+    else if (isRefetch(next)) refetched += 1;
+    else readOther += 1;
+  });
+
+  // A verdict is any journal action carrying the bounded verdict effect both verification tools
+  // write. Parsed with core's own schema rather than a local shape, for the usual reason.
+  const verdicts = actions.filter((a) => JournalVerdictEffectSchema.safeParse(a.effect).success);
+
+  return {
+    observed: true,
+    ...(input.dropped > 0 ? { truncated: true } : {}),
+    context: { calls: atSteps.length, atSteps, acted, refetched, readOther, nothingAfter },
+    intents: {
+      declared: intents.length,
+      open: intents.filter((it) => IntentState.PROVED !== it.state).length,
+    },
+    missed: {
+      // The coarse question, asked honestly. Nothing binds a verdict to a specific intent outside
+      // flow replay, so "covered" cannot mean "this intent proves this verdict" without inventing a
+      // link Reticle cannot observe — the same reason `undeclared-change.ts` asks only whether
+      // anything at all was declared. So this counts verdicts drawn against an EMPTY ledger, and
+      // stops at zero once anything is declared. That zero is not a claim that every verdict was
+      // covered; it is the end of what this can see.
+      verdictsWithNoIntentDeclared: 0 === intents.length ? verdicts.length : 0,
+      refetchedEstablished: calls.filter(isRefetch).length,
+    },
+  };
+}

--- a/packages/server/src/intent/open-intents.ts
+++ b/packages/server/src/intent/open-intents.ts
@@ -18,3 +18,18 @@ export async function openSessionIntents(
 ): Promise<Intent[]> {
   return new IntentStore(deps.fs, sessionRoot(deps, sessionId), { now: deps.now }).open();
 }
+
+/**
+ * EVERY intent in the ledger, proved ones included — the denominator the open list is a subset of.
+ *
+ * Separate from `openSessionIntents` rather than a flag on it, because the two answer different
+ * questions: "what does this project still owe" drives a verdict's honesty, and "was anything ever
+ * declared" is what decides whether `reticle_intent` is used at all. Same root resolution, for the
+ * same reason it is shared above.
+ */
+export async function allSessionIntents(
+  deps: ToolDeps,
+  sessionId: string | undefined,
+): Promise<Intent[]> {
+  return new IntentStore(deps.fs, sessionRoot(deps, sessionId), { now: deps.now }).read();
+}

--- a/packages/server/src/runs/run-context.ts
+++ b/packages/server/src/runs/run-context.ts
@@ -48,8 +48,13 @@ const Fact = {
   unsettled: (verb: string): string => `${verb} did not settle`,
 } as const;
 
-/** The SUBJECT a journal action was about: the ref it spent, else the target it resolved from. */
-function subjectOf(action: JournalAction): string | undefined {
+/**
+ * The SUBJECT a journal action was about: the ref it spent, else the target it resolved from.
+ *
+ * Exported so the feature-use instrument files a re-fetch under the same key this fold establishes
+ * it under. A second copy of this rule there would be a second definition of "the same subject".
+ */
+export function subjectOf(action: JournalAction): string | undefined {
   const ref = action.args['ref'];
   if ('string' === typeof ref && ref.length > 0) return ref;
   const target = action.args['target'];

--- a/packages/server/src/session/session.ts
+++ b/packages/server/src/session/session.ts
@@ -3,6 +3,7 @@ import type { ImpactSnapshot } from '@reticlehq/core';
 import { recordImpact } from '../impact/impact-recorder.js';
 import { LastAct } from './last-act.js';
 import { GapLedger } from '../honesty/gap-ledger.js';
+import { CaptureLedger } from '../honesty/feature-capture.js';
 import { commandTimeoutMessage, type PageRuntime } from './command-timeout.js';
 import { readHealthEvent, type SessionHealth } from './session-health.js';
 
@@ -471,6 +472,16 @@ export class Session {
     return `${ACTION_ID_PREFIX}${String(this.#actionSeq)}`;
   }
 
+  /**
+   * How many actions this session has dispatched.
+   *
+   * The counter that mints journal action ids, not a second one — so it equals the journal's own
+   * length, and `reticle_context`'s `step`, whenever this session journals at all.
+   */
+  get actionCount(): number {
+    return this.#actionSeq;
+  }
+
   /** Close the active action window, persisting its action record with the settle outcome. */
   finishAction(effect?: unknown, settled?: boolean, settledInMs?: number): void {
     this.#activeActionId = undefined;
@@ -512,6 +523,11 @@ export class Session {
    * end of it.
    */
   readonly gaps = new GapLedger();
+  /**
+   * The read-only calls the journal does not keep, so "was `reticle_context` ever called" has
+   * something to fold. See honesty/feature-capture.ts — it is the only state that instrument adds.
+   */
+  readonly capture = new CaptureLedger();
 
   // ── Server-authoritative liveness (immune to browser-tab throttling) ──────────────
 

--- a/packages/server/src/tools/captured-calls-recorded.test.ts
+++ b/packages/server/src/tools/captured-calls-recorded.test.ts
@@ -1,0 +1,93 @@
+/**
+ * The wiring, which is the half that can silently stop working.
+ *
+ * The fold in honesty/feature-capture.ts is pure and pinned by its own spec. Nothing there notices
+ * if the dispatch point stops feeding it — and a feature-use instrument that quietly records nothing
+ * reports "not observed" forever, which is exactly the unfalsifiable state it exists to end.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { SessionState } from '@reticlehq/core';
+import { ReticleTool } from './tool-names.js';
+import { runTool } from './invoke-tool.js';
+import { CaptureLedger } from '../honesty/feature-capture.js';
+import { createNodeFileSystem } from '../project/fs-port.js';
+import { BaselineStore } from '../project/baselines.js';
+import { RecordingStore } from '../flows/recordings.js';
+import { FlowStore } from '../flows/flows.js';
+import { ProjectStore } from '../project/project-store.js';
+import { AnnotationStore } from '../flows/annotation-store.js';
+import type { ToolDef, ToolDeps } from './tools.js';
+import type { Session, SessionManager } from '../session/session.js';
+
+const ROOT = '/tmp/reticle-captured-calls-test/.reticle';
+const SESSION_ID = 'sA';
+const REF = 'e4';
+const ACTIONS_SO_FAR = 5;
+const now = (): number => 0;
+
+function session(capture: CaptureLedger): Session {
+  return {
+    id: SESSION_ID,
+    url: 'http://localhost:5173/',
+    capture,
+    actionCount: ACTIONS_SO_FAR,
+    health: () => ({ lastSeenMs: 0, throttled: false, focused: true }),
+    getState: () => SessionState.ACTIVE,
+    drainInbox: () => [],
+    takeSessionLease: () => undefined,
+    ageWarning: () => undefined,
+  } as unknown as Session;
+}
+
+function deps(only: Session): ToolDeps {
+  const sessions: Partial<SessionManager> = {
+    resolve: () => only,
+    list: () => [{ sessionId: only.id, url: only.url }] as ReturnType<SessionManager['list']>,
+  };
+  const fs = createNodeFileSystem();
+  return {
+    sessions: sessions as SessionManager,
+    baselines: new BaselineStore(),
+    recordings: new RecordingStore(),
+    flows: new FlowStore(fs, ROOT, { now }),
+    project: new ProjectStore(fs, ROOT, { now }),
+    annotations: new AnnotationStore(),
+    fs,
+    reticleRoot: ROOT,
+    now,
+  };
+}
+
+const tool = (name: string): ToolDef => ({
+  name,
+  description: '',
+  inputSchema: {},
+  handler: () => Promise.resolve({ ok: true }),
+});
+
+describe('the dispatch point records the calls the journal never keeps', () => {
+  it('records a reticle_context call against the session, at the step it was made', async () => {
+    const capture = new CaptureLedger();
+
+    await runTool(tool(ReticleTool.CONTEXT), deps(session(capture)), {});
+
+    expect(capture.calls()).toEqual([{ tool: ReticleTool.CONTEXT, afterActions: ACTIONS_SO_FAR }]);
+  });
+
+  it('records the subject a read named, so a re-fetch can be told from a first look', async () => {
+    const capture = new CaptureLedger();
+
+    await runTool(tool(ReticleTool.INSPECT), deps(session(capture)), { ref: REF });
+
+    expect(capture.calls()[0]?.subject).toBe(REF);
+  });
+
+  it('records nothing for a tool that drives the page — the journal already holds those', async () => {
+    const capture = new CaptureLedger();
+
+    await runTool(tool(ReticleTool.ACT), deps(session(capture)), { ref: REF });
+
+    expect(capture.calls()).toEqual([]);
+  });
+});

--- a/packages/server/src/tools/coverage-tools.ts
+++ b/packages/server/src/tools/coverage-tools.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 import { coverageRegressed, observabilityOf } from '../honesty/observability.js';
+import { foldFeatureCapture } from '../honesty/feature-capture.js';
+import { allSessionIntents } from '../intent/open-intents.js';
 import { ReticleCommand, SnapshotMode } from '@reticlehq/core';
 import { ReticleTool } from './tool-names.js';
 import type { ToolDef, ToolDeps } from './tools.js';
@@ -93,6 +95,18 @@ export const COVERAGE_TOOLS: ToolDef[] = [
         .describe(
           'Of the controls you DROVE, how many Reticle could fully observe. `untouched` above is work left for you; this is work left in the APP, and driving more controls does not move it. `percent` is OMITTED when nothing was driven, because 0/0 is not 100%.',
         ),
+      featureUse: z
+        .object({
+          observed: z.boolean(),
+          truncated: z.boolean().optional(),
+          context: z.unknown().optional(),
+          intents: z.unknown().optional(),
+          missed: z.unknown().optional(),
+        })
+        .optional()
+        .describe(
+          'Whether this session used `reticle_context` and `reticle_intent` at all, and what it cost when it did not: `context` counts the calls and what followed each one, `intents` the ledger, `missed` the verdicts drawn against an empty ledger and the reads that re-fetched a fact already established. `observed:false` means nothing was recorded for this session — NOT that nothing was used. An instrument for deciding whether those two features earn their place; nothing here is a fault of yours.',
+        ),
       observabilityRegressed: z
         .object({ was: z.number(), now: z.number() })
         .optional()
@@ -124,6 +138,17 @@ export const COVERAGE_TOOLS: ToolDef[] = [
       // first without the second is how an agent finishes a pass believing it verified something the
       // app was never able to confirm.
       const gaps = session.gaps?.open() ?? [];
+      // Folded here rather than given a tool of its own: this is already the "am I done, and what is
+      // this verdict worth" read, and a number nobody has a reason to ask for separately is one
+      // nobody ever sees. It is a fold over the journal and the intent ledger plus the one thing
+      // neither records — see honesty/feature-capture.ts.
+      const featureUse = foldFeatureCapture({
+        calls: session.capture.calls(),
+        dropped: session.capture.dropped,
+        actions: await session.readJournalActions(),
+        intents: await allSessionIntents(deps, sessionId),
+        finalActions: session.actionCount,
+      });
       // The number, and the floor under it, together. A coverage figure that can only ever be
       // reported and never contradicted is one an agent learns to satisfy rather than to earn.
       const observability = observabilityOf(session.actedRefs(), gaps);
@@ -140,6 +165,7 @@ export const COVERAGE_TOOLS: ToolDef[] = [
         ...(gaps.length > 0 ? { instrumentationGaps: gaps, unproven: true } : {}),
         observability,
         ...(regressed === undefined ? {} : { observabilityRegressed: regressed }),
+        featureUse,
       };
     },
   },

--- a/packages/server/src/tools/invoke-tool.ts
+++ b/packages/server/src/tools/invoke-tool.ts
@@ -23,6 +23,7 @@ import { takeFeedbackPrompt } from './feedback-tools.js';
 import { takeFeedbackUndelivered } from '../telemetry/feedback-delivery.js';
 import type { Session } from '../session/session.js';
 import { noteRefsMinted, wrongTabRefusal } from '../session/ref-provenance.js';
+import { CAPTURED_TOOLS, noteCapturedCall } from '../honesty/feature-capture.js';
 import { span } from '../trace.js';
 import {
   deltaForToolResult,
@@ -328,6 +329,31 @@ export async function runTool<Ext>(
       session = deps.sessions.resolve(rawSessionId);
     } catch {
       session = undefined;
+    }
+  }
+  // The read-only calls the journal never keeps, recorded HERE because this is the one dispatch
+  // point every call routes through — a second recording site is a second thing to forget, and this
+  // instrument exists precisely because nothing was recorded before. Recorded before the handler
+  // runs: a read dispatches no action, so the counter reads the same either side.
+  //
+  // `reticle_context` is session-EXEMPT, so `session` above is undefined for it and it needs its own
+  // lenient resolve. Failing that resolve is silent by design: a call made with nothing connected
+  // has no per-session ledger to land in, and an instrument must never be why a tool call fails.
+  if (CAPTURED_TOOLS.has(tool.name)) {
+    let target = session;
+    if (target === undefined) {
+      try {
+        target = deps.sessions.resolve(rawSessionId);
+      } catch {
+        target = undefined;
+      }
+    }
+    if (target !== undefined) {
+      const subject = asString(args['ref']) ?? asString(args['target']);
+      noteCapturedCall(target, {
+        tool: tool.name,
+        ...(subject === undefined ? {} : { subject }),
+      });
     }
   }
   // A ref that was handed out by a DIFFERENT tab, on a call that named no session. Refused here, at


### PR DESCRIPTION
## The question this answers

Two features shipped whose disproof was pre-registered as *"if agents never call it, cut it"* — and nothing recorded whether they were called. A feature whose disproof cannot be run is one nobody can kill. That is the same defect the old push-based run context had.

`reticle_verify { action: "coverage" }` now carries a `featureUse` block answering it locally, per session:

- **Was `reticle_context` called?** `context.calls` and `context.atSteps`.
- **Was an intent declared?** `intents.declared` / `intents.open`. (`feat/inline-intent` is merged into main and does **not** add an inline intent field to a verdict — `reticle_intent` + `.reticle/intent.json` is the only declaration path today, so that is the one handled.)
- **Did calling `reticle_context` change what happened next?** `context.acted` / `refetched` / `readOther` / `nothingAfter`.
- **The miss side:** `missed.verdictsWithNoIntentDeclared` and `missed.refetchedEstablished` — the cost of *not* using either, countable with no agent cooperation.

## Mostly a fold, not a store

The intent ledger and the journal already answer three of the four questions, and they are read rather than duplicated — two ways to compute one number is worse than one way, and `run-context.ts` makes that argument at length. `subjectOf` is imported from that fold rather than rewritten, so "the same subject" has one definition.

The journal keeps **no read-only call** — it holds actions and verdicts only. So "was `reticle_context` called" has no ledger to fold, and that one thing is recorded in memory on the session by `CaptureLedger`, appended at the single dispatch chokepoint in `runTool`. It is the whole of the new state.

## What the behaviour-change proxy can and cannot see

**Can:** after a `reticle_context` call, whether the action counter moved before the next recorded call (`acted`), or the next call was a read of a subject the context had just supplied (`refetched`).

**Cannot:** whether the agent read or reasoned over the response; anything between two Reticle calls (source edits, other MCP servers, a turn ending); reads that name no ref or target — they land in `readOther`, so the direction of error is under-counting `refetched`, not over-counting it; causation, `acted` is proximity in a call sequence; `reticle_context` called with nothing connected; two agents interleaving in one session. All of that is written down beside the code.

## Honesty

**Absent is never zero.** A session this daemon recorded nothing for reports `observed: false` and states no counts. Not "the features went unused" — "we were not watching". The ledger's cap sets `truncated` rather than presenting a short count as complete.

`verdictsWithNoIntentDeclared` counts verdicts drawn against an **empty** ledger and stops at zero once anything is declared. Nothing binds a verdict to a specific intent outside flow replay, so a finer rule would be inference dressed as a fact — the same reason `undeclared-change.ts` asks only the coarse question. That is stated in the code, not implied.

Nothing here is a scold, and the field description says so to the agent reading it.

## Tests, red first

Pure fold — `packages/server/src/honesty/feature-capture.test.ts`, 14 tests, red on a missing module:
- counts a reticle_context call · reports the step each call was made at
- reads as not observed for a session with no journal and no recorded call
- counts verdicts drawn with no intent covering them · counts no uncovered verdict once the ledger holds an intent
- counts a read that re-fetched an already-established fact · **does not count a first look as a re-fetch** · does not count a read of a subject nothing established
- reads `acted` / `refetched` / `nothingAfter` — the proxy in both directions
- reports the intent ledger as declared and still open · says so when the ledger dropped calls

Wiring — `packages/server/src/tools/captured-calls-recorded.test.ts`, proven red by disabling the chokepoint block:
- records a reticle_context call against the session, at the step it was made
- records the subject a read named · records nothing for a tool that drives the page

## Gates

`pnpm format:check` · `pnpm lint` · `pnpm typecheck` · `pnpm test:unit` — all green (server 500 files / 4842 tests).

`pnpm test:e2e` is **warranted before merge**: this adds a field to a tool's output schema and touches the dispatch chokepoint, and the unit gate cannot see cross-package surface drift. Not run here (~8 min, and it wants three servers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)