### PR TITLE
Give the wire-constant test an explicit bound

### DIFF
--- a/packages/next/index.test.mjs
+++ b/packages/next/index.test.mjs
@@ -213,21 +213,46 @@ describe('withReticle forwards the discovered daemon', () => {
  * duplicate that drifts does not throw: it produces a URL nothing is listening on, which surfaces as
  * a silent no-connect and reads to a user as "Reticle is broken". Pin them to core's.
  */
+/**
+ * A BOUND, not a measurement.
+ *
+ * The test below does two slow things at once: a dynamic `import()` of a workspace package —
+ * resolving and evaluating @reticlehq/core's ESM build from a CJS test — and two real temp
+ * directories with file writes. Both are milliseconds when this package runs alone and neither is
+ * bounded by anything the test asserts.
+ *
+ * Against vitest's 5 s default that is a statement about the machine, which CLAUDE.md bans in
+ * assertions for the same reason it is wrong here: it passes on its own and fails only under
+ * full-monorepo parallel load, i.e. only in CI. Observed on release/v2.12.0 before this bound:
+ *
+ *   × builds the same bridge URL core does  5039ms
+ *     → Test timed out in 5000ms.
+ *
+ * while `pnpm --filter @reticlehq/next test:unit` alone passed 20/20 in 355 ms. A generous ceiling
+ * cannot make a broken test pass — the URL equality is still asserted — it only stops the suite
+ * reporting the runner.
+ */
+const WIRE_CONSTANT_TIMEOUT_MS = 30_000;
+
 describe('the duplicated wire constants match core', () => {
-  it('builds the same bridge URL core does', async () => {
-    const { bridgeWsUrl } = await import('@reticlehq/core');
-    const home = mkdtempSync(join(tmpdir(), 'reticle-const-home-'));
-    const cwd = mkdtempSync(join(tmpdir(), 'reticle-const-proj-'));
-    try {
-      writeFileSync(join(cwd, '.reticle.json'), JSON.stringify({ projectId: 'p' }));
-      writeFileSync(
-        join(home, 'daemon-4400.json'),
-        JSON.stringify({ port: 4400, pid: process.pid, projectId: 'p' }),
-      );
-      expect(discoverDaemonUrl(cwd, home, () => true)).toBe(bridgeWsUrl(4400));
-    } finally {
-      rmSync(home, { recursive: true, force: true });
-      rmSync(cwd, { recursive: true, force: true });
-    }
-  });
+  it(
+    'builds the same bridge URL core does',
+    async () => {
+      const { bridgeWsUrl } = await import('@reticlehq/core');
+      const home = mkdtempSync(join(tmpdir(), 'reticle-const-home-'));
+      const cwd = mkdtempSync(join(tmpdir(), 'reticle-const-proj-'));
+      try {
+        writeFileSync(join(cwd, '.reticle.json'), JSON.stringify({ projectId: 'p' }));
+        writeFileSync(
+          join(home, 'daemon-4400.json'),
+          JSON.stringify({ port: 4400, pid: process.pid, projectId: 'p' }),
+        );
+        expect(discoverDaemonUrl(cwd, home, () => true)).toBe(bridgeWsUrl(4400));
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    },
+    WIRE_CONSTANT_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
Found while verifying a rebase; reported on #468 and split out here.

## What I actually observed

`@reticlehq/next` → `the duplicated wire constants match core > builds the same bridge URL core does`, on **`release/v2.12.0`**:

```
× builds the same bridge URL core does   5039ms
  → Test timed out in 5000ms.

  217|   it('builds the same bridge URL core does', async () => {
  218|     const { bridgeWsUrl } = await import('@reticlehq/core');
```

Twice. **The second time on a clean checkout with none of my changes** (`git stash`, re-run) — so it is the branch, not a PR. The same run also emitted `@reticlehq/core:test:unit: Error: Worker exited unexpectedly`. Meanwhile `pnpm --filter @reticlehq/next test:unit` alone passed 20/20 in **355 ms**.

## What I cannot claim

**It does not reproduce now** — with or without this bound, and not under `pnpm test:unit --force` either.

Both observations were on a cold run straight after `pnpm install`, when the workspace was building *and* testing at once. Once turbo had cached, I could not get it back. I would rather say that plainly than dress two real observations up as a reliable repro.

That is also the argument for the change rather than against it: a failure you can only get when the machine is busy is exactly what CLAUDE.md means by a statement about the machine, and exactly why the 5 s default is the wrong thing for this test to rest on.

## Why this test in particular

It does two slow things and asserts neither:

- `await import('@reticlehq/core')` — resolving and evaluating a workspace package's **ESM build from a CJS test**, which is the one import in this file that is not `createRequire`'d at module load.
- **Two real temp directories** with file writes and recursive cleanup.

Both are milliseconds when the package runs alone. Neither is what the test is checking — the assertion is a URL equality, and that still has to hold. A generous ceiling cannot make it pass.

`WIRE_CONSTANT_TIMEOUT_MS = 30_000`, named per the convention in `project-tools.test.ts` and the files #333 annotated.

`pnpm test:unit` — **17/17 tasks**. Based on `release/v2.12.0`.

If you would rather chase the root cause than bound it, that is fair — the `Worker exited unexpectedly` alongside it suggests the pool is under real pressure on a cold full run, and that would be worth its own look.
