### PR TITLE
fix(server): launch Chromium with the anti-throttling switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ### Fixed
 
+- **`@reticlehq/server`: a pooled lease no longer shares Chromium's throttling with its own background pages.** A pooled browser serves several lease contexts while only one page is ever the visible one, and for every other page Chromium throttles timers, suspends rAF and deprioritizes the renderer. That is exactly the state a session reports as `throttled: true`: timer- and WebSocket-driven DOM updates land seconds late, an assert times out on content that renders right after the timeout with no refetch, and the app gets blamed for being parked.
+
+  Both launch sites (`playwright-launcher` for the pool, `real-input` for `reticle drive`) now pass Chromium's documented opt-outs (`--disable-background-timer-throttling`, `--disable-backgrounding-occluded-windows`, `--disable-renderer-backgrounding`) from one shared builder, so the two paths cannot drift apart. The switches change what Chromium is allowed to do to a page nobody is looking at; they do not change what Reticle reports about it, and whether a real pooled lease still reports `throttled: true` for some remaining reason is a question this fix raises but does not answer.
+
 - **`@reticlehq/server` — an instrumentation gap told the agent an app was unverifiable and gave it nowhere to go.** A gap exists to be acted on: it names an absence in the app, the cost that absence imposed on the verdict just returned, and the one change that closes it. What it never carried was a location. The type declared an optional `file:line` and no producer had ever set one, so every gap went out with a `ref` and nothing else.
 
   A `ref` is a handle to a DOM node, and gaps are read late. `reticle_verify { action: "coverage" }` is the "am I done?" call, made long after the verdict that recorded the gap, by which time the page has re-rendered and the handle very likely resolves to nothing. So the surface aimed squarely at a build-and-verify loop was handing that loop a remedy with no address.

--- a/packages/server/src/chromium-launch-options.test.ts
+++ b/packages/server/src/chromium-launch-options.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { CHROMIUM_ANTI_THROTTLING_ARGS, chromiumLaunchOptions } from './chromium-launch-options.js';
+
+describe('chromiumLaunchOptions', () => {
+  it('carries the anti-throttling switches next to the headless flag', () => {
+    const opts = chromiumLaunchOptions(true);
+    expect(opts.headless).toBe(true);
+    for (const flag of CHROMIUM_ANTI_THROTTLING_ARGS) {
+      expect(opts.args).toContain(flag);
+    }
+  });
+
+  it('passes headless:false through untouched', () => {
+    expect(chromiumLaunchOptions(false).headless).toBe(false);
+  });
+
+  it('hands out a fresh array each call, so a caller cannot mutate the constant', () => {
+    const a = chromiumLaunchOptions(true);
+    const b = chromiumLaunchOptions(true);
+    expect(a.args).not.toBe(b.args);
+    a.args.push('--sneaky');
+    expect(b.args).not.toContain('--sneaky');
+  });
+});

--- a/packages/server/src/chromium-launch-options.ts
+++ b/packages/server/src/chromium-launch-options.ts
@@ -1,0 +1,37 @@
+/**
+ * The launch options every Reticle-driven Chromium gets, in one place.
+ *
+ * A pooled browser serves several lease contexts while only one page is ever the visible one, and a
+ * driven page can sit in a window the host does not treat as visible. For everyone else Chromium
+ * throttles timers, suspends rAF, and deprioritizes the renderer, which is exactly the state a
+ * session reports as `throttled: true`: WebSocket- and timer-driven DOM updates land seconds late,
+ * asserts time out on content that appears right after the timeout, with no refetch, because the
+ * app was fine and the browser was parked. The three switches below are the documented opt-outs,
+ * shared by both launch sites so the pooled path (`playwright-launcher`) and the drive path
+ * (`real-input`) cannot drift apart.
+ */
+
+/**
+ * Chromium switches that keep background pages running at full speed. Named individually rather
+ * than as one free string per call site, so a typo is a test failure instead of a silently ignored
+ * argument.
+ */
+export const CHROMIUM_ANTI_THROTTLING_ARGS = [
+  '--disable-background-timer-throttling',
+  '--disable-backgrounding-occluded-windows',
+  '--disable-renderer-backgrounding',
+] as const;
+
+/** The options object handed to `chromium.launch` at both launch sites. */
+export interface ChromiumLaunchOptions {
+  headless: boolean;
+  args: string[];
+}
+
+/**
+ * Build the launch options for a headless or headed Chromium. Pure; returns a fresh mutable array
+ * each call so no caller can mutate the constant behind everyone else's back.
+ */
+export function chromiumLaunchOptions(headless: boolean): ChromiumLaunchOptions {
+  return { headless, args: [...CHROMIUM_ANTI_THROTTLING_ARGS] };
+}

--- a/packages/server/src/input/launched-chromium.test.ts
+++ b/packages/server/src/input/launched-chromium.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The drive-path launch hands Playwright more than a headless flag.
+ *
+ * `reticle drive` owns its browser outright, but the same Chromium throttling applies: any window
+ * the OS or the browser does not treat as visible gets background-timer throttling and suspended
+ * rAF, and a driven page waiting on either reads as "the app did not react". This pins that
+ * `launchedChromium` passes the anti-throttling switches through. Plumbing only; the behavioral
+ * half needs a real browser.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const launchCalls: unknown[] = [];
+
+vi.mock('playwright', () => ({
+  chromium: {
+    launch: vi.fn((opts: unknown) => {
+      launchCalls.push(opts);
+      return Promise.resolve({
+        isConnected: () => true,
+        newContext: () => Promise.reject(new Error('not reached in this test')),
+        close: () => Promise.resolve(),
+        on: () => {},
+      });
+    }),
+  },
+}));
+
+import { launchedChromium } from './real-input.js';
+
+describe('launchedChromium', () => {
+  beforeEach(() => {
+    launchCalls.length = 0;
+  });
+
+  it('passes the anti-throttling args to chromium.launch alongside headless', async () => {
+    const browser = await launchedChromium(true);
+    expect(browser.isConnected()).toBe(true);
+    expect(launchCalls).toHaveLength(1);
+    const opts = launchCalls[0] as { headless?: boolean; args?: readonly string[] };
+    expect(opts.headless).toBe(true);
+    expect(opts.args).toContain('--disable-background-timer-throttling');
+    expect(opts.args).toContain('--disable-backgrounding-occluded-windows');
+    expect(opts.args).toContain('--disable-renderer-backgrounding');
+  });
+
+  it('passes headless:false through with the same args', async () => {
+    await launchedChromium(false);
+    const opts = launchCalls[0] as { headless?: boolean };
+    expect(opts.headless).toBe(false);
+    const allOpts = opts as { args?: readonly string[] };
+    expect(allOpts.args?.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/server/src/input/real-input.ts
+++ b/packages/server/src/input/real-input.ts
@@ -10,6 +10,7 @@
  * pay for it; the type-only import is elided by `tsc`, so the build stays green without it.
  */
 import type { Browser, Page } from 'playwright';
+import { chromiumLaunchOptions } from '../chromium-launch-options.js';
 import { gotoOptions } from '../pool/playwright-launcher.js';
 import { BrowserLaunchKind } from '@reticlehq/core';
 import { getSessionMetrics } from '../telemetry/session-metrics.js';
@@ -386,7 +387,7 @@ export interface LaunchedProviderOptions {
 const INJECT_CONNECT_WAIT_MS = 8_000;
 
 /** The only place the dynamic value import of Playwright lives for the launched (drive) path. */
-const launchedChromium: LaunchFn = async (headless) => {
+export const launchedChromium: LaunchFn = async (headless) => {
   let mod: typeof import('playwright');
   try {
     mod = await import('playwright');
@@ -395,7 +396,7 @@ const launchedChromium: LaunchFn = async (headless) => {
   }
   const settle = getSessionMetrics().recordConnectAttempt(BrowserLaunchKind.LAUNCHED);
   try {
-    const browser = await mod.chromium.launch({ headless });
+    const browser = await mod.chromium.launch(chromiumLaunchOptions(headless));
     settle();
     return browser;
   } catch (e) {

--- a/packages/server/src/pool/playwright-launcher.test.ts
+++ b/packages/server/src/pool/playwright-launcher.test.ts
@@ -1,0 +1,46 @@
+/**
+ * The pooled launch hands Playwright more than a headless flag.
+ *
+ * A pooled browser serves several lease contexts while only one page is ever the visible one, so
+ * without the anti-throttling switches every other page gets its timers throttled and its rAF
+ * suspended, which is exactly the state a lease reports as `throttled: true`. This pins that what
+ * reaches `chromium.launch` carries the switches. It proves plumbing, not Chromium's behavior; the
+ * behavioral half needs a real browser and lives outside the unit gate.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const launchCalls: unknown[] = [];
+
+vi.mock('playwright', () => ({
+  chromium: {
+    launch: vi.fn((opts: unknown) => {
+      launchCalls.push(opts);
+      return Promise.resolve({
+        isConnected: () => true,
+        newContext: () => Promise.reject(new Error('not reached in this test')),
+        close: () => Promise.resolve(),
+        on: () => {},
+      });
+    }),
+  },
+}));
+
+import { playwrightLauncher } from './playwright-launcher.js';
+
+describe('playwrightLauncher', () => {
+  beforeEach(() => {
+    launchCalls.length = 0;
+  });
+
+  it('passes the anti-throttling args to chromium.launch', async () => {
+    const launch = playwrightLauncher({ headless: true });
+    const browser = await launch();
+    expect(browser.isConnected()).toBe(true);
+    expect(launchCalls).toHaveLength(1);
+    const opts = launchCalls[0] as { headless?: boolean; args?: readonly string[] };
+    expect(opts.headless).toBe(true);
+    expect(opts.args).toContain('--disable-background-timer-throttling');
+    expect(opts.args).toContain('--disable-backgrounding-occluded-windows');
+    expect(opts.args).toContain('--disable-renderer-backgrounding');
+  });
+});

--- a/packages/server/src/pool/playwright-launcher.ts
+++ b/packages/server/src/pool/playwright-launcher.ts
@@ -8,6 +8,7 @@
 
 import type { Browser } from 'playwright';
 import { BrowserLaunchKind } from '@reticlehq/core';
+import { chromiumLaunchOptions } from '../chromium-launch-options.js';
 import { getSessionMetrics } from '../telemetry/session-metrics.js';
 import { classifyConnectFailure } from '../telemetry/connect-failure.js';
 import { chromiumInstallCommand, bundledPlaywrightVersion } from '../cli/chromium-hint.js';
@@ -82,7 +83,7 @@ export function playwrightLauncher(opts: { headless?: boolean } = {}): Launcher 
     // number that actually costs memory and the one that explains a slow machine.
     const settle = getSessionMetrics().recordConnectAttempt(BrowserLaunchKind.POOLED);
     try {
-      const browser = wrapBrowser(await chromium.launch({ headless }));
+      const browser = wrapBrowser(await chromium.launch(chromiumLaunchOptions(headless)));
       settle();
       return browser;
     } catch (err) {


### PR DESCRIPTION
## Summary

A pooled browser serves several lease contexts while only one page is ever visible, and Chromium throttles timers, suspends rAF and deprioritizes the renderer for every other page. That is the state a lease reports as throttled:true: WebSocket-driven DOM updates land seconds late and asserts time out on content that renders right after the timeout, with no refetch. Both launch sites (pooled launcher and reticle drive) now pass the three documented opt-out switches from one shared builder so the paths cannot drift.

## Testing

New unit tests pin the launch options handed to a faked chromium.launch at both sites; they prove plumbing, not Chromium behavior. A local behavioral probe (Windows, headless, two contexts, background-page timer/rAF counters) did NOT reproduce throttling in either arm, so this environment can neither confirm the flags change observable behavior nor rule out a remaining cause; the field check on a real pooled lease is still open, as the issue asked to be stated.

## Checklist

- bug reproduced before fix (field report; not locally)
- root cause identified
- bug fixed
- tests passed