### PR TITLE
fix(server): diagnose ignored origin allow-list entries at startup

### DIFF
--- a/packages/server/src/bridge/bridge.security.test.ts
+++ b/packages/server/src/bridge/bridge.security.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { WebSocket } from 'ws';
 import {
   EventType,
@@ -164,6 +164,52 @@ describe('Bridge security boundary', () => {
     socket.send(JSON.stringify(hello('tauri', 'shared-secret')));
     await waitUntil(() => 1 === bridge.sessions.count());
     expect(bridge.sessions.get('tauri')).toBeDefined();
+  });
+
+  it('warns at startup when an allow-list entry fails to normalise', () => {
+    const writes: string[] = [];
+    const spy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(((chunk: unknown) => {
+        writes.push(String(chunk));
+        return true;
+      }) as typeof process.stderr.write);
+    try {
+      const bridge = new Bridge({
+        port: 0,
+        token: 'shared-secret',
+        allowedOrigins: ['myapp.test', 'https://app.example'],
+      });
+      bridges.push(bridge);
+    } finally {
+      spy.mockRestore();
+    }
+    const ignored = writes.find((line) => line.includes('origin_entry_ignored'));
+    expect(ignored).toBeDefined();
+    expect(ignored).toContain('myapp.test');
+    expect(ignored).toContain('http://myapp.test');
+    expect(writes.filter((line) => line.includes('origin_entry_ignored'))).toHaveLength(1);
+  });
+
+  it('stays silent at startup when every allow-list entry normalises', () => {
+    const writes: string[] = [];
+    const spy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(((chunk: unknown) => {
+        writes.push(String(chunk));
+        return true;
+      }) as typeof process.stderr.write);
+    try {
+      const bridge = new Bridge({
+        port: 0,
+        token: 'shared-secret',
+        allowedOrigins: ['https://app.example', 'tauri://localhost'],
+      });
+      bridges.push(bridge);
+    } finally {
+      spy.mockRestore();
+    }
+    expect(writes.filter((line) => line.includes('origin_entry_ignored'))).toHaveLength(0);
   });
 
   it('requires a token before binding beyond localhost', () => {

--- a/packages/server/src/bridge/bridge.ts
+++ b/packages/server/src/bridge/bridge.ts
@@ -95,10 +95,18 @@ export const WS_CLOSE_REASON = {
  */
 function originRejectedReason(origin: string | undefined): string {
   const named = origin === undefined || 0 === origin.length ? 'a page sending no Origin' : origin;
+  // When the refused origin is a real web origin, the fix is copy-pasteable: print the exact string
+  // to allow-list. Opaque origins ("null") and missing Origins are not fixable with an allow-list
+  // entry — the pairing token is the gate there — so no Add clause is offered for those.
+  const normalized = origin === undefined || 0 === origin.length ? null : normalizeOrigin(origin);
+  const addClause =
+    normalized !== null && !isOpaqueOrigin(normalized)
+      ? ` To allow it, add this exact origin to ${ReticleEnv.ALLOWED_ORIGINS}: "${normalized}".`
+      : '';
   return (
     `a browser dialled this daemon and was REFUSED at the origin gate: ${named} is not allowed. ` +
     'Off localhost the SDK needs BOTH `allowNonLocalhost: true` AND a pairing token, and the ' +
-    'daemon needs that origin allow-listed (RETICLE_ALLOWED_ORIGINS). The app is running and ' +
+    `daemon needs that origin allow-listed (${ReticleEnv.ALLOWED_ORIGINS}).${addClause} The app is running and ` +
     'instrumented — it was turned away, so do not go looking for a stopped dev server.'
   );
 }
@@ -253,11 +261,28 @@ export class Bridge {
     this.#clock = options.clock ?? (() => Date.now());
     this.#token =
       options.token !== undefined && options.token.length > 0 ? options.token : undefined;
-    this.#allowedOrigins = new Set(
-      (options.allowedOrigins ?? [])
-        .map(normalizeOrigin)
-        .filter((origin): origin is string => origin !== null),
-    );
+    // A scheme-less entry like `myapp.test` fails `new URL` and was silently dropped, leaving the
+    // allow-list empty: the daemon came up, accepted nothing, and said nothing. Warn for every entry
+    // that fails to normalise, naming the entry and the accepted form, so the misconfiguration is
+    // visible at startup instead of surfacing later as an origin-gate refusal.
+    const allowedOrigins = new Set<string>();
+    for (const entry of options.allowedOrigins ?? []) {
+      const normalized = normalizeOrigin(entry);
+      if (normalized === null) {
+        const looksLikeBareHost = /^[A-Za-z0-9._-]+(:\d+)?$/.test(entry);
+        log('origin_entry_ignored', {
+          entry,
+          hint: looksLikeBareHost
+            ? `${ReticleEnv.ALLOWED_ORIGINS} entry '${entry}' could not be parsed and was ignored — ` +
+              `origins must include a scheme, in the accepted form http://host:port (try 'http://${entry}')`
+            : `${ReticleEnv.ALLOWED_ORIGINS} entry '${entry}' could not be parsed and was ignored — ` +
+              'origins must be in the accepted form http://host:port',
+        });
+        continue;
+      }
+      allowedOrigins.add(normalized);
+    }
+    this.#allowedOrigins = allowedOrigins;
     // Binding beyond localhost means the browser dials in from a non-loopback Origin. With no
     // allow-list, #originAllowed rejects every such Origin at the WS handshake, so the bridge comes
     // up but accepts nothing — a silent, fail-closed footgun. Refuse to start with a clear message.

--- a/packages/server/src/bridge/refused-dial.test.ts
+++ b/packages/server/src/bridge/refused-dial.test.ts
@@ -63,6 +63,30 @@ describe('a dial refused at the origin gate is remembered', () => {
     expect(sessions.lastClosure()?.reason ?? '').toContain('tenant.myapp.test');
   });
 
+  it('prints the exact origin to add, so the fix is copy-pasteable', async () => {
+    const bridge = new Bridge({ port: 0 });
+    bridges.push(bridge);
+    const { sessions } = bridge;
+    const port = await bridge.ready;
+
+    await dial(port, 'https://tenant.myapp.test');
+
+    expect(sessions.lastClosure()?.reason ?? '').toContain(
+      'add this exact origin to RETICLE_ALLOWED_ORIGINS: "https://tenant.myapp.test"',
+    );
+  });
+
+  it('offers no allow-list entry for an opaque origin, where the token is the gate', async () => {
+    const bridge = new Bridge({ port: 0 });
+    bridges.push(bridge);
+    const { sessions } = bridge;
+    const port = await bridge.ready;
+
+    await dial(port, 'tauri://localhost');
+
+    expect(sessions.lastClosure()?.reason ?? '').not.toContain('add this exact origin');
+  });
+
   it('records nothing for an origin that is allowed', async () => {
     const bridge = new Bridge({ port: 0 });
     bridges.push(bridge);


### PR DESCRIPTION
## What

Diagnose origin allow-list entries that fail to normalise, at both ends of the flow:

1. **Daemon startup warning** — the `Bridge` constructor now warns (`origin_entry_ignored` log event) for every `RETICLE_ALLOWED_ORIGINS` entry that fails `normalizeOrigin`, instead of silently dropping it. The warning names the entry and the accepted form (`http://host:port`), and for entries that look like a bare `host[:port]` it suggests the concrete `http://host[:port]` string to use.
2. **Refusal message** — `originRejectedReason` now appends a copy-pasteable fix for refusals caused by a real web origin: `To allow it, add this exact origin to RETICLE_ALLOWED_ORIGINS: "https://tenant.myapp.test".` Opaque origins (where the pairing token is the gate, not the allow-list) get no add clause.

## Why

Setting `RETICLE_ALLOWED_ORIGINS=myapp.test` appeared to work and had no effect: `normalizeOrigin` returns `null` for a scheme-less entry, the nulls were filtered out, and an allow-list made entirely of scheme-less entries ended up empty. The page was refused at the origin gate and nothing anywhere said the entry had been dropped — the refusal read as a scheme mismatch in the page instead of a silently discarded config value.

## Testing

- Added `warns at startup when an allow-list entry fails to normalise` (asserts the `origin_entry_ignored` event names the entry and the `http://myapp.test` suggestion) and `stays silent at startup when every allow-list entry normalises`.
- Added `prints the exact origin to add, so the fix is copy-pasteable` and `offers no allow-list entry for an opaque origin, where the token is the gate`.
- Ran `pnpm exec vitest run src/bridge/refused-dial.test.ts src/bridge/bridge.security.test.ts src/session/no-session-causes.test.ts src/tools/lease-hint-evidence.test.ts` — 67 passed.
- Ran `pnpm exec tsc --noEmit -p tsconfig.json` (after building `@reticlehq/core`) — clean.
