### PR TITLE
chore(server): drop export on symbols used only in their own file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,12 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
   **A flow with no declared intent says so, and nothing is derived from its step names.** A guessed goal reads as the product owner's words and an agent will act on them, which is strictly worse than the honest absence — the same rule the source pointer follows. Older flow files parse, replay, and report exactly as they did, and the on-disk flow version does not move.
 
+### Changed
+
+- **`@reticlehq/server` — drop `export` on symbols used only inside their own file.** An export nobody imports is noise that makes the module surface look larger than it is, and it defeats dead-code detection for everything else: a symbol exported for no reason can never be reported as unused. The compiler is the proof — if typecheck passes, the removal was safe.
+
+  Test seams stay exported: a symbol referenced only by its own `.test.ts` is a seam, not dead. Barrel re-exports stay too. `@reticlehq/core` has none of this class — every export is re-exported from the package barrel. Other packages are follow-ups.
+
 ### Fixed
 
 - **`@reticlehq/server` — a `reticle_assert` verdict reported a `file:line` that could point at completely unrelated code.** An assertion drives nothing, so the tool had no location of its own and used the one the PREVIOUS action remembered. Driven against a real Next.js app: an assert about the site navigation was journaled with the file and line of the button an earlier click had touched, and an assert that matched nothing on the page at all was journaled with that same line. The old value was, in both cases, a location this verdict had never looked at — it sent the agent to innocent code, and because it is persisted into the session journal and read back by `reticle_context`'s `proven`, the wrong pointer outlived the turn that produced it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 - **`@reticlehq/server` — drop `export` on symbols used only inside their own file.** An export nobody imports is noise that makes the module surface look larger than it is, and it defeats dead-code detection for everything else: a symbol exported for no reason can never be reported as unused. The compiler is the proof — if typecheck passes, the removal was safe.
 
-  Test seams stay exported: a symbol referenced only by its own `.test.ts` is a seam, not dead. Barrel re-exports stay too. `@reticlehq/core` has none of this class — every export is re-exported from the package barrel. Other packages are follow-ups.
+  Test seams stay exported: a symbol referenced only by its own `.test.ts` is a seam, not dead. So is a name the e2e battery imports from `dist` — typecheck cannot see those, which is how `reportVersionChange` got dropped and the telemetry-events spec died with "is not a function". Barrel re-exports stay too. `@reticlehq/core` has none of this class — every export is re-exported from the package barrel. Other packages are follow-ups.
 
 ### Fixed
 

