### PR TITLE
fix: close high-severity audit holes (git since, pairing, epoch, install)

### DIFF
--- a/packages/browser/src/edit-epoch.test.ts
+++ b/packages/browser/src/edit-epoch.test.ts
@@ -114,4 +114,17 @@ describe('EditEpoch with a hot-update channel', () => {
       "ref 'not-a-ref' no longer resolves to an element",
     );
   });
+
+  it('ignores a second observe so HMR cannot stack listeners', () => {
+    const registry = new RefRegistry();
+    const epoch = new EditEpoch(registry);
+    const first = fakeHot();
+    const second = fakeHot();
+    epoch.observe(first);
+    epoch.observe(second);
+    first.fire({ type: 'update', updates: [{ path: '/src/A.tsx' }] });
+    second.fire({ type: 'update', updates: [{ path: '/src/B.tsx' }] });
+    // Only the first channel advances the epoch — one update, one tick.
+    expect(epoch.current).toBe(NO_EDITS_OBSERVED + 1);
+  });
 });

--- a/packages/browser/src/edit-epoch.ts
+++ b/packages/browser/src/edit-epoch.ts
@@ -70,6 +70,7 @@ function updatedPaths(payload: unknown): string[] {
 export class EditEpoch {
   #epoch: number = NO_EDITS_OBSERVED;
   #files: readonly string[] = [];
+  #observing = false;
   readonly #refs: RefRegistry;
 
   /** The registry is injected for the same reason the clock is: the interesting property is the
@@ -89,9 +90,11 @@ export class EditEpoch {
   }
 
   /** Subscribe to a hot-update channel if one was handed in. Anything else is silently ignored —
-   *  no channel is the normal case, not an error. */
+   *  no channel is the normal case, not an error. Once only: a connect module re-running under HMR
+   *  must not stack listeners on the surviving singleton (one Vite update would advance the epoch N times). */
   observe(hot: unknown): void {
-    if (!isHotLike(hot)) return;
+    if (this.#observing || !isHotLike(hot)) return;
+    this.#observing = true;
     hot.on(HOT_UPDATE_APPLIED, (payload) => this.applied(updatedPaths(payload)));
   }
 

--- a/packages/browser/src/observers/network.test.ts
+++ b/packages/browser/src/observers/network.test.ts
@@ -317,6 +317,24 @@ describe('installNetwork (fetch)', () => {
     expect(String(data['requestBody'])).not.toContain(formPasswordValue);
   });
 
+  it('captures the body from fetch(Request) when init has no body', async () => {
+    window.fetch = vi.fn(() =>
+      Promise.resolve(fakeResponseWithBody(200, 'application/json', '{"ok":true}')),
+    );
+    const { emit, events } = collect();
+    teardown = installNetwork(emit, { captureBodies: true });
+    const req = new Request('http://localhost:8787/api', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'a@b.com', password: 'req-pass-abcdef123' }),
+    });
+    await window.fetch(req);
+    await flushBody();
+    const data = eventOf(events, EventType.NET_REQUEST);
+    expect(String(data['requestBody'])).toContain('[REDACTED]');
+    expect(String(data['requestBody'])).not.toContain('req-pass-abcdef123');
+  });
+
   it('does NOT over-redact prose containing the words Bearer/Basic (no false positive)', async () => {
     const prose =
       'Basic subscription includes support. Bearer capacity exceeded the threshold today.';

--- a/packages/browser/src/observers/network.ts
+++ b/packages/browser/src/observers/network.ts
@@ -94,6 +94,31 @@ function projectRequestBody(body: unknown, captureBodies: boolean): Record<strin
   return truncated ? { requestBody: out, requestBodyTruncated: true } : { requestBody: out };
 }
 
+/**
+ * Request body for a fetch call. `init.body` is the common path; `fetch(new Request(url, { body }))`
+ * puts the body only on the Request, and reading only `init?.body` claimed "no body" for that form.
+ */
+async function projectFetchRequestBody(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  captureBodies: boolean,
+): Promise<Record<string, unknown>> {
+  if (!captureBodies) return {};
+  if (init?.body !== undefined && init.body !== null) {
+    return projectRequestBody(init.body, true);
+  }
+  if (typeof Request === 'undefined' || !(input instanceof Request) || null === input.body) {
+    return {};
+  }
+  try {
+    const text = await withBodyDeadline(input.clone().text());
+    if (text === undefined || 0 === text.length) return { requestBodyType: 'ReadableStream' };
+    return projectRequestBody(text, true);
+  } catch {
+    return { requestBodyType: 'ReadableStream' };
+  }
+}
+
 interface XhrMeta {
   id: string;
   method: string;
@@ -301,7 +326,10 @@ export function installNetwork(emit: Emit, opts: NetworkOptions = {}): Teardown 
     const initiatorStack = initiatorFrame();
     const initiatorFields = initiatorStack === undefined ? {} : { initiatorStack };
     emit(EventType.NET_PENDING, { id, method, url, initiator: 'fetch', ...initiatorFields });
+    let requestBodyFields: Record<string, unknown> = {};
     try {
+      // Capture BEFORE the app's fetch consumes a Request body stream.
+      requestBodyFields = await projectFetchRequestBody(input, init, captureBodies);
       const res = await callFetch(input, init);
       // The app's fetch resolves HERE — at headers — like a native fetch. durationMs is measured to
       // headers-received, so it stays honest whether or not we read the body.
@@ -322,7 +350,7 @@ export function installNetwork(emit: Emit, opts: NetworkOptions = {}): Teardown 
           ...initiatorFields,
           ...resourceTiming(rawUrl),
           ...netResponseMeta(res.statusText, contentType, res.headers.get('content-length')),
-          ...projectRequestBody(init?.body, captureBodies),
+          ...requestBodyFields,
           ...responseBodyFields,
           // Applied LAST so a reinterpreted verdict wins over the transport's own fields — a Tauri
           // command that returned Err still travelled down a fetch that answered HTTP 200.
@@ -386,6 +414,7 @@ export function installNetwork(emit: Emit, opts: NetworkOptions = {}): Teardown 
         durationMs: Math.round(performance.now() - start),
         initiator: 'fetch',
         ...initiatorFields,
+        ...requestBodyFields,
       });
       throw error;
     }

