### PR TITLE
fix(cli): reticle verify honours the port in .reticle.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,10 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ### Fixed
 
+- **`@reticlehq/server` — `reticle verify` ignored the port in `.reticle.json`, and its docstring said the opposite.** `parseCliArgs` already folds `RETICLE_PORT` and the project config into `defaultPort`, but the verify result had no `port` field, so `handleVerify` fell back to 4400 every time. A project on any other port got `MSG_NO_SESSION` ("your app is not running") rather than "I looked at the wrong port". `--port` was also rejected as an unknown argument.
+
+  Verify now carries the resolved port, `--port` overrides it, and the docstring is finally true.
+
 - **`@reticlehq/server` — a `reticle_assert` verdict reported a `file:line` that could point at completely unrelated code.** An assertion drives nothing, so the tool had no location of its own and used the one the PREVIOUS action remembered. Driven against a real Next.js app: an assert about the site navigation was journaled with the file and line of the button an earlier click had touched, and an assert that matched nothing on the page at all was journaled with that same line. The old value was, in both cases, a location this verdict had never looked at — it sent the agent to innocent code, and because it is persisted into the session journal and read back by `reticle_context`'s `proven`, the wrong pointer outlived the turn that produced it.
 
   A verdict now points only where it actually looked. An `element`/`text` assertion reports the matched element's own `file:line` — the descriptor already carried it — and reports nothing when the matched elements carry no location or disagree about it. The one borrow that remains is the documented one, on a failure only: a `signal`/`net`/`state` assertion has no element to point at, and the handler that should have fired the missing signal lives with the control last driven, which is what the tool's output schema has always said the field means. Everywhere else the field is now OMITTED, because an absent pointer costs the agent nothing and a wrong one costs it the trip.

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -186,6 +186,7 @@ describe('parseCliArgs', () => {
       kind: 'verify',
       url: URL,
       headless: true,
+      port: PORT,
     });
   });
 
@@ -195,6 +196,28 @@ describe('parseCliArgs', () => {
       url: URL,
       headless: false,
       timeoutMs: 5000,
+      port: PORT,
+    });
+  });
+
+  it('verify keeps the resolved default port (RETICLE_PORT / .reticle.json)', () => {
+    // cli.ts already folds env + .reticle.json into parseCliArgs's defaultPort. Dropping port
+    // from the verify result made handleVerify fall back to 4400 anyway, so a project on any
+    // other port got MSG_NO_SESSION and a docstring that claimed the opposite.
+    expect(parseCliArgs(['verify', URL], 4410)).toEqual({
+      kind: 'verify',
+      url: URL,
+      headless: true,
+      port: 4410,
+    });
+  });
+
+  it('verify --port overrides the resolved default', () => {
+    expect(parseCliArgs(['verify', URL, '--port', '4411'], 4400)).toEqual({
+      kind: 'verify',
+      url: URL,
+      headless: true,
+      port: 4411,
     });
   });
 
@@ -211,6 +234,7 @@ describe('parseCliArgs', () => {
       url: URL,
       headless: true,
       storageState: 'auth.json',
+      port: PORT,
     });
   });
 

