### PR TITLE
fix(browser): announce element crossings with boundary events during drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ### Fixed
 
+- **`@reticlehq/browser`: a drag now announces the crossing with boundary events, so drag-to-select extends.** A drag dispatched a held-button `mousedown`, a stepped path of moves and a clean `mouseup`, but never `mouseover`/`mouseout`/`pointerover`/`pointerout` or their non-bubbling enter/leave pairs as the pointer crossed from one element to another. React synthesises `onMouseEnter` from delegated `mouseover`/`mouseout`, so the standard drag-to-select grid (anchor set on `onMouseDown`, extended on `onMouseEnter`, cleared by a window-level `mouseup`) never grew its selection: every cell stayed exactly as the initial press left it.
+
+  The crossing is now announced where it happens: out/leave on the source when the path first leaves its box, over/enter on the destination when it first arrives inside theirs, with `buttons` still held and `relatedTarget` naming the element on the other side of the boundary, matching what a real pointer emits. A free drag (no target) crosses no boundary and fires none.
+
 - **`@reticlehq/server` — an instrumentation gap told the agent an app was unverifiable and gave it nowhere to go.** A gap exists to be acted on: it names an absence in the app, the cost that absence imposed on the verdict just returned, and the one change that closes it. What it never carried was a location. The type declared an optional `file:line` and no producer had ever set one, so every gap went out with a `ref` and nothing else.
 
   A `ref` is a handle to a DOM node, and gaps are read late. `reticle_verify { action: "coverage" }` is the "am I done?" call, made long after the verdict that recorded the gap, by which time the page has re-rendered and the handle very likely resolves to nothing. So the surface aimed squarely at a build-and-verify loop was handing that loop a remedy with no address.