--- a/packages/browser/src/observers/network.ts
+++ b/packages/browser/src/observers/network.ts
@@ -107,7 +107,7 @@ async function projectFetchRequestBody(
   if (init?.body !== undefined && init.body !== null) {
     return projectRequestBody(init.body, true);
   }
-  if (typeof Request === 'undefined' || !(input instanceof Request) || null === input.body) {
+  if (typeof Request === 'undefined' || !(input instanceof Request) || input.body === null) {
     return {};
   }
   try {

--- a/packages/browser/src/reticle.edit-epoch.test.ts
+++ b/packages/browser/src/reticle.edit-epoch.test.ts
@@ -6,8 +6,7 @@ import { buildEvent } from './reticle.js';
  * Every event says which round of source edits it was observed under.
  *
  * Stamped in `buildEvent` for the same reason `documentId` is: it is the one place every event
- * passes through, so an observer added later cannot emit an unstamped one. Absence reads as
- * "current" downstream, which is what makes an unstamped observer a silent regression.
+ * passes through, so an observer added later cannot emit an unstamped one.
  */
 
 const base = {
@@ -23,10 +22,10 @@ describe('buildEvent stamps the edit epoch', () => {
     expect(buildEvent({ ...base, editEpoch: 2 }).editEpoch).toBe(2);
   });
 
-  it('omits the field while no edit has been observed, rather than asserting none happened', () => {
-    // A page with no hot-update channel — Next, Electron, Tauri, a plain page — knows nothing about
-    // edits. Stamping zero on every event would spend wire on a value that means "unknown".
-    expect(buildEvent({ ...base, editEpoch: NO_EDITS_OBSERVED }).editEpoch).toBeUndefined();
+  it('stamps zero as zero so pre-edit events stay distinguishable after a hot update', () => {
+    // Omitting `NO_EDITS_OBSERVED` made `isSameEditEpoch(undefined, 1)` read as current, so
+    // EVIDENCE_PREDATES_EDIT never fired for events emitted before the first edit.
+    expect(buildEvent({ ...base, editEpoch: NO_EDITS_OBSERVED }).editEpoch).toBe(NO_EDITS_OBSERVED);
     expect(buildEvent(base).editEpoch).toBeUndefined();
   });
 

--- a/packages/browser/src/reticle.ts
+++ b/packages/browser/src/reticle.ts
@@ -18,7 +18,6 @@ import {
   RETICLE_SDK_VERSION_GLOBAL,
   CONTRACT_FINGERPRINT,
   newDocumentId,
-  NO_EDITS_OBSERVED,
   type CommandMessage,
   type HelloMessage,
   type RedactionConfig,
@@ -206,10 +205,10 @@ export function buildEvent(args: {
     // through: an observer added later would otherwise emit unstamped events, which read as
     // "current" by design and would reintroduce the defect silently for one event type.
     documentId: args.documentId,
-    // Which round of source edits this was observed under. Stamped HERE for exactly the reason
-    // documentId is, and omitted while nothing has hot-updated: absence already reads as "current"
-    // downstream, so `NO_EDITS_OBSERVED` on the wire would be bytes spent saying "unknown".
-    editEpoch: NO_EDITS_OBSERVED === args.editEpoch ? undefined : args.editEpoch,
+    // Which round of source edits this was observed under. Stamped HERE for the same reason as
+    // documentId. Epoch 0 is stamped as 0 — omitting it made pre-edit events look current after the
+    // first hot update (`isSameEditEpoch(undefined, 1)`), so EVIDENCE_PREDATES_EDIT never fired.
+    editEpoch: args.editEpoch,
     data: args.data,
   };
 }
@@ -460,7 +459,10 @@ export class Reticle {
   }
 
   disconnect(): void {
-    if (!this.#connected) return;
+    // Observers install before `#connected` flips true. If a later mount throws, `#connected` stays
+    // false while `#teardowns` still holds fetch/XHR/history patches — gating teardown on connected
+    // alone leaked those monkeypatches for the life of the page.
+    if (!this.#connected && 0 === this.#teardowns.length && this.#transport === undefined) return;
     for (const teardown of this.#teardowns) teardown();
     this.#teardowns = [];
     this.#transport?.close();

--- a/packages/browser/src/transport/transport.close-codes.test.ts
+++ b/packages/browser/src/transport/transport.close-codes.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { RETICLE_PROTOCOL_VERSION, MessageKind, type HelloMessage } from '@reticlehq/core';
+import {
+  RETICLE_PROTOCOL_VERSION,
+  MessageKind,
+  EventType,
+  type HelloMessage,
+} from '@reticlehq/core';
 import * as nativeConsole from '../timers/native-console.js';
 import { Transport } from './transport.js';
 
@@ -121,5 +126,56 @@ describe('transport stops retrying on a 1008 policy-violation close', () => {
     FakeWebSocket.instances[0]?.closeWith(1006, 'abnormal'); // NOT closed — retryable
     becomeVisible(); // foreground reopen still allowed (only 1008 sets #closed)
     expect(FakeWebSocket.instances.length).toBe(2);
+  });
+
+  it('discards events after a 1008 instead of queuing them for a later reconnect', () => {
+    class TrackingSocket {
+      static readonly OPEN = 1;
+      static instances: TrackingSocket[] = [];
+      onopen: (() => void) | null = null;
+      onmessage: ((e: MessageEvent) => void) | null = null;
+      onclose: ((e: { code: number; reason: string }) => void) | null = null;
+      onerror: (() => void) | null = null;
+      readyState = 0;
+      sent: string[] = [];
+      constructor(_url: string) {
+        TrackingSocket.instances.push(this);
+      }
+      send(data: string): void {
+        this.sent.push(data);
+      }
+      open(): void {
+        this.readyState = TrackingSocket.OPEN;
+        this.onopen?.();
+      }
+      closeWith(code: number, reason: string): void {
+        this.readyState = 3;
+        this.onclose?.({ code, reason });
+      }
+    }
+    vi.stubGlobal('WebSocket', TrackingSocket);
+    const t = new Transport({
+      url: 'ws://x',
+      hello,
+      handleCommand: () => Promise.resolve({ ok: true }),
+    });
+    t.connect();
+    TrackingSocket.instances[0]?.closeWith(1008, 'refused');
+    for (let i = 0; i < 20; i += 1) {
+      t.sendEvent({
+        t: i,
+        seq: i,
+        type: EventType.CONSOLE_ERROR,
+        sessionId: 's1',
+        data: {},
+      });
+    }
+    // A later connect() clears #closed (page rewired) — discarded events must not flush.
+    t.connect();
+    TrackingSocket.instances[1]?.open();
+    const flushed = (TrackingSocket.instances[1]?.sent ?? []).filter((m) =>
+      m.includes(EventType.CONSOLE_ERROR),
+    );
+    expect(flushed).toHaveLength(0);
   });
 });

--- a/packages/browser/src/transport/transport.ts
+++ b/packages/browser/src/transport/transport.ts
@@ -382,6 +382,10 @@ export class Transport {
   }
 
   #sendRaw(text: string, event?: QueuedMessage['event']): void {
+    // A terminal refusal (1008) sets `#closed` and never reconnects. Queuing after that fills the
+    // offline buffer forever — the gap marker only ships on a successful reopen that will not happen —
+    // so upstream looks clean while every observation is discarded. Drop instead of enqueue.
+    if (this.#closed) return;
     if (this.#ws !== undefined && this.#ws.readyState === WebSocket.OPEN) {
       this.#ws.send(text);
       return;

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -117,6 +117,11 @@ export const ReticleEnv = {
   HEARTBEAT: 'RETICLE_HEARTBEAT_MS',
   /** Directory holding the auto-provisioned pairing token. Defaults to ~/.reticle; relocatable for CI. */
   PAIRING_TOKEN_DIR: 'RETICLE_PAIRING_TOKEN_DIR',
+  /**
+   * Opt in to starting the bridge WITHOUT a pairing token when auto-provision fails (unwritable
+   * $HOME). Default is fail-closed: without a token any loopback page can drive sessions.
+   */
+  ALLOW_INSECURE: 'RETICLE_ALLOW_INSECURE',
   /** Force the durable causal journal off (`0`/`false`/`off`) or on (`1`/`true`/`on`); default on. */
   JOURNAL: 'RETICLE_JOURNAL',
   /**

--- a/packages/core/src/edit-epoch.test.ts
+++ b/packages/core/src/edit-epoch.test.ts
@@ -1,15 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { NO_EDITS_OBSERVED, isSameEditEpoch } from './edit-epoch.js';
 
-/**
- * Which round of source edits an observation belongs to.
- *
- * The document id answers "was this page replaced". It cannot answer "was this CODE replaced": a hot
- * update swaps modules and re-renders inside the SAME document, so the id an agent is comparing
- * against never moves. An agent that edits and verifies in a loop therefore reads observations of
- * code it has already replaced, with nothing marking them.
- */
-
 describe('isSameEditEpoch', () => {
   it('counts evidence from the current epoch as current', () => {
     expect(isSameEditEpoch(3, 3)).toBe(true);
@@ -17,22 +8,24 @@ describe('isSameEditEpoch', () => {
 
   it('counts evidence from an earlier epoch as NOT current', () => {
     expect(isSameEditEpoch(2, 3)).toBe(false);
+    expect(isSameEditEpoch(NO_EDITS_OBSERVED, 3)).toBe(false);
   });
 
-  it('counts UNSTAMPED evidence as current, exactly as isSameDocument does', () => {
-    // An SDK older than this field stamps nothing, and an app with no hot-update channel stamps
-    // nothing either. Reading either as "foreign" would make those installations silently stop
-    // reporting real contradictions, which is the failure this whole family of checks exists to
-    // avoid — a tool that quietly finds nothing is worse than one that occasionally over-reports.
-    expect(isSameEditEpoch(undefined, 3)).toBe(true);
-    expect(isSameEditEpoch(2, undefined)).toBe(true);
+  it('counts UNSTAMPED evidence as current only while no edit has been observed', () => {
+    // Older SDKs and pages with no hot channel stamp nothing; while current is unknown or zero,
+    // reading that as foreign would silence real contradictions.
     expect(isSameEditEpoch(undefined, undefined)).toBe(true);
+    expect(isSameEditEpoch(undefined, NO_EDITS_OBSERVED)).toBe(true);
+    expect(isSameEditEpoch(2, undefined)).toBe(true);
+  });
+
+  it('counts UNSTAMPED evidence as foreign once an edit has been observed', () => {
+    // Omitting epoch 0 on the wire left pre-edit events looking current after the first hot update.
+    expect(isSameEditEpoch(undefined, 1)).toBe(false);
+    expect(isSameEditEpoch(undefined, 3)).toBe(false);
   });
 
   it('counts everything as current while no edit has been observed', () => {
-    // Absence of hot-update support means UNKNOWN, never "no edits happened" — so the epoch nobody
-    // has advanced must not start excluding or labelling anything.
     expect(isSameEditEpoch(NO_EDITS_OBSERVED, NO_EDITS_OBSERVED)).toBe(true);
-    expect(isSameEditEpoch(undefined, NO_EDITS_OBSERVED)).toBe(true);
   });
 });

--- a/packages/core/src/edit-epoch.ts
+++ b/packages/core/src/edit-epoch.ts
@@ -29,16 +29,21 @@ export const NO_EDITS_OBSERVED = 0;
 /**
  * Was this evidence recorded under the edit epoch currently in force?
  *
- * **Unstamped evidence counts as current**, following `isSameDocument` exactly rather than inventing
- * a stricter rule beside it. An SDK older than this field stamps nothing, and so does a perfectly
- * current SDK in a page with no hot-update channel. Reading either as foreign would make those
- * installations silently stop reporting real contradictions, and a verification tool that quietly
- * finds nothing is worse than one that occasionally over-reports.
+ * While no edit has been observed (`current` is undefined or `NO_EDITS_OBSERVED`), unstamped
+ * evidence counts as current — same as `isSameDocument`, and required for older SDKs and pages with
+ * no hot-update channel.
+ *
+ * Once an edit HAS been observed (`current > 0`), unstamped evidence is foreign. Omitting `0` on
+ * the wire used to leave pre-edit events looking current forever after the first hot update; that
+ * made `EVIDENCE_PREDATES_EDIT` unreachable on the common path.
  */
 export function isSameEditEpoch(
   evidenceEpoch: number | undefined,
   currentEpoch: number | undefined,
 ): boolean {
-  if (undefined === evidenceEpoch || undefined === currentEpoch) return true;
+  if (undefined === currentEpoch || currentEpoch === NO_EDITS_OBSERVED) {
+    return true;
+  }
+  if (undefined === evidenceEpoch) return false;
   return evidenceEpoch === currentEpoch;
 }

--- a/packages/core/src/messages.ts
+++ b/packages/core/src/messages.ts
@@ -89,9 +89,9 @@ export const ReticleEventSchema = z.object({
    * hot update. A hot update replaces modules and re-renders INSIDE the same document, so
    * `documentId` cannot see it; this is the edit-shaped half of the same question.
    *
-   * Optional, and absent while nothing has hot-updated, which is why absence is read as "current"
-   * rather than "foreign" — see `isSameEditEpoch`. Most pages have no channel that could report an
-   * update at all, so a stamp of `NO_EDITS_OBSERVED` would be wire spent on the word "unknown".
+   * Optional for older SDKs that stamped nothing. The current SDK stamps `0` while no edit has been
+   * observed. Once `currentEditEpoch > 0`, absence is foreign — see `isSameEditEpoch`. Most pages
+   * have no hot channel, so `0` means "no edits OBSERVED", never "none happened".
    */
   editEpoch: z.number().int().min(NO_EDITS_OBSERVED).optional(),
   /** Event-type-specific payload. Kept open here; refined per observer at the edges. */

--- a/packages/core/src/run-context.test.ts
+++ b/packages/core/src/run-context.test.ts
@@ -95,12 +95,19 @@ describe('foldEstablished', () => {
   });
 
   /**
-   * An unstamped fact predates document identity. It is kept for the same reason unstamped EVIDENCE
-   * is treated as current: an older SDK stamps nothing, and dropping its facts would make the answer
-   * silently empty rather than honestly smaller.
+   * Unstamped facts are kept only while no edit has been observed — same as `isSameEditEpoch`.
+   * Once an edit landed, absence means foreign (older SDKs / omit-zero left pre-edit facts looking
+   * current forever after the first hot update).
    */
-  it('keeps an unstamped fact rather than dropping it as foreign', () => {
-    expect(foldEstablished([], [fact('e1', 'no document known')], 'd3', 4)).toHaveLength(1);
+  it('keeps an unstamped fact only while no edit has been observed', () => {
+    expect(foldEstablished([], [fact('e1', 'no document known')], 'd3', undefined)).toHaveLength(1);
+    expect(
+      foldEstablished([], [fact('e1', 'no document known')], 'd3', NO_EDITS_OBSERVED),
+    ).toHaveLength(1);
+  });
+
+  it('DROPS an unstamped fact once an edit has been observed', () => {
+    expect(foldEstablished([], [fact('e1', 'no document known')], 'd3', 4)).toEqual([]);
   });
 
   it('keeps a fact from a page where no edit was ever observed', () => {

--- a/packages/core/src/run-context.ts
+++ b/packages/core/src/run-context.ts
@@ -61,14 +61,13 @@ export const RUN_ESTABLISHED_CAP = 12;
 /**
  * Evidence scoped to the page and the source revision it was taken under.
  *
- * Both fields are optional and absence means "current", exactly as `isSameDocument` and
- * `isSameEditEpoch` already rule: an SDK predating either stamps nothing, and a page with no
- * hot-update channel never stamps an epoch at all.
+ * `doc` absence means "current" (`isSameDocument`). `epoch` absence means current only while no
+ * edit has been observed — once `currentEditEpoch > 0`, unstamped epoch is foreign (`isSameEditEpoch`).
  */
 interface ScopedEvidence {
   /** The document this was seen under. Absent only from evidence predating document identity. */
   readonly doc?: string | undefined;
-  /** The edit epoch this was seen under. Absent where no hot update could ever be observed. */
+  /** The edit epoch this was seen under. Absent from older SDKs; current SDK stamps `0` until an edit. */
   readonly epoch?: number | undefined;
 }
 

--- a/packages/next/index.cjs
+++ b/packages/next/index.cjs
@@ -7,29 +7,49 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const crypto = require('node:crypto');
 
 // Kept in sync with @reticlehq/core (ReticleDir / ReticleEnv). This package is plain CJS tooling and
 // deliberately has no ESM/TS dependency on core, so the two constants are mirrored here.
 const PAIRING_TOKEN_DIR_ENV = 'RETICLE_PAIRING_TOKEN_DIR';
 const PAIRING_TOKEN_FILE = 'pairing-token';
+/** Matches the daemon / Vite plugin token size. */
+const TOKEN_BYTES = 32;
 
 /**
- * Read the daemon's auto-provisioned pairing token (~/.reticle/pairing-token, or the
- * RETICLE_PAIRING_TOKEN_DIR override). Node-side only. Returns undefined if the daemon hasn't started
- * yet (start it before `next dev`); the client then connects without a token and the page reloads once
- * the daemon is up and the config is re-read.
+ * Read the daemon's auto-provisioned pairing token, or mint one if the file is missing.
+ *
+ * Same contract as `@reticlehq/vite-plugin`'s `ensurePairingToken`: whichever process starts first
+ * (Next config resolve vs daemon) must leave a token the other side will accept. Read-only left a
+ * Next app started before the daemon with an empty NEXT_PUBLIC_RETICLE_TOKEN baked in until a full
+ * restart after the daemon existed — classic silent non-connect.
  * @returns {string | undefined}
  */
-function readPairingToken() {
+function ensurePairingToken() {
   const override = process.env[PAIRING_TOKEN_DIR_ENV];
   const dir =
     override !== undefined && override.length > 0 ? override : path.join(os.homedir(), '.reticle');
+  const filePath = path.join(dir, PAIRING_TOKEN_FILE);
   try {
-    const token = fs.readFileSync(path.join(dir, PAIRING_TOKEN_FILE), 'utf8').trim();
-    return token.length > 0 ? token : undefined;
+    const existing = fs.readFileSync(filePath, 'utf8').trim();
+    if (existing.length > 0) return existing;
+  } catch {
+    /* missing or unreadable — fall through and create one */
+  }
+  try {
+    const token = crypto.randomBytes(TOKEN_BYTES).toString('hex');
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(filePath, token, { encoding: 'utf8', mode: 0o600 });
+    fs.chmodSync(filePath, 0o600);
+    return token;
   } catch {
     return undefined;
   }
+}
+
+/** @deprecated Prefer ensurePairingToken — kept as the historical export name for callers/tests. */
+function readPairingToken() {
+  return ensurePairingToken();
 }
 
 /**
@@ -151,7 +171,7 @@ function withReticle(nextConfig = {}) {
   if (process.env.NODE_ENV === 'production') return nextConfig;
 
   const userWebpack = nextConfig.webpack;
-  const token = readPairingToken();
+  const token = ensurePairingToken();
   return {
     ...nextConfig,
     ...(supportsTurbopackKey() ? { turbopack: turbopackConfig(nextConfig.turbopack) } : {}),
@@ -183,4 +203,4 @@ function withReticle(nextConfig = {}) {
   };
 }
 
-module.exports = { withReticle, readPairingToken };
+module.exports = { withReticle, readPairingToken, ensurePairingToken };

--- a/packages/next/index.test.mjs
+++ b/packages/next/index.test.mjs
@@ -28,10 +28,12 @@ describe('readPairingToken', () => {
     expect(readPairingToken()).toBe('tok-from-daemon');
   });
 
-  it('returns undefined when the file is missing, so connect proceeds without a token', () => {
+  it('mints a token when the file is missing, so Next started before the daemon still pairs', () => {
     dir = mkdtempSync(join(tmpdir(), 'reticle-next-token-'));
     process.env[TOKEN_ENV] = dir;
-    expect(readPairingToken()).toBeUndefined();
+    const token = readPairingToken();
+    expect(token).toBeTruthy();
+    expect(readPairingToken()).toBe(token);
   });
 });
 

--- a/packages/server/src/bridge/bridge-security.test.ts
+++ b/packages/server/src/bridge/bridge-security.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ReticleEnv } from '@reticlehq/core';
+import { resolveBridgeSecurityWithAutoToken } from './bridge-security.js';
+
+describe('resolveBridgeSecurityWithAutoToken', () => {
+  const previousAllow = process.env[ReticleEnv.ALLOW_INSECURE];
+  let dir: string | undefined;
+
+  afterEach(async () => {
+    if (previousAllow === undefined) delete process.env[ReticleEnv.ALLOW_INSECURE];
+    else process.env[ReticleEnv.ALLOW_INSECURE] = previousAllow;
+    if (dir !== undefined) await rm(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  it('provisions a token into a writable pairing dir', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'reticle-pair-'));
+    const security = await resolveBridgeSecurityWithAutoToken({ pairingTokenDir: dir });
+    expect(security.token).toBeTruthy();
+  });
+
+  it('refuses to start tokenless when provision fails', async () => {
+    // A path that cannot be created as a directory (file-as-parent).
+    dir = await mkdtemp(join(tmpdir(), 'reticle-pair-'));
+    const blocked = join(dir, 'not-a-dir');
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(blocked, 'x');
+    await expect(
+      resolveBridgeSecurityWithAutoToken({ pairingTokenDir: join(blocked, 'child') }),
+    ).rejects.toThrow(/refusing to start without auth/);
+  });
+
+  it('allows tokenless only when RETICLE_ALLOW_INSECURE is set', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'reticle-pair-'));
+    const blocked = join(dir, 'not-a-dir');
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(blocked, 'x');
+    process.env[ReticleEnv.ALLOW_INSECURE] = '1';
+    const security = await resolveBridgeSecurityWithAutoToken({
+      pairingTokenDir: join(blocked, 'child'),
+    });
+    expect(security.token).toBeUndefined();
+  });
+});

--- a/packages/server/src/bridge/bridge-security.ts
+++ b/packages/server/src/bridge/bridge-security.ts
@@ -42,8 +42,10 @@ export function resolveBridgeSecurity(options: StartOptions): BridgeSecurity {
  * Same as `resolveBridgeSecurity`, but when no explicit/env token is set it auto-provisions one from
  * ~/.reticle/pairing-token so the bridge always requires a secret by default — this is what closes the
  * "any loopback origin is trusted" gap (a rogue localhost app can't read the file to present it). The
- * build plugins read the same file and inject it, so plugin-served apps stay zero-config. Best-effort:
- * if provisioning fails, the daemon degrades to the prior tokenless behavior rather than failing to start.
+ * build plugins read the same file and inject it, so plugin-served apps stay zero-config.
+ *
+ * Fail-closed when provision fails: starting tokenless restores the attack pairing exists to stop.
+ * Set `RETICLE_ALLOW_INSECURE=1` only when that risk is acceptable (unwritable $HOME in a locked-down CI).
  */
 export async function resolveBridgeSecurityWithAutoToken(
   options: StartOptions,
@@ -53,13 +55,20 @@ export async function resolveBridgeSecurityWithAutoToken(
   const dir = options.pairingTokenDir ?? defaultPairingTokenDir();
   const token = await readOrCreatePairingToken(dir, nodePairingTokenDeps());
   if (token === undefined) {
-    // Fail-open is deliberate (never block a dev daemon on an unwritable $HOME), but it must be LOUD:
-    // the bridge is now trusting every loopback origin. Say so plainly, not just as a silent event.
+    const allowInsecure = process.env[ReticleEnv.ALLOW_INSECURE];
+    const insecure = allowInsecure === '1' || allowInsecure === 'true' || allowInsecure === 'on';
     log('pairing_token_provision_failed', {
       dir,
-      warning:
-        'SECURITY: could not provision a pairing token — the bridge is running WITHOUT auth and will trust any localhost origin. Any local process/page can drive your browser sessions. Fix write access to this dir, or set RETICLE_TOKEN.',
+      allowInsecure: insecure,
+      warning: insecure
+        ? 'SECURITY: could not provision a pairing token — RETICLE_ALLOW_INSECURE is set, so the bridge is running WITHOUT auth and will trust any localhost origin.'
+        : 'SECURITY: could not provision a pairing token — refusing to start without auth. Fix write access to this dir, set RETICLE_TOKEN, or set RETICLE_ALLOW_INSECURE=1 to opt into tokenless localhost trust.',
     });
+    if (!insecure) {
+      throw new Error(
+        `could not provision a pairing token in ${dir} — refusing to start without auth (set RETICLE_TOKEN, fix write access, or RETICLE_ALLOW_INSECURE=1)`,
+      );
+    }
     return security;
   }
   return { ...security, token };

--- a/packages/server/src/cli/cloud-cli.ts
+++ b/packages/server/src/cli/cloud-cli.ts
@@ -6,7 +6,7 @@
  * `credentials.json` (per-project api keys from `reticle link`). The non-secret repo binding + sync policy
  * is `<repo>/.reticle/cloud.json`. Auth for a command = `RETICLE_CLOUD_KEY` env (agent) OR the login token.
  */
-import { mkdir, writeFile, readFile } from 'node:fs/promises';
+import { mkdir, writeFile, readFile, chmod } from 'node:fs/promises';
 import { NodePlatform } from '../platform.js';
 import { spawn } from 'node:child_process';
 import { setTimeout as sleep } from 'node:timers/promises';
@@ -196,12 +196,15 @@ const openBrowser = (target: string): void => {
 
 /** Persist a session token under ~/.reticle and print the next step. Shared by both login paths. */
 const writeSession = async (url: string, token: string, orgName: string): Promise<void> => {
-  await mkdir(home(), { recursive: true });
-  await writeFile(
-    join(home(), SESSION_FILE),
-    `${JSON.stringify({ url, token, orgName }, null, 2)}\n`,
-  );
-  emit({ loggedIn: orgName, session: join(home(), SESSION_FILE) });
+  await mkdir(home(), { recursive: true, mode: 0o700 });
+  const sessionPath = join(home(), SESSION_FILE);
+  await writeFile(sessionPath, `${JSON.stringify({ url, token, orgName }, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
+  // writeFile keeps a pre-existing looser mode, so set it explicitly — same as the pairing token.
+  await chmod(sessionPath, 0o600);
+  emit({ loggedIn: orgName, session: sessionPath });
   hint(
     'next: `reticle link` to bind this repo to your Default project (or `reticle project create <name>` first)',
   );
@@ -422,13 +425,17 @@ const cmdLink = async (argv: readonly string[]): Promise<number> => {
   };
   await writeFile(linkPath, `${JSON.stringify(cloudJson, null, 2)}\n`);
 
-  await mkdir(home(), { recursive: true });
+  await mkdir(home(), { recursive: true, mode: 0o700 });
   const credPath = join(home(), CREDENTIALS_FILE);
   const creds = (await readJson(credPath)) ?? {};
   const credObj =
     'object' === typeof creds && creds !== null ? (creds as Record<string, unknown>) : {};
   credObj[projectId] = key;
-  await writeFile(credPath, `${JSON.stringify(credObj, null, 2)}\n`);
+  await writeFile(credPath, `${JSON.stringify(credObj, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
+  await chmod(credPath, 0o600);
 
   emit({ linked: projectName, projectId, cloudJson: linkPath, credentials: credPath });
   hint(

--- a/packages/server/src/flows/affected-tools.ts
+++ b/packages/server/src/flows/affected-tools.ts
@@ -46,7 +46,19 @@ export const AFFECTED_TOOLS: ToolDef[] = [
         ? (args['files'] as unknown[]).filter((f): f is string => 'string' === typeof f)
         : [];
       const since = 'string' === typeof args['since'] ? args['since'] : undefined;
-      const changedFiles = await resolveChangedFiles(files, since);
+      let changedFiles: string[];
+      try {
+        changedFiles = await resolveChangedFiles(files, since);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          changedFiles: [],
+          affected: [],
+          unknownProvenance: [],
+          observed: true,
+          note: `could not resolve the change set: ${message}`,
+        };
+      }
       const flows = await loadNamedFlows(deps.fs, deps.reticleRoot);
       const result = affectedSavedFlows(flows, changedFiles);
       // Three different situations produced the same empty answer: no files changed, no flows saved,

--- a/packages/server/src/flows/git-changed.test.ts
+++ b/packages/server/src/flows/git-changed.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { parseGitFiles } from './git-changed.js';
+import {
+  GIT_DIFF_FAILED,
+  GIT_REF_LOOKS_LIKE_OPTION,
+  changedFilesSince,
+  isSafeGitRef,
+  parseGitFiles,
+} from './git-changed.js';
 
 describe('parseGitFiles', () => {
   it('splits, trims, and drops empty lines from git diff output', () => {
@@ -14,5 +20,34 @@ describe('parseGitFiles', () => {
   it('returns an empty list for empty output', () => {
     expect(parseGitFiles('')).toEqual([]);
     expect(parseGitFiles('\n\n')).toEqual([]);
+  });
+});
+
+describe('isSafeGitRef', () => {
+  it('accepts ordinary revision names', () => {
+    expect(isSafeGitRef('main')).toBe(true);
+    expect(isSafeGitRef('HEAD~3')).toBe(true);
+    expect(isSafeGitRef('origin/main')).toBe(true);
+  });
+
+  it('refuses anything that git would parse as an option', () => {
+    // The field report shape: --output writes a file as the daemon user.
+    expect(isSafeGitRef('--output=/tmp/evil')).toBe(false);
+    expect(isSafeGitRef('-u')).toBe(false);
+    expect(isSafeGitRef('')).toBe(false);
+  });
+});
+
+describe('changedFilesSince', () => {
+  it('refuses a dash-prefixed ref before spawning git', async () => {
+    await expect(
+      changedFilesSince('--output=/tmp/reticle-should-not-exist', process.cwd()),
+    ).rejects.toThrow(GIT_REF_LOOKS_LIKE_OPTION);
+  });
+
+  it('throws a distinct failure when git cannot produce a diff', async () => {
+    await expect(
+      changedFilesSince('main', 'C:\\this\\path\\is\\not\\a\\git\\repo\\reticle-audit'),
+    ).rejects.toThrow(GIT_DIFF_FAILED);
   });
 });

--- a/packages/server/src/flows/git-changed.ts
+++ b/packages/server/src/flows/git-changed.ts
@@ -3,6 +3,24 @@ import { promisify } from 'node:util';
 
 const run = promisify(execFile);
 
+/** A git ref that cannot be used as a revision — leading `-` is an option, not a commit. */
+export const GIT_REF_LOOKS_LIKE_OPTION =
+  'git ref must name a revision, not a flag (refs starting with "-" are refused)';
+
+/** Git did not produce a diff — bad ref, not a repo, or the binary failed. Not the same as "no files changed". */
+export const GIT_DIFF_FAILED =
+  'git diff failed — the change set is unknown (not an empty diff). Fix the ref or run from a git checkout.';
+
+/**
+ * True when `ref` is safe to pass to `git` as a revision operand.
+ *
+ * A string starting with `-` is parsed as an option (`--output=…`, `--abort`, …), which is how a
+ * caller-controlled `--since` becomes arbitrary file write (CWE-88). Rejected before argv is built.
+ */
+export function isSafeGitRef(ref: string): boolean {
+  return ref.length > 0 && !ref.startsWith('-');
+}
+
 /** Parse `git diff --name-only` output into a clean file list. Pure; exported for testing. */
 export function parseGitFiles(output: string): string[] {
   return output
@@ -12,15 +30,25 @@ export function parseGitFiles(output: string): string[] {
 }
 
 /**
- * Files changed since a git ref (`git diff --name-only <ref>`), so `reticle gate --since main` works from
- * the real diff instead of hand-listed files. Returns [] on any git failure (not a repo, bad ref) rather
- * than throwing — the caller degrades to "no changes" and the gate simply passes, never crashes CI.
+ * Files changed since a git ref (`git diff --name-only <ref>`).
+ *
+ * Throws on an unsafe ref or any git failure. An empty array means exit 0 with no names — a real
+ * empty diff — never "git could not run". Callers that used to treat `[]` as "nothing changed" were
+ * false-greening the gate when the repo was missing or the ref was garbage.
  */
 export async function changedFilesSince(ref: string, cwd: string): Promise<string[]> {
+  if (!isSafeGitRef(ref)) {
+    throw new Error(GIT_REF_LOOKS_LIKE_OPTION);
+  }
   try {
-    const { stdout } = await run('git', ['diff', '--name-only', ref], { cwd });
+    // `--end-of-options` (git ≥ 2.24): everything after is a revision/path, never an option — belt
+    // beside `isSafeGitRef` for values that do not start with `-` but still confuse the parser.
+    const { stdout } = await run('git', ['diff', '--name-only', '--end-of-options', '--', ref], {
+      cwd,
+    });
     return parseGitFiles(stdout);
-  } catch {
-    return [];
+  } catch (error) {
+    if (error instanceof Error && error.message === GIT_REF_LOOKS_LIKE_OPTION) throw error;
+    throw new Error(GIT_DIFF_FAILED, { cause: error });
   }
 }

--- a/packages/server/src/flows/recordings.test.ts
+++ b/packages/server/src/flows/recordings.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { ActionType, DANGEROUS_ACTION_CONFIRM_ARG, QueryBy } from '@reticlehq/core';
-import { RecordingStore, type RecordedStep, type CompiledProgram } from './recordings.js';
+import {
+  RecordingStore,
+  MAX_RECORDING_STEPS,
+  type RecordedStep,
+  type CompiledProgram,
+} from './recordings.js';
 import { compileActStep, compileSequenceStep } from './replay.js';
 
 const step = (tool: string, stable = true): RecordedStep => ({ tool, stable, args: {} });
@@ -34,6 +39,15 @@ describe('RecordingStore', () => {
     store.capture(step('reticle_act'));
     expect(store.stop('a')?.steps).toHaveLength(1);
     expect(store.stop('b')?.steps).toHaveLength(1);
+  });
+
+  it('refuses further captures once a recording hits the step cap', () => {
+    const store = new RecordingStore();
+    store.start('flow', 0);
+    for (let i = 0; i < MAX_RECORDING_STEPS + 50; i++) store.capture(step('reticle_act'));
+    const rec = store.stop('flow');
+    expect(rec?.steps).toHaveLength(MAX_RECORDING_STEPS);
+    expect(rec?.capped).toBe(true);
   });
 
   it('round-trips compiled programs by name', () => {

--- a/packages/server/src/flows/recordings.ts
+++ b/packages/server/src/flows/recordings.ts
@@ -15,6 +15,8 @@ export interface RecordedStep {
 interface ActiveRecording {
   cursor: number;
   steps: RecordedStep[];
+  /** True once the step cap refused further captures — stop is still required to compile. */
+  capped?: boolean;
 }
 
 /** A finished, replayable program compiled from a recording. */
@@ -23,6 +25,12 @@ export interface CompiledProgram {
   version: number;
   steps: RecordedStep[];
 }
+
+/**
+ * Hard cap on steps per active recording. A forgotten `reticle_record` over a long crawl used to
+ * grow without bound (the event ring buffer is capped; recordings were not) and could OOM the daemon.
+ */
+export const MAX_RECORDING_STEPS = 500;
 
 /**
  * Tracks in-flight recordings (name -> { buffer cursor at record_start, captured steps })
@@ -49,9 +57,20 @@ export class RecordingStore {
     return this.#active.get(name)?.steps.length;
   }
 
-  /** Append a captured step to every active recording (steps belong to all in-flight spans). */
+  /**
+   * Append a captured step to every active recording that is under the step cap.
+   * Once a recording hits `MAX_RECORDING_STEPS`, further captures are refused for that span
+   * (the recording stays open so stop/save still works).
+   */
   capture(step: RecordedStep): void {
-    for (const rec of this.#active.values()) rec.steps.push(step);
+    for (const rec of this.#active.values()) {
+      if (rec.steps.length >= MAX_RECORDING_STEPS) {
+        rec.capped = true;
+        continue;
+      }
+      rec.steps.push(step);
+      if (rec.steps.length >= MAX_RECORDING_STEPS) rec.capped = true;
+    }
   }
 
   /** Returns the active recording (cursor + steps) and clears it, or undefined if not recording. */

--- a/packages/server/src/flows/verify-change-tools.ts
+++ b/packages/server/src/flows/verify-change-tools.ts
@@ -97,7 +97,20 @@ export const VERIFY_CHANGE_TOOLS: ToolDef[] = [
         ? (args['files'] as unknown[]).filter((f): f is string => 'string' === typeof f)
         : [];
       const since = asString(args['since']);
-      const changedFiles = await resolveChangedFiles(files, since);
+      let changedFiles: string[];
+      try {
+        changedFiles = await resolveChangedFiles(files, since);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          verified: Verified.UNKNOWN,
+          because: `could not resolve the change set: ${message}`,
+          changedFiles: [],
+          flowsRun: [],
+          unknownProvenance: [],
+          measured: [],
+        };
+      }
       // Same root flow_save wrote to. A read that resolved differently would report "no flows
       // covered this change" over flows that exist, which reads as a clean result rather than
       // an error, so the disagreement would be invisible.

--- a/packages/server/src/init/astro-patch.test.ts
+++ b/packages/server/src/init/astro-patch.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from 'vitest';
 import { ReticleDir } from '@reticlehq/core';
 import { patchAstroConfig, patchAstroLayout } from './astro-patch.js';
 import { PatchKind } from './patch-kind.js';
+import { UiLibrary } from './detect.js';
 
 const PLAIN_CONFIG = `import { defineConfig } from 'astro/config';
 
@@ -267,6 +268,13 @@ describe('the SDK is pre-declared so the first load is not lost to a dep-optimiz
     expect(patch.code).toContain('their-dep');
     expect(patch.code).toContain('@reticlehq/react');
     expect(patch.code.match(/include\s*:/g)?.length ?? 0).toBe(1);
+  });
+
+  it('declares @reticlehq/browser for a Vue Astro app, not the React kit', () => {
+    const patch = patchAstroConfig(PLAIN_CONFIG, UiLibrary.VUE);
+    if (patch.kind !== PatchKind.APPLY) throw new Error('expected a patch');
+    expect(patch.code).toContain("include: ['@reticlehq/browser']");
+    expect(patch.code).not.toContain('@reticlehq/react');
   });
 });
 

--- a/packages/server/src/init/astro-patch.ts
+++ b/packages/server/src/init/astro-patch.ts
@@ -25,16 +25,20 @@ const LAYOUT_MARKER = 'reticle.connect';
 /**
  * The SDK, declared so Vite pre-bundles it BEFORE the first page load.
  *
- * The connect script does `await import('@reticlehq/react')`. Undeclared, Vite meets that import
- * mid-load, pre-bundles it, and the hashed `/node_modules/.vite/deps/@reticlehq_react.js?v=…` URL
+ * The connect script does `await import(<sdk>)`. Undeclared, Vite meets that import
+ * mid-load, pre-bundles it, and the hashed `/node_modules/.vite/deps/…` URL
  * the browser already requested stops existing — the import rejects with "Failed to fetch
  * dynamically imported module", connect() never runs, and the page looks entirely normal. Measured
  * on astro-nanostores, intermittent on whether the dep cache was warm. The Vite plugin has declared
  * the SDK for this exact reason since the bug was first found on React; Astro is hand-patched and
  * never got it.
+ *
+ * Must match `sdkImport(uiLibrary)` — a Vue/Svelte Astro app installs `@reticlehq/browser`, and
+ * hardcoding `@reticlehq/react` here made optimizeDeps point at a package that is not in node_modules.
  */
-const SDK_INCLUDE_LITERAL = `'@reticlehq/react'`;
-/**
+function sdkIncludeLiteral(uiLibrary: UiLibrary): string {
+  return `'${sdkImport(uiLibrary).specifier}'`;
+} /**
  * The daemon's journal directory, kept out of the dev server's watcher.
  *
  * The daemon writes `.reticle/` into the project root and rewrites `ambient.json` atomically
@@ -89,29 +93,33 @@ import { join } from 'node:path';
  * `target: 'es2022'` was silently discarded while init reported success. Losing that target is not
  * cosmetic: Astro's default down-levels the modern SDK bundle and dies on a destructuring transform.
  */
-const VITE_KEYS: readonly { key: string; inner: string }[] = [
-  { key: 'build', inner: `\n      target: 'es2022',` },
-  {
-    key: 'optimizeDeps',
-    inner: `\n      include: [${SDK_INCLUDE_LITERAL}],\n      esbuildOptions: { target: 'es2022' },`,
-  },
-  {
-    key: 'define',
-    inner: `\n      __RETICLE_TOKEN__: JSON.stringify(reticleToken()),\n      __RETICLE_ROOT__: JSON.stringify(process.cwd()),`,
-  },
-  // Merged in first, so a `server: { port }` the app already set keeps its port. An app that
-  // already sets `server.watch` itself is the one shape this loses to — the inner `watch` key would
-  // be duplicated and the app's would win — which is the same nested-merge ceiling `build` has.
-  { key: 'server', inner: `\n      watch: { ignored: [${WATCH_IGNORE_LITERAL}] },` },
-];
+function viteKeys(include: string): readonly { key: string; inner: string }[] {
+  return [
+    { key: 'build', inner: `\n      target: 'es2022',` },
+    {
+      key: 'optimizeDeps',
+      inner: `\n      include: [${include}],\n      esbuildOptions: { target: 'es2022' },`,
+    },
+    {
+      key: 'define',
+      inner: `\n      __RETICLE_TOKEN__: JSON.stringify(reticleToken()),\n      __RETICLE_ROOT__: JSON.stringify(process.cwd()),`,
+    },
+    // Merged in first, so a `server: { port }` the app already set keeps its port. An app that
+    // already sets `server.watch` itself is the one shape this loses to — the inner `watch` key would
+    // be duplicated and the app's would win — which is the same nested-merge ceiling `build` has.
+    { key: 'server', inner: `\n      watch: { ignored: [${WATCH_IGNORE_LITERAL}] },` },
+  ];
+}
 
 /** Whole-key form, for a `vite:` block that does not have the key at all. */
-const WHOLE: Readonly<Record<string, string>> = {
-  build: `\n    build: { target: 'es2022' },`,
-  optimizeDeps: `\n    optimizeDeps: { include: [${SDK_INCLUDE_LITERAL}], esbuildOptions: { target: 'es2022' } },`,
-  define: `\n    define: {\n      __RETICLE_TOKEN__: JSON.stringify(reticleToken()),\n      __RETICLE_ROOT__: JSON.stringify(process.cwd()),\n    },`,
-  server: `\n    server: { watch: { ignored: [${WATCH_IGNORE_LITERAL}] } },`,
-};
+function wholeKeys(include: string): Readonly<Record<string, string>> {
+  return {
+    build: `\n    build: { target: 'es2022' },`,
+    optimizeDeps: `\n    optimizeDeps: { include: [${include}], esbuildOptions: { target: 'es2022' } },`,
+    define: `\n    define: {\n      __RETICLE_TOKEN__: JSON.stringify(reticleToken()),\n      __RETICLE_ROOT__: JSON.stringify(process.cwd()),\n    },`,
+    server: `\n    server: { watch: { ignored: [${WATCH_IGNORE_LITERAL}] } },`,
+  };
+}
 
 /**
  * Add our keys to an existing `vite: { ... }` block, merging into any the app already set.
@@ -119,14 +127,16 @@ const WHOLE: Readonly<Record<string, string>> = {
  * Returns null when a colliding key is not an object literal (`build: sharedConfig`) — there is no
  * brace to merge into, and duplicating or replacing it would corrupt someone's build.
  */
-function mergeIntoViteBlock(source: string, braceAt: number): string | null {
+function mergeIntoViteBlock(source: string, braceAt: number, include: string): string | null {
   let out = source;
-  for (const { key, inner } of VITE_KEYS) {
+  const keys = viteKeys(include);
+  const whole = wholeKeys(include);
+  for (const { key, inner } of keys) {
     // Scoped to the vite block by searching from its opening brace: a `build:` under `markdown:` or
     // at the top level is somebody else's key and must not be touched.
     const existing = new RegExp(`(\\n\\s*${key}\\s*:\\s*)([\\{A-Za-z_])`).exec(out.slice(braceAt));
     if (existing?.index === undefined) {
-      out = `${out.slice(0, braceAt)}${WHOLE[key] ?? ''}${out.slice(braceAt)}`;
+      out = `${out.slice(0, braceAt)}${whole[key] ?? ''}${out.slice(braceAt)}`;
       continue;
     }
     // The character after the colon decides: `{` is a literal we can open; anything else is a
@@ -145,8 +155,8 @@ function mergeIntoViteBlock(source: string, braceAt: number): string | null {
     }
     // Their array first, then the rest of our keys at the block's start — inserting at the LOWER
     // offset second keeps the first offset valid.
-    out = insertAt(out, at + own.index + own[0].length, `${SDK_INCLUDE_LITERAL}, `);
-    out = insertAt(out, at, withoutInclude(inner));
+    out = insertAt(out, at + own.index + own[0].length, `${include}, `);
+    out = insertAt(out, at, withoutInclude(inner, include));
   }
   return out;
 }
@@ -176,8 +186,8 @@ function blockAfter(source: string, at: number): string {
 }
 
 /** The optimizeDeps inner minus our `include:` line, for when the app already has one to join. */
-function withoutInclude(inner: string): string {
-  return inner.replace(`\n      include: [${SDK_INCLUDE_LITERAL}],`, '');
+function withoutInclude(inner: string, include: string): string {
+  return inner.replace(`\n      include: [${include}],`, '');
 }
 
 /**
@@ -185,9 +195,10 @@ function withoutInclude(inner: string): string {
  * modern SDK bundle and dies on a destructuring transform; `__RETICLE_ROOT__` is defined because
  * without it every source pointer comes back as an absolute path from the machine that ran `init`.
  */
-const VITE_BLOCK = `  vite: {
+function viteBlock(include: string): string {
+  return `  vite: {
     build: { target: 'es2022' },
-    optimizeDeps: { include: [${SDK_INCLUDE_LITERAL}], esbuildOptions: { target: 'es2022' } },
+    optimizeDeps: { include: [${include}], esbuildOptions: { target: 'es2022' } },
     define: {
       __RETICLE_TOKEN__: JSON.stringify(reticleToken()),
       __RETICLE_ROOT__: JSON.stringify(process.cwd()),
@@ -195,8 +206,13 @@ const VITE_BLOCK = `  vite: {
     server: { watch: { ignored: [${WATCH_IGNORE_LITERAL}] } },
   },
 `;
+}
 
-export function patchAstroConfig(source: string): SourcePatch {
+export function patchAstroConfig(
+  source: string,
+  uiLibrary: UiLibrary = UiLibrary.REACT,
+): SourcePatch {
+  const include = sdkIncludeLiteral(uiLibrary);
   if (source.includes(CONFIG_MARKER)) return { kind: PatchKind.ALREADY };
   // A `vite: { ... }` block is an object literal, so our keys can go straight after the brace and
   // whatever is already in there is untouched. Refusing outright was the only genuine install defect
@@ -206,7 +222,7 @@ export function patchAstroConfig(source: string): SourcePatch {
   const viteObject = VITE_OBJECT_KEY.exec(source);
   if (viteObject?.index !== undefined) {
     const at = viteObject.index + viteObject[0].length;
-    const merged = mergeIntoViteBlock(source, at);
+    const merged = mergeIntoViteBlock(source, at, include);
     if (merged !== null) {
       return {
         kind: PatchKind.APPLY,
@@ -237,7 +253,7 @@ export function patchAstroConfig(source: string): SourcePatch {
     };
   }
   const at = opening.index + opening[0].length;
-  const withBlock = `${source.slice(0, at)}\n${VITE_BLOCK}${source.slice(at)}`;
+  const withBlock = `${source.slice(0, at)}\n${viteBlock(include)}${source.slice(at)}`;
   return {
     kind: PatchKind.APPLY,
     code: `${HELPER_IMPORTS}${withBlock.trimStart()}\n${HELPER}`.trimEnd() + '\n',

--- a/packages/server/src/init/connect-steps.test.ts
+++ b/packages/server/src/init/connect-steps.test.ts
@@ -53,6 +53,7 @@ describe('steps without which no session can ever appear', () => {
       'Reticle client hook',
       'Reticle connect module',
       'Vite plugin',
+      'Next config (withReticle)',
     ]) {
       expect(isConnectStep(title), title).toBe(true);
     }

--- a/packages/server/src/init/connect-steps.ts
+++ b/packages/server/src/init/connect-steps.ts
@@ -43,6 +43,9 @@ const CONNECT_STEP_TITLES: ReadonlySet<string> = new Set([
   // not, and `gate:install` scaffolds no CRA app, so that change would ship with no coverage of the
   // path it changes. It is worth doing, and worth doing with a scaffold behind it.
   'Vite plugin',
+  // Without withReticle the pairing token never reaches the client and Next never dials the bridge.
+  // Mounting ReticleDev alone looked green while the config stayed MANUAL — classic silent non-connect.
+  'Next config (withReticle)',
 ]);
 
 /** True when this step is what makes the app dial the daemon. */

--- a/packages/server/src/init/plan-framework.ts
+++ b/packages/server/src/init/plan-framework.ts
@@ -471,7 +471,12 @@ export function svelteKitSteps(input: PlanInput): Step[] {
 export function astroSteps(input: PlanInput): Step[] {
   const config = input.astroConfig ?? null;
   const layout = input.astroLayout ?? null;
-  const manual = astroManual(input.options.port, input.options.projectId, layout?.path);
+  const manual = astroManual(
+    input.options.port,
+    input.options.projectId,
+    layout?.path,
+    input.detection.uiLibrary,
+  );
   if (null === config || null === layout) {
     return [
       {
@@ -490,8 +495,13 @@ export function astroSteps(input: PlanInput): Step[] {
   // real fixture — config ⚠, layout ✓ — which reads as one step done and one caveat when it is
   // actually a guaranteed non-connection. If either half cannot be applied, BOTH go manual with the
   // single recipe that does the whole job.
-  const manualWithLayout = astroManual(input.options.port, input.options.projectId, layout.path);
-  const configPatch = patchAstroConfig(config.source);
+  const manualWithLayout = astroManual(
+    input.options.port,
+    input.options.projectId,
+    layout.path,
+    input.detection.uiLibrary,
+  );
+  const configPatch = patchAstroConfig(config.source, input.detection.uiLibrary);
   const layoutPatch = patchAstroLayout(
     layout.source,
     input.options.port,

--- a/packages/server/src/init/snippets.ts
+++ b/packages/server/src/init/snippets.ts
@@ -226,7 +226,9 @@ export function astroManual(
    * reader, and cost them the time it takes to go and confirm it is missing.
    */
   layoutPath?: string,
+  uiLibrary: UiLibrary = UiLibrary.REACT,
 ): string {
+  const sdk = sdkImport(uiLibrary);
   const extra =
     port !== undefined && port !== RETICLE_DEFAULT_PORT
       ? `\n          url: '${bridgeWsUrl(port)}',`
@@ -250,7 +252,7 @@ export function astroManual(
     vite: {
       // Astro's default target down-levels the modern SDK bundle and fails on a destructuring transform.
       build: { target: 'es2022' },
-      optimizeDeps: { esbuildOptions: { target: 'es2022' } },
+      optimizeDeps: { include: ['${sdk.specifier}'], esbuildOptions: { target: 'es2022' } },
       define: {
         __RETICLE_TOKEN__: JSON.stringify(reticleToken()),
         // Without this, source pointers come back as absolute paths from YOUR machine — useless in a
@@ -266,8 +268,8 @@ ${layoutHost(layoutPath)}
     if (import.meta.env.DEV) {
       const token = typeof __RETICLE_TOKEN__ !== 'undefined' ? __RETICLE_TOKEN__ : '';
       const root = typeof __RETICLE_ROOT__ !== 'undefined' ? __RETICLE_ROOT__ : '';
-      const { reticle, install } = await import('@reticlehq/react');
-      install();
+      const { reticle${sdk.usesInstall ? ', install' : ''} } = await import('${sdk.specifier}');
+      ${sdk.usesInstall ? 'install();' : '// The sensor has no install(); that is the React adapter.'}
       reticle.connect({${id}${extra}
           ...(token.length > 0 ? { token } : {}),
           ...(root.length > 0 ? { root } : {}),


### PR DESCRIPTION
## Summary
- **Security / false-green:** reject dash-leading `since` git refs (`--end-of-options -- <ref>`), throw on git failure instead of returning `[]`; MCP `affected` / `verify_change` report honest unknown notes.
- **Observation integrity:** discard transport queue after WS 1008; tear down observers when connect fails mid-way; stamp `editEpoch: 0` and treat unstamped evidence as foreign once an edit was observed; observe hot updates once.
- **Install / pairing:** fail closed if pairing token cannot be provisioned (opt-in `RETICLE_ALLOW_INSECURE=1`); Next `withReticle` is connect-critical and mints the pairing token like Vite; Astro `optimizeDeps` / manual recipe use `sdkImport(uiLibrary)`.
- **Hardening:** cloud session/credentials `0o600`; recording step cap (500); capture `fetch(Request)` bodies.

## Test plan
- [x] Targeted unit tests (git-changed, bridge-security, edit-epoch, transport close-codes, recordings, connect-steps, astro-patch, next token mint, network Request body)
- [x] `typecheck` on core / browser / server
- [ ] CI `verify` + unit battery on the PR