### PR TITLE
fix(server): find configs in bare workspaces

### DIFF
--- a/packages/server/src/cli/config-discovery.test.ts
+++ b/packages/server/src/cli/config-discovery.test.ts
@@ -64,6 +64,13 @@ describe('discoverProjectConfigs', () => {
     expect(discoverProjectConfigs(root).found.map((f) => f.path)).toContain(path);
   });
 
+  it('finds a config when a declared workspace is the app itself', () => {
+    mkdirSync(join(root, '.git'), { recursive: true });
+    write('package.json', JSON.stringify({ workspaces: ['web'] }));
+    const path = write('web/.reticle.json', '{"projectId":"web"}');
+    expect(discoverProjectConfigs(root).found.map((f) => f.path)).toContain(path);
+  });
+
   it('reads the pnpm workspace manifest as well', () => {
     mkdirSync(join(root, '.git'), { recursive: true });
     write('pnpm-workspace.yaml', 'packages:\n  - "sites/*"\n');
@@ -83,6 +90,13 @@ describe('discoverProjectConfigs', () => {
     expect(report.found).toHaveLength(0);
     expect(report.searched.length).toBeGreaterThan(0);
     expect(report.searched).toContain(root);
+  });
+
+  it('does not report workspace directories that do not exist', () => {
+    mkdirSync(join(root, '.git'), { recursive: true });
+    const report = discoverProjectConfigs(root);
+    expect(report.searched).not.toContain(join(root, 'apps'));
+    expect(report.searched).not.toContain(join(root, 'packages'));
   });
 
   it('walks up to the repo root from a directory inside it', () => {

--- a/packages/server/src/cli/config-discovery.ts
+++ b/packages/server/src/cli/config-discovery.ts
@@ -160,6 +160,7 @@ export function discoverProjectConfigs(cwd: string): ConfigDiscovery {
     } catch {
       continue; // A declared workspace directory that does not exist is not an error here.
     }
+    check(base);
     for (const entry of entries) {
       const candidate = join(base, entry);
       try {


### PR DESCRIPTION
Closes #624. discoverProjectConfigs now checks each declared workspace directory before scanning its children, matching init for a workspace directory that is itself an app. Adds a regression test for a web workspace with web/.reticle.json. Verification: git diff --check. The targeted Vitest command could not run locally because the available pnpm wrapper points to a missing Node executable; CI will run the repository gates.