### PR TITLE
fix(e2e): align Next install baselines with the probe testid

### DIFF
--- a/apps/e2e/install-baseline.json
+++ b/apps/e2e/install-baseline.json
@@ -11,7 +11,6 @@
     "✓ Install dependencies → package.json",
     "✓ Reticle config → .reticle.json",
     "✓ ReticleDev component → app/reticle-dev.tsx",
-    "ℹ AGENT: finish the capabilities file → app/reticle-dev.tsx",
     "✓ Next config (withReticle) → next.config.ts",
     "✓ Mount ReticleDev → app/layout.tsx"
   ],
@@ -20,7 +19,6 @@
     "✓ Install dependencies → package.json",
     "✓ Reticle config → .reticle.json",
     "✓ ReticleDev component → components/reticle-dev.tsx",
-    "ℹ AGENT: finish the capabilities file → components/reticle-dev.tsx",
     "✓ Next config (withReticle) → next.config.ts",
     "✓ Mount ReticleDev → pages/_app.tsx"
   ],
@@ -30,7 +28,6 @@
     "✓ Reticle config → .reticle.json",
     "✓ Reticle config (agent root) → <root>/.reticle.json",
     "✓ ReticleDev component → app/reticle-dev.tsx",
-    "ℹ AGENT: finish the capabilities file → app/reticle-dev.tsx",
     "✓ Next config (withReticle) → next.config.ts",
     "✓ Mount ReticleDev → app/layout.tsx"
   ],


### PR DESCRIPTION
## Summary
- #564`s install-gate is red only because Next/monorepo baselines still expect `ℹ AGENT: finish the capabilities file`
- After #575 stamped a probe `data-testid`, init registers something and correctly omits that notice (Vite baselines were updated; Next were not)
- Session/state checks already pass on retry — this is the remaining plan-diff failure

Unblocks merge of https://github.com/reticlehq/reticle/pull/564 (lands #502 and the rest of 2.12.0).

## Test plan
- [x] Diff is three deletions in `apps/e2e/install-baseline.json` only
- [ ] CI `install-gate` green on this PR
- [ ] Re-run / merge into `release/v2.12.0`, then #564 install-gate should match
