### PR TITLE
fix(core): one InstrumentationGapKind vocabulary for honesty and oracles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,10 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
   **A flow with no declared intent says so, and nothing is derived from its step names.** A guessed goal reads as the product owner's words and an agent will act on them, which is strictly worse than the honest absence — the same rule the source pointer follows. Older flow files parse, replay, and report exactly as they did, and the on-disk flow version does not move.
 
+### Changed
+
+- **`@reticlehq/core` + `@reticlehq/server` — there is one `InstrumentationGapKind` vocabulary.** Honesty and `reticle_assert` spoke core (`no-signal-on-mutation`, `no-store-registered`). `reticle_domain` spoke a server-local copy (`missing-signal`, `unregistered-store`) of the same absences, so an agent that read both saw two names for one gap. Oracles now use the core kinds. `missing-testid` — the one kind only oracles emitted — is a core kind, so a later honesty emit cannot pick a third name.
+
 ### Fixed
 
 - **`@reticlehq/server` — a `reticle_assert` verdict reported a `file:line` that could point at completely unrelated code.** An assertion drives nothing, so the tool had no location of its own and used the one the PREVIOUS action remembered. Driven against a real Next.js app: an assert about the site navigation was journaled with the file and line of the button an earlier click had touched, and an assert that matched nothing on the page at all was journaled with that same line. The old value was, in both cases, a location this verdict had never looked at — it sent the agent to innocent code, and because it is persisted into the session journal and read back by `reticle_context`'s `proven`, the wrong pointer outlived the turn that produced it.

