### PR TITLE
fix(server): a failure waited out on a throttled tab says so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ### Fixed
 
+- **`@reticlehq/server`: a predicate failure waited out on a throttled tab now says the tab was throttled.** A starved tab and a missing element read identically as a bare near-miss: after a hard reload a backgrounded tab can sit on its loading state forever (hydration starved, nothing painted), and `reticle_wait_for { text }` timing out there looks exactly like "the code did not render" — the one answer an agent cannot tell apart from "the tab was never allowed to run". The health envelope already rode alongside every result saying `throttled:true`, but nothing connected it to the verdict an agent actually gates on.
+
+  `reticle_assert` and `reticle_wait_for` now append the starvation fact to a failing verdict's own `failureReason`, with the remedy in the same sentence. The original diagnosis still leads, a pass is returned untouched, and on a healthy tab the failure says exactly what it always said.
+
 - **`@reticlehq/server` — an instrumentation gap told the agent an app was unverifiable and gave it nowhere to go.** A gap exists to be acted on: it names an absence in the app, the cost that absence imposed on the verdict just returned, and the one change that closes it. What it never carried was a location. The type declared an optional `file:line` and no producer had ever set one, so every gap went out with a `ref` and nothing else.
 
   A `ref` is a handle to a DOM node, and gaps are read late. `reticle_verify { action: "coverage" }` is the "am I done?" call, made long after the verdict that recorded the gap, by which time the page has re-rendered and the handle very likely resolves to nothing. So the surface aimed squarely at a build-and-verify loop was handing that loop a remedy with no address.

--- a/packages/server/src/session/session-health.ts
+++ b/packages/server/src/session/session-health.ts
@@ -61,6 +61,33 @@ export function refuseIfThrottled(session: Session, refuse: unknown): void {
   }
 }
 
