### PR TITLE
fix(session): decide leaseExpired from the session that departed, not a lifetime counter

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -647,7 +647,7 @@ export async function startDaemon(options: StartOptions = {}): Promise<RunningSe
     bridge.sessions,
     readProjectId(process.cwd()),
     port,
-    () => pool.reapedLeaseCount(),
+    (sessionId) => pool.wasReapedLease(sessionId),
     (url) => pool.acquire(url),
   );
   const deps = {

--- a/packages/server/src/pool/browser-pool.ts
+++ b/packages/server/src/pool/browser-pool.ts
@@ -64,6 +64,12 @@ export const DEFAULT_LEASE_TTL_MS = 5 * 60_000;
 /** Default cap on how long a lease's initial navigation may take before it fails (frees the slot). */
 const DEFAULT_NAV_TIMEOUT_MS = 30_000;
 
+/**
+ * How many reaped lease ids to remember. Only the most recent departure is ever asked about, so
+ * this is slack for a burst sweep, not a history.
+ */
+const MAX_REMEMBERED_REAPED_LEASES = 64;
+
 interface BrowserPoolOptions {
   /** Max simultaneous leased contexts. Over-cap acquires queue. */
   maxContexts: number;
@@ -110,6 +116,18 @@ export class BrowserPool {
   #closed = false;
   /** Leases reclaimed for going stale — see reapedLeaseCount(). */
   #reapedLeases = 0;
+  /**
+   * The session ids of recently reaped leases, most recent last.
+   *
+   * The count above answers "has anything ever aged out", which is not a
+   * question any caller actually has: it latches true for the life of the
+   * daemon (#611). The ids answer the question the no-session diagnosis is
+   * really asking — was THIS session a lease that aged out — so a closed
+   * human tab is no longer blamed on an expired lease forever after.
+   *
+   * Bounded because a long-lived daemon reaps unboundedly many.
+   */
+  readonly #reapedLeaseIds: string[] = [];
   readonly #active = new Map<string, ActiveLease>();
   /** Registered-session-id → lease id, for apps that keep their own session name. See `alias`. */
   readonly #aliases = new Map<string, string>();
@@ -235,19 +253,39 @@ export class BrowserPool {
       .map(([sessionId]) => sessionId);
     for (const sessionId of expired) await this.#release(sessionId);
     this.#reapedLeases += expired.length;
+    for (const sessionId of expired) {
+      this.#reapedLeaseIds.push(sessionId);
+      if (this.#reapedLeaseIds.length > MAX_REMEMBERED_REAPED_LEASES) this.#reapedLeaseIds.shift();
+    }
     return expired;
   }
 
   /**
    * How many leases this pool has reclaimed for going stale.
    *
-   * Read by the no-session diagnosis: an aged-out lease used to be reported as "the tab was closed
-   * … ask the human to reopen the app", which is wrong on every clause and sent one reporter looking
-   * for a port mismatch (#157). A count is enough — the message says "likeliest", not "certainly",
-   * because nothing here knows WHICH session the caller just lost.
+   * Kept for reporting. NOT a basis for diagnosis: it is a lifetime total that never resets, so
+   * `count > 0` latches true forever after the first reap. Ask `wasReapedLease` instead, which
+   * answers about a specific session.
    */
   reapedLeaseCount(): number {
     return this.#reapedLeases;
+  }
+
+  /**
+   * Did THIS session id belong to a lease this pool aged out?
+   *
+   * The question the no-session diagnosis actually has. It used to ask `reapedLeaseCount() > 0`,
+   * which meant that once any lease had ever aged out, every closed human tab for the rest of the
+   * daemon's life was reported as an expired lease — and the recovery that followed
+   * (`reticle_lease {acquire}`) would open an unauthenticated headless context and lose the app
+   * session (#611).
+   *
+   * Only the last {@link MAX_REMEMBERED_REAPED_LEASES} are remembered, so this answers `false` for
+   * a lease reaped long enough ago that thousands have followed. That direction is the safe one:
+   * it falls back to the generic "the tab was closed" wording rather than inventing a lease.
+   */
+  wasReapedLease(sessionId: string): boolean {
+    return this.#reapedLeaseIds.includes(sessionId);
   }
 
   /**

--- a/packages/server/src/session/lease-expiry-attribution.test.ts
+++ b/packages/server/src/session/lease-expiry-attribution.test.ts
@@ -57,7 +57,8 @@ function hintFor(departed: string | undefined, reaped: string[]): string {
     initialized: true,
     directory: projectDir(),
     wasReapedLease: (id) => reaped.includes(id),
-    occupiedSiblings: async () => [],
+    // Not `async () =>`: the repo's require-await rule rejects an async function with no await.
+    occupiedSiblings: () => Promise.resolve([]),
   });
   const text = hint();
   stop();

--- a/packages/server/src/session/lease-expiry-attribution.test.ts
+++ b/packages/server/src/session/lease-expiry-attribution.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Which vanished session gets blamed on an expired lease.
+ *
+ * `leaseExpired` used to be `reapedLeaseCount() > 0` — a monotonic lifetime total on the pool that
+ * is never reset and carries no identity. So once ANY lease had ever aged out, the diagnosis led
+ * with the lease story for every closed session for the rest of the daemon's life, including plain
+ * human tabs that were never leases. The advice that followed pointed at
+ * `reticle_lease {acquire}`, which opens an unauthenticated headless context and loses the app
+ * session: the worst available next action, recommended confidently (#611).
+ *
+ * The flag is now decided from the session that actually went away.
+ */
+import { describe, expect, it, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { startNoSessionWatch } from './no-session-watch.js';
+import type { SessionManager } from './session-manager.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function projectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'reticle-lease-attr-'));
+  dirs.push(dir);
+  return dir;
+}
+
+/** The few things the watch asks of a SessionManager, and nothing else. */
+function stubSessions(departed: string | undefined): {
+  manager: SessionManager;
+  hint: () => string;
+} {
+  let installed: (() => string | undefined) | undefined;
+  const manager = {
+    count: () => 0,
+    // The daemon has had a session before: that is what puts the diagnosis on the branch where
+    // the lease sentence is a candidate at all.
+    everConnected: () => true,
+    lastDeparted: () => departed,
+    setNoSessionHint: (hint: (() => string | undefined) | undefined) => {
+      installed = hint;
+    },
+    setNoSessionNextAction: () => undefined,
+    setConnectionRecorder: () => undefined,
+  } as unknown as SessionManager;
+  return { manager, hint: () => installed?.() ?? '' };
+}
+
+function hintFor(departed: string | undefined, reaped: string[]): string {
+  const { manager, hint } = stubSessions(departed);
+  const stop = startNoSessionWatch({
+    sessions: manager,
+    port: 4599,
+    initialized: true,
+    directory: projectDir(),
+    wasReapedLease: (id) => reaped.includes(id),
+    occupiedSiblings: async () => [],
+  });
+  const text = hint();
+  stop();
+  return text;
+}
+
+describe('attributing a vanished session to an expired lease', () => {
+  it('blames the lease when the session that went away was the reaped lease', () => {
+    expect(hintFor('lease-1', ['lease-1'])).toContain('was a pooled lease and it aged out');
+  });
+
+  it('does not blame the lease for a human tab, even after a lease has aged out', () => {
+    // The reported bug: 'human-tab' was never a lease, but a lease had aged out earlier in the
+    // daemon's life, so the old lifetime-count flag reported this as an expired lease anyway.
+    const text = hintFor('human-tab', ['lease-1']);
+    expect(text).not.toContain('was a pooled lease and it aged out');
+    expect(text).toContain('closed');
+  });
+
+  it('keeps answering correctly for later human tabs, not just the first', () => {
+    // The latch was permanent: this is the assertion that the flag no longer sticks.
+    expect(hintFor('human-tab-2', ['lease-1', 'lease-2'])).not.toContain(
+      'was a pooled lease and it aged out',
+    );
+  });
+
+  it('does not blame a lease when nothing has departed at all', () => {
+    expect(hintFor(undefined, ['lease-1'])).not.toContain('was a pooled lease and it aged out');
+  });
+});

--- a/packages/server/src/session/no-session-auto-attach.test.ts
+++ b/packages/server/src/session/no-session-auto-attach.test.ts
@@ -64,6 +64,8 @@ function stubSessions(count = 0): Stub {
   const manager = {
     count: () => count,
     everConnected: () => false,
+    // Nothing has departed in these cases, so the lease branch stays off.
+    lastDeparted: () => undefined,
     setNoSessionHint: (fn: (() => string | undefined) | undefined) => {
       hint = fn;
     },

--- a/packages/server/src/session/no-session-diagnosis.ts
+++ b/packages/server/src/session/no-session-diagnosis.ts
@@ -456,16 +456,19 @@ export function diagnoseNoSession(facts: NoSessionFacts): string {
     // from the field (#157): an aged-out lease produced "the tab was closed … ask the human to
     // reopen the app", which is wrong on every clause — there is no human tab, and the recovery it
     // names is unavailable to the caller while the one that works goes unmentioned. The reporter
-    // went looking for a port mismatch. Hedged rather than swapped: a human tab may ALSO have
-    // closed, and this does not know which session went.
+    // went looking for a port mismatch.
+    //
+    // The hedge that used to close this branch ("if you were driving a human tab instead…") is
+    // gone with the reason for it. `leaseExpired` was a lifetime count of reaps, so it could not
+    // tell which session went and had to cover both; it now names the session that actually
+    // departed (#611), so this branch is only reached when the thing that vanished WAS the lease.
     if (true === facts.leaseExpired) {
       return (
         'no browser session connected, but one WAS connected to this daemon earlier, so the wiring ' +
-        'is correct. This daemon has expired at least one pooled lease, so the likeliest cause is ' +
-        'that a lease you were using aged out; a lease is a headless context, not a human tab, and ' +
-        'it takes its cookies with it (so an authenticated app needs signing in again). Re-acquire ' +
-        'with reticle_lease {action:"acquire", url} and carry on. If you were driving a human tab ' +
-        `instead, it went away — reopen it or run ${OPEN_CMD_BARE}. ${RETRY}`
+        'is correct. The session that went away was a pooled lease and it aged out; a lease is a ' +
+        'headless context, not a human tab, and it takes its cookies with it (so an authenticated ' +
+        'app needs signing in again). Re-acquire with reticle_lease {action:"acquire", url} and ' +
+        `carry on. ${RETRY}`
       );
     }
     return (

--- a/packages/server/src/session/no-session-watch.test.ts
+++ b/packages/server/src/session/no-session-watch.test.ts
@@ -42,6 +42,8 @@ function stubSessions(): {
   const manager = {
     count: () => 0,
     everConnected: () => false,
+    // Nothing has departed in these cases, so the lease branch stays off.
+    lastDeparted: () => undefined,
     setNoSessionHint: (hint: (() => string | undefined) | undefined) => {
       installed = hint;
     },

--- a/packages/server/src/session/no-session-watch.ts
+++ b/packages/server/src/session/no-session-watch.ts
@@ -67,11 +67,15 @@ interface NoSessionWatchOptions {
    */
   occupiedSiblings?: () => Promise<readonly number[]>;
   /**
-   * How many pooled leases have aged out, if a pool exists. Injected as a reader rather than the
-   * pool itself: the diagnosis needs one number, and taking the whole pool would tie the session
-   * layer to the browser layer for it.
+   * Whether a given session id belonged to a pooled lease that aged out, if a pool exists.
+   * Injected as a predicate rather than the pool itself: the diagnosis needs one answer, and
+   * taking the whole pool would tie the session layer to the browser layer for it.
+   *
+   * Was a lifetime `reapedLeases: () => number` count, asked as `> 0`. That latched: after the
+   * first reap, every closed human tab was reported as an expired lease for the rest of the
+   * daemon's life, and the recovery it named would have thrown away the app session (#611).
    */
-  reapedLeases?: () => number;
+  wasReapedLease?: (sessionId: string) => boolean;
   /**
    * Opens a URL in a browser Reticle owns, and resolves once it is open.
    *
@@ -273,7 +277,12 @@ export function startNoSessionWatch(options: NoSessionWatchOptions): () => void 
           const framework = readProjectFramework(directory);
           return framework === undefined ? {} : { framework };
         })(),
-        leaseExpired: (options.reapedLeases?.() ?? 0) > 0,
+        // Decided from the session that actually went away, not from a lifetime tally: the lease
+        // sentence is only right when the thing that vanished WAS a lease.
+        leaseExpired: (() => {
+          const departed = options.sessions.lastDeparted();
+          return departed === undefined ? false : (options.wasReapedLease?.(departed) ?? false);
+        })(),
         // How long this daemon has been waiting with no app. The diagnosis uses it to surface
         // "install never finished" — the same condition telemetry already knows about.
         ...(() => {
@@ -314,8 +323,8 @@ export function wireSessionScope(
   sessions: SessionManager,
   activeProjectId: string | undefined,
   port: number,
-  /** Reader for the pool's aged-out-lease count; omitted when this daemon runs no pool. */
-  reapedLeases?: () => number,
+  /** Asks the pool whether a session id was a lease it aged out; omitted when there is no pool. */
+  wasReapedLease?: (sessionId: string) => boolean,
   /** Opens a URL in a Reticle-owned browser (the pool). Omitted ⇒ auto-attach is off. */
   attach?: (url: string) => Promise<unknown>,
 ): () => void {
@@ -324,7 +333,7 @@ export function wireSessionScope(
     sessions,
     port,
     initialized: activeProjectId !== undefined,
-    ...(reapedLeases === undefined ? {} : { reapedLeases }),
+    ...(wasReapedLease === undefined ? {} : { wasReapedLease }),
     ...(attach === undefined ? {} : { attach }),
   });
 }

--- a/packages/server/src/session/session-manager.ts
+++ b/packages/server/src/session/session-manager.ts
@@ -321,6 +321,22 @@ export class SessionManager {
   }
 
   /**
+   * The id of the session that most recently went away, if any.
+   *
+   * Distinct from {@link lastClosure}, which only records closes the bridge itself initiated
+   * (handshake refusals, auth failures) — an ordinary disconnect never reaches it. This reads the
+   * tombstone ring `remove()` maintains, so it covers every departure.
+   *
+   * Read by the no-session diagnosis, which needs to say something about the session that actually
+   * vanished rather than about the daemon's lifetime history (#611).
+   */
+  lastDeparted(): string | undefined {
+    let last: string | undefined;
+    for (const id of this.#tombstones.keys()) last = id;
+    return last;
+  }
+
+  /**
    * A dead `sessionId`, answered with what the caller needs to recover — not with an errand.
    *
    * Telemetry, 2026-08-10: one agent called `reticle_navigate` twelve times against an id that was


### PR DESCRIPTION
Fixes #611.

## The latch

`leaseExpired` was `(options.reapedLeases?.() ?? 0) > 0`, reading `BrowserPool`'s `#reapedLeases` — a monotonic lifetime total, never reset, carrying no identity. Once any lease had ever aged out, `no-session-diagnosis.ts:461` was taken for every closed session for the rest of the daemon's life, so a human tab that was never a lease got the lease story and the `reticle_lease {acquire}` recovery — which opens an unauthenticated headless context and throws the app session away.

## The identity was already there

`sweepExpired()` computes the expired **session ids** and then folds them into a count. This keeps them: `BrowserPool` answers `wasReapedLease(sessionId)` from a bounded ring of recently reaped ids (64 — only the most recent departure is ever asked about, so it is slack for a burst sweep, not a history). `reapedLeaseCount()` stays for reporting, now documented as *not* a basis for diagnosis.

## One correction to the issue

The suggested fix names `sessions.lastClosure()`, but that only records **bridge-initiated** closes — `noteClosure` is called for handshake-pool-full, protocol mismatch and auth failure. An ordinary disconnect never reaches it, so keying off it would have left the lease sentence almost permanently off instead of permanently on.

`SessionManager` grows `lastDeparted()` instead, reading the tombstone ring that `remove()` already maintains — that path covers every departure. If you'd rather this hung off `lastClosure()` being widened to record ordinary disconnects too, say so and I'll rework it.

## The prose

With identity in hand the lease branch stops hedging. The trailing *"If you were driving a human tab instead, it went away — reopen it…"* existed only because a count could not tell which session went; that clause is now reachable only in the case where it would be wrong, so it is gone and the sentence is definite.

## Verification

- New `src/session/lease-expiry-attribution.test.ts` — 4 cases: the lease is blamed when the departed session *was* the reaped lease; a human tab is not blamed after a lease has aged out (the reported bug); it keeps answering correctly for *later* human tabs (the latch specifically); and nothing is blamed when nothing departed.
- Two existing partial `SessionManager` doubles gained `lastDeparted` — they omit what the watch does not ask for, and it now asks for this.
- Full server suite: **562 files, 5483 tests, all passing**. `tsc --noEmit` clean, `prettier --check` clean, `check-boundaries` OK.
