### PR TITLE
babel-plugin test: count the attribute core names, not a literal

### DIFF
--- a/packages/babel-plugin/src/index.test.ts
+++ b/packages/babel-plugin/src/index.test.ts
@@ -41,6 +41,9 @@ describe('reticle babel plugin', () => {
 
   it('is idempotent (does not double-stamp)', () => {
     const out = transform(`const x = <div ${SOURCE_ATTR}="existing">x</div>;`);
-    expect((out.match(/data-reticle-source/g) ?? []).length).toBe(1);
+    // Built from SOURCE_ATTR, not the literal. Hardcoded, this counts occurrences of a string the
+    // plugin no longer stamps the moment core renames the constant — so a legitimate rename reddens
+    // it while real plugin-core drift stays unasserted, which is the alarm pointing the wrong way.
+    expect((out.match(new RegExp(SOURCE_ATTR, 'g')) ?? []).length).toBe(1);
   });
 });


### PR DESCRIPTION
One line, from your review of #468 — item 2 there applies to what landed in `25aae8f` too.

`index.test.ts` had moved every other reference to `SOURCE_ATTR`, but the idempotence check still counted `/data-reticle-source/g`. Hardcoded, it counts a string the plugin stops stamping the moment core renames the constant: a legitimate rename reddens it, while real plugin↔core drift stays unasserted.

**Verified both directions, since a test that only fails is no better than one that only passes:**

| | before | after |
|---|---|---|
| rename `DATA_RETICLE_SOURCE_ATTR` in core, rebuild | **fails** | passes |
| re-hardcode the plugin's own `SOURCE_ATTR` so it drifts from core | fails | **still fails** |

Based on `release/v2.12.0`.