--- a/packages/server/src/bridge/bridge.ts
+++ b/packages/server/src/bridge/bridge.ts
@@ -93,7 +93,7 @@ export const WS_CLOSE_REASON = {
  * The origin is IN the message because it is the fix: it is either the alias to allow-list, or the
  * proof that the page is not being served from where the developer thinks it is.
  */
-export function originRejectedReason(origin: string | undefined): string {
+function originRejectedReason(origin: string | undefined): string {
   const named = origin === undefined || 0 === origin.length ? 'a page sending no Origin' : origin;
   return (
     `a browser dialled this daemon and was REFUSED at the origin gate: ${named} is not allowed. ` +

--- a/packages/server/src/capsule/capsule-store.ts
+++ b/packages/server/src/capsule/capsule-store.ts
@@ -21,7 +21,7 @@ import { reticleDirPaths } from '../project/reticle-dir.js';
  */
 export const CAPSULE_VERSION = 1;
 
-export const CapsuleSchema = z.object({
+const CapsuleSchema = z.object({
   version: z.literal(CAPSULE_VERSION),
   id: z.string(),
   /** The flow the failure happened in, when it came from one (a bare assert has no flow). */

--- a/packages/server/src/capsule/causal-summary.ts
+++ b/packages/server/src/capsule/causal-summary.ts
@@ -5,7 +5,7 @@ import { EventType, PerfMetric, isDevToolingUrl, type ReticleEvent } from '@reti
  * app did in the act's window, as counts + a headline, not a raw event dump. Diffs come from the
  * storage/state events; attribution from. Pure composition over the attributed event window.
  */
-export interface StateDiff {
+interface StateDiff {
   path: string;
   from: unknown;
   to: unknown;
@@ -21,7 +21,7 @@ export interface StateDiff {
    */
   atMs: number;
 }
-export interface StorageDiff {
+interface StorageDiff {
   key: string;
   from?: unknown;
   to?: unknown;

--- a/packages/server/src/cli/cli-kill.ts
+++ b/packages/server/src/cli/cli-kill.ts
@@ -33,7 +33,7 @@ export const KillAction = {
 } as const;
 export type KillAction = (typeof KillAction)[keyof typeof KillAction];
 
-export interface KillPlan {
+interface KillPlan {
   action: KillAction;
   /** The single pid to signal. Present only for `kill`. */
   pid?: number;

--- a/packages/server/src/cli/config-discovery.ts
+++ b/packages/server/src/cli/config-discovery.ts
@@ -38,7 +38,7 @@ const CONVENTIONAL_WORKSPACES: readonly string[] = ['apps', 'packages'];
 /** How many entries of one workspace directory to stat. A backstop, not a policy. */
 const MAX_WORKSPACE_ENTRIES = 64;
 
-export interface FoundConfig {
+interface FoundConfig {
   /** Absolute path to the `.reticle.json`. */
   path: string;
   /** The directory it configures — what a reader needs in order to act. */

--- a/packages/server/src/cloud/cloud-config.ts
+++ b/packages/server/src/cloud/cloud-config.ts
@@ -20,7 +20,7 @@ export const CLOUD_LINK_FILE = 'cloud.json';
 export const CREDENTIALS_FILE = 'credentials.json';
 
 /** What the daemon mirrors to the cloud for a project. Each surface is independently toggleable. */
-export interface SyncPolicy {
+interface SyncPolicy {
   /** Push verification-run artifacts to the dashboard Runs tab. */
   runs: boolean;
   /** Push per-flow project-memory outcomes (the regression history). */

--- a/packages/server/src/cloud/cloud-sync.ts
+++ b/packages/server/src/cloud/cloud-sync.ts
@@ -48,7 +48,7 @@ export function resolveCloudConfig(env: NodeJS.ProcessEnv): CloudConfig | null {
  * which blocks while a real browser runs the suite server-side — a normal response there is minutes,
  * not seconds, so it gets its own (still bounded) budget rather than dragging the common one up.
  */
-export const CLOUD_FETCH_TIMEOUT_MS = 30_000;
+const CLOUD_FETCH_TIMEOUT_MS = 30_000;
 export const CLOUD_VERIFY_TIMEOUT_MS = 120_000;
 
 /** Names Node gives an abort: `AbortSignal.timeout` raises TimeoutError, an explicit abort AbortError. */

--- a/packages/server/src/crawl/crawl.ts
+++ b/packages/server/src/crawl/crawl.ts
@@ -91,7 +91,7 @@ export const CAPPED_SNAPSHOT_NOTE =
  * The same words as the capped-snapshot case on purpose — it is the same idea (interactiveFound is a
  * floor) reached by a different route, and a second vocabulary for it would just be more to learn.
  */
-export function revealedControlsNote(count: number): string {
+function revealedControlsNote(count: number): string {
   return (
     `the page changed as you clicked: ${String(count)} control(s) that did not exist when this crawl ` +
     'started were never visited — interactiveFound is a floor, not a total; re-run the crawl from ' +

--- a/packages/server/src/daemon/heartbeat.ts
+++ b/packages/server/src/daemon/heartbeat.ts
@@ -21,9 +21,9 @@
 /** The event name a beat carries. One `grep` separates liveness from everything else in the file. */
 export const DAEMON_HEARTBEAT_EVENT = 'reticle_daemon_alive';
 /** Written by installExitTrace when the process exits through Node. */
-export const DAEMON_EXIT_EVENT = 'reticle_daemon_exiting';
+const DAEMON_EXIT_EVENT = 'reticle_daemon_exiting';
 /** Written by installExitTrace when a signal arrives, which is a CAUSE the exit line does not carry. */
-export const DAEMON_SIGNAL_EVENT = 'reticle_daemon_signalled';
+const DAEMON_SIGNAL_EVENT = 'reticle_daemon_signalled';
 
 /**
  * How often a live daemon says so.

--- a/packages/server/src/dev/stale-issue-guard.ts
+++ b/packages/server/src/dev/stale-issue-guard.ts
@@ -30,7 +30,7 @@ export interface IssueState {
 }
 
 /** The label that means "fixed, waiting for a release" — an honest reason to still be open. */
-export const PENDING_RELEASE_LABEL = 'fixed-pending-release';
+const PENDING_RELEASE_LABEL = 'fixed-pending-release';
 
 /**
  * Issue numbers a commit message CLAIMS to have closed.

--- a/packages/server/src/flows/coverage.ts
+++ b/packages/server/src/flows/coverage.ts
@@ -45,7 +45,7 @@ export const NO_FLOWS = 'no_flows';
  * that errors is a second dead end on top of the first (see suggested-commands-exist.test.ts). Same
  * wording as the empty-suite verdict, which is the same situation reached from `reticle verify`.
  */
-export const NO_FLOWS_NOTE =
+const NO_FLOWS_NOTE =
   'no flows recorded — nothing was checked. Record one with reticle_record { action: "start" }, then reticle_flow_save.';
 
 /** The gate's flow-coverage line. `pct` and `outcome` are mutually exclusive by construction. */

--- a/packages/server/src/flows/flake.ts
+++ b/packages/server/src/flows/flake.ts
@@ -22,7 +22,7 @@ export const FlakeFileSchema = z.object({
 });
 
 /** Minimum unchanged-code replays before flakiness can be judged (too few = noise). */
-export const DEFAULT_MIN_FLAKE_RUNS = 5;
+const DEFAULT_MIN_FLAKE_RUNS = 5;
 
 export function emptyRecord(): FlakeRecord {
   return { runs: 0, fails: 0 };

--- a/packages/server/src/flows/flow-intent.ts
+++ b/packages/server/src/flows/flow-intent.ts
@@ -42,7 +42,7 @@ export function flowReplayVerdictId(flowName: string, at: number): string {
  * An explicit `intentId` wins, so a flow can discharge an intent that was declared before it existed.
  * Otherwise the flow's own prose implies one. A flow with neither has no intent, and says so.
  */
-export function intentIdOf(flow: FlowFile): string | undefined {
+function intentIdOf(flow: FlowFile): string | undefined {
   if (flow.intentId !== undefined) return flow.intentId;
   return flow.intent === undefined ? undefined : flowIntentId(flow.name);
 }

--- a/packages/server/src/honesty/blind-spots.ts
+++ b/packages/server/src/honesty/blind-spots.ts
@@ -170,7 +170,7 @@ export function blindSpotsFromState(state: Readonly<Record<string, number>>): Bl
  * every real app, and a caveat that is always present is one nobody reads. TRANSPORT_OVERFLOW is the
  * honest "arbitrary events are gone" marker — it cannot say which.
  */
-export function droppedByTransport(events: readonly ReticleEvent[]): number {
+function droppedByTransport(events: readonly ReticleEvent[]): number {
   let dropped = 0;
   for (const e of events) {
     if (e.type !== EventType.TRANSPORT_OVERFLOW) continue;

--- a/packages/server/src/http-server.ts
+++ b/packages/server/src/http-server.ts
@@ -404,7 +404,7 @@ function schemeOf(url: string): string | undefined {
   }
 }
 
-export function driveSchemeRefusal(url: string): string | undefined {
+function driveSchemeRefusal(url: string): string | undefined {
   const scheme = schemeOf(url);
   if (scheme !== undefined && DRIVEABLE_SCHEMES.includes(scheme)) return undefined;
   // Names what it got, because the caller is a CLI printing this to somebody who typed the url and

--- a/packages/server/src/hunt/hunt-report.ts
+++ b/packages/server/src/hunt/hunt-report.ts
@@ -20,7 +20,7 @@
  */
 
 /** The contradiction kinds — cross-channel disagreement, as opposed to a single-channel fault. */
-export const CONTRADICTION_KINDS: readonly string[] = [
+const CONTRADICTION_KINDS: readonly string[] = [
   'ui-advanced-request-failed',
   'signal-contradicted',
   'response-ignored',

--- a/packages/server/src/impact/impact-store.ts
+++ b/packages/server/src/impact/impact-store.ts
@@ -38,7 +38,7 @@ export interface ImpactPaths {
  * `reticleRoot` is the project's own `.reticle` directory (what every other store here is handed);
  * the global scope always lives beside the daemon's own state in `~/.reticle`.
  */
-export function impactPaths(reticleRoot: string): ImpactPaths {
+function impactPaths(reticleRoot: string): ImpactPaths {
   return {
     project: join(reticleRoot, ReticleDir.IMPACT_FILE),
     global: join(homedir(), ReticleDir.ROOT, ReticleDir.IMPACT_FILE),

--- a/packages/server/src/init/capabilities.ts
+++ b/packages/server/src/init/capabilities.ts
@@ -119,7 +119,7 @@ function importPathFor(storePath: string, fromDir: string): string {
 }
 
 /** Where the generated dev module lives, for Vite. Next passes its own. */
-export const DEFAULT_DEV_MODULE_DIR = 'src';
+const DEFAULT_DEV_MODULE_DIR = 'src';
 
 /**
  * Store instances declared in the app's own source, ready to import and register.

--- a/packages/server/src/init/confirm.ts
+++ b/packages/server/src/init/confirm.ts
@@ -37,8 +37,8 @@ import { reportInitOutcome } from '../telemetry/init-telemetry.js';
  * has not restarted their dev server yet is not held hostage by a wait that cannot succeed — they
  * have not typed the command that would make it succeed, and the message tells them which one.
  */
-export const CONFIRM_WINDOW_MS = 12_000;
-export const CONFIRM_POLL_MS = 500;
+const CONFIRM_WINDOW_MS = 12_000;
+const CONFIRM_POLL_MS = 500;
 
 export interface ConfirmDeps {
   /** Session ids connected right now, or null when nothing is listening on the bridge port. */
@@ -140,7 +140,7 @@ export function confirmationMessage(confirmation: InitConfirmation, port: number
  * on the machine and "a session exists" is satisfied by somebody else's app, which is the false
  * green `confirmAppConnected` refuses by design.
  */
-export function unwatchedMessage(port: number): string {
+function unwatchedMessage(port: number): string {
   return (
     '  [ℹ] the files are written. An app CONNECTING is what finishes the install, and this run did ' +
     'not wait to see one.\n' +

--- a/packages/server/src/init/plan.ts
+++ b/packages/server/src/init/plan.ts
@@ -73,7 +73,7 @@ const RETICLE_NEXT_PLUGIN = '@reticlehq/next';
  * and nothing on either side names a version. Asking for the CLI's exact version makes the cache
  * irrelevant, and a skewed pair impossible to install by accident.
  */
-export function pinnedPackages(
+function pinnedPackages(
   packages: readonly string[],
   version: string | undefined,
 ): readonly string[] {
@@ -607,7 +607,7 @@ const AgentId = {
   CLAUDE: 'claude',
   CURSOR: 'cursor',
 } as const;
-export type AgentId = (typeof AgentId)[keyof typeof AgentId];
+type AgentId = (typeof AgentId)[keyof typeof AgentId];
 
 interface AgentIntegration {
   readonly id: AgentId;

--- a/packages/server/src/journal/envelope.ts
+++ b/packages/server/src/journal/envelope.ts
@@ -10,7 +10,7 @@ import type { SegmentRollup } from './rollups.js';
  */
 
 /** Online mean/variance/max for one metric (Welford's algorithm). Immutable: addStat returns a copy. */
-export interface MetricStats {
+interface MetricStats {
   count: number;
   mean: number;
   /** Sum of squared deviations (Welford M2); variance = m2/(count-1). */
@@ -42,7 +42,7 @@ export function zScore(stats: MetricStats, x: number): number {
 
 /** The metrics an envelope tracks per route. */
 const ENVELOPE_METRICS = ['durationMs', 'net', 'netErrors', 'consoleErrors'] as const;
-export type EnvelopeMetric = (typeof ENVELOPE_METRICS)[number];
+type EnvelopeMetric = (typeof ENVELOPE_METRICS)[number];
 
 export interface RouteEnvelope {
   route: string;

--- a/packages/server/src/mcp/mcp-proxy.ts
+++ b/packages/server/src/mcp/mcp-proxy.ts
@@ -187,7 +187,7 @@ const TRANSPORT_LOSS_CODE = -32001;
  * `nextStep` is appended when the caller knows one. Without it this reply describes a condition and
  * stops there, which is all a first-run user got out of their first ever tool call.
  */
-export function transportLossReply(id: unknown, reason: string, nextStep?: string): string {
+function transportLossReply(id: unknown, reason: string, nextStep?: string): string {
   return JSON.stringify({
     jsonrpc: '2.0',
     id,

--- a/packages/server/src/runs/run-diff.ts
+++ b/packages/server/src/runs/run-diff.ts
@@ -1,7 +1,7 @@
 import type { ReticleVerificationRun, RunFlowResult } from '@reticlehq/core';
 
 /** A per-flow change between two runs. Only flows with a meaningful change are reported. */
-export interface FlowDelta {
+interface FlowDelta {
   name: string;
   beforeMs: number;
   afterMs: number;

--- a/packages/server/src/session/dev-server-probe.ts
+++ b/packages/server/src/session/dev-server-probe.ts
@@ -159,7 +159,7 @@ export async function probeDevServerStates(
  * still seen at its best — the same "either, not both" rule `anyFamilyServes` follows, extended to
  * three states.
  */
-export async function anyFamilyState(
+async function anyFamilyState(
   port: number,
   probe: (port: number, host: string) => Promise<PortState> = probeState,
 ): Promise<PortState> {

--- a/packages/server/src/telemetry/automation-hint.ts
+++ b/packages/server/src/telemetry/automation-hint.ts
@@ -38,7 +38,7 @@ const HOSTED_WORKSPACE_ENV = [
   'REMOTE_CONTAINERS',
 ] as const;
 
-export interface AutomationInput {
+interface AutomationInput {
   env: NodeJS.ProcessEnv;
   fileExists: (path: string) => boolean;
   hasTty: boolean;

--- a/packages/server/src/telemetry/feedback-outbox.ts
+++ b/packages/server/src/telemetry/feedback-outbox.ts
@@ -23,7 +23,7 @@ import { randomUUID } from 'node:crypto';
 import { ReticleDir } from '@reticlehq/core';
 
 /** One queued report: the payload, plus what is needed to find and remove it again. */
-export interface OutboxEntry {
+interface OutboxEntry {
   id: string;
   t: string;
   payload: unknown;

--- a/packages/server/src/telemetry/project-profile.ts
+++ b/packages/server/src/telemetry/project-profile.ts
@@ -30,7 +30,7 @@ export const FeatureFamily = {
   BUG_CAPSULES: 'bug_capsules',
   CROSS_RUN_HISTORY: 'cross_run_history',
 } as const;
-export type FeatureFamily = (typeof FeatureFamily)[keyof typeof FeatureFamily];
+type FeatureFamily = (typeof FeatureFamily)[keyof typeof FeatureFamily];
 
 const ALL_FAMILIES = Object.values(FeatureFamily);
 
@@ -51,7 +51,7 @@ const MAX_WALK_DEPTH = 8;
 const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
 
 /** Count source files, stopping at the cap (the cap itself lands in the largest bucket, correctly). */
-export function countSourceFiles(root: string, readDir: DirReader = defaultReadDir): number {
+function countSourceFiles(root: string, readDir: DirReader = defaultReadDir): number {
   let count = 0;
   const walk = (dir: string, depth: number): void => {
     if (depth > MAX_WALK_DEPTH || count >= MAX_FILES_SCANNED) return;

--- a/packages/server/src/telemetry/run-telemetry.ts
+++ b/packages/server/src/telemetry/run-telemetry.ts
@@ -23,7 +23,7 @@ import { getSessionMetrics } from './session-metrics.js';
 import { getTelemetry } from './telemetry.js';
 
 /** The tool name reported for this path, so CI runs are distinguishable from agent-driven ones. */
-export const VERIFY_SURFACE = 'reticle_verify';
+const VERIFY_SURFACE = 'reticle_verify';
 
 /**
  * Report one completed verification run: the verdict, and one bug per failing flow.

--- a/packages/server/src/tools/e2e-dist-exports.test.ts
+++ b/packages/server/src/tools/e2e-dist-exports.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Named imports from server `dist` in the telemetry-events e2e spec must still be exported.
+ *
+ * That spec is the one that can see whether an emit actually lands (unit tests cannot: fire-and-forget
+ * plus `process.exit`). It loads the built modules by name. Dropping `export` on one of those names
+ * typechecks, unit-tests green, and then CI e2e dies with "X is not a function" — which is exactly
+ * what happened to `reportVersionChange` when a dead-export sweep treated "no colocated .test.ts
+ * importer" as "safe to unexport". Knip does not see `apps/e2e`. This gate does.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, '..', '..', '..', '..');
+const TELEMETRY_EVENTS_SPEC = join(REPO, 'apps', 'e2e', 'specs', 'telemetry-events-test.mjs');
+const SERVER_SRC = join(REPO, 'packages', 'server', 'src');
+const DIST_IMPORT = /const \{([^}]+)\} = await import\(`\$\{DIST\}\/([^`]+)`\)/g;
+const JS_SUFFIX = '.js';
+const TS_SUFFIX = '.ts';
+
+function isValueExport(source: string, name: string): boolean {
+  const patterns = [
+    new RegExp(`^export async function ${name}\\b`, 'm'),
+    new RegExp(`^export function ${name}\\b`, 'm'),
+    new RegExp(`^export const ${name}\\b`, 'm'),
+    new RegExp(`^export class ${name}\\b`, 'm'),
+    new RegExp(`^export enum ${name}\\b`, 'm'),
+    new RegExp(`^export \\{[^}]*\\b${name}\\b[^}]*\\}`, 'm'),
+  ];
+  return patterns.some((p) => p.test(source));
+}
+
+function distImports(spec: string): readonly { names: readonly string[]; distPath: string }[] {
+  const found: { names: readonly string[]; distPath: string }[] = [];
+  for (const match of spec.matchAll(DIST_IMPORT)) {
+    const namesRaw = match[1];
+    const distPath = match[2];
+    if (namesRaw === undefined || distPath === undefined) continue;
+    const names = namesRaw
+      .split(',')
+      .map((n) => n.trim())
+      .filter((n) => n.length > 0);
+    found.push({ names, distPath });
+  }
+  return found;
+}
+
+describe('e2e dist named imports stay exported from server source', () => {
+  it('every name telemetry-events-test.mjs loads from dist is still an export', () => {
+    const spec = readFileSync(TELEMETRY_EVENTS_SPEC, 'utf8');
+    const imports = distImports(spec);
+    expect(imports.length).toBeGreaterThan(0);
+
+    const missing: string[] = [];
+    for (const { names, distPath } of imports) {
+      const rel = distPath.endsWith(JS_SUFFIX) ? distPath.slice(0, -JS_SUFFIX.length) : distPath;
+      const srcPath = join(SERVER_SRC, `${rel}${TS_SUFFIX}`);
+      expect(existsSync(srcPath), srcPath).toBe(true);
+      const source = readFileSync(srcPath, 'utf8');
+      for (const name of names) {
+        if (!isValueExport(source, name)) missing.push(`${rel}: ${name}`);
+      }
+    }
+    expect(missing, missing.join(', ')).toEqual([]);
+  });
+});

--- a/packages/server/src/tools/error-recovery.ts
+++ b/packages/server/src/tools/error-recovery.ts
@@ -366,7 +366,7 @@ function issueClause(issue: ZodIssueShape): string {
  * Conservative by construction: it only rewrites a JSON ARRAY whose every element carries both
  * `code` and `message`. A tool that legitimately returns JSON is left alone.
  */
-export function zodArrayAsSentence(message: string): string {
+function zodArrayAsSentence(message: string): string {
   const text = message.trim();
   if (!text.startsWith('[')) return message;
   let parsed: unknown;

--- a/packages/server/src/tools/lease-tools.ts
+++ b/packages/server/src/tools/lease-tools.ts
@@ -279,7 +279,7 @@ export const LEASE_ACQUIRE_TOOL: ToolDef = {
   },
 };
 
-export const LEASE_RELEASE_TOOL: ToolDef = {
+const LEASE_RELEASE_TOOL: ToolDef = {
   name: ReticleTool.LEASE_RELEASE,
   description:
     'Release a leased browser context by sessionId, closing it and freeing the pool slot for a queued acquire. Call this when a flow finishes so the pool stays within its concurrency cap.',

--- a/packages/server/src/tools/navigate-arrival.ts
+++ b/packages/server/src/tools/navigate-arrival.ts
@@ -16,7 +16,7 @@ import type { SessionManager } from '../session/session-manager.js';
 import type { NavigateArrival } from './navigate-result.js';
 
 /** Long enough for a dev server to serve a page and the SDK to dial back; short enough to not hang. */
-export const ARRIVAL_TIMEOUT_MS = 5_000;
+const ARRIVAL_TIMEOUT_MS = 5_000;
 const POLL_MS = 100;
 
 /**

--- a/packages/server/src/tools/resolve-target.ts
+++ b/packages/server/src/tools/resolve-target.ts
@@ -1,7 +1,7 @@
 import { asRecord } from './tools-helpers.js';
 
 /** One candidate the browser returned for a target query. */
-export interface TargetCandidate {
+interface TargetCandidate {
   ref?: unknown;
   role?: unknown;
   name?: unknown;

--- a/packages/server/src/tools/snapshot-delta.ts
+++ b/packages/server/src/tools/snapshot-delta.ts
@@ -196,7 +196,7 @@ interface SnapshotDelta {
 }
 
 /** Where focus moved, when it moved. Absent fields mean nothing held focus on that side. */
-export interface FocusChange {
+interface FocusChange {
   from?: string;
   to?: string;
 }

--- a/packages/server/src/tools/tool-surface.ts
+++ b/packages/server/src/tools/tool-surface.ts
@@ -84,7 +84,7 @@ export type ToolSurface = (typeof TOOL_SURFACE)[keyof typeof TOOL_SURFACE];
 export const ADVERTISE_ALL_ENV = 'RETICLE_ADVERTISE_ALL_TOOLS';
 
 /** Opt into the smallest verdict-capable surface. Read by the DAEMON at startup, like the others. */
-export const VERIFY_SURFACE_ENV = 'RETICLE_VERIFY_SURFACE';
+const VERIFY_SURFACE_ENV = 'RETICLE_VERIFY_SURFACE';
 
 /**
  * The retired setting, still read so nobody's shell profile breaks.
@@ -236,7 +236,7 @@ export const EXTENDED_TOOL_NAMES: ReadonlySet<string> = new Set([
  * everything else. `act_and_wait` can resolve its own target, so no query tool is needed to name an
  * element — that round trip was half the token cost of a verification.
  */
-export const VERIFY_TOOL_NAMES: ReadonlySet<string> = new Set([ReticleTool.ACT_AND_WAIT]);
+const VERIFY_TOOL_NAMES: ReadonlySet<string> = new Set([ReticleTool.ACT_AND_WAIT]);
 
 /** Is the truthy form of a boolean env var set? `1`, `true`, `yes` — anything else is off. */
 function envFlagOn(raw: string | undefined): boolean {

--- a/packages/server/src/update/update-nudge.ts
+++ b/packages/server/src/update/update-nudge.ts
@@ -30,7 +30,7 @@ import { creditNudge } from './nudge-credit.js';
  * story rests on. Numeric per segment, so 2.10.0 correctly beats 2.9.0 (string order does not), and
  * a bare release beats its own prerelease.
  */
-export function isNewerVersion(candidate: string, current: string): boolean {
+function isNewerVersion(candidate: string, current: string): boolean {
   const parse = (v: string): { parts: number[]; pre: boolean } => {
     const [core = '', ...rest] = v.split(/[-+]/);
     return { parts: core.split('.').map((n) => Number.parseInt(n, 10) || 0), pre: rest.length > 0 };

--- a/packages/server/src/update/updater.ts
+++ b/packages/server/src/update/updater.ts
@@ -24,7 +24,7 @@ type VersionChangeDirection = (typeof VersionChangeDirection)[keyof typeof Versi
  * install and then `process.exit`, so there is no way to reach this through them in a test without
  * mocking the package manager and the process itself.
  */
-async function reportVersionChange(
+export async function reportVersionChange(
   from: string,
   to: string,
   direction: VersionChangeDirection,

--- a/packages/server/src/update/updater.ts
+++ b/packages/server/src/update/updater.ts
@@ -15,8 +15,7 @@ const VersionChangeDirection = {
   UPDATE: 'update',
   ROLLBACK: 'rollback',
 } as const;
-export type VersionChangeDirection =
-  (typeof VersionChangeDirection)[keyof typeof VersionChangeDirection];
+type VersionChangeDirection = (typeof VersionChangeDirection)[keyof typeof VersionChangeDirection];
 
 /**
  * Report a completed version move. Never throws — an install that worked must still be reported done.
@@ -25,7 +24,7 @@ export type VersionChangeDirection =
  * install and then `process.exit`, so there is no way to reach this through them in a test without
  * mocking the package manager and the process itself.
  */
-export async function reportVersionChange(
+async function reportVersionChange(
   from: string,
   to: string,
   direction: VersionChangeDirection,


### PR DESCRIPTION
the audit in #557 has three groups. this pr is the third: drop `export` on symbols referenced only inside their own file. keep the code.

server first, as the issue asked. `@reticlehq/core` has none of this class because the package barrel re-exports everything, so knip never sees a local-only export there.

kept on purpose:
- anything a test file imports (a test seam, not dead). knip ignores tests, so those look unused and are not.
- barrel re-exports. the proxy log is imported via `mcp-proxy.js`, not `proxy-log.js`.

typecheck is the proof. remaining packages are follow-ups, so this does not close the issue.

## test plan
- [x] `pnpm --filter @reticlehq/server typecheck`
- [x] `pnpm --filter @reticlehq/server test:unit`
- [x] `pnpm format:check && pnpm --filter @reticlehq/server lint`