+/**
+ * The sentence appended to a FAILED predicate verdict waited out on a throttled tab.
+ *
+ * A starved tab and a missing element read identically as a bare near-miss: after a hard reload a
+ * backgrounded tab can sit on its loading state forever (hydration starved, nothing painted), and
+ * `wait_for { text }` timing out there looks exactly like "the code did not render" (#521). The
+ * health envelope already rode alongside saying `throttled:true`, but nothing connected it to the
+ * verdict an agent actually gates on. Appended, not replacing: the original diagnosis still leads,
+ * and on a healthy tab the failure says exactly what it always said.
+ */
+const STARVED_WAIT_NOTE =
+  ' (the tab was throttled during this wait, so starvation can look exactly like absence: bring it to the front and re-check before concluding this is genuinely missing)';
+
+/**
+ * Suffix the starvation note onto a FAILED predicate verdict when the tab is throttled. A pass is
+ * returned untouched — starvation is context for a failure, not a reason to doubt a hold. Pure and
+ * generic over the verdict shape so assert/wait_for/act_and_wait share one rule.
+ */
+export function annotateStarvedFailure<V extends { pass?: boolean; failureReason?: string }>(
+  session: Session,
+  verdict: V,
+): V {
+  if (true === verdict.pass || verdict.failureReason === undefined) return verdict;
+  if (true !== session.throttled()) return verdict;
+  return { ...verdict, failureReason: `${verdict.failureReason}${STARVED_WAIT_NOTE}` };
+}
+
 /** The page's own visibility/runtime report, narrowed out of an untrusted PAGE_HEALTH payload. */
 interface HealthReport {
   hidden: boolean | undefined;

--- a/packages/server/src/tools/assert-buffer-honesty.test.ts
+++ b/packages/server/src/tools/assert-buffer-honesty.test.ts
@@ -31,6 +31,7 @@ function depsWithBuffer(dropped: number, lastActSource?: string): ToolDeps {
     eventsSince: () => [],
     queryEvents: () => Promise.resolve([]),
     elapsed: () => 1000,
+    throttled: () => false,
     health: () => ({ lastSeenMs: 5, throttled: false, focused: true, hidden: false }),
     getState: () => SessionState.ACTIVE,
     drainInbox: () => [],

--- a/packages/server/src/tools/assert-throttled-window.test.ts
+++ b/packages/server/src/tools/assert-throttled-window.test.ts
@@ -1,0 +1,90 @@
+/**
+ * A starved tab and a missing element must not read alike.
+ *
+ * Reported from a hidden, throttled tab on a Next.js app (#521): after a hard reload the
+ * backgrounded tab sat on its loading state forever because throttling starved hydration, and every
+ * read saw the placeholder. `reticle_wait_for { text }` timed out as a near-miss that reads exactly
+ * like "the code did not render" — the one answer an agent cannot distinguish from "the tab was
+ * never allowed to run". The health envelope already rides alongside saying `throttled:true`, but
+ * nothing connects it to the verdict an agent actually gates on.
+ *
+ * These tests pin the connection: a FAILED predicate waited out on a throttled tab names the
+ * starvation in its own failureReason; a healthy tab's failure says exactly what it said before.
+ */
+import { describe, expect, it } from 'vitest';
+import { SessionState } from '@reticlehq/core';
+import { LastAct } from '../session/last-act.js';
+import { TOOLS, type ToolDef, type ToolDeps } from './tools.js';
+import { ReticleTool } from './tool-names.js';
+import type { Session, SessionManager } from '../session/session.js';
+
+function depsWithThrottle(throttled: boolean): ToolDeps {
+  const session: Partial<Session> = {
+    id: 'demo',
+    recordAction: () => 'a1',
+    lastAct: new LastAct(),
+    bufferHealth: () => ({ total: 4, dropped: 0 }),
+    blindSpots: () => ({}),
+    eventsSince: () => [],
+    queryEvents: () => Promise.resolve([]),
+    onEvent: () => () => {},
+    elapsed: () => 1000,
+    throttled: () => throttled,
+    health: () => ({
+      lastSeenMs: 5,
+      throttled,
+      focused: !throttled,
+      ...(throttled ? { recommendation: 'refocus it' } : {}),
+    }),
+    getState: () => SessionState.ACTIVE,
+    drainInbox: () => [],
+  };
+  const sessions: Partial<SessionManager> = { resolve: () => session as Session };
+  return { sessions: sessions as SessionManager } as unknown as ToolDeps;
+}
+
+const tool = (name: string): ToolDef => {
+  const found = TOOLS.find((t) => t.name === name);
+  if (found === undefined) throw new Error(`${name} is not on the surface`);
+  return found;
+};
+
+const missingSignal = {
+  predicate: { kind: 'signal', name: 'compose:generated' },
+  timeout_ms: 0,
+};
+
+describe('a failure waited out on a throttled tab says so', () => {
+  for (const name of [ReticleTool.ASSERT, ReticleTool.WAIT_FOR]) {
+    it(`${name} names starvation in the failureReason`, async () => {
+      const result = (await tool(name).handler(depsWithThrottle(true), missingSignal)) as {
+        pass: boolean;
+        failureReason?: string;
+      };
+      expect(result.pass).toBe(false);
+      expect(result.failureReason).toContain('throttled');
+      expect(result.failureReason).toContain('re-check');
+    });
+
+    it(`${name} leaves a healthy tab's failure untouched`, async () => {
+      const result = (await tool(name).handler(depsWithThrottle(false), missingSignal)) as {
+        pass: boolean;
+        failureReason?: string;
+      };
+      expect(result.pass).toBe(false);
+      expect(result.failureReason).toBeTypeOf('string');
+      expect(result.failureReason).not.toContain('throttled');
+      expect(result.failureReason).not.toContain('re-check');
+    });
+  }
+
+  it('the annotation is a suffix, so the original diagnosis still leads', async () => {
+    const result = (await tool(ReticleTool.ASSERT).handler(
+      depsWithThrottle(true),
+      missingSignal,
+    )) as { failureReason?: string };
+    const reason = result.failureReason ?? '';
+    expect(reason.startsWith('no signal matched')).toBe(true);
+    expect(reason.indexOf('matched')).toBeLessThan(reason.indexOf('throttled'));
+  });
+});

--- a/packages/server/src/tools/observe-tools.ts
+++ b/packages/server/src/tools/observe-tools.ts
@@ -33,7 +33,11 @@ import {
   withSizeCost,
   DEFAULT_QUERY_LIMIT,
 } from '../session/output-budget.js';
-import { healthEnvelope, bufferEnvelope } from '../session/session-health.js';
+import {
+  annotateStarvedFailure,
+  healthEnvelope,
+  bufferEnvelope,
+} from '../session/session-health.js';
 import type { Session } from '../session/session.js';
 import {
   assertsDerivedIpcStatus,
@@ -321,7 +325,7 @@ export const OBSERVE_TOOLS: ToolDef[] = [
       // match reticle_assert — wrap with control + session health (throttle matters most while blocking)
       // and the buffer envelope, so a verdict reached over an evicted window says so.
       return withControl(session, {
-        ...verdict,
+        ...annotateStarvedFailure(session, verdict),
         ...lastActSourceOnFailure(session, verdict.pass),
         ...healthEnvelope(session),
         ...bufferEnvelope(session),
@@ -464,7 +468,7 @@ export const OBSERVE_TOOLS: ToolDef[] = [
       session.recordAction(ReticleTool.ASSERT, asRecord(args), verdictEffect);
       return withControl(session, {
         ...decision,
-        ...verdict,
+        ...annotateStarvedFailure(session, verdict),
         ...(contradictions.length > 0 ? { contradictions } : {}),
         // What the app did not tell Reticle, on the same rule the act path uses.
         ...(gaps.length > 0 ? { instrumentationGaps: gaps } : {}),

--- a/packages/server/src/tools/tools.assert-advice.test.ts
+++ b/packages/server/src/tools/tools.assert-advice.test.ts
@@ -31,6 +31,7 @@ function depsWith(opts: { matched?: boolean; events?: ReticleEvent[] }): ToolDep
         result: name === ReticleCommand.MATCH ? matchResult : {},
       }),
     eventsSince: () => opts.events ?? [],
+    throttled: () => false,
     health: () => ({ lastSeenMs: 0, throttled: false, focused: true }),
     // A verdict now carries the buffer-honesty block, so the fake has to be able to report it.
     // An intact buffer keeps the block omitted, which is what these advice assertions expect.


### PR DESCRIPTION
## Summary

A starved tab and a missing element read identically as a bare near-miss: after a hard reload a backgrounded tab can sit on its loading state forever (hydration starved, nothing painted), and reticle_wait_for { text } timing out there reads exactly like "the code did not render". The health envelope already said throttled:true beside every result, but nothing connected it to the verdict an agent gates on. reticle_assert and reticle_wait_for now append the starvation fact, with the remedy, to a failing verdict's own failureReason; passes are untouched and healthy tabs fail exactly as before.

## Testing

New unit tests pin the annotation on both tools (throttled tab: failureReason names starvation and keeps the original diagnosis first; healthy tab: unchanged), plus two existing fakes updated to stub throttled() now that the handler reads it. Full server suite, lint, typecheck and prettier verified locally.

## Checklist

- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed