### PR TITLE
Share one union walk, export the wrapper peeling, blame one field

### DIFF
--- a/packages/server/src/events/predicate-parse.ts
+++ b/packages/server/src/events/predicate-parse.ts
@@ -88,7 +88,7 @@ export function parsePredicate(input: unknown): z.infer<typeof PredicateSchema> 
   const issues = parsed.error.issues.slice(0, 3).map(describeIssue).join('; ');
   throw new Error(
     `that predicate did not parse (kind "${kind}"): ${issues}. Nothing ran — the predicate was ` +
-      `not evaluated, so no verdict was produced. ${accepted(kind)} ` +
+      `not evaluated, so no verdict was produced. ${accepted(kind, parsed.error.issues)} ` +
       `A valid ${kind} predicate looks like: ${exampleFor(kind)}`,
   );
 }
@@ -100,12 +100,26 @@ export function parsePredicate(input: unknown): z.infer<typeof PredicateSchema> 
  * round trip on the one call path that produces verdicts. Naming the accepted fields — or, when the
  * kind itself is the mistake, the accepted kinds — makes the retry informed instead.
  */
-function accepted(kind: string): string {
+function accepted(kind: string, issues: readonly z.ZodIssue[]): string {
   const fields = predicateFieldsFor(kind);
   if (0 < fields.length) {
     // A field whose value is an object is the one an agent cannot guess from its name alone, so
     // expand it in the same breath rather than making the shape a second round trip.
-    const nested = Object.entries(predicateNestedFieldsFor(kind))
+    //
+    // Only the field the rejection actually points at, though. Expanding every object-valued field
+    // of the kind makes the sentence longer the more the schema grows, and buries the one clause
+    // that answers the question asked — the same argument this file already makes for showing one
+    // example per kind instead of a generic one. `element` is the only kind with an object-valued
+    // field today, so the two agree except when the mistake is somewhere else entirely, which is
+    // the case pinned in the tests.
+    const all = predicateNestedFieldsFor(kind);
+    const blamed = new Set(
+      issues
+        .map((issue) => issue.path[0])
+        .filter((field): field is string => 'string' === typeof field),
+    );
+    const nested = Object.entries(all)
+      .filter(([field]) => blamed.has(field))
       .map(([field, keys]) => ` ${field} accepts: ${keys.join(', ')}.`)
       .join('');
     return `${kind} accepts: ${fields.join(', ')}.${nested}`;

--- a/packages/server/src/events/predicate-schema.ts
+++ b/packages/server/src/events/predicate-schema.ts
@@ -433,13 +433,24 @@ export const PredicateSchema = z.lazy(() =>
  * wall. Empty for a kind that is not in the union.
  */
 export function predicateFieldsFor(kind: string): readonly string[] {
+  const shape = shapeForKind(kind);
+  if (null === shape) return [];
+  return Object.keys(shape).filter((field) => 'kind' !== field);
+}
+
+/**
+ * The union option for `kind`, or null when the kind is not one.
+ *
+ * One place that walks the union, so the field list and the nested lookup cannot disagree about
+ * which option a kind resolves to — and so adding a third reader is a call rather than a fourth
+ * copy of the same loop.
+ */
+function shapeForKind(kind: string): z.ZodRawShape | null {
   for (const option of predicateUnion().options) {
     const literal = option.shape['kind'];
-    if (literal instanceof z.ZodLiteral && literal.value === kind) {
-      return Object.keys(option.shape).filter((field) => 'kind' !== field);
-    }
+    if (literal instanceof z.ZodLiteral && literal.value === kind) return option.shape;
   }
-  return [];
+  return null;
 }
 
 /**
@@ -487,6 +498,26 @@ export function predicateGrammar(): Readonly<Record<string, string>> {
   return grammar;
 }
 
+/**
+ * The keys of a field that is an object, once its wrappers are peeled. Empty for anything else.
+ *
+ * Exported so the wrapper handling is asserted against THIS function rather than through the
+ * rendered sentence. Reached only that way, a wrapper it fails to peel returns `[]`, the old
+ * message prints unchanged, and nothing reddens — a regression with no symptom.
+ *
+ * No top-level predicate field is currently declared behind a wrapper, so the real schema exercises
+ * none of these paths; that is exactly why they are worth a case each.
+ */
+export function nestedKeysOf(schema: z.ZodTypeAny | undefined): readonly string[] {
+  if (undefined === schema) return [];
+  const inner = unwrapSchema(schema);
+  // `instanceof z.ZodObject` narrows to ZodObject<any>, whose `.shape` is `any`. Name the shape
+  // type so the keys are read off something typed rather than laundering an `any` through
+  // Object.keys.
+  if (!(inner instanceof z.ZodObject)) return [];
+  return Object.keys((inner as z.ZodObject<z.ZodRawShape>).shape);
+}
+
 /** Peel optional/nullable/default/effects wrappers off a field to reach the schema underneath. */
 function unwrapSchema(schema: z.ZodTypeAny): z.ZodTypeAny {
   let current = schema;
@@ -521,22 +552,13 @@ function unwrapSchema(schema: z.ZodTypeAny): z.ZodTypeAny {
 export function predicateNestedFieldsFor(
   kind: string,
 ): Readonly<Record<string, readonly string[]>> {
-  for (const option of predicateUnion().options) {
-    const literal = option.shape['kind'];
-    if (!(literal instanceof z.ZodLiteral) || literal.value !== kind) continue;
-    const nested: Record<string, readonly string[]> = {};
-    for (const [field, schema] of Object.entries(option.shape)) {
-      if ('kind' === field) continue;
-      const inner = unwrapSchema(schema as z.ZodTypeAny);
-      // `instanceof z.ZodObject` narrows to ZodObject<any>, whose `.shape` is `any`. Name the shape
-      // type so the keys are read off something typed rather than laundering an `any` through
-      // Object.keys.
-      if (inner instanceof z.ZodObject) {
-        const shape = (inner as z.ZodObject<z.ZodRawShape>).shape;
-        nested[field] = Object.keys(shape);
-      }
-    }
-    return nested;
+  const shape = shapeForKind(kind);
+  if (null === shape) return {};
+  const nested: Record<string, readonly string[]> = {};
+  for (const [field, schema] of Object.entries(shape)) {
+    if ('kind' === field) continue;
+    const keys = nestedKeysOf(schema);
+    if (0 < keys.length) nested[field] = keys;
   }
-  return {};
+  return nested;
 }

--- a/packages/server/src/events/predicate-shape.test.ts
+++ b/packages/server/src/events/predicate-shape.test.ts
@@ -18,7 +18,8 @@
 import { describe, expect, it } from 'vitest';
 import { PredicateKind } from '@reticlehq/core';
 import { parsePredicate } from './predicate-parse.js';
-import { predicateFieldsFor } from './predicate-eval.js';
+import { nestedKeysOf, predicateFieldsFor } from './predicate-eval.js';
+import { z } from 'zod';
 
 const messageOf = (input: unknown): string => {
   try {
@@ -135,5 +136,59 @@ describe('scoping the text predicate', () => {
 
   it('names `scope` among the fields the text predicate accepts', () => {
     expect(predicateFieldsFor(PredicateKind.TEXT)).toContain('scope');
+  });
+});
+
+describe('nestedKeysOf reaches one level into an object field', () => {
+  it.each([
+    ['bare', z.object({ a: z.string() })],
+    ['optional', z.object({ a: z.string() }).optional()],
+    ['with a default', z.object({ a: z.string() }).default({ a: 'x' })],
+    ['nullable', z.object({ a: z.string() }).nullable()],
+    ['optional and nullable', z.object({ a: z.string() }).nullable().optional()],
+    ['behind an effect', z.object({ a: z.string() }).refine(() => true)],
+  ])('peels a %s object field', (_label, schema) => {
+    // No top-level predicate field is declared behind any of these today, so the real schema
+    // exercises none of them. That is the reason for a case each rather than one standing for the
+    // rest: the failure is silent — [] comes back, the old sentence prints, nothing reddens.
+    expect(nestedKeysOf(schema)).toEqual(['a']);
+  });
+
+  it.each([
+    ['a string', z.string()],
+    ['an array', z.array(z.string())],
+    ['a native enum', z.nativeEnum({ A: 'a' } as const)],
+    ['undefined', undefined],
+  ])('is empty for %s', (_label, schema) => {
+    expect(nestedKeysOf(schema)).toEqual([]);
+  });
+
+  it('does not expand transitively', () => {
+    // One level is the contract: the sentence exists to make the next call land, not to print the
+    // schema. `query.source` is an object too.
+    const nested = nestedKeysOf(z.object({ a: z.object({ b: z.string() }) }));
+    expect(nested).toEqual(['a']);
+  });
+});
+
+describe('the error expands only the field the caller got wrong', () => {
+  it('names query when query is what failed', () => {
+    const message = messageOf({ kind: PredicateKind.ELEMENT, query: 'a string' });
+    expect(message).toContain('query accepts:');
+    expect(message).toContain('role');
+  });
+
+  it('leaves query out when the mistake is somewhere else', () => {
+    // `element` is the only kind with an object-valued field today, so expanding-the-blamed-field
+    // and expanding-every-object-field agree almost everywhere. Here they do not: the rejection is
+    // an unknown top-level key, nothing to do with `query`, and dragging query's shape in makes the
+    // sentence longer without answering what was asked.
+    const message = messageOf({ kind: PredicateKind.ELEMENT, query: { role: 'button' }, bogus: 1 });
+    expect(message).toContain('bogus');
+    expect(message).toContain('element accepts:');
+    expect(
+      message,
+      `query was expanded for an error that is not about it: ${message}`,
+    ).not.toContain('query accepts:');
   });
 });


### PR DESCRIPTION
Follow-up to #451. No hard feelings about the coin toss — nine minutes is nine minutes, and the note you left was a better outcome than a merge.

The three things you asked to carry over, on top of what landed in #450.

## 1. `shapeForKind` extracted

`predicateFieldsFor` and `predicateNestedFieldsFor` each walked `predicateUnion().options` to resolve the same kind. One traversal now, shared — and a third reader becomes a call rather than a fourth copy of the loop.

## 2. `nestedKeysOf` exported and asserted directly

Your reasoning, which I could not improve on: reached only through the rendered sentence, a wrapper it fails to peel returns `[]`, the old message prints unchanged, and nothing reddens.

**No top-level predicate field is declared behind any wrapper today**, so the real schema exercises none of those paths. That is the argument for a case each rather than one standing for the rest — optional, default, nullable, both together, and `ZodEffects` (which I had missed in #451 and #450 got right).

## 3. Only the field that was actually blamed

`accepted()` now filters the nested expansions by the fields the zod issues point at.

You noted these are identical today because `element.query` is the only object-valued predicate field. They are not *quite*: they diverge whenever the mistake is somewhere else on `element`.

```
{ kind: "element", query: { role: "button" }, bogus: 1 }
```

Merged: recites `query accepts: by, value, role, …` for a rejection that has nothing to do with `query`.
Here: says `bogus` is unknown and stops.

So the divergence is pinned by a test that works on the current schema, rather than waiting for a second object-valued field to exist.

## Verification

Both behaviours mutation-checked:

| mutation | result |
|---|---|
| revert to expand-every-object-field (what merged does) | **1 failed** \| 27 passed |
| remove the wrapper peeling from `nestedKeysOf` | **5 failed** \| 23 passed |

Gates: `format:check`, `lint`, `typecheck` green. `pnpm --filter @reticlehq/server test:unit` — **503 files, 4901 tests passed**.

I kept the `it.each` shape from #451 for the three literal calls in the field report, since you said that was the right one.