--- a/packages/browser/src/actions/actions-dom.ts
+++ b/packages/browser/src/actions/actions-dom.ts
@@ -191,11 +191,19 @@ export async function dragElement(
    * Everything here was missing before, and each omission breaks a different, standard library
    * pattern: without coordinates a geometry-based collision resolver sees a zero delta and reports
    * the source as its own drop target; without `buttons: 1` the usual "was the mouse released?"
-   * guard (`event.buttons === 0`) bails out mid-drag.
+   * guard (`event.buttons === 0`) bails out mid-drag. Boundary events (`over`/`out` bubbling,
+   * `enter`/`leave` not) do not bubble exactly when a real pointer's would not.
    */
-  const fire = (el: Element, type: string, at: Point, buttons: number): void => {
+  const fire = (
+    el: Element,
+    type: string,
+    at: Point,
+    buttons: number,
+    related?: Element | null,
+  ): void => {
+    const bubbles = !(type.endsWith('enter') || type.endsWith('leave'));
     const init = {
-      bubbles: true,
+      bubbles,
       cancelable: true,
       clientX: at.x,
       clientY: at.y,
@@ -203,6 +211,7 @@ export async function dragElement(
       screenY: at.y,
       buttons,
       button: 0,
+      ...(related !== undefined ? { relatedTarget: related } : {}),
     };
     if ('function' === typeof PointerEvent && type.startsWith('pointer')) {
       el.dispatchEvent(new PointerEvent(type, { ...init, pointerId: 1, isPrimary: true }));
@@ -210,17 +219,54 @@ export async function dragElement(
       el.dispatchEvent(new MouseEvent(type, init));
     }
   };
+  /** Is this path point inside an element's box? Rects are cached; jsdom reports zeros otherwise. */
+  const sourceRect = source.getBoundingClientRect();
+  const destRect = target !== null ? dest.getBoundingClientRect() : null;
+  const crosses = (rect: DOMRect, p: Point): boolean =>
+    p.x >= rect.left && p.x <= rect.right && p.y >= rect.top && p.y <= rect.bottom;
+
   fire(source, 'pointerdown', from, BUTTON_HELD);
   fire(source, 'mousedown', from, BUTTON_HELD);
   await nativeFrame();
   // A path, not a jump. `activationConstraint: { distance: N }` is the standard way to keep a
   // draggable card clickable, and a sensor only starts a drag once it has SEEN the pointer travel
   // that far — which a single move from A to B never shows it.
+  //
+  // The crossing announces itself: the first step outside the source fires out/leave on it, and
+  // the first step inside the destination fires over/enter on it, both with the button still held.
+  // Without these, React never synthesises `onMouseEnter` on the destination (it derives that from
+  // delegated `mouseover`/`mouseout`), so drag-to-select grids never extend their selection.
+  let leftSource = false;
+  let enteredDest = false;
   for (let step = 1; step <= DRAG_STEPS; step += 1) {
     const at = lerp(from, to, step / DRAG_STEPS);
+    if (!leftSource && !crosses(sourceRect, at)) {
+      leftSource = true;
+      // relatedTarget is the element the pointer crossed TO/FROM; React's enter/leave synthesis
+      // reads it off the delegated over/out pair to know which boundary was crossed.
+      fire(source, 'pointerout', at, BUTTON_HELD, dest);
+      fire(source, 'mouseout', at, BUTTON_HELD, dest);
+      fire(source, 'pointerleave', at, BUTTON_HELD, dest);
+      fire(source, 'mouseleave', at, BUTTON_HELD, dest);
+    }
+    if (leftSource && !enteredDest && destRect !== null && crosses(destRect, at)) {
+      enteredDest = true;
+      fire(dest, 'pointerover', at, BUTTON_HELD, source);
+      fire(dest, 'mouseover', at, BUTTON_HELD, source);
+      fire(dest, 'pointerenter', at, BUTTON_HELD, source);
+      fire(dest, 'mouseenter', at, BUTTON_HELD, source);
+    }
     fire(dest, 'pointermove', at, BUTTON_HELD);
     fire(dest, 'mousemove', at, BUTTON_HELD);
     await nativeFrame();
+  }
+  // A short hop whose sampled steps never land inside the destination box still crossed into it;
+  // announce the arrival rather than silently skipping the pair.
+  if (!enteredDest && destRect !== null) {
+    fire(dest, 'pointerover', to, BUTTON_HELD, source);
+    fire(dest, 'mouseover', to, BUTTON_HELD, source);
+    fire(dest, 'pointerenter', to, BUTTON_HELD, source);
+    fire(dest, 'mouseenter', to, BUTTON_HELD, source);
   }
   fire(dest, 'pointerup', to, BUTTON_RELEASED);
   fire(dest, 'mouseup', to, BUTTON_RELEASED);

--- a/packages/browser/src/actions/actions.drag-boundary.test.ts
+++ b/packages/browser/src/actions/actions.drag-boundary.test.ts
@@ -1,0 +1,120 @@
+/**
+ * A drag that never announces where the pointer went cannot drive drag-to-select.
+ *
+ * Reported on a plain-HTML data grid: `onMouseDown` on a cell sets the selection anchor,
+ * `onMouseEnter` on other cells extends the selection while that anchor is set, and a window-level
+ * `mouseup` clears it. The drag dispatched a real held-button `mousedown` and a stepped path of
+ * moves, but never the boundary events a real pointer produces when it crosses from one element to
+ * another, so React (which synthesises `onMouseEnter` from delegated `mouseover`/`mouseout`) never
+ * called the extend handler and the selection never grew.
+ */
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import { dragElement } from './actions-dom.js';
+
+interface Captured {
+  type: string;
+  buttons: number;
+}
+
+function boxed(el: HTMLElement, x: number, y: number, w = 100, h = 40): HTMLElement {
+  el.getBoundingClientRect = () =>
+    ({ x, y, left: x, top: y, right: x + w, bottom: y + h, width: w, height: h }) as DOMRect;
+  return el;
+}
+
+function recorder(el: HTMLElement, log: Captured[]): void {
+  for (const type of [
+    'pointerdown',
+    'mousedown',
+    'pointerout',
+    'mouseout',
+    'pointerleave',
+    'mouseleave',
+    'pointerover',
+    'mouseover',
+    'pointerenter',
+    'mouseenter',
+    'pointermove',
+    'mousemove',
+    'pointerup',
+    'mouseup',
+  ]) {
+    el.addEventListener(type, (e) => {
+      log.push({ type, buttons: (e as MouseEvent).buttons });
+    });
+  }
+}
+
+describe('dragElement boundary events', () => {
+  let source: HTMLElement;
+  let dest: HTMLElement;
+  let onSource: Captured[];
+  let onDest: Captured[];
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    source = boxed(document.createElement('div'), 0, 0);
+    dest = boxed(document.createElement('div'), 300, 0);
+    document.body.append(source, dest);
+    onSource = [];
+    onDest = [];
+    recorder(source, onSource);
+    recorder(dest, onDest);
+  });
+
+  const seen = (log: Captured[], type: string): Captured[] => log.filter((c) => c.type === type);
+
+  it('the source sees out/leave and the destination sees over/enter, button still held', async () => {
+    await dragElement(source, dest, undefined);
+
+    for (const type of ['pointerout', 'mouseout', 'pointerleave', 'mouseleave']) {
+      const events = seen(onSource, type);
+      expect(events, `source should see ${type}`).toHaveLength(1);
+      expect(events[0]?.buttons).toBe(1);
+    }
+    for (const type of ['pointerover', 'mouseover', 'pointerenter', 'mouseenter']) {
+      const events = seen(onDest, type);
+      expect(events, `destination should see ${type}`).toHaveLength(1);
+      expect(events[0]?.buttons).toBe(1);
+    }
+  });
+
+  it('boundary events fire between mousedown and mouseup, in the crossing order', async () => {
+    await dragElement(source, dest, undefined);
+
+    const sourceOrder = onSource.map((c) => c.type);
+    expect(sourceOrder.indexOf('mouseout')).toBeGreaterThan(sourceOrder.indexOf('mousedown'));
+    const destOrder = onDest.map((c) => c.type);
+    expect(destOrder.indexOf('mouseover')).toBeGreaterThan(-1);
+    expect(destOrder.indexOf('mouseup')).toBeGreaterThan(destOrder.indexOf('mouseover'));
+    // The enter pair arrives while the button is still held, not as part of release cleanup.
+    expect(seen(onDest, 'mouseenter')[0]?.buttons).toBe(1);
+    expect(seen(onDest, 'mouseup')[0]?.buttons).toBe(0);
+  });
+
+  it('a free drag (no target) crosses no boundary and fires no enter/leave pair', async () => {
+    await dragElement(source, null, undefined);
+    expect(seen(onSource, 'mouseenter')).toHaveLength(0);
+    expect(seen(onSource, 'mouseleave')).toHaveLength(0);
+    expect(seen(onSource, 'mousemove').length).toBeGreaterThan(0);
+  });
+
+  it('over/out bubble and enter/leave do not, matching what a real pointer emits', async () => {
+    const bubbles: Record<string, boolean> = {};
+    const watch = (el: HTMLElement): void => {
+      for (const type of ['mouseover', 'mouseout', 'mouseenter', 'mouseleave']) {
+        el.addEventListener(type, (e) => {
+          bubbles[type] = e.bubbles;
+        });
+      }
+    };
+    watch(source);
+    watch(dest);
+    await dragElement(source, dest, undefined);
+    expect(bubbles['mouseover']).toBe(true);
+    expect(bubbles['mouseout']).toBe(true);
+    expect(bubbles['mouseenter']).toBe(false);
+    expect(bubbles['mouseleave']).toBe(false);
+  });
+});

--- a/packages/react/src/drag-select.test.ts
+++ b/packages/react/src/drag-select.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Drag-to-select through React's own delegation, the shape reported in the field.
+ *
+ * `onMouseDown` on a cell sets the selection anchor, `onMouseEnter` extends the selection while
+ * that anchor lives, and a window-level `mouseup` clears it. React never delivers `onMouseEnter`
+ * from a native `mouseenter`: its root-level plugin synthesises enter/leave pairs from delegated
+ * native `mouseover`/`mouseout` as the pointer crosses element boundaries. So if the drag action
+ * does not announce the crossing with those bubbling boundary events, the extend handler never
+ * runs and the selection stays one cell. The rendered `data-selected` attributes are the oracle;
+ * the assertion reads what the app rendered, not what our events did.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { act, createElement, useEffect, useRef, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { ActionType } from '@reticlehq/core';
+import { executeAction, refs } from '@reticlehq/browser';
+
+type CellRef = ReturnType<typeof refs.refFor>;
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const CELL_COUNT = 4;
+const CELL_W = 100;
+const CELL_GAP = 50;
+
+function boxed(el: HTMLElement, index: number): HTMLElement {
+  const left = index * (CELL_W + CELL_GAP);
+  el.getBoundingClientRect = () =>
+    ({
+      x: left,
+      y: 0,
+      left,
+      top: 0,
+      right: left + CELL_W,
+      bottom: 40,
+      width: CELL_W,
+      height: 40,
+    }) as DOMRect;
+  return el;
+}
+
+describe('React drag-to-select grid driven by the drag action', () => {
+  let container: HTMLDivElement;
+  let cellRefs: CellRef[];
+
+  /** The #510 app shape, verbatim: including its window-level mouseup that clears the anchor. */
+  function Grid(): ReturnType<typeof createElement> {
+    const [sel, setSel] = useState<ReadonlySet<number>>(new Set());
+    const anchor = useRef<number | null>(null);
+    useEffect(() => {
+      const clear = (): void => {
+        anchor.current = null;
+      };
+      window.addEventListener('mouseup', clear);
+      return (): void => window.removeEventListener('mouseup', clear);
+    }, []);
+    return createElement(
+      'div',
+      null,
+      Array.from({ length: CELL_COUNT }, (_, i) =>
+        createElement('div', {
+          key: i,
+          'data-testid': `cell-${String(i)}`,
+          'data-selected': sel.has(i) ? 'true' : 'false',
+          style: { width: `${CELL_W}px`, height: '40px' },
+          onMouseDown: (): void => {
+            anchor.current = i;
+            setSel((prev) => new Set(prev).add(i));
+          },
+          onMouseEnter: (): void => {
+            if (anchor.current !== null) setSel((prev) => new Set(prev).add(i));
+          },
+        }),
+      ),
+    );
+  }
+
+  const selectedIds = (): string[] =>
+    [...container.querySelectorAll('[data-selected="true"]')].flatMap((el) => {
+      const id = el.getAttribute('data-testid');
+      return id !== null ? [id] : [];
+    });
+
+  beforeEach(async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      await Promise.resolve();
+      root.render(createElement(Grid));
+    });
+    cellRefs = [];
+    for (let i = 0; i < CELL_COUNT; i += 1) {
+      const el = container.querySelector<HTMLElement>(`[data-testid="cell-${String(i)}"]`);
+      if (null === el) throw new Error(`cell ${String(i)} did not mount`);
+      cellRefs.push(refs.refFor(boxed(el, i)));
+    }
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('mousedown on A anchors, dragging to C extends the selection through delegation', async () => {
+    const sourceEl = container.querySelector<HTMLElement>('[data-testid="cell-0"]');
+    expect(sourceEl).not.toBeNull();
+    sourceEl?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    await act(async () => {});
+    expect(selectedIds()).toEqual(['cell-0']);
+
+    const sourceRef = cellRefs[0];
+    const targetRef = cellRefs[2];
+    if (sourceRef === undefined || targetRef === undefined) throw new Error('refs missing');
+    await act(async () => {
+      await executeAction(sourceRef, ActionType.DRAG, { toRef: targetRef });
+    });
+
+    expect(selectedIds()).toEqual(['cell-0', 'cell-2']);
+  });
+
+  it('the drag-ending mouseup clears the anchor, so later enters extend nothing', async () => {
+    const sourceEl = container.querySelector<HTMLElement>('[data-testid="cell-0"]');
+    sourceEl?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    await act(async () => {});
+
+    const sourceRef = cellRefs[0];
+    const targetRef = cellRefs[2];
+    if (sourceRef === undefined || targetRef === undefined) throw new Error('refs missing');
+    await act(async () => {
+      await executeAction(sourceRef, ActionType.DRAG, { toRef: targetRef });
+    });
+    expect(selectedIds()).toEqual(['cell-0', 'cell-2']);
+
+    // The anchor was cleared by the window mouseup the drag ended with, so hovering another
+    // cell afterwards must not grow the old selection.
+    const other = container.querySelector<HTMLElement>('[data-testid="cell-1"]');
+    other?.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    await act(async () => {});
+    expect(selectedIds()).toEqual(['cell-0', 'cell-2']);
+  });
+});


### PR DESCRIPTION
## Summary

The drag action dispatched a held-button mousedown, a stepped move path and a clean mouseup, but never the boundary events a real pointer fires crossing between elements. React synthesises onMouseEnter from delegated mouseover/mouseout, so the standard drag-to-select grid (mousedown anchors, mouseEnter extends, window mouseup clears) never extended its selection. The path now fires out/leave on the source and over/enter on the destination at the crossing, buttons held, with relatedTarget set; a free drag fires none.

## Testing

New jsdom suite pins the boundary events, ordering, button state and bubble semantics; a new React 19 integration test in packages/react mounts the reported app shape and asserts through rendered output that selection now extends A to C. Unit gates run with --force per the cache-replay trap. Full e2e battery was run twice locally; its failing set is unstable (25/36 then 22/36) with all failures being infra-level timeouts and port/process issues on this Windows machine, none touching the drag path.

## Checklist

- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed