### PR TITLE
fix(server): warn when an allow-list origin entry fails to normalize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ### Fixed
 
+- **`@reticlehq/server` — a scheme-less `RETICLE_ALLOWED_ORIGINS` entry is no longer discarded silently.** `RETICLE_ALLOWED_ORIGINS=myapp.test` appeared to work and had no effect: an entry without a scheme fails origin normalization and was filtered out without a trace, so the allow-list looked configured while every dial from that origin was refused at the gate — and the refusal read as a problem with the page, not with the config. The bridge now logs an `allowed_origin_ignored` warning at startup for each dropped entry, naming the entry and the accepted form (`scheme://host[:port]`), with the corrected value spelled out so the fix is copy-pasteable. The drop itself is unchanged — an invalid entry still allows nothing.
+
 - **`reticle-tauri` — macOS `RETICLE_HEADLESS=1` parks off-screen instead of `hide()`.** Hiding after first paint is the remaining headless path we have not proved safe on every macOS WKWebView: a hidden window has been observed to go quiet after a pause while capture still works (it renders the webview, not the screen). Linux and Windows still hide. The timeout copy names that pause as a candidate, not a fact.
 
 ## [2.12.0] - 2026-08-24

--- a/packages/server/src/bridge/bridge.security.test.ts
+++ b/packages/server/src/bridge/bridge.security.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { WebSocket } from 'ws';
 import {
   EventType,
@@ -174,6 +174,36 @@ describe('Bridge security boundary', () => {
     expect(() => new Bridge({ port: 0, host: '0.0.0.0', token: 'shared-secret' })).toThrow(
       /ALLOWED_ORIGINS/,
     );
+  });
+
+  // A scheme-less entry (`RETICLE_ALLOWED_ORIGINS=myapp.test`) fails URL construction and used to
+  // be filtered out with NO trace: the allow-list looked configured, every dial was refused, and
+  // nothing anywhere said the entry had been dropped. The drop stands (fail closed), but it must
+  // be loud and name the accepted form, so the fix is copy-pasteable from the log.
+  it('warns with the copy-pasteable form when an allow-list entry has no scheme', async () => {
+    const written: string[] = [];
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+      written.push(String(chunk));
+      return true;
+    });
+    let port: number;
+    try {
+      ({ port } = await makeBridge({ allowedOrigins: ['myapp.test', 'https://app.example'] }));
+    } finally {
+      spy.mockRestore();
+    }
+    const line = written.find((entry) => entry.includes('allowed_origin_ignored'));
+    expect(line, 'dropping a configured origin must leave a trace').toBeDefined();
+    const parsed = JSON.parse(line ?? '{}') as Record<string, unknown>;
+    expect(parsed['entry']).toBe('myapp.test');
+    expect(String(parsed['warning'])).toContain('http://myapp.test');
+    // The drop itself is unchanged — the scheme-less entry does not allow-list anything…
+    await expect(openSocket(port, 'http://myapp.test')).rejects.toThrow(
+      /Unexpected server response: 403/,
+    );
+    // …and the valid sibling entry still made it into the allow-list.
+    const socket = await openSocket(port, 'https://app.example');
+    socket.close();
   });
 
   it('rejects protocol mismatches with a distinct "upgrade" reason (not a generic drop)', async () => {

--- a/packages/server/src/bridge/bridge.ts
+++ b/packages/server/src/bridge/bridge.ts
@@ -253,11 +253,25 @@ export class Bridge {
     this.#clock = options.clock ?? (() => Date.now());
     this.#token =
       options.token !== undefined && options.token.length > 0 ? options.token : undefined;
-    this.#allowedOrigins = new Set(
-      (options.allowedOrigins ?? [])
-        .map(normalizeOrigin)
-        .filter((origin): origin is string => origin !== null),
-    );
+    // An entry that fails to normalize — typically a scheme-less `myapp.test` — used to be
+    // filtered out with no trace: the allow-list LOOKED configured, every dial from that origin
+    // was refused at the gate, and the refusal read as a scheme mismatch in the page rather than
+    // as a config value that was silently discarded. Warn at construction, naming the entry and
+    // the accepted form, so the config error surfaces at startup instead of as a mystery 403.
+    this.#allowedOrigins = new Set<string>();
+    for (const entry of options.allowedOrigins ?? []) {
+      const normalized = normalizeOrigin(entry);
+      if (null === normalized) {
+        log('allowed_origin_ignored', {
+          entry,
+          warning:
+            `${ReticleEnv.ALLOWED_ORIGINS} entry "${entry}" is not a valid origin and was ` +
+            `IGNORED — an origin needs a scheme, e.g. "http://${entry}" (scheme://host[:port]).`,
+        });
+        continue;
+      }
+      this.#allowedOrigins.add(normalized);
+    }
     // Binding beyond localhost means the browser dials in from a non-loopback Origin. With no
     // allow-list, #originAllowed rejects every such Origin at the WS handshake, so the bridge comes
     // up but accepts nothing — a silent, fail-closed footgun. Refuse to start with a clear message.


### PR DESCRIPTION
## What & why

An origin in `RETICLE_ALLOWED_ORIGINS` without a scheme (`myapp.test`) is silently discarded: `normalizeOrigin` returns `null` for it and the null is filtered out when the Bridge builds its allow-list, so the config looks applied while every dial from that origin is refused at the gate — nothing anywhere says the entry was dropped.

The Bridge constructor now logs an `allowed_origin_ignored` warning for each entry that fails to normalize, naming the entry and the accepted form (`scheme://host[:port]`) with the corrected value spelled out (`"http://myapp.test"`), so the fix is copy-pasteable from the startup log. The drop itself is unchanged — an invalid entry still allows nothing (fail closed), and the existing beyond-localhost startup error still fires when the resulting allow-list is empty, now preceded by the warning that explains why.

Closes #598

## How it was verified

- New test in `bridge.security.test.ts`: a scheme-less entry emits the warning naming the entry and the copy-pasteable form, the scheme-less origin is still refused (403), and a valid sibling entry still allow-lists. Verified RED without the `bridge.ts` change, GREEN with it.
- Full server suite: 560 files / 5472 tests pass.

## Gates run

- [x] `pnpm lint && pnpm typecheck && pnpm test:unit` (~2 min — **always**)
- [ ] `pnpm test:e2e` (~8 min) — _touched the tool surface, `packages/core`, an observer, or telemetry_
- [ ] `pnpm gate:install` (~15 min) — _touched `reticle init`, `vite-plugin`, `next`, or `babel-plugin`_
- [ ] `pnpm test:e2e:desktop` (~3 min) — _touched `packages/electron`, `packages/tauri`, or desktop capture_
- [x] None of the above tiers apply to this change

## Checklist

- [x] **Every commit is signed off** (`git commit -s`) — CI's DCO check fails the PR without it. Already pushed? `git rebase --signoff origin/main && git push --force-with-lease`
- [x] Tests added/updated (RED → GREEN); the change is covered by a test that would fail without it
- [x] No `any`, no free strings (wire strings live in `@reticlehq/core`), no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 1000-line cap
- [x] Docs and `CHANGELOG.md` updated if this is user-facing (entry under `[Unreleased]`)
- [x] Security-affecting? Auth/redaction/trust-boundary changes keep the localhost-only, no-app-data-leaves-the-machine, no-arbitrary-JS posture (usage telemetry stays anonymous + opt-out per `docs/telemetry.md`) and are covered by a test
