### PR TITLE
fix(browser): migrate scroll observer to AbortController (#453)

### DIFF
--- a/packages/browser/src/observers/scroll.test.ts
+++ b/packages/browser/src/observers/scroll.test.ts
@@ -37,4 +37,15 @@ describe('installScroll — trailing edge captures the resting position', () => 
     // The resting position (500) must be reported — a leading-only throttle dropped it entirely.
     expect(positions().at(-1)?.data['y']).toBe(500);
   });
+
+  it('teardown removes the scroll listener', () => {
+    const events: Captured[] = [];
+    const td = installScroll((type, data) => events.push({ type, data }));
+    td();
+    events.length = 0;
+
+    setScrollY(200);
+    window.dispatchEvent(new Event('scroll'));
+    expect(events.filter((e) => e.type === EventType.SCROLL_POSITION)).toHaveLength(0);
+  });
 });

--- a/packages/browser/src/observers/scroll.ts
+++ b/packages/browser/src/observers/scroll.ts
@@ -8,6 +8,9 @@ const REVEAL_SELECTOR = '[data-reticle-reveal], [data-reveal], section';
 
 /** Observe scroll position + reveal-on-scroll for modern scroll-reactive UIs. */
 export function installScroll(emit: Emit): Teardown {
+  const ac = new AbortController();
+  const { signal } = ac;
+
   let lastEmit = 0;
   let lastY = 0;
   let trailingTimer: number | undefined;
@@ -44,7 +47,7 @@ export function installScroll(emit: Emit): Teardown {
       }, THROTTLE_MS - elapsed);
     }
   };
-  window.addEventListener('scroll', onScroll, { passive: true });
+  window.addEventListener('scroll', onScroll, { passive: true, signal });
 
   let io: IntersectionObserver | undefined;
   if ('function' === typeof IntersectionObserver) {
@@ -73,7 +76,7 @@ export function installScroll(emit: Emit): Teardown {
   }
 
   return () => {
-    window.removeEventListener('scroll', onScroll);
+    ac.abort();
     if (trailingTimer !== undefined) nativeClearTimeout(trailingTimer);
     io?.disconnect();
   };


### PR DESCRIPTION
## Summary

- Replaces manual `removeEventListener('scroll', ...)` in `packages/browser/src/observers/scroll.ts` with an `AbortController` signal passed to `addEventListener`
- Preserves the `passive: true` option alongside the signal
- `IntersectionObserver` still uses `.disconnect()` (no signal support in that API)
- Adds a teardown test verifying scroll events stop after teardown

Closes part of #453 (`src/observers/scroll.ts`)

## Test plan

- [x] `pnpm vitest run src/observers/scroll.test.ts` — 2/2 pass (existing + new teardown test)
- [x] `pnpm --filter @reticlehq/browser typecheck` — clean
- [x] Throttle behavior + trailing emit unchanged

Signed-off-by: Dev Chiniwala <dev.chiniwala@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)