### PR TITLE
feat(server): an optional `intent` on the two tools that draw a verdict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ### Added
 
+- **`@reticlehq/server` — `reticle_act_and_wait` and `reticle_assert` now take an optional `intent`, so declaring one costs nothing.** `reticle_intent` sits on the extended surface, which means an agent has to discover a tool it was not handed, decide to use it, and spend a round trip before it has driven anything. Every one of those is a place the declaration silently does not happen, and it mostly does not. The two tools that draw a verdict are in every agent's tool list already, so the cheapest place to say what a change was FOR is the call that is about to check it.
+
+  It is a shortcut into the EXISTING ledger, never a second one. The prose lands in `.reticle/intent.json` through the same store `reticle_intent { action: "declare" }` writes, in the same vocabulary, so a reviewer reads one git-checked file and cannot tell from the row which door an intent came in by. `flows/flow-intent.ts` already did this for a saved flow; this is the same link, made from the verdict instead.
+
+  **The verdict IS the proof attempt, and only a real one discharges.** The predicate about to be evaluated is bound as what would prove the intent, and a green verdict marks it proved and records itself as the proof. A red leaves it open, because it proved nothing. A wait that named no consequence — a bare settle — leaves it open too: the ledger's own rule refuses to discharge an unbound intent, so no proof is invented for a verdict that did not produce one.
+
+  **One field, carrying prose or an id.** Pass the id of an intent already in the ledger and this verdict answers to that row rather than restating it, so several verdicts can prove one statement and a binding somebody bound deliberately is left alone rather than quietly narrowed to whatever this call happened to assert. A second field would have doubled the cost of the idea to make one of its two readings marginally more explicit.
+
+  **The undeclared-change gap goes quiet on the SAME verdict, not the next one.** The intent is written before the verdict is drawn, so the check that asks whether anything is outstanding finds it, and the discharge happens after. An agent that did exactly the right thing is not told off for it, which is the fastest way to teach it to stop reading findings. Omit the argument and nothing changes at all: no ledger is read, no ledger is written, and the result is byte-identical to what it was.
+
 - **`@reticlehq/server` — `reticle_context` and `reticle_intent` are now named where an agent will actually read them.** Both sit on the extended surface, so neither appears in the tool list an agent is handed by default, and neither was mentioned in the MCP server instructions or the skill. Nothing an agent reads on connect said either tool existed. Two features can be perfectly built and still have an effect size of zero, because nobody can call what nobody has heard of.
 
   The instructions now carry two sentences saying what each is FOR — ask what this run established instead of re-snapshotting to rediscover it; declare what a change was meant to do so the verdict has something to check against other than itself — and `SKILL.md` carries the `reticle_run` call shape for both, beside the one it already documents for `reticle_verify`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -265,6 +265,14 @@ reticle_run({ tool: "reticle_context", args: {} })
 reticle_run({ tool: "reticle_intent", args: { action: "declare", intents: [{ id: "checkin", statement: "clicking Send check-in makes the badge read 'checked in'" }] } })
 ```
 
+Or say it on the verdict itself and skip the round trip. `reticle_act_and_wait` and `reticle_assert` both take an optional `intent`, writing the same ledger:
+
+```
+reticle_act_and_wait({ ref: "e42", action: "click", until: { kind: "signal", name: "checkin:sent" }, intent: "clicking Send check-in makes the badge read 'checked in'" })
+```
+
+The verdict that passes is the one that proves it. Already declared it? Pass the intent's **id** there instead of the prose, and several verdicts can answer to one statement.
+
 ## Record once, replay cheaply
 
 The first drive of a journey is expensive. The rest should not be. After you drive something worth keeping:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -183,7 +183,7 @@ The timeline + summary of what happened.
 
 Act, then wait for a predicate: the whole act→observe→assert loop in one hop.
 
-- **args:** `ref`, `action`, `args?`, `until: <predicate>`, `timeout_ms?` (default 4000; 0 = evaluate once), `refuseWhenThrottled?`, `sessionId?`.
+- **args:** `ref`, `action`, `args?`, `until: <predicate>`, `timeout_ms?` (default 4000; 0 = evaluate once), `refuseWhenThrottled?`, `intent?`, `sessionId?`.
 - **returns:** `{ effect, verdict, trace, session, warning? }`. `effect` is the action result (`{ ok, ref, action }`), `verdict` is `{ pass, evidence?, failureReason? }`, `trace` is the reaction report of everything the app did after the action, and `session` is the tab-health block `{ lastSeenMs, throttled, focused }` (with a `warning` when throttled). A failing `verdict` still returns `effect` + `trace` so you can see what _did_ happen. The predicate is automatically floored at this act's cursor, so it only matches events the action actually caused.
 
 ### `reticle_wait_for`
@@ -197,9 +197,10 @@ Block until a predicate holds (or time out). Looks both backward (recent buffer)
 
 Verify a predicate; optionally wait for it.
 
-- **args:** `predicate`, `timeout_ms?` (0 = evaluate once), `since?`, `sessionId?`.
+- **args:** `predicate`, `timeout_ms?` (0 = evaluate once), `since?`, `intent?`, `sessionId?`.
 - Same `since` default as `reticle_wait_for`: scoped to your last act so a stale buffered event can't fake a pass; override with an explicit `since`.
 - **returns:** `{ verified, because, pass, evidence, contradictions?, coverage?, failureReason?, session, warning? }`. On failure includes a **near-miss** (e.g. "found the dialog but not visible", or "no button named 'Submit'; saw: Cancel"). The `session` block `{ lastSeenMs, throttled, focused }` reports tab health on every assert; when throttled a `warning` is attached so you never assert against a tab that is silently no-oping.
+- **`intent` declares what the change was FOR, inline.** Pass a sentence in your own words and it lands in `.reticle/intent.json`, the same git-checked ledger `reticle_intent` writes, before the verdict is drawn; a green verdict then marks it proved and names itself as the proof. Pass the **id** of an intent you already declared instead, to point several verdicts at one statement rather than restating it. `reticle_act_and_wait` takes the same argument. Omit it and nothing is written.
 - **Read `verified`, not `pass`.** `pass` says the predicate held; `verified` says whether that means anything. It is `"no"` when a channel contradicts the assertion (a failed write under a green screen, a batch whose body reports per-item failures, a request still in flight), and `"unknown"` when the outcome could not be known yet: a `202 Accepted` that has not reconciled, or a write whose response body was never recorded. `because` names the deciding evidence in one sentence.
 
 ### `reticle_reconcile`

--- a/packages/server/src/intent/inline-intent.test.ts
+++ b/packages/server/src/intent/inline-intent.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'vitest';
+import type { WebSocket } from 'ws';
+import {
+  EventType,
+  InstrumentationGapKind,
+  IntentState,
+  MessageKind,
+  RETICLE_PROTOCOL_VERSION,
+  SessionState,
+  Verified,
+  type CommandResult,
+  type HelloMessage,
+  type InstrumentationGap,
+  type ReticleEvent,
+} from '@reticlehq/core';
+import { createMemoryFs } from '../project/memory-fs.js';
+import { IntentStore } from './intent-store.js';
+import { LastAct } from '../session/last-act.js';
+import { RecordingStore } from '../flows/recordings.js';
+import { Session, type SessionManager } from '../session/session.js';
+import { TOOLS, type ToolDef, type ToolDeps } from '../tools/tools.js';
+import { ReticleTool } from '../tools/tool-names.js';
+
+/**
+ * Intent declared INLINE, on the two tools that draw a verdict.
+ *
+ * `reticle_intent` lives on the extended surface, so declaring intent costs an agent a discovery, a
+ * decision and a round trip before it has done anything — and an option with three ways to be
+ * skipped is one that gets skipped. `reticle_act_and_wait` and `reticle_assert` are in every agent's
+ * tool list already, so an `intent` argument there is discoverable by construction and free.
+ *
+ * What these pin is that the shortcut is not a second mechanism: it writes the SAME ledger, in the
+ * same vocabulary, and it is discharged only by a verdict that actually proved something.
+ */
+
+const ROOT = '/repo/app/.reticle';
+const SIGNAL_NAME = 'todo:added';
+const STATEMENT = 'adding a todo announces it to the list';
+const EDIT_EPOCH = 7;
+
+const noopSocket = { send: () => undefined, close: () => undefined } as unknown as WebSocket;
+
+function tool(name: string): ToolDef {
+  const found = TOOLS.find((t) => t.name === name);
+  if (found === undefined) throw new Error(`${name} is not on the surface`);
+  return found;
+}
+
+function hello(): HelloMessage {
+  return {
+    kind: MessageKind.HELLO,
+    protocolVersion: RETICLE_PROTOCOL_VERSION,
+    sessionId: 'demo',
+    url: 'http://localhost/',
+    title: 'Demo',
+    adapters: [],
+  };
+}
+
+function signalEvent(): ReticleEvent {
+  return {
+    t: 1,
+    seq: 1,
+    type: EventType.SIGNAL,
+    sessionId: 'demo',
+    editEpoch: EDIT_EPOCH,
+    data: { name: SIGNAL_NAME },
+  };
+}
+
+/** A live session plus deps whose ledger is in memory, so the file it wrote can be read back. */
+function harness(): { session: Session; deps: ToolDeps; ledger: IntentStore } {
+  const session = new Session(hello(), noopSocket, () => 0);
+  const { fs } = createMemoryFs();
+  const sessions: Partial<SessionManager> = { resolve: () => session };
+  const deps = {
+    sessions: sessions as SessionManager,
+    fs,
+    reticleRoot: ROOT,
+    now: () => 1_000,
+  } as unknown as ToolDeps;
+  return { session, deps, ledger: new IntentStore(fs, ROOT, { now: () => 1_000 }) };
+}
+
+/** The act path needs a driven page; only the fields the handler reads are stubbed. */
+function actHarness(events: ReticleEvent[]): { deps: ToolDeps; ledger: IntentStore } {
+  const command = (): Promise<CommandResult> =>
+    Promise.resolve({
+      kind: 'command_result',
+      id: 'c',
+      ok: true,
+      result: { dispatched: true, settled: true, effect: { domMutatedWithin: 1 } },
+    });
+  const stub: Partial<Session> = {
+    id: 'demo',
+    url: 'http://localhost/',
+    elapsed: () => 1_000,
+    lastAct: new LastAct(),
+    beginAction: () => 'a1',
+    finishAction: () => undefined,
+    command,
+    queryEvents: () => Promise.resolve(events),
+    eventsSince: () => events,
+    bufferHealth: () => ({ total: 10, dropped: 0 }),
+    lostSince: () => false,
+    blindSpots: () => ({}),
+    health: () => ({ lastSeenMs: 0, throttled: false, focused: true }),
+    throttled: () => false,
+    getState: () => SessionState.ACTIVE,
+    drainInbox: () => [],
+    inboxSize: () => 0,
+    onEvent: () => () => undefined,
+    ambientCounts: () => ({}),
+    currentEditEpoch: EDIT_EPOCH,
+  };
+  const session = stub as Session;
+  const { fs } = createMemoryFs();
+  const sessions: Partial<SessionManager> = { resolve: () => session };
+  const deps = {
+    sessions: sessions as SessionManager,
+    recordings: new RecordingStore(),
+    fs,
+    reticleRoot: ROOT,
+    now: () => 1_000,
+  } as unknown as ToolDeps;
+  return { deps, ledger: new IntentStore(fs, ROOT, { now: () => 1_000 }) };
+}
+
+const assertSignal = { predicate: { kind: 'signal', name: SIGNAL_NAME }, timeout_ms: 0 };
+
+interface VerdictResult {
+  verified?: string;
+  instrumentationGaps?: InstrumentationGap[];
+}
+
+describe('an inline intent lands in the same ledger reticle_intent writes', () => {
+  it('records the prose on reticle_assert', async () => {
+    const { session, deps, ledger } = harness();
+    session.pushEvent(signalEvent());
+    await tool(ReticleTool.ASSERT).handler(deps, { ...assertSignal, intent: STATEMENT });
+    const [intent] = await ledger.read();
+    expect(intent?.statement).toBe(STATEMENT);
+  });
+
+  it('records the prose on reticle_act_and_wait', async () => {
+    const { deps, ledger } = actHarness([signalEvent()]);
+    await tool(ReticleTool.ACT_AND_WAIT).handler(deps, {
+      ref: 'e1',
+      action: 'click',
+      until: { kind: 'signal', name: SIGNAL_NAME },
+      timeout_ms: 0,
+      intent: STATEMENT,
+    });
+    const [intent] = await ledger.read();
+    expect(intent?.statement).toBe(STATEMENT);
+  });
+});
+
+describe('a verdict discharges the intent it proved, and nothing it did not', () => {
+  it('marks the intent proved, naming the verdict that did it', async () => {
+    const { session, deps, ledger } = harness();
+    session.pushEvent(signalEvent());
+    const result = (await tool(ReticleTool.ASSERT).handler(deps, {
+      ...assertSignal,
+      intent: STATEMENT,
+    })) as VerdictResult;
+    expect(result.verified).toBe(Verified.YES);
+    const [intent] = await ledger.read();
+    expect(intent?.state).toBe(IntentState.PROVED);
+    expect(intent?.provenBy?.verdictId).toContain(ReticleTool.ASSERT);
+  });
+
+  it('leaves it undischarged when the verdict failed', async () => {
+    const { session, deps, ledger } = harness();
+    session.pushEvent(signalEvent());
+    await tool(ReticleTool.ASSERT).handler(deps, {
+      predicate: { kind: 'signal', name: 'never:fired' },
+      timeout_ms: 0,
+      intent: STATEMENT,
+    });
+    const [intent] = await ledger.read();
+    expect(intent?.state).not.toBe(IntentState.PROVED);
+    expect(intent?.provenBy).toBeUndefined();
+  });
+});
+
+describe('the undeclared-change gap is silent on the verdict that declared inline', () => {
+  const gapKinds = (result: VerdictResult): string[] =>
+    (result.instrumentationGaps ?? []).map((gap) => gap.kind);
+
+  it('still reports the gap when nothing was declared', async () => {
+    const { session, deps } = harness();
+    session.pushEvent(signalEvent());
+    const result = (await tool(ReticleTool.ASSERT).handler(deps, assertSignal)) as VerdictResult;
+    expect(gapKinds(result)).toContain(InstrumentationGapKind.UNDECLARED_CHANGE);
+  });
+
+  it('goes quiet on the SAME verdict the intent was declared on, not the next one', async () => {
+    const { session, deps } = harness();
+    session.pushEvent(signalEvent());
+    const result = (await tool(ReticleTool.ASSERT).handler(deps, {
+      ...assertSignal,
+      intent: STATEMENT,
+    })) as VerdictResult;
+    expect(gapKinds(result)).not.toContain(InstrumentationGapKind.UNDECLARED_CHANGE);
+  });
+});
+
+describe('an intent already in the ledger is referenced by id, not restated', () => {
+  it('proves the existing row and keeps its own words', async () => {
+    const { session, deps, ledger } = harness();
+    await ledger.declare([{ id: 'checkin', statement: STATEMENT }]);
+    session.pushEvent(signalEvent());
+    await tool(ReticleTool.ASSERT).handler(deps, { ...assertSignal, intent: 'checkin' });
+    const intents = await ledger.read();
+    expect(intents).toHaveLength(1);
+    expect(intents[0]?.statement).toBe(STATEMENT);
+    expect(intents[0]?.state).toBe(IntentState.PROVED);
+  });
+
+  it('does not overwrite a binding the agent bound deliberately', async () => {
+    const { session, deps, ledger } = harness();
+    await ledger.declare([{ id: 'checkin', statement: STATEMENT }]);
+    const deliberate = { kind: 'net', urlContains: '/api/todos' };
+    await ledger.bind('checkin', deliberate);
+    session.pushEvent(signalEvent());
+    await tool(ReticleTool.ASSERT).handler(deps, { ...assertSignal, intent: 'checkin' });
+    expect((await ledger.read())[0]?.binding).toEqual(deliberate);
+  });
+});
+
+describe('omitting intent changes nothing at all', () => {
+  it('writes no ledger and returns the same verdict', async () => {
+    const { session, deps, ledger } = harness();
+    session.pushEvent(signalEvent());
+    const result = (await tool(ReticleTool.ASSERT).handler(deps, assertSignal)) as VerdictResult;
+    expect(result.verified).toBe(Verified.YES);
+    expect(await ledger.read()).toEqual([]);
+  });
+
+  it('writes no ledger from the act path either', async () => {
+    const { deps, ledger } = actHarness([signalEvent()]);
+    await tool(ReticleTool.ACT_AND_WAIT).handler(deps, {
+      ref: 'e1',
+      action: 'click',
+      until: { kind: 'signal', name: SIGNAL_NAME },
+      timeout_ms: 0,
+    });
+    expect(await ledger.read()).toEqual([]);
+  });
+});

--- a/packages/server/src/intent/inline-intent.ts
+++ b/packages/server/src/intent/inline-intent.ts
@@ -1,0 +1,113 @@
+import { createHash } from 'node:crypto';
+import { IntentStore } from './intent-store.js';
+import { sessionRoot } from '../project/session-root.js';
+import type { ToolDeps } from '../tools/tool-kit.js';
+
+/**
+ * Intent declared INLINE, on the tool that is already drawing the verdict.
+ *
+ * `reticle_intent` is on the extended surface, so declaring intent costs an agent a discovery, a
+ * decision and a round trip before it has done anything — three places the capture silently fails,
+ * and it does. `reticle_act_and_wait` and `reticle_assert` are in every agent's tool list already,
+ * so one optional argument there makes the declaration free and discoverable by construction.
+ *
+ * This is a shortcut into the EXISTING ledger, never a second one. It writes `.reticle/intent.json`
+ * through `IntentStore` exactly as `reticle_intent { action: "declare" }` does, so a reviewer reads
+ * one file in one vocabulary and cannot tell from the row which door the intent came in by. The
+ * pattern is `flows/flow-intent.ts`, which does the same job for a saved flow.
+ */
+
+/** Namespaced like `flow:`, so an inline id never collides with one an agent chose by hand. */
+const INLINE_INTENT_ID_PREFIX = 'inline:';
+const ID_SEPARATOR = ':';
+const SLUG_SEPARATOR = '-';
+const SLUG_MAX = 48;
+const HASH_LENGTH = 8;
+const HASH_ALGORITHM = 'sha1';
+const NON_SLUG = /[^a-z0-9]+/g;
+const SLUG_EDGES = /^-+|-+$/g;
+
+/**
+ * The ledger id a piece of inline prose is declared under.
+ *
+ * Derived from the statement rather than minted, so the same sentence declared on five verdicts is
+ * one row rather than five, and a DIFFERENT sentence is a different row rather than a false
+ * amendment of the first. The slug is there because the id is what an agent later types to reference
+ * the intent, and a bare digest is unreadable; the digest is there because the slug is truncated and
+ * two long statements sharing a prefix must not share a row.
+ */
+export function inlineIntentId(statement: string): string {
+  const slug = statement
+    .toLowerCase()
+    .replace(NON_SLUG, SLUG_SEPARATOR)
+    .replace(SLUG_EDGES, '')
+    .slice(0, SLUG_MAX)
+    .replace(SLUG_EDGES, '');
+  const digest = createHash(HASH_ALGORITHM).update(statement).digest('hex').slice(0, HASH_LENGTH);
+  return `${INLINE_INTENT_ID_PREFIX}${slug}${SLUG_SEPARATOR}${digest}`;
+}
+
+/** What `provenBy` records: which tool drew the verdict, and when. */
+export function inlineVerdictId(tool: string, at: number): string {
+  return `${tool}${ID_SEPARATOR}${String(at)}`;
+}
+
+/**
+ * Put an inline intent in the ledger and attach the predicate about to be evaluated. Returns the id
+ * the verdict may later discharge, or undefined when there was no intent to record.
+ *
+ * `intent` carries EITHER prose OR the id of an intent already in the ledger. One field rather than
+ * two because the surface is the scarce thing here and the two cases are told apart by the ledger
+ * itself: a string that names an existing row is a reference, anything else is prose. A statement
+ * that happens to equal an existing id is the same intent said twice, so pointing at the row is the
+ * right answer there too, not a collision.
+ *
+ * A referenced intent is never re-declared, which would overwrite the agent's own words with an id,
+ * and its binding is left alone when it already has one — a predicate bound deliberately through
+ * `reticle_intent { action: "bind" }` is a stronger statement than whatever this one call asserts,
+ * and quietly replacing it is exactly the narrowing the ledger exists to make visible.
+ *
+ * Best-effort by construction: a ledger that cannot be written is a small problem, and a verdict
+ * that fails to return because of one is a large problem.
+ */
+export async function linkInlineIntent(
+  deps: ToolDeps,
+  sessionId: string | undefined,
+  intent: string | undefined,
+  /** The predicate this verdict will evaluate, or undefined when it proves nothing (a bare settle). */
+  binding: unknown,
+): Promise<string | undefined> {
+  if (intent === undefined || 0 === intent.trim().length) return undefined;
+  try {
+    const store = new IntentStore(deps.fs, sessionRoot(deps, sessionId), { now: deps.now });
+    const existing = (await store.read()).find((row) => row.id === intent);
+    const id = existing?.id ?? inlineIntentId(intent);
+    if (existing === undefined) await store.declare([{ id, statement: intent }]);
+    if (binding !== undefined && existing?.binding === undefined) await store.bind(id, binding);
+    return id;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Record that this verdict proved the intent. Call only for a verdict that actually proved something.
+ *
+ * The ledger's own rule does the rest: `dischargeIntent` refuses an intent with no binding, so an
+ * intent declared inline on a wait that asserted no consequence stays open and honest instead of
+ * collecting a proof nothing earned.
+ */
+export async function dischargeInlineIntent(
+  deps: ToolDeps,
+  sessionId: string | undefined,
+  id: string | undefined,
+  proof: { verdictId: string; grade: string; at: number },
+): Promise<void> {
+  if (id === undefined) return;
+  try {
+    const store = new IntentStore(deps.fs, sessionRoot(deps, sessionId), { now: deps.now });
+    await store.discharge(id, proof);
+  } catch {
+    // The verdict already stood. The proof is simply not recorded — see dischargeFlowIntent.
+  }
+}

--- a/packages/server/src/tools/act-tools.ts
+++ b/packages/server/src/tools/act-tools.ts
@@ -32,6 +32,11 @@ import { gapsForAction } from '../honesty/instrumentation-gaps.js';
 import { noteSessionGaps } from '../honesty/gap-ledger.js';
 import { isChangeUndeclared } from '../honesty/undeclared-change.js';
 import { openSessionIntents } from '../intent/open-intents.js';
+import {
+  dischargeInlineIntent,
+  inlineVerdictId,
+  linkInlineIntent,
+} from '../intent/inline-intent.js';
 import { declaresState } from '../events/predicate-asks.js';
 import { isStateUnwatched } from '../honesty/blind-spots.js';
 import {
@@ -71,7 +76,7 @@ import {
   PAUSED_NO_VERDICT,
 } from '../session/control-envelope.js';
 import { asString, asNumber, asRecord, sourceOf } from './tools-helpers.js';
-import { type ToolDef, sessionIdShape } from './tool-kit.js';
+import { type ToolDef, intentArg, sessionIdShape } from './tool-kit.js';
 import { asActionType, gradeOf } from './act-helpers.js';
 import { tryRealInput } from './real-input-attempt.js';
 
@@ -455,6 +460,7 @@ export const ACT_TOOLS: ToolDef[] = [
         .boolean()
         .optional()
         .describe('Throw if the tab is throttled. Default: false.'),
+      intent: intentArg,
       ...sessionIdShape,
     },
     outputSchema: {
@@ -565,6 +571,15 @@ export const ACT_TOOLS: ToolDef[] = [
           ? parsePredicate(withUntil['until'])
           : ({ kind: PredicateKind.SETTLED } as const);
       const timeout = asNumber(args['timeout_ms']) ?? DEFAULT_ASSERT_TIMEOUT_MS;
+      // An intent declared here lands in the ledger BEFORE the verdict is drawn, which is what makes
+      // the undeclared-change gap silent on THIS verdict rather than the next one: it reads the
+      // ledger below and finds something open. The discharge comes after that read.
+      const intentId = await linkInlineIntent(
+        deps,
+        asString(args['sessionId']),
+        asString(args['intent']),
+        PredicateKind.SETTLED === until.kind ? undefined : until,
+      );
 
       // Before anything is driven: this path cannot honour a native-input request, and taking the
       // argument and ignoring it told the agent its trusted click had happened. See act-danger.
@@ -702,8 +717,11 @@ export const ACT_TOOLS: ToolDef[] = [
           ...(gapNote === undefined ? [] : [CaptureLoss.TRANSPORT_GAP]),
           ...(impeaching.note === undefined ? [] : [CaptureLoss.BLIND_SPOT]),
         ];
+        // Named because the discharge below records the same grade the verdict reports, rather than a
+        // second reading of the same evidence that could drift from it.
+        const grade = gradeOf(gradedLinks);
         const honesty = buildHonestyBlock({
-          grade: gradeOf(gradedLinks),
+          grade,
           attribution: 'window',
           // Did the buffer lose scarce evidence FROM THIS WINDOW — not "did it evict anything while
           // the action ran", which was the previous rule and which is true on essentially every live
@@ -816,6 +834,18 @@ export const ACT_TOOLS: ToolDef[] = [
           routeChanged: actionSummary.route !== undefined,
           routeSignalFired: actionSummary.signals.some((name) => name.startsWith('route')),
         });
+        // The verdict IS the proof attempt, so a green one discharges the intent it was drawn for.
+        // Only a green: a red proved nothing, and `dischargeIntent` refuses an unbound intent anyway,
+        // so a bare settle leaves it open rather than collecting a proof nothing earned. The id is
+        // checked here rather than only inside the helper so a caller that declared no intent touches
+        // nothing at all, not even the clock.
+        if (intentId !== undefined && Verified.YES === decision.verified) {
+          await dischargeInlineIntent(deps, asString(args['sessionId']), intentId, {
+            verdictId: inlineVerdictId(ReticleTool.ACT_AND_WAIT, deps.now()),
+            grade,
+            at: deps.now(),
+          });
+        }
         verdictEffect = {
           claim: describeWaitTarget(until),
           verified: decision.verified,

--- a/packages/server/src/tools/observe-tools.ts
+++ b/packages/server/src/tools/observe-tools.ts
@@ -10,6 +10,7 @@ import {
   ReticleCommand,
   DEFAULT_ASSERT_TIMEOUT_MS,
   PredicateKind,
+  Verified,
 } from '@reticlehq/core';
 import { ReticleTool } from './tool-names.js';
 import { buildReactionReport } from '../events/reaction.js';
@@ -44,10 +45,16 @@ import {
 import { assertVerdict } from './assert-verdict.js';
 import { isChangeUndeclared } from '../honesty/undeclared-change.js';
 import { openSessionIntents } from '../intent/open-intents.js';
+import {
+  dischargeInlineIntent,
+  inlineVerdictId,
+  linkInlineIntent,
+} from '../intent/inline-intent.js';
 import { bodiesNotCaptured } from '../honesty/uncaptured-bodies.js';
 import { withControl } from '../session/control-envelope.js';
 import { asString, asNumber, asRecord } from './tools-helpers.js';
-import { type ToolDef, sessionIdShape, commandOrThrow } from './tool-kit.js';
+import { type ToolDef, intentArg, sessionIdShape, commandOrThrow } from './tool-kit.js';
+import { gradeOfPredicate } from './assert-grade.js';
 
 /**
  * Evidence-completeness block: present on observe/network/console only when the ring buffer has
@@ -359,6 +366,7 @@ export const OBSERVE_TOOLS: ToolDef[] = [
         .describe(
           'Cursor from a prior reticle_act — scopes the assertion to events after that act.',
         ),
+      intent: intentArg,
       ...sessionIdShape,
     },
     outputSchema: {
@@ -427,6 +435,14 @@ export const OBSERVE_TOOLS: ToolDef[] = [
       const timeout = asNumber(args['timeout_ms']) ?? 0;
       // Honesty: explicit since wins; else default to the last act's cursor; else the whole buffer.
       const since = asNumber(args['since']) ?? session.lastAct.cursor() ?? 0;
+      // Declared BEFORE the verdict, so the undeclared-change read below finds it open and stays
+      // quiet on THIS verdict rather than on the next one. Discharged after that read.
+      const intentId = await linkInlineIntent(
+        deps,
+        asString(args['sessionId']),
+        asString(args['intent']),
+        PredicateKind.SETTLED === predicate.kind ? undefined : predicate,
+      );
       const verdict =
         timeout > 0
           ? await waitForPredicate(session, predicate, timeout, since)
@@ -457,6 +473,17 @@ export const OBSERVE_TOOLS: ToolDef[] = [
         verdict.observationLost,
         changeUndeclared,
       );
+      // The assertion IS the proof attempt, so a green one discharges the intent it was drawn for. A
+      // red proved nothing, and an unbound intent refuses discharge anyway — see inline-intent.ts.
+      // The id is checked HERE rather than only inside the helper so a caller that declared no intent
+      // touches nothing at all, not even the clock.
+      if (intentId !== undefined && Verified.YES === decision['verified']) {
+        await dischargeInlineIntent(deps, asString(args['sessionId']), intentId, {
+          verdictId: inlineVerdictId(ReticleTool.ASSERT, deps.now()),
+          grade: gradeOfPredicate(predicate),
+          at: deps.now(),
+        });
+      }
       // Journal the verdict so a LATER turn can read what this one proved. A verdict that lives only
       // in the response lives only in the agent's context window, which is the copy a compaction
       // destroys — see runs/run-context.ts. Recorded WITHOUT an attribution window: this tool drives

--- a/packages/server/src/tools/tool-kit.ts
+++ b/packages/server/src/tools/tool-kit.ts
@@ -134,6 +134,25 @@ export interface ToolDef<Ext = unknown> {
   handler(deps: ToolDeps<Ext>, args: Record<string, unknown>): Promise<unknown>;
 }
 
+/**
+ * The optional inline intent, on every tool that draws a verdict.
+ *
+ * One field, carrying either prose or the id of an intent already declared, because the surface is
+ * the scarce thing and a second field for the reference case would double the cost of the idea to
+ * make one of its two uses marginally more explicit. Told apart by the ledger — see
+ * `intent/inline-intent.ts`.
+ *
+ * The first sentence is what a lean surface advertises, so it carries both readings; the rest is for
+ * the profiles that send the whole description.
+ */
+export const intentArg = z
+  .string()
+  .optional()
+  .describe(
+    'What this change is meant to make true, in your own words, or the id of an intent you already declared. ' +
+      'Recorded in .reticle/intent.json, the same ledger reticle_intent writes, and marked proved by this verdict if it passes.',
+  );
+
 export const sessionIdShape = {
   sessionId: z
     .string()


### PR DESCRIPTION
## Why

`reticle_intent` is on the EXTENDED surface. To declare intent an agent has to (a) discover a tool that is not in the list it was handed, (b) decide to use it, and (c) spend a round trip. Every one of those is a place the capture silently fails, and the measured consequence is that intent is essentially never declared.

`reticle_act_and_wait` and `reticle_assert` are on the default surface — their schemas are in every agent's tool list already. An optional `intent` there makes declaring it inline, discoverable by construction, and free of an extra call.

## What

- **One optional `intent` argument** on `reticle_act_and_wait` and `reticle_assert`, defined once as `intentArg` in `tool-kit.ts` so both tools say the same thing.
- **Same ledger, not a parallel one.** It writes `.reticle/intent.json` through `IntentStore`, exactly as `reticle_intent { action: "declare" }` does. `intent/inline-intent.ts` is the link, modelled on `flows/flow-intent.ts`.
- **Bound and discharged where it is honest to.** The predicate about to be evaluated is bound as what would prove the intent; a green verdict discharges it and records itself in `provenBy`. A red leaves it undischarged. A bare `settled` wait binds nothing, and `dischargeIntent` already refuses to prove an unbound intent, so no proof is invented for a verdict that produced none.
- **Prose or an id, in the same field.** A string that names a row already in the ledger is a reference: the row keeps its own words, and a binding bound deliberately through `reticle_intent { action: "bind" }` is left alone rather than narrowed to whatever this call asserted. Anything else is prose, declared under an id derived from the statement (`inline:<slug>-<digest>`) so the same sentence is one row rather than five.
- **The undeclared-change gap is silent on the SAME verdict.** The declaration happens before the verdict is drawn, so `isChangeUndeclared` finds it open; the discharge happens after that read. An agent that did exactly the right thing is not told off for it.
- **Omitting `intent` changes nothing at all** — no ledger read, no ledger write, not even a clock call.

## Tests, red first

`packages/server/src/intent/inline-intent.test.ts` drives the real tools. Written before the implementation, 5 of its 10 assertions red (the other 5 are the negative controls and the no-change guarantee, which passed by construction):

- an inline intent lands in the ledger, on both tools
- a passing verdict marks it proved and names the verdict that did it
- a failing verdict leaves it undischarged
- the undeclared-change gap still fires when nothing was declared, and goes quiet on the verdict that declared inline
- an existing id is referenced rather than restated, and its deliberate binding survives
- omitting `intent` writes no ledger and returns the same verdict

## Surface size

Unchanged — no tool added, so `surface-sizes.test.ts` is untouched at 18 / 30 / 3. The friendly unknown-arg refusal and the "every documented tool argument exists" gate both read `inputSchema`, so they pick the new argument up on their own.

## Gates

`pnpm format:check` · `pnpm lint` · `pnpm typecheck` · `pnpm test:unit` (4835 passed) · `pnpm lint:docs` · `pnpm test:e2e` **36/36 specs** — run because this changes the tool surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)