--- a/packages/server/src/cli/cli-parse.ts
+++ b/packages/server/src/cli/cli-parse.ts
@@ -37,7 +37,7 @@ export const CLI_USAGE = `usage:  npx @reticlehq/server <command>   (or \`reticl
   reticle status [--port N]
   reticle doctor [--port N]                            (one command to diagnose setup: Chromium, daemon, port)
   reticle open  [url] [--port N]                        (show the app: reuse the connected tab, else open one)
-  reticle verify <url> [--headed] [--timeout N] [--storage-state <file>]  (one-shot: drive the URL, verify saved flows, exit 0=pass)
+  reticle verify <url> [--port N] [--headed] [--timeout N] [--storage-state <file>]  (one-shot: drive the URL, verify saved flows, exit 0=pass)
   reticle affected [--since <ref>] [file...]           (which saved flows must re-verify for the changed files)
   reticle gate [--since <ref>] [file...]               (exit non-zero unless passing artifacts cover the affected flows)
   reticle watch [url]                                  (on save, report which saved flows must re-verify)
@@ -216,7 +216,14 @@ export type CliResult =
       httpToken?: string;
     }
   | { kind: 'drive'; port: number; driveUrl: string; headless: boolean }
-  | { kind: 'verify'; url: string; headless: boolean; timeoutMs?: number; storageState?: string }
+  | {
+      kind: 'verify';
+      url: string;
+      headless: boolean;
+      port: number;
+      timeoutMs?: number;
+      storageState?: string;
+    }
   | { kind: 'affected'; files: string[]; since?: string }
   | { kind: 'hunt'; dir: string }
   | { kind: 'capsules' }
@@ -383,24 +390,39 @@ function parseDriveSuffix(args: string[], port: number, defaultHeadless: boolean
 }
 
 type VerifySuffix =
-  | { kind: 'ok'; url: string; headless: boolean; timeoutMs?: number; storageState?: string }
+  | {
+      kind: 'ok';
+      url: string;
+      headless: boolean;
+      port: number;
+      timeoutMs?: number;
+      storageState?: string;
+    }
   | { kind: 'error'; message: string };
 
 /**
- * Parse `verify <url> [--headed] [--timeout N] [--storage-state <file>]`. The first non-flag token is
- * the preview URL.
+ * Parse `verify <url> [--port N] [--headed] [--timeout N] [--storage-state <file>]`. The first
+ * non-flag token is the preview URL. `defaultPort` is already env + `.reticle.json` + 4400.
  */
-function parseVerifySuffix(args: string[]): VerifySuffix {
+function parseVerifySuffix(args: string[], defaultPort: number): VerifySuffix {
   let headless = true;
   let url: string | undefined;
   let timeoutMs: number | undefined;
   let storageState: string | undefined;
+  let port = defaultPort;
   let i = 0;
   while (i < args.length) {
     const arg = args[i];
     if (arg === undefined) break;
     if (arg === HEADED_FLAG) {
       headless = false;
+    } else if (arg === PORT_FLAG) {
+      i++;
+      const n = args[i];
+      if (n === undefined) return missingValue(PORT_FLAG);
+      const parsed = parseInt(n, 10);
+      if (isNaN(parsed)) return notANumber(PORT_FLAG, n);
+      port = parsed;
     } else if (arg === TIMEOUT_FLAG) {
       i++;
       const n = args[i];
@@ -427,6 +449,7 @@ function parseVerifySuffix(args: string[]): VerifySuffix {
     kind: 'ok',
     url,
     headless,
+    port,
     ...(timeoutMs !== undefined ? { timeoutMs } : {}),
     ...(storageState !== undefined ? { storageState } : {}),
   };
@@ -647,12 +670,13 @@ export function parseCliArgs(
       };
     }
     case VERIFY_COMMAND: {
-      const r = parseVerifySuffix(rest);
+      const r = parseVerifySuffix(rest, defaultPort);
       if ('error' === r.kind) return r;
       return {
         kind: 'verify',
         url: r.url,
         headless: r.headless,
+        port: r.port,
         ...(r.timeoutMs !== undefined ? { timeoutMs: r.timeoutMs } : {}),
         ...(r.storageState !== undefined ? { storageState: r.storageState } : {}),
       };

--- a/packages/server/src/cli/cli-verify.ts
+++ b/packages/server/src/cli/cli-verify.ts
@@ -303,7 +303,7 @@ export function handleVerify(parsed: {
   timeoutMs?: number;
   storageState?: string;
   /** Bridge port — parseCliArgs already resolves --port / RETICLE_PORT / .reticle.json into this. */
-  port?: number;
+  port: number;
 }): void {
   const now = (): number => Date.now();
   const reticleRoot = join(process.cwd(), ReticleDir.ROOT);


### PR DESCRIPTION
## summary

`reticle verify` ignored the port in `.reticle.json`. `parseCliArgs` already folds `RETICLE_PORT` and the project config into `defaultPort`, but the verify result had no `port` field, so `handleVerify` fell back to 4400 every time. a project on any other port got `MSG_NO_SESSION`, which reads as "your app is not running" rather than "i looked at the wrong port". the docstring on `handleVerify` claimed the opposite.

verify now carries the resolved port. `--port` overrides it instead of being rejected as an unknown argument.

closes #554

## test plan

- [x] `parseCliArgs(['verify', url], 4410)` keeps port 4410 (the `.reticle.json` / env seam)
- [x] `parseCliArgs(['verify', url, '--port', '4411'], 4400)` overrides to 4411
- [x] existing verify parse cases still pass, now asserting the resolved port
- [x] `@reticlehq/server` typecheck