### PR TITLE
feat(server): a lean tool surface that keeps the evidence tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ### Added
 
+- **`@reticlehq/server` — an experimental `lean` tool surface, opt-in and under measurement.** Set `RETICLE_TOOL_PROFILE=lean` in the DAEMON's environment before it starts. It is not a recommendation and nothing changes for anyone who does not set it: `default` is untouched, and no tool was deleted.
+
+  It exists to split a finding the repo already has. The `verify` surface — one acting tool plus the two meta-tools — was measured over the same thirty-bug set as `default` and held detection while cutting the bill 37% and TRIPLING false alarms. The five new false alarms were not scattered: each one was a defect whose evidence lives in `reticle_state`, `reticle_network` or `reticle_observe`. Strip the observation tools and the model stops observing — it reaches for a verdict without evidence and calls a healthy build broken. So the saving and the loss came from two different cuts, and `lean` pays for only one of them.
+
+  It advertises look (`reticle_snapshot`, `reticle_query`), the four evidence tools (`reticle_state`, `reticle_network`, `reticle_console`, `reticle_observe`), both verdict tools (`reticle_act_and_wait`, `reticle_assert` — the second because `act_and_wait` requires an action and so cannot express a standing assertion), and the two meta-tools. Everything else stays in the registry, stays catalogued by `reticle_tools`, and stays callable by name through `reticle_run` — a name this surface drops still comes back with the call that works, never as "not found".
+
+  **The known ceiling is `reticle_feedback`.** It is not advertised here, and an unadvertised feedback channel collects little to nothing. That is tolerable only because this profile is opt-in and short-lived by construction; a surface that stops being an experiment gets feedback back before anything else.
+
+  Its membership is pinned by a test, because an experiment whose independent variable drifts mid-flight measures nothing — and so is `default`'s, because the control arm has to hold still too.
+
 - **`@reticlehq/server` — `reticle_verify { action: "coverage" }` now reports whether this session used `reticle_context` and `reticle_intent` at all.** Both features shipped with the same pre-registered disproof — _if agents never call it, cut it_ — and nothing recorded whether they were called, so the disproof could never be run. A feature whose disproof cannot be run is one nobody can kill, which is the same defect that kept the old push-based run context alive.
 
   The new `featureUse` block answers it locally, per session: how many times `reticle_context` was called and at which step, what the intent ledger holds, and the two costs of NOT using either — verdicts drawn while the ledger was empty, and read-only calls that re-fetched a fact the run had already established. It also carries a mechanical proxy for whether calling `reticle_context` changed anything: after each call, did the agent ACT, or did it re-read a subject the context had just supplied. That proxy is proximity in a call sequence and nothing more; what it cannot see is written down beside it.

