### PR TITLE
fix(tauri): park the macOS headless window off-screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ### Fixed
 
-- **`reticle-tauri` — a hidden macOS WKWebView no longer goes silent after a pause.** `RETICLE_HEADLESS=1` used to `hide()` the window after first paint. Capture still worked (it renders the webview, not the screen), but commands that need the page to execute JavaScript timed out after roughly twelve seconds. Linux was fine: WebKitGTK keeps running while hidden, which is why CI stayed green. macOS now parks the window off-screen instead of hiding it. The timeout copy no longer says hiding after load is safe.
+- **`reticle-tauri` — macOS `RETICLE_HEADLESS=1` parks off-screen instead of `hide()`.** Hiding after first paint is the remaining headless path we have not proved safe on every macOS WKWebView: a hidden window has been observed to go quiet after a pause while capture still works (it renders the webview, not the screen). Linux and Windows still hide. The timeout copy names that pause as a candidate, not a fact.
 
 ## [2.12.0] - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
+### Fixed
+
+- **`reticle-tauri` — a hidden macOS WKWebView no longer goes silent after a pause.** `RETICLE_HEADLESS=1` used to `hide()` the window after first paint. Capture still worked (it renders the webview, not the screen), but commands that need the page to execute JavaScript timed out after roughly twelve seconds. Linux was fine: WebKitGTK keeps running while hidden, which is why CI stayed green. macOS now parks the window off-screen instead of hiding it. The timeout copy no longer says hiding after load is safe.
+
 ## [2.12.0] - 2026-08-24
 
 ### Fixed

--- a/packages/core/src/desktop-contract.test.ts
+++ b/packages/core/src/desktop-contract.test.ts
@@ -99,8 +99,9 @@ describe('desktop contract — the Rust capture helper', () => {
   });
 
   /**
-   * `hide()` after load used to be the headless path on every OS. On macOS a hidden WKWebView
-   * stops answering commands after a short pause. The macOS arm parks off-screen instead.
+   * `hide()` after load used to be the headless path on every OS. A hidden macOS WKWebView has
+   * been observed to go quiet after a pause; the macOS arm parks off-screen instead of asserting
+   * that `hide()` is dead on every machine.
    */
   it('parks the macOS headless window off-screen rather than calling hide()', () => {
     const lib = join(process.cwd(), '..', 'tauri', 'src', 'lib.rs');

--- a/packages/core/src/desktop-contract.test.ts
+++ b/packages/core/src/desktop-contract.test.ts
@@ -97,4 +97,23 @@ describe('desktop contract — the Rust capture helper', () => {
     if ('' === capture) return;
     expect(capture).toContain(`pub async fn ${DESKTOP_CONTRACT.RETICLE_TAURI_CAPTURE_COMMAND}(`);
   });
+
+  /**
+   * `hide()` after load used to be the headless path on every OS. On macOS a hidden WKWebView
+   * stops answering commands after a short pause. The macOS arm parks off-screen instead.
+   */
+  it('parks the macOS headless window off-screen rather than calling hide()', () => {
+    const lib = join(process.cwd(), '..', 'tauri', 'src', 'lib.rs');
+    if (!existsSync(lib)) return;
+    const source = readFileSync(lib, 'utf8');
+    expect(source).toContain('OFFSCREEN_PX');
+    const fn = source.split('pub fn on_page_load')[1];
+    expect(fn, 'on_page_load missing from lib.rs').toBeDefined();
+    const macosArm = (fn ?? '').split('target_os = "macos"')[1];
+    expect(macosArm, 'macOS arm missing from on_page_load').toBeDefined();
+    const arm = macosArm ?? '';
+    const untilNextCfg = arm.split('#[cfg')[0] ?? arm;
+    expect(untilNextCfg).toContain('set_position');
+    expect(untilNextCfg).not.toMatch(/\.hide\(\)/);
+  });
 });

