### PR TITLE
fix(browser): migrate focus observer to AbortController (#453)

### DIFF
--- a/packages/browser/src/observers/focus.ts
+++ b/packages/browser/src/observers/focus.ts
@@ -20,6 +20,8 @@ function toBody(el: EventTarget | null): boolean {
  * FOCUS_CHANGE {to, from, toBody}. Reversible.
  */
 export function installFocus(emit: Emit): Teardown {
+  const ac = new AbortController();
+  const { signal } = ac;
   let last: EventTarget | null = null;
 
   const onFocusIn = (event: FocusEvent): void => {
@@ -34,7 +36,6 @@ export function installFocus(emit: Emit): Teardown {
   };
 
   const onFocusOut = (event: FocusEvent): void => {
-    // Focus left with nothing gaining it → it dropped to the body (the regression case).
     if (event.relatedTarget !== null) return;
     const from = last;
     last = null;
@@ -44,10 +45,7 @@ export function installFocus(emit: Emit): Teardown {
     });
   };
 
-  document.addEventListener('focusin', onFocusIn);
-  document.addEventListener('focusout', onFocusOut);
-  return () => {
-    document.removeEventListener('focusin', onFocusIn);
-    document.removeEventListener('focusout', onFocusOut);
-  };
+  document.addEventListener('focusin', onFocusIn, { signal });
+  document.addEventListener('focusout', onFocusOut, { signal });
+  return () => ac.abort();
 }


### PR DESCRIPTION
## Summary

- Replaces 2 manual `removeEventListener` calls in `packages/browser/src/observers/focus.ts` with a single `AbortController`
- Teardown becomes `ac.abort()` — one line, cannot drift from registrations
- Existing teardown test (line 59) validates the behavior

Closes part of #453 (`src/observers/focus.ts`)

## Test plan

- [x] `pnpm vitest run src/observers/focus.test.ts` — 5/5 pass (existing teardown test covers this)
- [x] `pnpm --filter @reticlehq/browser typecheck` — clean
- [x] Focus tracking behavior (focusin/focusout, toBody detection) unchanged

Signed-off-by: Dev Chiniwala <dev.chiniwala@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)