--- a/bench/harness/schema-tax.mjs
+++ b/bench/harness/schema-tax.mjs
@@ -26,6 +26,10 @@ import { measure } from './tokenizer.mjs';
 const RETICLE_SURFACES = [
   { label: 'default', env: {} },
   { label: 'all', env: { RETICLE_ADVERTISE_ALL_TOOLS: '1' } },
+  // The two trimmed surfaces. Measured here rather than reasoned about, because the whole claim being
+  // tested is that the MENU is most of the bill — and that claim is only checkable off the wire.
+  { label: 'verify', env: { RETICLE_VERIFY_SURFACE: '1' } },
+  { label: 'lean', env: { RETICLE_TOOL_PROFILE: 'lean' } },
 ];
 
 const COMPETITORS = {

--- a/packages/server/src/mcp/mcp.ts
+++ b/packages/server/src/mcp/mcp.ts
@@ -296,7 +296,13 @@ export function advertisedConfig(
   // `verify` is lean for the same reason `default` is, and more so: it exists to make a verdict
   // cheap, and it was serving FULL descriptions plus outputSchema because the check named only the
   // default. That put 8,207 bytes on the wire for three tools.
-  const lean = profile === TOOL_SURFACE.DEFAULT || profile === TOOL_SURFACE.VERIFY;
+  // `lean` here is the ADJECTIVE (terse descriptions, no output schemas), which every trimmed surface
+  // wants — including TOOL_SURFACE.LEAN, the profile that borrows the word. A trimmed surface serving
+  // full prose plus output schemas is the exact defect that put 8,207 bytes on `verify`'s three tools.
+  const lean =
+    profile === TOOL_SURFACE.DEFAULT ||
+    profile === TOOL_SURFACE.VERIFY ||
+    profile === TOOL_SURFACE.LEAN;
   const terse = lean && !isMetaTool;
   // The first advertised tool carrying a predicate spells the grammar out; the rest point at it.
   const anchor = advertised.find((t) =>

--- a/packages/server/src/tools/lean-surface.test.ts
+++ b/packages/server/src/tools/lean-surface.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The `lean` surface is an EXPERIMENT, and an experiment whose independent variable can drift is not
+ * an experiment. These pin the three things a mid-flight edit could silently change: which tools it
+ * advertises, that nothing it drops became unreachable, and that `default` — the control arm — is
+ * still the same list it was before `lean` existed.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { advertisedConfig, advertisedTools } from '../mcp/mcp.js';
+import { TOOLS } from './tools.js';
+import { ReticleTool } from './tool-names.js';
+import {
+  CORE_TOOL_NAMES,
+  LEAN_TOOL_NAMES,
+  TOOL_SURFACE,
+  TOOL_PROFILE_ENV,
+  type ToolSurface,
+  filterTools,
+  resolveToolSurface,
+} from './tool-surface.js';
+
+/** The composition under measurement. Changing this changes what the numbers mean — see CHANGELOG. */
+const PINNED_LEAN = [
+  ReticleTool.SNAPSHOT,
+  ReticleTool.QUERY,
+  ReticleTool.ACT_AND_WAIT,
+  ReticleTool.ASSERT,
+  ReticleTool.OBSERVE,
+  ReticleTool.NETWORK,
+  ReticleTool.CONSOLE,
+  ReticleTool.STATE,
+];
+
+/**
+ * The control arm. `lean` is only measurable against a `default` that did not move, so this is a
+ * literal transcription of the set as it stood when the experiment was set up, not a re-derivation.
+ */
+const PINNED_DEFAULT = [
+  ReticleTool.SESSIONS,
+  ReticleTool.NAVIGATE,
+  ReticleTool.SNAPSHOT,
+  ReticleTool.QUERY,
+  ReticleTool.ACT,
+  ReticleTool.ACT_AND_WAIT,
+  ReticleTool.ACT_SEQUENCE,
+  ReticleTool.OBSERVE,
+  ReticleTool.NETWORK,
+  ReticleTool.CONSOLE,
+  ReticleTool.WAIT_FOR,
+  ReticleTool.ASSERT,
+  ReticleTool.STATE,
+  ReticleTool.INSPECT,
+  ReticleTool.FEEDBACK,
+  ReticleTool.SESSION,
+];
+
+/**
+ * The advertised PROSE of a surface, in bytes.
+ *
+ * Not the exact wire payload — that is measured off a real `tools/list` by
+ * bench/harness/schema-tax.mjs — but the component the surface controls: descriptions are re-sent
+ * every turn, and per the measurement in tool-surface.ts the tool description plus its parameter
+ * descriptions are the bulk of what an output-schema-free surface puts on the wire. A gate over an
+ * approximation that moves WITH the payload beats no gate over the exact one.
+ */
+function advertisedProseBytes(surface: ToolSurface): number {
+  const advertised = advertisedTools(surface);
+  let bytes = 0;
+  for (const tool of advertised) {
+    const config = advertisedConfig(tool, advertised, surface);
+    bytes += Buffer.byteLength(`${tool.name}${config.description}`, 'utf8');
+    for (const shape of Object.values(config.inputSchema)) {
+      bytes += Buffer.byteLength(shape.description ?? '', 'utf8');
+    }
+  }
+  return bytes;
+}
+
+describe('the lean surface', () => {
+  const original = process.env[TOOL_PROFILE_ENV];
+  beforeEach(() => {
+    delete process.env[TOOL_PROFILE_ENV];
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env[TOOL_PROFILE_ENV];
+    else process.env[TOOL_PROFILE_ENV] = original;
+  });
+
+  it('resolves from the tool-profile setting', () => {
+    process.env[TOOL_PROFILE_ENV] = TOOL_SURFACE.LEAN;
+    expect(resolveToolSurface()).toBe(TOOL_SURFACE.LEAN);
+  });
+
+  it('resolves from an explicit request, so a caller never depends on process env', () => {
+    expect(resolveToolSurface(TOOL_SURFACE.LEAN)).toBe(TOOL_SURFACE.LEAN);
+  });
+
+  it('advertises EXACTLY the pinned composition, plus the two meta-tools', () => {
+    const filtered = filterTools(TOOLS, TOOL_SURFACE.LEAN)
+      .map((t) => t.name)
+      .sort();
+    expect(filtered).toEqual([...PINNED_LEAN].sort());
+    expect(new Set(LEAN_TOOL_NAMES)).toEqual(new Set(PINNED_LEAN));
+    const advertised = advertisedTools(TOOL_SURFACE.LEAN).map((t) => t.name);
+    expect(advertised).toContain(ReticleTool.RUN);
+    expect(advertised).toContain(ReticleTool.TOOLS);
+  });
+
+  it('leaves every tool it drops reachable through the escape hatch', () => {
+    const advertised = new Set(advertisedTools(TOOL_SURFACE.LEAN).map((t) => t.name));
+    expect(advertised, 'without the hatch a trim is a removal').toContain(ReticleTool.RUN);
+    const registry = new Set(TOOLS.map((t) => t.name));
+    const unreachable = [...CORE_TOOL_NAMES].filter(
+      (name) => !advertised.has(name) && !registry.has(name),
+    );
+    expect(unreachable, 'a dropped tool that is not in the registry is a capability LOSS').toEqual(
+      [],
+    );
+  });
+
+  it('does not move the control arm: default membership is unchanged', () => {
+    expect([...CORE_TOOL_NAMES].sort()).toEqual([...PINNED_DEFAULT].sort());
+    const filtered = filterTools(TOOLS, TOOL_SURFACE.DEFAULT)
+      .map((t) => t.name)
+      .sort();
+    expect(filtered).toEqual([...PINNED_DEFAULT].sort());
+  });
+
+  it('puts materially less prose on the wire than default, or it buys nothing', () => {
+    const lean = advertisedProseBytes(TOOL_SURFACE.LEAN);
+    const fallback = advertisedProseBytes(TOOL_SURFACE.DEFAULT);
+    expect(lean).toBeLessThan(fallback * 0.75);
+  });
+});

--- a/packages/server/src/tools/surface-sizes.test.ts
+++ b/packages/server/src/tools/surface-sizes.test.ts
@@ -38,6 +38,11 @@ const EXPECTED_SIZE: Record<ToolSurface, number> = {
   // target, plus the two meta-tools that reach the rest. See tool-surface.ts for why it is not the
   // default.
   [TOOL_SURFACE.VERIFY]: 3,
+  // The experimental middle: the four evidence tools plus look, act-with-a-verdict and assert, and
+  // the two meta-tools. Sized against `verify`'s measured failure — that surface saved 37% and
+  // tripled false alarms, and only the observation cut caused the second half. Membership itself is
+  // pinned in lean-surface.test.ts; this is only its count.
+  [TOOL_SURFACE.LEAN]: 10,
 };
 
 /**

--- a/packages/server/src/tools/tool-surface.test.ts
+++ b/packages/server/src/tools/tool-surface.test.ts
@@ -147,9 +147,17 @@ describe('one surface, plus two switches', () => {
    * until re-measured on the same 30-bug set.
    *
    * If that measurement fails, the entry comes out. An unmeasured third surface IS a menu.
+   *
+   * `lean` is admitted on strictly narrower terms again: it is not offered, not documented as a
+   * recommendation, and exists to RUN the measurement that `verify` failed — same 30-bug set,
+   * observation tools retained. `verify` proved the token saving and the accuracy loss come from two
+   * different cuts; `lean` pays for only one of them. It is an EXPERIMENT with the same exit as the
+   * others: if it does not hold detection and false alarms against `default`, the entry comes out.
    */
-  it('offers exactly three internal surfaces, each a switch rather than a choice', () => {
-    expect(new Set(Object.values(TOOL_SURFACE))).toEqual(new Set(['default', 'all', 'verify']));
+  it('offers exactly four internal surfaces, each a switch rather than a choice', () => {
+    expect(new Set(Object.values(TOOL_SURFACE))).toEqual(
+      new Set([TOOL_SURFACE.DEFAULT, TOOL_SURFACE.ALL, TOOL_SURFACE.VERIFY, TOOL_SURFACE.LEAN]),
+    );
   });
 
   it('verify still reaches every other tool, or it is a trap rather than a saving', () => {

--- a/packages/server/src/tools/tool-surface.ts
+++ b/packages/server/src/tools/tool-surface.ts
@@ -72,6 +72,45 @@ export const TOOL_SURFACE = {
    * supplies the evidence the surface would otherwise have to go and find.
    */
   VERIFY: 'verify',
+  /**
+   * EXPERIMENTAL, opt-in, and UNDER MEASUREMENT. Not a recommendation, and not on a path to becoming
+   * the default until it has a number of its own.
+   *
+   * It exists because of the finding recorded on VERIFY above, read forwards instead of backwards.
+   * That surface cut the bill 37% and TRIPLED false alarms, and the five new false alarms were not
+   * scattered: every one of them was a defect whose evidence lives in `reticle_state`,
+   * `reticle_network` or `reticle_observe`. So the token saving and the accuracy loss came from two
+   * different cuts, and only one of them has to be paid for. `lean` keeps every observation tool and
+   * cuts the rest.
+   *
+   * What stays, and why each one is not a candidate for removal:
+   *   SNAPSHOT / QUERY   look. Without them the agent cannot name an element it did not already know.
+   *   STATE / NETWORK / CONSOLE / OBSERVE   the four evidence tools. Dropping these is the MEASURED
+   *                      cause of the tripled false-alarm rate. They are the point of the profile.
+   *   ACT_AND_WAIT       the only tool that acts AND returns a verdict. Omitting `until` makes it
+   *                      act-then-settle, which is what `reticle_act` does, so `act` is redundant here.
+   *   ASSERT             the only way to get a verdict WITHOUT acting. `act_and_wait` requires an
+   *                      `action`, so this is a capability it genuinely cannot express, not a synonym.
+   *
+   * What goes, and what it costs (one `reticle_run` hop each — `unadvertisedToolHelp` hands the agent
+   * the exact call, so a dropped name never comes back as "not found"):
+   *   ACT                subsumed: `act_and_wait` with `until` omitted is act-then-settle.
+   *   WAIT_FOR           subsumed: `act_and_wait { until }` takes the same PredicateSchema.
+   *   ACT_SEQUENCE       batching is a cost optimisation on top of a surface built to be cheap.
+   *   NAVIGATE           once per run, not once per turn — the wrong thing to pay for every turn.
+   *   SESSIONS           the CLI answers this (`reticle status`) without spending any turn budget.
+   *   INSPECT            fix-side, not verdict-side: it is called once a bug is FOUND, so its hop is
+   *                      paid once per finding rather than once per turn. Nothing else maps a node to
+   *                      a source file, which is why it is a hop and not a deletion.
+   *   SESSION            the lease block and the pause hint name it in prose, which is what made it
+   *                      load-bearing on the default surface. Under a trimmed surface the
+   *                      unadvertised-tool help turns that into a working `reticle_run` call.
+   *   FEEDBACK           the one drop with a KNOWN CEILING: an unadvertised feedback channel collects
+   *                      little to nothing, so a long-lived profile must not ship without it. Acceptable
+   *                      only because this profile is opt-in and short-lived by construction; if it
+   *                      ever stops being an experiment, feedback comes back first.
+   */
+  LEAN: 'lean',
 } as const;
 export type ToolSurface = (typeof TOOL_SURFACE)[keyof typeof TOOL_SURFACE];
 
@@ -238,6 +277,22 @@ export const EXTENDED_TOOL_NAMES: ReadonlySet<string> = new Set([
  */
 export const VERIFY_TOOL_NAMES: ReadonlySet<string> = new Set([ReticleTool.ACT_AND_WAIT]);
 
+/**
+ * The lean surface: look, observe, act-with-a-verdict, assert. Pinned by lean-surface.test.ts,
+ * because an experiment whose independent variable drifts mid-flight measures nothing. Every
+ * inclusion and every exclusion is argued at TOOL_SURFACE.LEAN.
+ */
+export const LEAN_TOOL_NAMES: ReadonlySet<string> = new Set([
+  ReticleTool.SNAPSHOT,
+  ReticleTool.QUERY,
+  ReticleTool.ACT_AND_WAIT,
+  ReticleTool.ASSERT,
+  ReticleTool.OBSERVE,
+  ReticleTool.NETWORK,
+  ReticleTool.CONSOLE,
+  ReticleTool.STATE,
+]);
+
 /** Is the truthy form of a boolean env var set? `1`, `true`, `yes` — anything else is off. */
 function envFlagOn(raw: string | undefined): boolean {
   if (raw === undefined) return false;
@@ -252,11 +307,17 @@ function envFlagOn(raw: string | undefined): boolean {
  * switch decides, and the retired setting is honoured last so an old shell profile still works.
  */
 export function resolveToolSurface(explicit?: string): ToolSurface {
+  if (explicit === TOOL_SURFACE.LEAN) return TOOL_SURFACE.LEAN;
   if (explicit === TOOL_SURFACE.VERIFY) return TOOL_SURFACE.VERIFY;
   if (explicit === TOOL_SURFACE.ALL) return TOOL_SURFACE.ALL;
   if (explicit === TOOL_SURFACE.DEFAULT) return TOOL_SURFACE.DEFAULT;
   const retiredExplicit = explicit === undefined ? undefined : RETIRED_PROFILE_VALUES[explicit];
   if (retiredExplicit !== undefined) return retiredExplicit;
+  // The one LIVE value of the otherwise-retired setting. It rides there rather than on a switch of
+  // its own because the experiment is an A/B between two surfaces, and a boolean cannot name an arm.
+  if (TOOL_SURFACE.LEAN === process.env[TOOL_PROFILE_ENV]?.trim().toLowerCase()) {
+    return TOOL_SURFACE.LEAN;
+  }
   if (envFlagOn(process.env[VERIFY_SURFACE_ENV])) return TOOL_SURFACE.VERIFY;
   if (envFlagOn(process.env[ADVERTISE_ALL_ENV])) return TOOL_SURFACE.ALL;
   const retiredEnv = RETIRED_PROFILE_VALUES[process.env[TOOL_PROFILE_ENV] ?? ''];
@@ -280,6 +341,14 @@ export interface ToolSurfaceOrigin {
  */
 export function describeToolSurface(active: ToolSurface, requested?: string): ToolSurfaceOrigin {
   const retired = requested ?? process.env[TOOL_PROFILE_ENV];
+  // `lean` is the one value of this setting that is NOT retired. Reporting it as retired would tell
+  // an agent its arm did not take, which on an A/B is worse than saying nothing.
+  if (TOOL_SURFACE.LEAN === active) {
+    return {
+      active,
+      source: `${TOOL_PROFILE_ENV}=${TOOL_SURFACE.LEAN} — an EXPERIMENTAL surface under measurement; unadvertised tools stay callable via ${ReticleTool.RUN}`,
+    };
+  }
   if (retired !== undefined && retired in RETIRED_PROFILE_VALUES) {
     return {
       active,
@@ -311,6 +380,7 @@ export function filterTools(tools: ToolDef[], surface: ToolSurface): ToolDef[] {
   // CORE_TOOL_NAMES is what it always really was: the set advertised directly. It was never the
   // interesting thing about the `core` PROFILE, whose only distinction was a second name for this.
   if (surface === TOOL_SURFACE.VERIFY) return tools.filter((t) => VERIFY_TOOL_NAMES.has(t.name));
+  if (surface === TOOL_SURFACE.LEAN) return tools.filter((t) => LEAN_TOOL_NAMES.has(t.name));
   if (surface === TOOL_SURFACE.DEFAULT) return tools.filter((t) => CORE_TOOL_NAMES.has(t.name));
   // `all` is the extended surface, not the whole registry — the cap is a hard budget shared with
   // every other MCP server the user has connected. surface-sizes.test.ts enforces it.


### PR DESCRIPTION
## Why

`TOOL_SURFACE.VERIFY` (act_and_wait + the two meta-tools) was measured over the same thirty-bug set as `default`:

| | default | verify |
| --- | --- | --- |
| detection | 23/27 | 24/28 (held) |
| **false alarms** | 2/29 | **7/30 (tripled)** |
| tokens | 179,959 | 113,599 (37% cheaper) |

The five new false alarms were not scattered — `mutation-leak`, `generate-blast-filter`, `kpi-deploys-tamper`, `debounce-broken`, `route-stuck-deployments` — each a defect whose evidence lives in `reticle_state`, `reticle_network` or `reticle_observe`. Strip the observation tools and the model stops observing: it reaches for a verdict without evidence and calls a healthy build broken.

So the token saving and the accuracy loss came from two different cuts. `lean` pays for only one of them.

## What it advertises (10)

| tool | why it stays |
| --- | --- |
| `reticle_snapshot`, `reticle_query` | look — without them the agent cannot name an element it did not already know |
| `reticle_state`, `reticle_network`, `reticle_console`, `reticle_observe` | the four evidence tools. Dropping these is the measured cause of the tripled false-alarm rate |
| `reticle_act_and_wait` | the only tool that acts AND returns a verdict; with `until` omitted it is act-then-settle, so `reticle_act` is redundant here |
| `reticle_assert` | the only verdict WITHOUT acting — `act_and_wait` requires an `action`, so this is not a synonym |
| `reticle_run`, `reticle_tools` | the escape hatch, and the lookup that makes the hatch usable |

Dropped, one `reticle_run` hop each (`unadvertisedToolHelp` hands the agent the exact call, so a dropped name never returns "not found"): `act`, `wait_for` (both subsumed by `act_and_wait { until }`, same `PredicateSchema`), `act_sequence`, `navigate`, `sessions`, `inspect`, `session`, `feedback`.

## Measured off the wire

`node bench/harness/schema-tax.mjs reticle`, fresh daemon per reading (the setting is read at daemon startup):

| surface | tools | bytes | tokens/turn |
| --- | --- | --- | --- |
| `default` | 18 | 21,593 | 5,089 |
| `all` | 30 | 106,041 | 24,567 |
| **`lean`** | **10** | **12,546** | **2,930** |
| `verify` | 3 | 4,212 | 990 |

`lean` is 42% cheaper per turn than `default` while retaining every observation tool.

## Known ceiling

`reticle_feedback` is not advertised here, and an unadvertised feedback channel collects little to nothing. That is tolerable only because this profile is opt-in and short-lived by construction; if it ever stops being an experiment, feedback comes back first. It is stated in the code, the CHANGELOG and here rather than discovered later.

## Not a recommendation

Opt in with `RETICLE_TOOL_PROFILE=lean` in the **daemon's** environment before it starts. `default` is untouched so the two A/B on the same build; no tool was deleted.

## Tests (red first)

New `lean-surface.test.ts` — all six failed to compile before the implementation existed:
- resolves from the tool-profile setting / from an explicit request
- advertises EXACTLY the pinned composition, plus the two meta-tools
- leaves every tool it drops reachable through the escape hatch
- does not move the control arm: default membership is unchanged
- puts materially less prose on the wire than default, or it buys nothing

Plus `surface-sizes.test.ts` (count) and the anti-menu guard in `tool-surface.test.ts`, updated with the terms `lean` is admitted on and the exit condition if the measurement does not hold.

## Gates

`format:check` · `lint` · `typecheck` · `test:unit` · `lint:docs` all green. `pnpm test:e2e` run because this touches the tool surface: **36/36 specs**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
