### PR TITLE
fix(bench): sanitize tool profile output

### DIFF
--- a/bench/harness/tool-profile-output.mjs
+++ b/bench/harness/tool-profile-output.mjs
@@ -1,0 +1,60 @@
+export function toolProfileFailureReason(record) {
+  if ('timeout' === record.reason || record.timed_out) return 'timeout';
+  if ('tool_error' === record.reason || 'isError' === record.reason || record.is_error) {
+    return 'tool_error';
+  }
+  if ('rpc_error' === record.reason || record.protocol_error) return 'rpc_error';
+  if ('string' === typeof record.reason && record.reason.length > 0) return 'rpc_error';
+  return 'unknown';
+}
+
+export function toPersistableToolRecord(record) {
+  return {
+    tool: record.tool,
+    latency_ms: record.latency_ms,
+    is_error: record.is_error,
+    protocol_error: null !== record.protocol_error && undefined !== record.protocol_error,
+    timed_out: record.timed_out,
+    bytes: record.bytes,
+    chars: record.chars,
+    tokens_o200k: record.tokens_o200k,
+    success: record.success,
+  };
+}
+
+export function toPersistableToolSummary(summary) {
+  return {
+    total: summary.total,
+    passed: summary.passed,
+    failed: summary.failed,
+    mean_latency_ms: summary.mean_latency_ms,
+    failing_tools: summary.failing_tools.map((r) => ({
+      tool: r.tool,
+      reason: toolProfileFailureReason(r),
+    })),
+  };
+}
+
+export function buildToolProfileOutput(allFixtureResults, fixtureIds, toolsProfiledPerFixture) {
+  const matrix = {};
+  for (const fixtureId of fixtureIds) {
+    const fixtureData = allFixtureResults[fixtureId];
+    if (!fixtureData) continue;
+    matrix[fixtureId] = {
+      fixtureName: fixtureData.fixtureName,
+      tools_profiled: fixtureData.tools_profiled,
+      results: fixtureData.results.map(toPersistableToolRecord),
+      summary: toPersistableToolSummary(fixtureData.summary),
+    };
+  }
+  const fixtures = Object.keys(matrix);
+  const firstFixtureId = fixtures[0];
+
+  return {
+    fixtures,
+    tools_profiled_per_fixture: toolsProfiledPerFixture,
+    matrix,
+    results: matrix[firstFixtureId]?.results ?? [],
+    summary: matrix[firstFixtureId]?.summary ?? {},
+  };
+}

--- a/bench/harness/tool-profile-output.test.mjs
+++ b/bench/harness/tool-profile-output.test.mjs
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { buildToolProfileOutput, toPersistableToolRecord } from './tool-profile-output.mjs';
+
+describe('tool profile output', () => {
+  it('drops volatile previews and per-run error text from persisted records', () => {
+    const record = toPersistableToolRecord({
+      tool: 'reticle_sessions',
+      latency_ms: 12,
+      is_error: false,
+      protocol_error: 'ENOENT: /Users/Alice/project/.reticle/runs/session-abc123.json',
+      timed_out: false,
+      bytes: 250,
+      chars: 120,
+      tokens_o200k: 36,
+      success: false,
+      text_preview:
+        '{"sessionId":"session-abc123","projectRoot":"/Users/Alice/project","path":"C:\\\\Users\\\\Alice\\\\project"}',
+    });
+
+    expect(record).toEqual({
+      tool: 'reticle_sessions',
+      latency_ms: 12,
+      is_error: false,
+      protocol_error: true,
+      timed_out: false,
+      bytes: 250,
+      chars: 120,
+      tokens_o200k: 36,
+      success: false,
+    });
+  });
+
+  it('builds commit-safe JSON without run timestamps or raw failure strings', () => {
+    const output = buildToolProfileOutput(
+      {
+        'bench-app': {
+          fixtureName: 'Vite + React (Bench App)',
+          tools_profiled: 1,
+          results: [
+            {
+              tool: 'reticle_query',
+              latency_ms: 5,
+              is_error: false,
+              protocol_error: '/home/alice/checkout failed for session-xyz',
+              timed_out: false,
+              bytes: 10,
+              chars: 10,
+              tokens_o200k: 3,
+              success: false,
+              text_preview: '/home/alice/checkout session-xyz',
+            },
+          ],
+          summary: {
+            total: 1,
+            passed: 0,
+            failed: 1,
+            mean_latency_ms: 5,
+            failing_tools: [
+              {
+                tool: 'reticle_query',
+                reason: '/home/alice/checkout failed for session-xyz',
+              },
+            ],
+          },
+        },
+      },
+      ['bench-app'],
+      1,
+    );
+
+    const persisted = JSON.stringify(output);
+    expect(output).not.toHaveProperty('timestamp');
+    expect(persisted).not.toContain('text_preview');
+    expect(persisted).not.toContain('/home/alice');
+    expect(persisted).not.toContain('session-xyz');
+    expect(output.matrix['bench-app'].summary.failing_tools).toEqual([
+      { tool: 'reticle_query', reason: 'rpc_error' },
+    ]);
+  });
+});

