### PR TITLE
fix(server): fold captured request bodies into the duplicate-request key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,12 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
   **The `sharp` security override in the root manifest stays.** It looks orphaned once the direct dependency goes and it is not: `next` and `astro` both pull `sharp` as an optional dependency in the fixtures under `apps/`, so the override is still the floor on a transitive install. Removing a version floor because the direct dependant left is how a patched transitive quietly slides back down.
 
+### Fixed
+
+- **`@reticlehq/server`: `duplicate-request` no longer reports every distinct write to one URL as a double submit.** A command-bus API posts every mutation to a single endpoint and discriminates on a JSON body field (`{"command":"study.stage.set"}` vs `{"command":"mesh.plan"}`). The rule keyed repeats on method + URL alone, so one click firing three genuinely different commands read as "the same write fired 3 times": nearly every `act_and_wait` in such a session was flagged, and verdicts that had genuinely passed degraded to `unknown` behind doubles that were never doubles. Reported from the field.
+
+  A captured request body now joins the identity, so writes that differ in what they sent are no longer counted as repeats, and identical bodies still are. With body capture off (or a non-text body, which reports a type marker instead) there is nothing to compare and the URL alone stands, exactly as before; a window where only some calls carried bodies compares nothing rather than guess. The finding's `detail` still names `method url ×N`, so nothing downstream had to change.
+
 ## [2.11.0] — 2026-08-22
 
 ### Added

--- a/packages/server/src/events/contradictions.test.ts
+++ b/packages/server/src/events/contradictions.test.ts
@@ -162,6 +162,63 @@ describe('findContradictions — cross-channel disagreement', () => {
     ).toEqual([]);
   });
 
+  /**
+   * A command-bus API sends every mutation to ONE URL and discriminates on a JSON body field.
+   * Reported from the field: one click firing three genuinely different commands read as "the same
+   * write fired 3 times", nearly every act_and_wait in the session was flagged, and otherwise-clean
+   * verdicts degraded to unknown behind repeats that were never repeats. The bodies that
+   * disambiguate the calls ride on the events already; folding them into the identity costs
+   * nothing and saves the accusation for writes that are actually identical.
+   */
+  describe('writes distinguished only by their captured request body', () => {
+    const commandBus = (command: string): ReticleEvent =>
+      ev(EventType.NET_REQUEST, {
+        id: `n${String(seq)}`,
+        method: 'POST',
+        url: '/api/v0/studies/1/command',
+        status: 200,
+        ok: true,
+        requestBody: JSON.stringify({ command }),
+      });
+
+    it('are not a duplicate when the bodies differ', () => {
+      const events = [
+        commandBus('study.stage.set'),
+        commandBus('mesh.controls.set'),
+        commandBus('mesh.plan'),
+        domChanged(),
+      ];
+      expect(
+        findContradictions(events, { actionSince: events[0]?.t ?? 0 }).map((c) => c.kind),
+      ).not.toContain(ContradictionKind.DUPLICATE_REQUEST);
+    });
+
+    it('are still a duplicate when the bodies are identical', () => {
+      const events = [commandBus('mesh.plan'), commandBus('mesh.plan'), domChanged()];
+      expect(
+        findContradictions(events, { actionSince: events[0]?.t ?? 0 }).find(
+          (c) => c.kind === ContradictionKind.DUPLICATE_REQUEST,
+        )?.detail,
+      ).toContain('/api/v0/studies/1/command');
+    });
+
+    it('stay un-compared, and therefore un-flagged, when only one side carried a body', () => {
+      const withBody = commandBus('study.stage.set');
+      const withoutBody = ev(EventType.NET_REQUEST, {
+        id: `n${String(seq)}`,
+        method: 'POST',
+        url: '/api/v0/studies/1/command',
+        status: 200,
+        ok: true,
+      });
+      expect(
+        findContradictions([withBody, withoutBody, domChanged()], {
+          actionSince: withBody.t,
+        }).map((c) => c.kind),
+      ).not.toContain(ContradictionKind.DUPLICATE_REQUEST);
+    });
+  });
+
   it('catches the UI advancing over a request that never settled', () => {
     const pending = ev(EventType.NET_PENDING, { id: 'n99', method: 'POST', url: '/api/slow' });
     expect(kinds([pending, domChanged()])).toEqual([ContradictionKind.REQUEST_NEVER_SETTLED]);

--- a/packages/server/src/events/contradictions.ts
+++ b/packages/server/src/events/contradictions.ts
@@ -573,23 +573,35 @@ function findWindowContradictions(
   // Attribution is the whole rule here, not a refinement of it: counting `method + url` over whatever
   // window the caller handed in turns two legitimate separate saves into a double submit. See
   // ContradictionOptions.actionSince.
+  //
+  // A captured request body joins the identity. A command-bus API posts every mutation to one URL
+  // and discriminates on a body field (`{"command":"study.stage.set"}` vs `{"command":"mesh.plan"}`),
+  // so under URL alone each of those distinct writes read as a repeat of the first, and clean
+  // verdicts degraded to unknown behind doubles that were never doubles. When no body was captured
+  // (capture off, or a non-text body, which reports a type marker instead) there is nothing to
+  // compare and the URL alone stands, as before; a window where only some calls carried bodies
+  // compares nothing rather than guess.
   const actionSince = options.actionSince;
   if (actionSince !== undefined) {
-    const writeCounts = new Map<string, number>();
+    const writeCounts = new Map<string, { label: string; count: number }>();
     for (const event of events) {
       if (event.type !== EventType.NET_REQUEST || event.t < actionSince) continue;
       const call = netCall(event);
       if (!isMutating(call)) continue;
-      const key = `${call.method} ${call.url}`;
-      writeCounts.set(key, (writeCounts.get(key) ?? 0) + 1);
+      const label = `${call.method} ${call.url}`;
+      const body = asString(event.data['requestBody']);
+      const key = body === undefined || 0 === body.length ? label : `${label} ${body}`;
+      const entry = writeCounts.get(key) ?? { label, count: 0 };
+      entry.count += 1;
+      writeCounts.set(key, entry);
     }
-    for (const [key, count] of writeCounts) {
+    for (const [, { label, count }] of writeCounts) {
       if (count < 2) continue;
       found.push({
         kind: ContradictionKind.DUPLICATE_REQUEST,
         claim: 'one user action was performed',
         counter: `the same write fired ${String(count)} times`,
-        detail: `${key} ×${String(count)}`,
+        detail: `${label} ×${String(count)}`,
       });
     }
   }


### PR DESCRIPTION
## Summary

The duplicate-request contradiction keyed repeats on method + URL alone, so a command-bus API that posts every mutation to one endpoint and discriminates on a JSON body field had every distinct write reported as a double submit, degrading clean verdicts to unknown. A captured request body now joins the identity. Without body capture the behavior is unchanged, and the finding detail still reads `method url xN`, so nothing downstream changed.

## Testing

Unit tests in contradictions.test.ts cover all three cases: three POSTs to one URL with different bodies no longer flag DUPLICATE_REQUEST, identical bodies still do, and a window where only one side carried a body stays un-compared. Focused suite, full server suite, lint, typecheck and prettier verified locally.

## Checklist

- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed