### PR TITLE
fix(browser): migrate animation observer to AbortController (#453)

### DIFF
--- a/packages/browser/src/observers/animation.test.ts
+++ b/packages/browser/src/observers/animation.test.ts
@@ -84,4 +84,20 @@ describe('animation observer: overlay self-pollution', () => {
 
     expect(events.map((e) => e.type)).toContain(EventType.ANIM_END);
   });
+
+  it('stops emitting after teardown', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const { emit, events } = collect();
+    teardown = installAnimation(emit);
+    teardown();
+    teardown = undefined;
+    events.length = 0;
+
+    fireAnim(el, 'animationstart', 'fade');
+    fireAnim(el, 'animationend', 'fade');
+    fireTransitionEnd(el, 'opacity');
+
+    expect(events).toHaveLength(0);
+  });
 });

--- a/packages/browser/src/observers/animation.ts
+++ b/packages/browser/src/observers/animation.ts
@@ -5,10 +5,11 @@ import type { Emit, Teardown } from './types.js';
 
 /** Observe CSS animations + transitions and emit anim.start / anim.end. */
 export function installAnimation(emit: Emit): Teardown {
+  const ac = new AbortController();
+  const { signal } = ac;
+
   const onStart = (event: AnimationEvent): void => {
     const target = event.target;
-    // Skip Reticle's own HUD keyframes (reticle-pulse/reticle-shimmer/…) so observe/record never
-    // self-pollute the agent's view of the app (matches the DOM observer's overlay filter).
     if (target instanceof Element && !isReticleOverlay(target)) {
       emit(EventType.ANIM_START, { name: event.animationName }, refs.refFor(target));
     }
@@ -30,13 +31,9 @@ export function installAnimation(emit: Emit): Teardown {
     }
   };
 
-  document.addEventListener('animationstart', onStart, true);
-  document.addEventListener('animationend', onEnd, true);
-  document.addEventListener('transitionend', onTransitionEnd, true);
+  document.addEventListener('animationstart', onStart, { capture: true, signal });
+  document.addEventListener('animationend', onEnd, { capture: true, signal });
+  document.addEventListener('transitionend', onTransitionEnd, { capture: true, signal });
 
-  return () => {
-    document.removeEventListener('animationstart', onStart, true);
-    document.removeEventListener('animationend', onEnd, true);
-    document.removeEventListener('transitionend', onTransitionEnd, true);
-  };
+  return () => ac.abort();
 }


### PR DESCRIPTION
## Summary

- Replaces hand-rolled `removeEventListener` teardown in `installAnimation()` with a single `AbortController` signal
- All three capture-phase listeners (`animationstart`, `animationend`, `transitionend`) are removed by one `ac.abort()` call — teardown cannot drift from registrations
- Adds a teardown test verifying no events fire after abort

## Context

Part of #453 — one file per PR. This covers `src/observers/animation.ts` (3 listeners).

## Test plan

- [x] `npx vitest run src/observers/animation.test.ts` — 4 tests green
- [x] Existing overlay-filter tests still pass (no behavioral change)
- [x] New teardown test: install → teardown → dispatch all 3 event types → assert 0 emitted

Signed-off-by: Dev Chiniwala <dev.chiniwala@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)