--- a/bench/harness/tool-profile.mjs
+++ b/bench/harness/tool-profile.mjs
@@ -15,6 +15,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { McpStdioClient, RETICLE_CLI } from './mcp-client.mjs';
 import { measure } from './tokenizer.mjs';
+import { buildToolProfileOutput } from './tool-profile-output.mjs';
 import * as PORTS from './ports.mjs';
 
 const NO_BOOT = process.argv.includes('--no-boot');
@@ -640,15 +641,11 @@ for (const fixture of FIXTURES) {
 }
 
 // Write JSON output
-const output = {
-  timestamp: new Date().toISOString(),
-  fixtures: Object.keys(multiResults),
-  tools_profiled_per_fixture: totalToolsProfiledCount,
-  matrix: multiResults,
-  // Flat backward-compatible results field for single fixture consumption
-  results: multiResults[FIXTURES[0].id]?.results ?? [],
-  summary: multiResults[FIXTURES[0].id]?.summary ?? {},
-};
+const output = buildToolProfileOutput(
+  multiResults,
+  FIXTURES.map((f) => f.id),
+  totalToolsProfiledCount,
+);
 
 const rawPath = join('bench', 'raw', 'tool-profile.json');
 mkdirSync(join('bench', 'raw'), { recursive: true });


### PR DESCRIPTION
## What & why

Closes #628.

`tool-profile.mjs` now writes a commit-safe JSON shape instead of persisting full tool-response previews or raw protocol-error text. The saved matrix keeps the fields the bench output needs, and records protocol failures as a boolean plus a normalized summary reason.

## How it was verified

New `bench/harness/tool-profile-output.test.mjs` covers dropping `text_preview`, absolute paths, session ids, timestamps, and raw failure strings from the persisted output.

Local checks run:

```bash
pnpm lint
pnpm test:bench
vitest run bench/harness/tool-profile-output.test.mjs bench/harness/tool-coverage.test.mjs bench/harness/baseline-provenance.test.mjs
prettier --check bench/harness/tool-profile-output.mjs bench/harness/tool-profile-output.test.mjs bench/harness/tool-profile.mjs
git diff --check
```

`pnpm typecheck` and `turbo run test:unit --concurrency=1` hit the devbox inotify watcher limit (`ENOSPC`) in Vite/Remix watcher paths. GitHub CI passed the full PR matrix, including `verify`, `bench`, `e2e`, `desktop-e2e`, platform jobs, CodeQL, DCO, and package-quality.

## Gates run

- [x] `pnpm lint && pnpm typecheck && pnpm test:unit` (~2 min — **always**) — `pnpm lint` passed locally; `verify` passed in CI
- [ ] `pnpm test:e2e` (~8 min) — not applicable to bench output serialization
- [ ] `pnpm gate:install` (~15 min) — not applicable
- [ ] `pnpm test:e2e:desktop` (~3 min) — not applicable
- [x] None of the above tiers apply to this change

## Checklist

- [x] **Every commit is signed off** (`git commit -s`) — CI's DCO check fails the PR without it. Already pushed? `git rebase --signoff origin/main && git push --force-with-lease`
- [x] Tests added/updated (RED → GREEN); the change is covered by a test that would fail without it
- [x] No `any`, no free strings (wire strings live in `@reticlehq/core`), no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 1000-line cap
- [ ] Docs and `CHANGELOG.md` updated if this is user-facing (entry under `[Unreleased]`) — not user-facing
- [x] Security-affecting? Auth/redaction/trust-boundary changes keep the localhost-only, no-app-data-leaves-the-machine, no-arbitrary-JS posture (usage telemetry stays anonymous + opt-out per `docs/telemetry.md`) and are covered by a test