### PR TITLE
fix(server): record renamed tools as tombstones in the reticle_tools catalog

### DIFF
--- a/packages/server/src/tools/dynamic-tools.test.ts
+++ b/packages/server/src/tools/dynamic-tools.test.ts
@@ -47,6 +47,26 @@ describe('buildDynamicTools — the dynamic profile meta-tools', () => {
     expect(out.tools[0]?.summary).not.toContain('second sentence');
   });
 
+  it('reticle_tools catalog carries tombstones for merged and retired tools', async () => {
+    const tools = buildDynamicTools(fakeTools);
+    const discover = tools.find((t) => t.name === ReticleTool.TOOLS);
+    const out = (await discover?.handler(NO_DEPS, {})) as {
+      total: number;
+      tools: { name: string; summary: string }[];
+      retired: { name: string; retired: string }[];
+    };
+    // The total counts LIVE tools only — a tombstone is not callable.
+    expect(out.total).toBe(out.tools.length);
+    // A merged tool's old name carries the migration in the catalog itself.
+    const crawl = out.retired.find((t) => t.name === ReticleTool.CRAWL);
+    expect(crawl).toBeDefined();
+    expect(crawl?.retired).toContain('retired; use');
+    expect(crawl?.retired).toContain(ReticleTool.VERIFY);
+    expect(crawl?.retired).toContain('"crawl"');
+    // ...and does not appear among the live tools.
+    expect(out.tools.map((t) => t.name)).not.toContain(ReticleTool.CRAWL);
+  });
+
   it('reticle_tools with names loads full params for known tools and flags unknown ones', async () => {
     const tools = buildDynamicTools(fakeTools);
     const discover = tools.find((t) => t.name === ReticleTool.TOOLS);

--- a/packages/server/src/tools/dynamic-tools.ts
+++ b/packages/server/src/tools/dynamic-tools.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { ToolDef, ToolDeps } from './tools.js';
 import { runTool } from './invoke-tool.js';
 import { buildErrorPayload } from './error-recovery.js';
-import { mergedNameRedirect, mergedNameMessage } from './merged-name-redirect.js';
+import { mergedNameRedirect, mergedNameMessage, mergedNameTombstones } from './merged-name-redirect.js';
 import { ReticleTool } from './tool-names.js';
 import { ADVERTISE_ALL_ENV, type ToolSurfaceOrigin } from './tool-surface.js';
 import { getSessionMetrics } from '../telemetry/session-metrics.js';
@@ -128,9 +128,15 @@ export function buildDynamicTools(allTools: ToolDef[], profile?: ToolSurfaceOrig
           name: t.name,
           summary: firstSentence(t.description),
         }));
+        // Renamed/merged tools keep a tombstone in the catalog so older instructions are
+        // self-correcting: the surface itself says where each old name went, instead of making the
+        // agent trip over `unknown tool` and read the migration out of an error string. Live tools
+        // stay in `tools`; the `total` counts only those, and tombstones are not callable.
+        const tombstones = mergedNameTombstones();
         return Promise.resolve({
           total: catalog.length,
           tools: catalog,
+          ...(0 === tombstones.length ? {} : { retired: tombstones }),
           ...profileBlock,
           next: `All ${catalog.length} tools above are callable, advertised or not. Load full params with reticle_tools { names:[…] }, then call reticle_run { tool, args }.`,
         });

--- a/packages/server/src/tools/merged-name-redirect.ts
+++ b/packages/server/src/tools/merged-name-redirect.ts
@@ -58,6 +58,34 @@ export function mergedNameRedirect(name: string): MergedNameRedirect | undefined
   return BY_OLD_NAME.get(name);
 }
 
+/** A retired name, in the one-line form the `reticle_tools` catalog reports it. */
+export interface MergedNameTombstone {
+  /** The name an agent still uses. */
+  name: string;
+  /** Where it went: `retired; use reticle_verify { action: "crawl" }`. */
+  retired: string;
+}
+
+/**
+ * Every merged/retired name, for the `reticle_tools` catalog.
+ *
+ * The redirect table only answered when an agent CALLED an old name — `reticle_run` returned the
+ * migration, but the tool surface itself never recorded the rename, so an agent working from older
+ * instructions had to find the new name from an error string, or not at all. Tombstones make the
+ * migration discoverable in the one place every agent lists first.
+ */
+export function mergedNameTombstones(): MergedNameTombstone[] {
+  return [...BY_OLD_NAME.entries()]
+    .map(([name, redirect]) => ({
+      name,
+      retired:
+        redirect.action === undefined
+          ? `retired; ${redirect.note ?? `use ${redirect.tool}`}`
+          : `retired; use ${redirect.tool} { action: "${redirect.action}" }`,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
 /** The sentence handed to an agent that called `name`. */
 export function mergedNameMessage(name: string, redirect: MergedNameRedirect): string {
   return redirect.action === undefined


### PR DESCRIPTION
## What

The `reticle_tools` catalog now carries **tombstone entries** for every merged or retired tool name. Calling `reticle_tools` with no arguments returns, alongside the live catalog:

```
retired: [
  { name: "reticle_crawl", retired: "retired; use reticle_verify { action: "crawl" }" },
  ...
]
```

The list is derived from the existing `MERGE_PLANS` / `RETIRED_FROM_SURFACE` tables (via a new `mergedNameTombstones()` export), so any future merge or rename is covered automatically. Live tools stay in `tools`, `total` counts only live tools, and tombstones are not callable.

## Why

The redirect table only answered when an agent *called* an old name — `reticle_run` returned the migration, but the tool surface itself never recorded the rename. An agent working from older instructions had to find the new name from an error string, or not at all. Instructions written against a previous version are a permanent fact of the product, so the catalog — the first thing every agent lists — should carry the migration.

## Testing

- Added `reticle_tools catalog carries tombstones for merged and retired tools`: asserts the `retired` list contains `reticle_crawl` with `retired; use reticle_verify { action: "crawl" }`, that `total` equals the live tool count, and that tombstoned names do not appear among live tools.
- Ran `pnpm exec vitest run src/tools/dynamic-tools.test.ts src/tools/merged-name-redirect.test.ts` — 19 passed.
- Ran `pnpm exec tsc --noEmit -p tsconfig.json` — clean.