--- a/packages/server/src/session/command-timeout.test.ts
+++ b/packages/server/src/session/command-timeout.test.ts
@@ -100,6 +100,21 @@ describe('commandTimeoutMessage — an 8s timeout should say what to DO', () => 
   });
 
   /**
+   * Hiding AFTER load used to be documented as safe. On macOS it is not: a loaded WKWebView that
+   * stays hidden stops answering commands after a short pause, even though capture still works.
+   * The timeout must not send someone back to hide() as the fix.
+   */
+  it('does not claim that hiding after load is safe', () => {
+    const message = commandTimeoutMessage('snapshot', 8000, {
+      url: TAURI,
+      hidden: true,
+      runtime: 'tauri',
+    });
+    expect(message).not.toMatch(/hiding it is safe/i);
+    expect(message).toMatch(/off-screen/);
+  });
+
+  /**
    * Electron shows its window before hiding it, so it never hits this. Diagnosing it there would
    * send the user to change code that was never the problem.
    */

--- a/packages/server/src/session/command-timeout.test.ts
+++ b/packages/server/src/session/command-timeout.test.ts
@@ -100,9 +100,9 @@ describe('commandTimeoutMessage — an 8s timeout should say what to DO', () => 
   });
 
   /**
-   * Hiding AFTER load used to be documented as safe. On macOS it is not: a loaded WKWebView that
-   * stays hidden stops answering commands after a short pause, even though capture still works.
-   * The timeout must not send someone back to hide() as the fix.
+   * Hiding AFTER load used to be documented as safe. A hidden macOS WKWebView has been observed
+   * to go quiet after a pause, even though capture still works — and the timeout must not send
+   * someone back to hide() as the fix, even on a machine that never hits that pause.
    */
   it('does not claim that hiding after load is safe', () => {
     const message = commandTimeoutMessage('snapshot', 8000, {
@@ -112,6 +112,9 @@ describe('commandTimeoutMessage — an 8s timeout should say what to DO', () => 
     });
     expect(message).not.toMatch(/hiding it is safe/i);
     expect(message).toMatch(/off-screen/);
+    // Rank the pause as observed, never as a fact every Mac will hit.
+    expect(message).toMatch(/observed/);
+    expect(message).not.toMatch(/stops answering/);
   });
 
   /**

--- a/packages/server/src/session/command-timeout.ts
+++ b/packages/server/src/session/command-timeout.ts
@@ -11,8 +11,10 @@ import { AppRuntime, isOpaqueOrigin } from '@reticlehq/core';
  *
  * This advice previously blamed occlusion — "macOS suspends an occluded or off-Space WKWebView" —
  * which is false for those states, and was the kind of wrong steer this function exists to prevent.
- * A LOADED Tauri webview keeps answering while minimized, occluded, and on another Space. What it
- * does not survive is `hide()`: on macOS a hidden WKWebView stops answering after a short pause.
+ * A LOADED Tauri webview keeps answering while minimized, occluded, and on another Space. `hide()`
+ * after load is the remaining headless path: a hidden macOS WKWebView has been observed to go quiet
+ * after a pause, but that is not something every machine demonstrates, so this message names it as
+ * a candidate rather than a fact.
  *
  * It then over-corrected: it asserted the hidden-before-load ordering as FACT. But the only evidence
  * here is `hidden === true` — the ordering is never observed. Measured on a Tauri shell pointed at an
@@ -62,8 +64,8 @@ const HIDDEN_ADVICE =
   'most likely not running the page at all. Two known causes, commonest first: (1) the window was ' +
   'hidden BEFORE its first page load — a webview that has never been presented never loads, so park ' +
   'it from `on_page_load` instead of `setup` (see `reticle_tauri::on_page_load`, which does this for ' +
-  'RETICLE_HEADLESS=1). (2) the window was hidden after load and then went quiet — a loaded macOS ' +
-  'WKWebView stops answering commands after a short pause even though capture still works; park it ' +
+  'RETICLE_HEADLESS=1). (2) the window was hidden after load and then went quiet — that has been ' +
+  'observed on a hidden macOS WKWebView after a pause, even though capture still works; park it ' +
   'off-screen rather than calling hide. If neither fits, the page is reachable but not executing, ' +
   'which is worth reporting.';
 

--- a/packages/server/src/session/command-timeout.ts
+++ b/packages/server/src/session/command-timeout.ts
@@ -10,8 +10,9 @@ import { AppRuntime, isOpaqueOrigin } from '@reticlehq/core';
  * developer goes hunting through their own code for a fault that is not there.
  *
  * This advice previously blamed occlusion — "macOS suspends an occluded or off-Space WKWebView" —
- * which is false, and was the kind of wrong steer this function exists to prevent. A LOADED Tauri
- * webview keeps answering while minimized, app-hidden, occluded, and on another Space.
+ * which is false for those states, and was the kind of wrong steer this function exists to prevent.
+ * A LOADED Tauri webview keeps answering while minimized, occluded, and on another Space. What it
+ * does not survive is `hide()`: on macOS a hidden WKWebView stops answering after a short pause.
  *
  * It then over-corrected: it asserted the hidden-before-load ordering as FACT. But the only evidence
  * here is `hidden === true` — the ordering is never observed. Measured on a Tauri shell pointed at an
@@ -59,11 +60,12 @@ const ONE_WAY_ADVICE =
 const HIDDEN_ADVICE =
   'The page last reported itself hidden, and this is a WKWebView (Tauri) window, so the webview is ' +
   'most likely not running the page at all. Two known causes, commonest first: (1) the window was ' +
-  'hidden BEFORE its first page load — a webview that has never been presented never loads, so hide ' +
+  'hidden BEFORE its first page load — a webview that has never been presented never loads, so park ' +
   'it from `on_page_load` instead of `setup` (see `reticle_tauri::on_page_load`, which does this for ' +
-  'RETICLE_HEADLESS=1); once the page HAS loaded, hiding it is safe. (2) the window never presented ' +
-  'for another reason — check that it is declared with a visible size and that the page URL actually ' +
-  'loaded. If neither fits, the page is reachable but not executing, which is worth reporting.';
+  'RETICLE_HEADLESS=1). (2) the window was hidden after load and then went quiet — a loaded macOS ' +
+  'WKWebView stops answering commands after a short pause even though capture still works; park it ' +
+  'off-screen rather than calling hide. If neither fits, the page is reachable but not executing, ' +
+  'which is worth reporting.';
 
 /** True when this session is a WebKit desktop shell — the only runtime that suffers this. */
 function isWebKitDesktop(context: TimeoutContext): boolean {

--- a/packages/tauri/Cargo.lock
+++ b/packages/tauri/Cargo.lock
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "reticle-tauri"
-version = "0.1.0"
+version = "2.12.0"
 dependencies = [
  "block2",
  "cairo-rs",

--- a/packages/tauri/README.md
+++ b/packages/tauri/README.md
@@ -47,6 +47,6 @@ RETICLE_HEADLESS=1 cargo tauri dev
 
 The ordering matters and is the whole reason this is a function rather than a config flag. Acting during `setup` runs _before_ the webview has been presented, and a webview that has never been presented never loads its page — so the app answers nothing. Show, load, then park.
 
-On macOS the park is off-screen, not `hide()`. A loaded WKWebView that stays hidden stops answering commands after a short pause (capture still works, because it renders the webview). Linux and Windows still hide: WebKitGTK keeps executing while hidden.
+On macOS the park is off-screen, not `hide()`. A loaded WKWebView that is then hidden has been observed to go quiet after a pause (capture still works, because it renders the webview); parking keeps the page scheduled without claiming every Mac will hit that pause. Linux and Windows still hide: WebKitGTK keeps executing while hidden.
 
 `xvfb-run -a cargo tauri dev` also works on Linux and needs no app-side change.

--- a/packages/tauri/README.md
+++ b/packages/tauri/README.md
@@ -39,12 +39,14 @@ All three capture the visible viewport by default, so a baseline taken on one pl
 
 ### Headless
 
-`on_page_load` hides the window when `RETICLE_HEADLESS=1`:
+`on_page_load` parks the window when `RETICLE_HEADLESS=1`:
 
 ```sh
 RETICLE_HEADLESS=1 cargo tauri dev
 ```
 
-The ordering matters and is the whole reason this is a function rather than a config flag. Hiding the window during `setup` hides it _before_ the webview has been presented, and a webview that has never been presented never loads its page — so the app answers nothing and looks suspended. Hiding it after the first page load leaves everything running: a loaded webview keeps executing JavaScript while minimized, app-hidden, occluded, or on another macOS Space.
+The ordering matters and is the whole reason this is a function rather than a config flag. Acting during `setup` runs _before_ the webview has been presented, and a webview that has never been presented never loads its page — so the app answers nothing. Show, load, then park.
+
+On macOS the park is off-screen, not `hide()`. A loaded WKWebView that stays hidden stops answering commands after a short pause (capture still works, because it renders the webview). Linux and Windows still hide: WebKitGTK keeps executing while hidden.
 
 `xvfb-run -a cargo tauri dev` also works on Linux and needs no app-side change.

--- a/packages/tauri/src/lib.rs
+++ b/packages/tauri/src/lib.rs
@@ -40,9 +40,15 @@ const HEADLESS_ENV: &str = "RETICLE_HEADLESS";
 
 /// Far enough off every display that nothing is on screen, without calling `hide()`.
 ///
-/// A hidden WKWebView on macOS stops executing JavaScript after a short pause. Capture still works
-/// (it renders the webview, not the screen). Parking keeps `document.hidden` false so the page
-/// keeps answering.
+/// A hidden WKWebView on macOS has been observed to stop executing JavaScript after a short pause.
+/// Capture still works (it renders the webview, not the screen). Parking keeps `document.hidden`
+/// false so the page keeps being scheduled. That pause is not something every machine demonstrates,
+/// so this is the mechanism we can show, not a claim that `hide()` is dead everywhere.
+///
+/// AppKit is not guaranteed to honour this origin. `constrainFrameRect:toScreen:` can pull a window
+/// back so its title bar stays on a display (Stage Manager, Mission Control, extra screens). A
+/// headless run that then shows a window is louder than the pause we are avoiding; we still park
+/// rather than hide because a visible-but-unwanted window is recoverable and a silent webview is not.
 #[cfg(target_os = "macos")]
 const OFFSCREEN_PX: i32 = -32_000;
 
@@ -53,9 +59,11 @@ const OFFSCREEN_PX: i32 = -32_000;
 /// webview that has never been presented never loads its page — so every command times out and
 /// the app looks dead. Show, load, then park.
 ///
-/// On macOS the park is off-screen, not `hide()`. A loaded WKWebView that is hidden stops answering
-/// commands after a short pause even though capture still works. Linux and Windows still `hide()`:
-/// WebKitGTK keeps executing while hidden, which is why the Linux desktop battery stays green.
+/// On macOS the park is off-screen, not `hide()`. A loaded WKWebView that is then hidden has been
+/// observed to go quiet after a pause even though capture still works; parking is the path that
+/// keeps the page scheduled without claiming every Mac will hit that pause. Linux and Windows still
+/// `hide()`: WebKitGTK keeps executing while hidden, which is why the Linux desktop battery stays
+/// green.
 ///
 /// Screenshots keep working, because `reticle_capture` renders the webview rather than the screen.
 pub fn on_page_load<R: Runtime>(

--- a/packages/tauri/src/lib.rs
+++ b/packages/tauri/src/lib.rs
@@ -72,7 +72,6 @@ pub fn on_page_load<R: Runtime>(
     {
         let window = webview.window();
         let _ = window.set_position(tauri::PhysicalPosition::new(OFFSCREEN_PX, OFFSCREEN_PX));
-        return;
     }
     #[cfg(not(target_os = "macos"))]
     {

--- a/packages/tauri/src/lib.rs
+++ b/packages/tauri/src/lib.rs
@@ -38,14 +38,24 @@ pub const FULL_PAGE_UNSUPPORTED: &str = "full-page-unsupported";
 /// Environment variable that asks for a window nobody can see.
 const HEADLESS_ENV: &str = "RETICLE_HEADLESS";
 
-/// Hide the window once its page has loaded, when `RETICLE_HEADLESS=1`.
+/// Far enough off every display that nothing is on screen, without calling `hide()`.
+///
+/// A hidden WKWebView on macOS stops executing JavaScript after a short pause. Capture still works
+/// (it renders the webview, not the screen). Parking keeps `document.hidden` false so the page
+/// keeps answering.
+#[cfg(target_os = "macos")]
+const OFFSCREEN_PX: i32 = -32_000;
+
+/// Park the window once its page has loaded, when `RETICLE_HEADLESS=1`.
 ///
 /// The ordering is the entire trick, and getting it backwards is what made headless Tauri look
-/// impossible: hiding the window during `setup` hides it BEFORE the webview has ever been presented,
-/// and a webview that has never been presented never loads its page — so every command times out and
-/// the app looks suspended. A webview that HAS loaded keeps running JavaScript through every state
-/// that gets blamed for this: minimized, app-hidden, fully occluded, and on another macOS Space
-/// behind a fullscreen app. So: show, load, then hide. Nothing is on screen afterwards.
+/// impossible: acting during `setup` runs BEFORE the webview has ever been presented, and a
+/// webview that has never been presented never loads its page — so every command times out and
+/// the app looks dead. Show, load, then park.
+///
+/// On macOS the park is off-screen, not `hide()`. A loaded WKWebView that is hidden stops answering
+/// commands after a short pause even though capture still works. Linux and Windows still `hide()`:
+/// WebKitGTK keeps executing while hidden, which is why the Linux desktop battery stays green.
 ///
 /// Screenshots keep working, because `reticle_capture` renders the webview rather than the screen.
 pub fn on_page_load<R: Runtime>(
@@ -58,5 +68,14 @@ pub fn on_page_load<R: Runtime>(
     if std::env::var(HEADLESS_ENV).as_deref() != Ok("1") {
         return;
     }
-    let _ = webview.window().hide();
+    #[cfg(target_os = "macos")]
+    {
+        let window = webview.window();
+        let _ = window.set_position(tauri::PhysicalPosition::new(OFFSCREEN_PX, OFFSCREEN_PX));
+        return;
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = webview.window().hide();
+    }
 }


### PR DESCRIPTION
## Summary

- `RETICLE_HEADLESS=1` hid the Tauri window after first paint. a hidden macOS WKWebView has been observed to stop answering after a pause; capture still worked because it renders the webview, not the screen. that is why #335 failed on a mac and stayed green on linux (WebKitGTK). the current durability probe stays green on `hide()` on at least one Apple-silicon machine, so this PR does not claim every mac hits that pause
- macOS now parks the window off-screen instead of `hide()`. linux and windows still hide
- timeout copy names the pause as observed, not as a fact. AppKit is not guaranteed to leave `(-32000, -32000)` off-screen (`constrainFrameRect:toScreen:` can pull the title bar back)

closes #335

## Test plan

- [x] command-timeout: does not claim hiding after load is safe; names the off-screen park as observed
- [x] desktop-contract lock: macOS `on_page_load` arm uses `set_position`, not `hide()`
- [x] `cargo check` on `reticle-tauri`
- [ ] `pnpm test:e2e:desktop` on an Apple-silicon mac (maintainer ran both arms: 17/17 with this PR and 17/17 on `hide()`)