### PR TITLE
refactor(server): rename VERIFICATION_TOOLS to VERDICT_TOOLS

### DIFF
--- a/packages/server/src/telemetry/telemetry-contract.test.ts
+++ b/packages/server/src/telemetry/telemetry-contract.test.ts
@@ -19,7 +19,7 @@ import {
 import { generateKeyPairSync } from 'node:crypto';
 import { TOOLS } from '../tools/tools.js';
 import { ReticleTool } from '../tools/tool-names.js';
-import { VERIFICATION_TOOLS } from '../tools/feedback-tools.js';
+import { VERDICT_TOOLS } from '../tools/feedback-tools.js';
 import { bugsInResult, type BugCandidate } from './bug-found.js';
 import { describeParam } from './argument-shape.js';
 import { licenseFacts } from './license-activation.js';
@@ -124,18 +124,18 @@ describe('every tool is classified for telemetry', () => {
   });
 
   /**
-   * A verification tool that is not in VERIFICATION_TOOLS produces no `verification_completed` and no
+   * A verification tool that is not in VERDICT_TOOLS produces no `verification_completed` and no
    * human feedback prompt — it silently stops counting toward the metric the product exists to
    * report. The name is the tell, so the check is on the name.
    */
-  it('every tool whose name implies a VERDICT is in VERIFICATION_TOOLS', () => {
+  it('every tool whose name implies a VERDICT is in VERDICT_TOOLS', () => {
     const verdictish = TOOLS.map((t) => t.name).filter(
       (name) => /assert|verify/.test(name) && name !== ReticleTool.FLOW_SAVE_RECORDED,
     );
     for (const name of verdictish) {
       expect(
-        VERIFICATION_TOOLS.has(name),
-        `'${name}' looks like it produces a verdict but is not in VERIFICATION_TOOLS — ` +
+        VERDICT_TOOLS.has(name),
+        `'${name}' looks like it produces a verdict but is not in VERDICT_TOOLS — ` +
           'it will not emit verification_completed. Add it there, or rename it if it does not.',
       ).toBe(true);
     }
@@ -147,7 +147,7 @@ describe('every tool is classified for telemetry', () => {
    * `reticle_act_and_wait` declares `verified` in its outputSchema, returns the full verdict block
    * (verified / because / honesty), and its own description calls it "one hop for the act->observe->
    * assert loop". It matches neither /assert/ nor /verify/, so the tripwire never fired and it was
-   * never added to VERIFICATION_TOOLS — meaning every verification performed through it emitted no
+   * never added to VERDICT_TOOLS — meaning every verification performed through it emitted no
    * `verification_completed` at all.
    *
    * Measured over a day of real telemetry: `reticle_act_and_wait` 14 calls, `reticle_assert` ZERO,
@@ -157,7 +157,7 @@ describe('every tool is classified for telemetry', () => {
    * So the check is on the SHAPE, not the name: a tool that declares a `verified` verdict is a
    * verification tool, whatever it happens to be called.
    */
-  it('every tool that DECLARES a `verified` verdict is in VERIFICATION_TOOLS', () => {
+  it('every tool that DECLARES a `verified` verdict is in VERDICT_TOOLS', () => {
     const declaresVerdict = TOOLS.filter(
       (tool) => tool.outputSchema !== undefined && 'verified' in tool.outputSchema,
     ).map((tool) => tool.name);
@@ -165,9 +165,9 @@ describe('every tool is classified for telemetry', () => {
     expect(declaresVerdict.length).toBeGreaterThan(0);
     for (const name of declaresVerdict) {
       expect(
-        VERIFICATION_TOOLS.has(name),
+        VERDICT_TOOLS.has(name),
         `'${name}' declares a \`verified\` verdict in its outputSchema but is not in ` +
-          'VERIFICATION_TOOLS, so every verdict it returns is invisible to verification_completed.',
+          'VERDICT_TOOLS, so every verdict it returns is invisible to verification_completed.',
       ).toBe(true);
     }
   });

--- a/packages/server/src/telemetry/verification-of.ts
+++ b/packages/server/src/telemetry/verification-of.ts
@@ -13,7 +13,7 @@
  * be readable and testable on its own rather than inferred from a ternary inside a dispatcher.
  */
 import { type BrowserBrand, CaptureLoss, type Verification, VerifiedReason } from '@reticlehq/core';
-import { VERIFICATION_TOOLS } from '../tools/feedback-tools.js';
+import { VERDICT_TOOLS } from '../tools/feedback-tools.js';
 import { getBrowserMode } from './browser-mode.js';
 
 /**
@@ -101,7 +101,7 @@ export function verificationOf(
   durationMs: number,
   brand?: BrowserBrand,
 ): Verification | undefined {
-  if (!VERIFICATION_TOOLS.has(toolName)) return undefined;
+  if (!VERDICT_TOOLS.has(toolName)) return undefined;
   // A paused session REFUSES the call — nothing driven, nothing asserted. The refusal carries a
   // verdict field so the agent never reads undefined off it, and that field must not be mistaken
   // here for work that happened.

--- a/packages/server/src/tools/feedback-tools.test.ts
+++ b/packages/server/src/tools/feedback-tools.test.ts
@@ -7,8 +7,7 @@ import { TOOLS } from './tools.js';
 import { ReticleTool } from './tool-names.js';
 import { TOOL_SURFACE, filterTools } from './tool-surface.js';
 import { buildErrorPayload, FEEDBACK_ASK, RECOVERY } from './error-recovery.js';
-import { resetFeedbackPrompt, takeFeedbackPrompt, VERIFICATION_TOOLS } from './feedback-tools.js';
-
+import { resetFeedbackPrompt, takeFeedbackPrompt, VERDICT_TOOLS } from './feedback-tools.js';
 describe('reticle_feedback', () => {
   const tool = TOOLS.find((t) => t.name === ReticleTool.FEEDBACK);
 
@@ -83,11 +82,11 @@ describe('the one-shot human prompt', () => {
   });
 
   it('covers the tools that actually end a verification', () => {
-    expect(VERIFICATION_TOOLS.has(ReticleTool.ASSERT)).toBe(true);
+    expect(VERDICT_TOOLS.has(ReticleTool.ASSERT)).toBe(true);
     // Whole-suite replay and change verification are actions on the merged tool now, so the NAME
     // that has to be covered is the merged one — the members are never dispatched by their own name.
-    expect(VERIFICATION_TOOLS.has(ReticleTool.VERIFY)).toBe(true);
-    expect(VERIFICATION_TOOLS.has(ReticleTool.ACT_AND_WAIT)).toBe(true);
+    expect(VERDICT_TOOLS.has(ReticleTool.VERIFY)).toBe(true);
+    expect(VERDICT_TOOLS.has(ReticleTool.ACT_AND_WAIT)).toBe(true);
   });
 });
 

--- a/packages/server/src/tools/feedback-tools.ts
+++ b/packages/server/src/tools/feedback-tools.ts
@@ -212,7 +212,7 @@ export const FEEDBACK_PROMPT = {
  * calls, assert ZERO, verification_completed 2. Agents were verifying the entire time and the metric
  * could not see it. The contract test now checks the SHAPE instead.
  */
-export const VERIFICATION_TOOLS: ReadonlySet<string> = new Set([
+export const VERDICT_TOOLS: ReadonlySet<string> = new Set([
   ReticleTool.ACT_AND_WAIT,
   ReticleTool.ASSERT,
   // Merged: `flow_verify` and `verify_change` are actions on this tool now. Naming the merged tool
@@ -248,7 +248,7 @@ let verificationsSincePrompt = 0;
  * collect is worse than not asking: it spends their attention on a message with nowhere to go.
  */
 export function takeFeedbackPrompt(toolName: string): typeof FEEDBACK_PROMPT | undefined {
-  if (!VERIFICATION_TOOLS.has(toolName)) return undefined;
+  if (!VERDICT_TOOLS.has(toolName)) return undefined;
   if (feedbackDisabled() || !getTelemetry().enabled) return undefined;
   if (promptsDelivered >= MAX_PROMPTS_PER_PROCESS) return undefined;
   // The very first verification asks immediately; later ones only after another run of work, so the


### PR DESCRIPTION
Resolves #550 by renaming the constant to make its purpose clear and avoid confusion with VERIFY_TOOL_NAMES.

<!-- Thanks for contributing to Reticle! Please fill this out so review is fast. -->

## What & why

Renames `VERIFICATION_TOOLS` to `VERDICT_TOOLS` in `packages/server` to eliminate confusion with the surface profile `VERIFY_TOOL_NAMES`. 

Closes #550

## How it was verified

- Verified that all remaining references to the constant were correctly updated.
- Ran `pnpm test:unit` locally, and the entire test suite passed successfully.

## Gates run

- [x] `pnpm lint && pnpm typecheck && pnpm test:unit` (~2 min — **always**)
- [ ] `pnpm test:e2e` (~8 min) — _touched the tool surface, `packages/core`, an observer, or telemetry_
- [ ] `pnpm gate:install` (~15 min) — _touched `reticle init`, `vite-plugin`, `next`, or `babel-plugin`_
- [ ] `pnpm test:e2e:desktop` (~3 min) — _touched `packages/electron`, `packages/tauri`, or desktop capture_
- [ ] None of the above tiers apply to this change

## Checklist

- [x] **Every commit is signed off** (`git commit -s`) — CI's DCO check fails the PR without it. Already pushed? `git rebase --signoff origin/main && git push --force-with-lease`
- [x] Tests added/updated (RED → GREEN); the change is covered by a test that would fail without it
- [x] No `any`, no free strings (wire strings live in `@reticlehq/core`), no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 1000-line cap
- [ ] Docs and `CHANGELOG.md` updated if this is user-facing (entry under `[Unreleased]`)
- [ ] Security-affecting? Auth/redaction/trust-boundary changes keep the localhost-only, no-app-data-leaves-the-machine, no-arbitrary-JS posture (usage telemetry stays anonymous + opt-out per `docs/telemetry.md`) and are covered by a test
