### PR TITLE
fix(browser): migrate health observer to AbortController (#453)

### DIFF
--- a/packages/browser/src/observers/health.test.ts
+++ b/packages/browser/src/observers/health.test.ts
@@ -56,6 +56,18 @@ describe('installHealth (jsdom)', () => {
     expect(blur?.[0]).toBe(EventType.PAGE_HEALTH);
     teardown();
   });
+
+  it('teardown removes focus and blur listeners from window', async () => {
+    const { installHealth } = await import('./health.js');
+    const emit = vi.fn();
+    const teardown = installHealth(emit);
+    teardown();
+    emit.mockClear();
+
+    window.dispatchEvent(new Event('focus'));
+    window.dispatchEvent(new Event('blur'));
+    expect(emit).not.toHaveBeenCalled();
+  });
 });
 
 /**

--- a/packages/browser/src/observers/health.ts
+++ b/packages/browser/src/observers/health.ts
@@ -116,19 +116,18 @@ function snapshotHealth(): {
  * tab blind. Uses a native (pre-bound) timer so a frozen app clock (reticle_clock) never stalls it.
  */
 export function installHealth(emit: Emit): Teardown {
+  const ac = new AbortController();
+  const { signal } = ac;
+
   const report = (reason: HealthReason): void => {
     emit(EventType.PAGE_HEALTH, { ...snapshotHealth(), reason });
   };
 
-  const onVisibility = (): void => report(HealthReason.VISIBILITY);
-  const onFocus = (): void => report(HealthReason.FOCUS);
-  const onBlur = (): void => report(HealthReason.BLUR);
+  document.addEventListener('visibilitychange', () => report(HealthReason.VISIBILITY), { signal });
+  window.addEventListener('focus', () => report(HealthReason.FOCUS), { signal });
+  window.addEventListener('blur', () => report(HealthReason.BLUR), { signal });
 
-  document.addEventListener('visibilitychange', onVisibility);
-  window.addEventListener('focus', onFocus);
-  window.addEventListener('blur', onBlur);
-
-  report(HealthReason.INITIAL); // baseline so the server knows state before the first change
+  report(HealthReason.INITIAL);
   const stopHeartbeat = nativeSetInterval(
     () => report(HealthReason.HEARTBEAT),
     SESSION_HEALTH.HEARTBEAT_MS,
@@ -136,8 +135,6 @@ export function installHealth(emit: Emit): Teardown {
 
   return () => {
     stopHeartbeat();
-    document.removeEventListener('visibilitychange', onVisibility);
-    window.removeEventListener('focus', onFocus);
-    window.removeEventListener('blur', onBlur);
+    ac.abort();
   };
 }


### PR DESCRIPTION
## Summary

- Replaces 3 manual `addEventListener`/`removeEventListener` pairs in `packages/browser/src/observers/health.ts` with a single `AbortController` whose signal is passed to all listeners
- Teardown becomes `ac.abort()` — one call that cannot drift from the registrations
- Adds a teardown test verifying focus/blur listeners are removed on abort

Closes part of #453 (`src/observers/health.ts`)

## Test plan

- [x] `pnpm vitest run src/observers/health.test.ts` — 17/17 pass (including new teardown test)
- [x] `pnpm --filter @reticlehq/browser typecheck` — clean
- [x] Existing behavior preserved: initial report, visibility/focus/blur events, heartbeat

Signed-off-by: Dev Chiniwala <dev.chiniwala@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)