--- a/packages/core/src/instrumentation-gap.test.ts
+++ b/packages/core/src/instrumentation-gap.test.ts
@@ -37,6 +37,7 @@ describe('instrumentation gaps', () => {
     expect(fixForGap(InstrumentationGapKind.NO_STORE_REGISTERED)).toContain('registerStore');
     expect(fixForGap(InstrumentationGapKind.NO_SIGNAL_ON_MUTATION)).toContain('reticle.signal');
     expect(fixForGap(InstrumentationGapKind.UNDECLARED_CONTROL)).toContain('reticle.describe');
+    expect(fixForGap(InstrumentationGapKind.MISSING_TESTID)).toContain('data-testid');
   });
 
   /**

--- a/packages/core/src/instrumentation-gap.ts
+++ b/packages/core/src/instrumentation-gap.ts
@@ -48,6 +48,15 @@ export const InstrumentationGapKind = {
   /** A control was driven that the declared capability contract does not mention. */
   UNDECLARED_CONTROL: 'undeclared-control',
   /**
+   * A flow cannot name a control with a stable testid, so the proposal is to add one.
+   *
+   * Honesty does not emit this on a verdict today — a missing testid is not itself a weaker
+   * channel the way a missing signal is. Oracles do, when they can locate the control. It
+   * belongs in this vocabulary so `reticle_domain` and a later honesty emit cannot disagree
+   * about the name of the same absence.
+   */
+  MISSING_TESTID: 'missing-testid',
+  /**
    * Code changed, and this verdict is the first one taken since — with nothing declaring what the
    * change was supposed to make true.
    *
@@ -111,6 +120,8 @@ const GAP_FIX: Readonly<Record<InstrumentationGapKind, string>> = {
     'let the Reticle router adapter observe navigation, or fire reticle.signal on route commit',
   [InstrumentationGapKind.UNDECLARED_CONTROL]:
     'add this control to reticle.describe() so the capability contract matches what the app actually exposes',
+  [InstrumentationGapKind.MISSING_TESTID]:
+    'add data-testid="..." on this control so the flow can name it after a refactor',
   [InstrumentationGapKind.UNDECLARED_CHANGE]:
     'declare it with reticle_intent { action: "declare", intents: [{ id, statement }] } — the statement is prose, in your own words: which user does what, and what should become true',
   [InstrumentationGapKind.NO_FLOW_INTENT]:

--- a/packages/server/src/oracles/flow-instrument-gaps.test.ts
+++ b/packages/server/src/oracles/flow-instrument-gaps.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { ActionType, AnchorKind, type FlowStep } from '@reticlehq/core';
+import { ActionType, AnchorKind, InstrumentationGapKind, type FlowStep } from '@reticlehq/core';
 import { instrumentationGapsForFlows, lastSource } from './flow-instrument-gaps.js';
 import { proposeInstrumentation } from './self-instrument.js';
 
@@ -26,12 +26,12 @@ describe('lastSource', () => {
 });
 
 describe('instrumentationGapsForFlows', () => {
-  it('turns an unasserted flow into a located missing-signal gap → a real proposal', () => {
+  it('turns an unasserted flow into a located no-signal-on-mutation gap → a real proposal', () => {
     const steps = new Map<string, FlowStep[]>([['checkout', [componentStep('Checkout.tsx', 114)]]]);
     const gaps = instrumentationGapsForFlows(['checkout'], steps);
     expect(gaps).toEqual([
       {
-        kind: 'missing-signal',
+        kind: InstrumentationGapKind.NO_SIGNAL_ON_MUTATION,
         file: 'Checkout.tsx',
         line: 114,
         name: 'checkout:done',

--- a/packages/server/src/oracles/flow-instrument-gaps.ts
+++ b/packages/server/src/oracles/flow-instrument-gaps.ts
@@ -1,5 +1,5 @@
-import { AnchorKind, type FlowStep } from '@reticlehq/core';
-import { InstrumentationGapKind, type InstrumentationGap } from './self-instrument.js';
+import { AnchorKind, InstrumentationGapKind, type FlowStep } from '@reticlehq/core';
+import type { LocatedGap } from './self-instrument.js';
 
 /**
  * Bridge domain gaps → LOCATED instrumentation gaps. A flow that asserts no consequence should emit one —
@@ -24,20 +24,20 @@ export function lastSource(steps: readonly FlowStep[]): { file: string; line: nu
 }
 
 /**
- * Turn unasserted flows into missing-signal gaps at each flow's source location. Flows with no stamped
- * source are skipped (no location to propose). The suggested signal name is `<flow>:done`.
+ * Turn unasserted flows into no-signal-on-mutation gaps at each flow's source location. Flows with
+ * no stamped source are skipped (no location to propose). The suggested signal name is `<flow>:done`.
  */
 export function instrumentationGapsForFlows(
   unassertedFlows: readonly string[],
   flowStepsByName: ReadonlyMap<string, readonly FlowStep[]>,
-): InstrumentationGap[] {
-  const gaps: InstrumentationGap[] = [];
+): LocatedGap[] {
+  const gaps: LocatedGap[] = [];
   for (const name of unassertedFlows) {
     const steps = flowStepsByName.get(name);
     const source = steps === undefined ? undefined : lastSource(steps);
     if (source === undefined) continue;
     gaps.push({
-      kind: InstrumentationGapKind.MISSING_SIGNAL,
+      kind: InstrumentationGapKind.NO_SIGNAL_ON_MUTATION,
       file: source.file,
       line: source.line,
       name: `${name}:done`,

--- a/packages/server/src/oracles/gap-kind-is-core.test.ts
+++ b/packages/server/src/oracles/gap-kind-is-core.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Two InstrumentationGapKind enums is how `reticle_domain` says `missing-signal` while honesty
+ * says `no-signal-on-mutation` for the same absence. Core is the contract. This file must not
+ * grow a second copy.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+describe('oracles use the core gap vocabulary', () => {
+  it('self-instrument.ts does not declare its own InstrumentationGapKind', () => {
+    const src = readFileSync(join(HERE, 'self-instrument.ts'), 'utf8');
+    expect(src).not.toMatch(/export const InstrumentationGapKind/);
+    expect(src).toMatch(/from '@reticlehq\/core'/);
+  });
+
+  it('flow-instrument-gaps.ts does not import a local gap kind', () => {
+    const src = readFileSync(join(HERE, 'flow-instrument-gaps.ts'), 'utf8');
+    expect(src).not.toMatch(/InstrumentationGapKind.*from '\.\/self-instrument/);
+    expect(src).toMatch(/InstrumentationGapKind.*from '@reticlehq\/core'/);
+  });
+
+  it('does not emit the retired oracle-local kind strings', () => {
+    const self = readFileSync(join(HERE, 'self-instrument.ts'), 'utf8');
+    const flow = readFileSync(join(HERE, 'flow-instrument-gaps.ts'), 'utf8');
+    for (const src of [self, flow]) {
+      expect(src).not.toMatch(/['"]missing-signal['"]/);
+      expect(src).not.toMatch(/['"]unregistered-store['"]/);
+    }
+  });
+});

--- a/packages/server/src/oracles/self-instrument.test.ts
+++ b/packages/server/src/oracles/self-instrument.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { InstrumentationGapKind, proposeInstrumentation } from './self-instrument.js';
+import { InstrumentationGapKind } from '@reticlehq/core';
+import { proposeInstrumentation } from './self-instrument.js';
 
 describe('proposeInstrumentation', () => {
-  it('proposes a signal call for a missing-signal gap, at the located file:line', () => {
+  it('proposes a signal call for a no-signal-on-mutation gap, at the located file:line', () => {
     const [proposal] = proposeInstrumentation([
       {
-        kind: InstrumentationGapKind.MISSING_SIGNAL,
+        kind: InstrumentationGapKind.NO_SIGNAL_ON_MUTATION,
         file: 'src/Checkout.tsx',
         line: 114,
         name: 'order:placed',
@@ -23,7 +24,7 @@ describe('proposeInstrumentation', () => {
   it('proposes a registerStore call (PascalCased hook) for an unregistered store', () => {
     const [proposal] = proposeInstrumentation([
       {
-        kind: InstrumentationGapKind.UNREGISTERED_STORE,
+        kind: InstrumentationGapKind.NO_STORE_REGISTERED,
         file: 'src/store.ts',
         line: 1,
         name: 'cart',

--- a/packages/server/src/oracles/self-instrument.ts
+++ b/packages/server/src/oracles/self-instrument.ts
@@ -4,18 +4,20 @@
  * apply instrumentation proposals as concrete diffs, so the AGENT closes the gap and the app's
  * observability compounds run over run — instead of a human being a prerequisite. Deterministic mapping
  * from a located gap to the code to insert; pure and testable. Result-enrichment wiring is a later step.
+ *
+ * Kinds come from `@reticlehq/core`. A second enum here is how `reticle_domain` used to say
+ * `missing-signal` while honesty said `no-signal-on-mutation` for the same absence.
  */
+import { InstrumentationGapKind } from '@reticlehq/core';
 
-export const InstrumentationGapKind = {
-  MISSING_SIGNAL: 'missing-signal',
-  UNREGISTERED_STORE: 'unregistered-store',
-  MISSING_TESTID: 'missing-testid',
-} as const;
-export type InstrumentationGapKind =
-  (typeof InstrumentationGapKind)[keyof typeof InstrumentationGapKind];
+/** The three core kinds a located proposal can close. Other kinds are verdict-side, not insert-side. */
+export type LocatableGapKind =
+  | typeof InstrumentationGapKind.NO_SIGNAL_ON_MUTATION
+  | typeof InstrumentationGapKind.NO_STORE_REGISTERED
+  | typeof InstrumentationGapKind.MISSING_TESTID;
 
-export interface InstrumentationGap {
-  kind: InstrumentationGapKind;
+export interface LocatedGap {
+  kind: LocatableGapKind;
   file: string;
   line: number;
   /** The name to instrument with — a signal name, store name, or testid. */
@@ -37,31 +39,35 @@ function pascal(name: string): string {
   return 0 === name.length ? name : name[0]?.toUpperCase() + name.slice(1);
 }
 
-function insertFor(gap: InstrumentationGap): string {
+function insertFor(gap: LocatedGap): string {
   switch (gap.kind) {
-    case InstrumentationGapKind.MISSING_SIGNAL:
+    case InstrumentationGapKind.NO_SIGNAL_ON_MUTATION:
       return `reticle.signal('${gap.name}');`;
-    case InstrumentationGapKind.UNREGISTERED_STORE:
+    case InstrumentationGapKind.NO_STORE_REGISTERED:
       return `registerStore('${gap.name}', () => use${pascal(gap.name)}.getState());`;
     case InstrumentationGapKind.MISSING_TESTID:
       return `data-testid="${gap.name}"`;
   }
 }
 
-function rationaleFor(gap: InstrumentationGap): string {
-  const base =
-    gap.kind === InstrumentationGapKind.MISSING_SIGNAL
-      ? `emit a consequence signal so verification proves the outcome, not just presence`
-      : gap.kind === InstrumentationGapKind.UNREGISTERED_STORE
-        ? `register the store so state assertions can read the source of truth`
-        : `add a stable testid so the anchor survives refactors`;
-  return gap.context === undefined ? base : `${base} — ${gap.context}`;
+function rationaleFor(gap: LocatedGap): string {
+  let base: string;
+  switch (gap.kind) {
+    case InstrumentationGapKind.NO_SIGNAL_ON_MUTATION:
+      base = `emit a consequence signal so verification proves the outcome, not just presence`;
+      break;
+    case InstrumentationGapKind.NO_STORE_REGISTERED:
+      base = `register the store so state assertions can read the source of truth`;
+      break;
+    case InstrumentationGapKind.MISSING_TESTID:
+      base = `add a stable testid so the anchor survives refactors`;
+      break;
+  }
+  return undefined === gap.context ? base : `${base} — ${gap.context}`;
 }
 
 /** Turn located capability gaps into ready-to-apply instrumentation proposals. Deterministic. */
-export function proposeInstrumentation(
-  gaps: readonly InstrumentationGap[],
-): InstrumentationProposal[] {
+export function proposeInstrumentation(gaps: readonly LocatedGap[]): InstrumentationProposal[] {
   return gaps.map((gap) => ({
     file: gap.file,
     line: gap.line,


### PR DESCRIPTION
## summary
- honesty and `reticle_assert` already spoke core kinds (`no-signal-on-mutation`, `no-store-registered`). `reticle_domain` spoke a server-local copy (`missing-signal`, `unregistered-store`) of the same absences, so an agent that read both saw two names for one gap.
- oracles now import `InstrumentationGapKind` from `@reticlehq/core`. the located-proposal shape stays local (`LocatedGap`: file, line, insert) because it is not a verdict gap.
- `missing-testid` (the one kind only oracles emitted) is now a core kind, so a later honesty emit cannot pick a third name. this does not fold `oracles/` into `honesty/`.

## test plan
- [x] `instrumentation-gap.test.ts` requires a `data-testid` remedy for `MISSING_TESTID` (the existing `Object.values` loop also fails if `GAP_FIX` is missing)
- [x] oracle tests emit `NO_SIGNAL_ON_MUTATION` / `NO_STORE_REGISTERED` / `MISSING_TESTID`, not the retired strings
- [x] `gap-kind-is-core.test.ts` fails if `self-instrument.ts` grows a second enum or if `flow-instrument-gaps.ts` imports the kind locally, and fails if `'missing-signal'` / `'unregistered-store'` come back as values
- [x] `pnpm --filter @reticlehq/{core,server} lint` and `typecheck` clean

closes #553