### PR TITLE
fix(server): grade an echo only when the response is echo-shaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ### Fixed
 
+- **`@reticlehq/server`: `write-field-ignored` no longer fires when the response is not an echo at all.** A command bus POSTs `{"command":"chat.send", ...}` and deliberately answers with the current viewer snapshot; the message itself arrives over WebSocket and renders. Collecting scalar values by key name at any depth made one key the two bodies happened to share read as an attempted echo of what was asked, so a write that fully applied was reported as half-applied.
+
+  The diff now runs only when the response is echo-shaped: a strict majority of the request's scalar keys must reappear somewhere in it. An envelope restating most of what was sent still grades exactly as before; a snapshot that shares an incidental key or two does not. Like every guard in this file, that trades the rare genuinely half-echoed write away rather than cry wolf.
+
 - **`@reticlehq/server` — an instrumentation gap told the agent an app was unverifiable and gave it nowhere to go.** A gap exists to be acted on: it names an absence in the app, the cost that absence imposed on the verdict just returned, and the one change that closes it. What it never carried was a location. The type declared an optional `file:line` and no producer had ever set one, so every gap went out with a `ref` and nothing else.
 
   A `ref` is a handle to a DOM node, and gaps are read late. `reticle_verify { action: "coverage" }` is the "am I done?" call, made long after the verdict that recorded the gap, by which time the page has re-rendered and the handle very likely resolves to nothing. So the surface aimed squarely at a build-and-verify loop was handing that loop a remedy with no address.

--- a/packages/server/src/events/echo-mismatch.test.ts
+++ b/packages/server/src/events/echo-mismatch.test.ts
@@ -159,3 +159,51 @@ describe('findEchoMismatches — the request has to be a write', () => {
     expect(found?.detail).not.toContain('before the action');
   });
 });
+
+describe('findEchoMismatches — the response has to be echo-shaped', () => {
+  /**
+   * A command bus POSTs `{"command":"chat.send","text":"..."}` and the server deliberately answers
+   * with the current viewer SNAPSHOT, not an echo of the request; the chat message itself arrives
+   * over WebSocket and renders (#506). Key names collected at any depth made one incidental shared
+   * key read as an attempted echo, and the act was reported as write-field-ignored over a write that
+   * fully applied. An echo restates what was sent; a snapshot that happens to share a key or two is
+   * not a restatement. So the diff only runs when a MAJORITY of the request's scalar keys appear in
+   * the response at all. That keeps every documented true positive (an envelope restates most of its
+   * fields) and trades the rare half-echoed write away, exactly like MAX_ECHO_KEYS does.
+   */
+  it('stays silent when the response shares none of the request keys', () => {
+    expect(
+      kinds(
+        write(
+          { command: 'chat.send', text: 'hello there' },
+          { viewer: { id: 'u1', name: 'Ada' }, rooms: [{ id: 'r1', title: 'general' }] },
+        ),
+      ),
+    ).toEqual([]);
+  });
+
+  it('stays silent when only half the request keys reappear, under other names for their values', () => {
+    // One incidental "text" on an unrelated snapshot field must not read as the echo of the
+    // message's text while the operation discriminator is nowhere in the response.
+    expect(
+      kinds(write({ command: 'chat.send', text: 'hello' }, { text: 'draft autosave', ok: true })),
+    ).toEqual([]);
+  });
+
+  it('still grades an envelope restating most of what was sent', () => {
+    expect(
+      kinds(
+        write(
+          { density: 'compact', locale: 'fr', theme: 'dark' },
+          { ok: true, saved: { density: 'compact', locale: 'en', theme: 'dark' } },
+        ),
+      ),
+    ).toContain(ContradictionKind.WRITE_FIELD_IGNORED);
+  });
+
+  it('still grades a one-key write whose single key comes back different', () => {
+    expect(kinds(write({ qty: 5 }, { ok: true, saved: { qty: 3 } }))).toContain(
+      ContradictionKind.WRITE_FIELD_IGNORED,
+    );
+  });
+});

--- a/packages/server/src/events/echo-mismatch.ts
+++ b/packages/server/src/events/echo-mismatch.ts
@@ -139,6 +139,18 @@ export function findEchoMismatches(
 
     const echoed = scalarsByKey(response);
     const asked = scalarsByKey(request);
+    // The response has to be ECHO-SHAPED before any key can contradict anything. An echo restates
+    // what was sent, so most of the request's scalar keys reappear somewhere in it; a snapshot that
+    // happens to share a key or two does not (#506: `{"command":"chat.send"}` answered with the
+    // viewer snapshot read one incidental shared key as an attempted echo of a write that fully
+    // applied). Requiring a strict majority of the request's keys to appear keeps every documented
+    // true positive — an envelope restates most of its fields — and deliberately trades the rare
+    // half-echoed write away, the same direction MAX_ECHO_KEYS already trades in.
+    let shared = 0;
+    for (const key of asked.keys()) {
+      if (echoed.has(key)) shared += 1;
+    }
+    if (shared * 2 <= asked.size) continue;
     const dropped: string[] = [];
     for (const [key, wanted] of asked) {
       // More than one requested value for a key (a before/after pair, a list of items) makes "what


### PR DESCRIPTION
## Summary

A command bus POSTs {"command":"chat.send", ...} and deliberately answers with the current viewer snapshot, while the message arrives over WebSocket and renders. Scalars collected by key name at any depth made one incidental shared key read as an attempted echo, so a fully-applied write was reported as write-field-ignored. The diff now runs only when a strict majority of the request's scalar keys reappear somewhere in the response; envelopes restating most of what was sent still grade as before, keeping the file's deliberate trade of false negatives over crying wolf.

## Testing

New tests pin the reported snapshot shape (no shared keys, and one incidental shared key), alongside the surviving true positives (multi-field envelope, single-key write). Existing echo suite green; full server events suite 41/41; lint, typecheck and prettier verified locally.

## Checklist

- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed