### PR TITLE
fix(server): name the throttled-tab escape hatch in-protocol first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ### Fixed
 
+- **`@reticlehq/server`: the throttled-tab escape hatch is named in-protocol before it is named as a CLI command.** An agent whose only connected session was a hidden, throttled tab followed the advice to "run `reticle drive <url>`" and could not: an MCP-only client has no shell, so the recommendation sent it out of the protocol to do something only a human could do. The same sentence sat in all three places an agent meets while hunting a way out: the `reticle_sessions` description, the `recommendation` payload on each affected session row, and the recovery hint for throttled-tab refusals.
+
+  All three now lead with the route the agent itself can take, `reticle_run { tool: "reticle_lease", action: "acquire", url }`, and keep `reticle drive <url>` in the sentence as the human-side equivalent. This finishes what the timeout recovery already did when it stopped naming bare `reticle_lease`: recovery advice the caller cannot act on is spent on discovery instead of the retry.
+
 - **`@reticlehq/server` — an instrumentation gap told the agent an app was unverifiable and gave it nowhere to go.** A gap exists to be acted on: it names an absence in the app, the cost that absence imposed on the verdict just returned, and the one change that closes it. What it never carried was a location. The type declared an optional `file:line` and no producer had ever set one, so every gap went out with a `ref` and nothing else.
 
   A `ref` is a handle to a DOM node, and gaps are read late. `reticle_verify { action: "coverage" }` is the "am I done?" call, made long after the verdict that recorded the gap, by which time the page has re-rendered and the handle very likely resolves to nothing. So the surface aimed squarely at a build-and-verify loop was handing that loop a remedy with no address.

--- a/packages/core/src/notices.ts
+++ b/packages/core/src/notices.ts
@@ -89,8 +89,10 @@ export const YIELD_WITHOUT_SESSION_NOTE =
 /**
  * Actionable companion to THROTTLED_WARNING. Surfaced on act/assert results and
  * reticle_sessions rows when a tab is hidden/throttled and may be un-focusable/un-recoverable from
- * the in-page SDK + CDP path. Points at the `reticle drive` escape hatch (a guaranteed scriptable
- * context). Reticle cannot bring such a tab to front or recover it, so it names the limit instead.
+ * the in-page SDK + CDP path. Names the escape hatch the AGENT can take first (`reticle_lease`
+ * through `reticle_run`, since lease is not on the default surface) and leaves `reticle drive` as
+ * the human-side equivalent: an MCP-only agent has no shell, so a CLI sentence is advice it cannot
+ * follow. Reticle cannot bring such a tab to front or recover it, so it names the limit instead.
  */
 export const UNSCRIPTABLE_TAB_RECOMMENDATION =
-  'tab hidden/throttled and may be un-focusable from here; refocus it, or run `reticle drive <url>` for a guaranteed scriptable context';
+  'tab hidden/throttled and may be un-focusable from here; refocus it, or acquire a guaranteed scriptable context yourself with `reticle_run { tool: "reticle_lease", action: "acquire", url }` (a human can equivalently run `reticle drive <url>`)';

--- a/packages/server/src/session/session-recommendation.test.ts
+++ b/packages/server/src/session/session-recommendation.test.ts
@@ -9,6 +9,15 @@ describe('buildSessionRecommendation', () => {
     expect(rec).toContain('reticle drive');
   });
 
+  it('names the in-protocol escape hatch before the CLI one (#521)', () => {
+    // An MCP-only agent has no shell: `reticle drive` is a sentence for the human, while
+    // `reticle_run { tool: "reticle_lease" }` is the route the agent itself can take. The agent's
+    // option leads; the CLI follows as the human's equivalent.
+    const rec = UNSCRIPTABLE_TAB_RECOMMENDATION;
+    expect(rec).toContain('reticle_run { tool: "reticle_lease"');
+    expect(rec.indexOf('reticle_run')).toBeLessThan(rec.indexOf('reticle drive'));
+  });
+
   it('recommends when throttled even if not hidden', () => {
     expect(buildSessionRecommendation({ hidden: false, throttled: true, focused: true })).toBe(
       UNSCRIPTABLE_TAB_RECOMMENDATION,
@@ -34,6 +43,7 @@ describe('buildSessionRecommendation', () => {
   });
 
   it('the recommendation is the named UNSCRIPTABLE_TAB_RECOMMENDATION constant', () => {
+    expect(UNSCRIPTABLE_TAB_RECOMMENDATION).toContain('reticle_run { tool: "reticle_lease"');
     expect(UNSCRIPTABLE_TAB_RECOMMENDATION).toContain('reticle drive');
     expect(UNSCRIPTABLE_TAB_RECOMMENDATION).toContain('refocus');
   });

--- a/packages/server/src/tools/error-recovery.test.ts
+++ b/packages/server/src/tools/error-recovery.test.ts
@@ -24,12 +24,22 @@ describe('recoveryFor — every known error carries an actionable next move', ()
     expect(recoveryFor("no connected session with id 'ghost'")).toBe(RECOVERY.UNKNOWN_SESSION);
   });
 
-  it('maps a throttled-tab refusal to the refocus / reticle drive escape hatch', () => {
+  it('maps a throttled-tab refusal to the refocus / escape-hatch recovery', () => {
     expect(
       recoveryFor(
         'refusing to act: tab throttled; timer/rAF/pointer gestures may silently no-op — refocus before driving',
       ),
     ).toBe(RECOVERY.THROTTLED);
+  });
+
+  it('THROTTLED names the in-protocol route first and leaves the CLI to the human (#521)', () => {
+    // Same defect COMMAND_TIMEOUT had: an MCP-only agent has no shell, so "run `reticle drive`"
+    // sent it nowhere. The agent's own route is `reticle_run { tool: "reticle_lease" }`; the CLI
+    // stays in the sentence as the human's equivalent.
+    expect(RECOVERY.THROTTLED).toContain('reticle_run { tool: "reticle_lease"');
+    expect(RECOVERY.THROTTLED.indexOf('reticle_run')).toBeLessThan(
+      RECOVERY.THROTTLED.indexOf('reticle drive'),
+    );
   });
 
   it('names reticle_lease through reticle_run, since it is unadvertised by default (#400)', () => {

--- a/packages/server/src/tools/error-recovery.ts
+++ b/packages/server/src/tools/error-recovery.ts
@@ -74,7 +74,9 @@ export const RECOVERY = {
     'That sessionId is not connected. Call reticle_sessions for the current ids and retry with a valid one.',
   THROTTLED:
     'The target tab is backgrounded/throttled, so actions may silently no-op. Ask the human to bring ' +
-    'the tab to the front, or run `reticle drive <url>` for a guaranteed scriptable context.',
+    'the tab to the front, or acquire a guaranteed scriptable context yourself with ' +
+    '`reticle_run { tool: "reticle_lease", action: "acquire", url }` (a human can equivalently run ' +
+    '`reticle drive <url>`).',
   MISSING_BASELINE:
     'That baseline does not exist yet. Call reticle_baseline { action: "list" } to see saved names, or ' +
     'reticle_baseline { action: "save", name } to capture one before diffing against it.',

--- a/packages/server/src/tools/tools.ts
+++ b/packages/server/src/tools/tools.ts
@@ -56,7 +56,7 @@ const RAW_TOOLS: ToolDef[] = [
   {
     name: ReticleTool.SESSIONS,
     description:
-      'List connected browser sessions (tab url/title, sessionId, last-seen, health: hidden/focused/throttled, and `realInputAvailable` — true when native CDP/launched real input is driving this tab), plus a `recommendation` pointing to `reticle drive` when a tab is hidden/throttled and may be un-scriptable from here.',
+      'List connected browser sessions (tab url/title, sessionId, last-seen, health: hidden/focused/throttled, and `realInputAvailable` — true when native CDP/launched real input is driving this tab), plus a `recommendation` naming the in-protocol escape hatch (`reticle_run { tool: "reticle_lease" }`, with `reticle drive` as the human-side equivalent) when a tab is hidden/throttled and may be un-scriptable from here.',
     inputSchema: {},
     outputSchema: {
       sessions: z


### PR DESCRIPTION
## Summary

An MCP-only agent has no shell, so the throttled-tab advice "run reticle drive <url>" told it to do something only a human could do. That sentence sat in three places: the reticle_sessions description, the recommendation payload on hidden/throttled session rows, and the throttled-refusal recovery hint. All three now lead with reticle_run { tool: "reticle_lease", action: "acquire", url } and keep the CLI as the human-side equivalent, matching what the timeout recovery already does.

## Testing

Unit tests pin that all three strings name the in-protocol route and place it before any CLI mention; the constant-level tests keep refocus present. Core suite 31/31, server suite green except one documented pre-existing environment failure, lint/typecheck/prettier clean.

## Checklist

- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed