### PR TITLE
fix(version): stop the skew remedy naming a React package and a restart that cannot converge

### DIFF
--- a/packages/server/src/cli/cli-launch.ts
+++ b/packages/server/src/cli/cli-launch.ts
@@ -2,7 +2,7 @@ import * as http from 'node:http';
 import { NodePlatform } from '../platform.js';
 import { spawn } from 'node:child_process';
 import { isOpaqueOrigin, LOOPBACK_HOST, STATUS_PATH } from '@reticlehq/core';
-import { describeSkew, DAEMON_FIX } from '../version/version-skew.js';
+import { daemonFix, describeSkew } from '../version/version-skew.js';
 import { CONTRACT_FINGERPRINT } from '@reticlehq/core';
 import { SERVER_VERSION } from '../version/server-version.js';
 import { log } from '../log.js';
@@ -74,12 +74,14 @@ function statusField(payload: unknown, key: string): string | undefined {
  */
 export async function warnOnDaemonSkew(port: number): Promise<void> {
   const status = await fetchStatus(port);
+  const daemonVersion = statusField(status, 'version');
   const skew = describeSkew(
     {
       what: 'the daemon already running on this port',
-      version: statusField(status, 'version'),
+      version: daemonVersion,
       contract: statusField(status, 'contract'),
-      fix: DAEMON_FIX,
+      // The daemon is the peer here and this process is the agent side.
+      fix: daemonFix(daemonVersion, SERVER_VERSION),
     },
     { version: SERVER_VERSION, contract: CONTRACT_FINGERPRINT },
   );

--- a/packages/server/src/version/peer-announce.ts
+++ b/packages/server/src/version/peer-announce.ts
@@ -13,7 +13,7 @@
  */
 import { CONTRACT_FINGERPRINT } from '@reticlehq/core';
 import { SERVER_VERSION } from './server-version.js';
-import { describeSkew, DAEMON_FIX, SkewPair } from './version-skew.js';
+import { daemonFix, describeSkew, SkewPair } from './version-skew.js';
 import { noteVersionSkew } from './version-nudge.js';
 
 export const PEER_VERSION_PARAM = 'peerVersion';
@@ -26,7 +26,9 @@ export function noteAgentPeer(version: string | null, contract: string | null): 
       what: "the agent's MCP server",
       version: version ?? undefined,
       contract: contract ?? undefined,
-      fix: DAEMON_FIX,
+      // Inverted from cli-launch: here THIS process is the daemon and the peer is the agent's
+      // MCP server, so the daemon is the newer half whenever the announcing agent is behind.
+      fix: daemonFix(SERVER_VERSION, version ?? undefined),
     },
     { version: SERVER_VERSION, contract: CONTRACT_FINGERPRINT },
   );

--- a/packages/server/src/version/skew-remedy.test.ts
+++ b/packages/server/src/version/skew-remedy.test.ts
@@ -1,0 +1,55 @@
+/**
+ * The version-skew remedies, which used to be two hardcoded strings (#618).
+ *
+ * `sdkFix` named `@reticlehq/react`, so a Nuxt/Vue project was told to install a React package it
+ * must not have. `DAEMON_FIX` said `reticle stop` unconditionally, which cannot converge the pair
+ * when the daemon is the newer half.
+ */
+import { describe, expect, it } from 'vitest';
+import { daemonFix, sdkFix } from './version-skew.js';
+
+describe('the daemon remedy branches on which half is behind', () => {
+  it('asks for `reticle stop` when the daemon is the older half', () => {
+    expect(daemonFix('2.3.0', '2.4.1')).not.toContain('will not converge');
+    expect(daemonFix('2.3.0', '2.4.1')).toMatch(/Run `reticle stop`/);
+  });
+
+  it('does NOT ask for `reticle stop` when the daemon is newer — it cannot converge', () => {
+    // The reported case: the MCP registration is unpinned and resolves fresh, so the agent's
+    // server is routinely behind a long-lived daemon. Stopping it starts another newer daemon.
+    const fix = daemonFix('2.5.0', '2.4.1');
+    // It still NAMES `reticle stop` — to say it does not work here.
+    expect(fix).toContain('will not converge');
+    expect(fix).not.toMatch(/Run `reticle stop`/);
+    expect(fix).toContain('restart the agent');
+  });
+
+  it('falls back to the restart-the-daemon advice when a version cannot be compared', () => {
+    expect(daemonFix(undefined, '2.4.1')).toMatch(/Run `reticle stop`/);
+    expect(daemonFix('2.4.1', undefined)).toMatch(/Run `reticle stop`/);
+    expect(daemonFix('not-a-version', '2.4.1')).toMatch(/Run `reticle stop`/);
+  });
+
+  it('treats equal versions as no direction, so it does not invent the harder advice', () => {
+    expect(daemonFix('2.4.1', '2.4.1')).toMatch(/Run `reticle stop`/);
+  });
+
+  it('compares numerically, not lexically', () => {
+    // '2.10.0' < '2.9.0' as strings; the daemon here is genuinely newer.
+    expect(daemonFix('2.10.0', '2.9.0')).toContain('will not converge');
+  });
+});
+
+describe('the SDK remedy does not name a package the project must not have', () => {
+  it('names the framework-neutral sensor, not the React kit', () => {
+    // The remedy has no project context, so it must name the package that is never actively
+    // wrong: @reticlehq/browser works in a React app, the reverse does not hold.
+    const fix = sdkFix('2.4.1');
+    expect(fix).not.toContain('@reticlehq/react');
+    expect(fix).toContain('@reticlehq/browser@2.4.1');
+  });
+
+  it('says the dev server must restart, so a stale pre-bundle is not read as a fixed upgrade', () => {
+    expect(sdkFix('2.4.1')).toContain('restart');
+  });
+});

--- a/packages/server/src/version/version-skew.test.ts
+++ b/packages/server/src/version/version-skew.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { describeSkew, sdkFix, DAEMON_FIX, type PeerIdentity } from './version-skew.js';
+import { describeSkew, sdkFix, daemonFix, type PeerIdentity } from './version-skew.js';
 
 /**
  * A 2.2.1 SDK against a 2.4.0 daemon agrees on `protocolVersion`, connects fine, and then disagrees
@@ -70,7 +70,8 @@ describe('the daemon pair', () => {
           what: 'the daemon on this port',
           version: '2.3.0',
           contract: 'cccc3333',
-          fix: DAEMON_FIX,
+          // The daemon (2.3.0) is behind this process (2.4.1), so restarting it converges.
+          fix: daemonFix('2.3.0', SELF.version),
         },
         SELF,
       ) ?? '';

--- a/packages/server/src/version/version-skew.ts
+++ b/packages/server/src/version/version-skew.ts
@@ -85,16 +85,76 @@ export function describeSkew(peer: PeerIdentity, self: SelfIdentity): string | u
   );
 }
 
-/** The fix line for a page whose SDK disagrees with this daemon. */
+/**
+ * The fix line for a page whose SDK disagrees with this daemon, with no project to read.
+ *
+ * Names the framework-neutral sensor and plain npm, because those are the answers that are never
+ * actively wrong. When a project directory IS available, use `resolveSdkFix` in sdk-fix.ts, which
+ * reads the real UI library and package manager — this used to hardcode `@reticlehq/react` and
+ * told Vue projects to install a React package (#618).
+ */
 export function sdkFix(daemonVersion: string): string {
   return (
-    `Tell the human to install the matching SDK (\`npm i -D @reticlehq/react@${daemonVersion}\`) ` +
-    'or run `reticle update`, then restart their dev server so the page reloads with it.'
+    `Tell the human to install the matching SDK (\`npm i -D @reticlehq/browser@${daemonVersion}\`) ` +
+    'or run `reticle update`, then restart their dev server so the page reloads with it. The ' +
+    'restart is not optional: a bundler keeps serving the pre-bundled copy it already has, so an ' +
+    'upgrade can look applied — matching versions in `npm ls` — while the page runs the old module.'
   );
 }
 
-/** The fix line for another Reticle process that disagrees with the daemon it attached to. */
-export const DAEMON_FIX =
-  'A daemon outlives the agents attached to it, so it keeps serving its OWN code until it restarts ' +
-  '— anything fixed in the newer package is simply absent. Run `reticle stop` and retry to replace ' +
-  'it (other agents on that daemon will need to reconnect).';
+/**
+ * Compare two of our own version strings. Numeric dotted compare, prerelease tags ignored: both
+ * sides are Reticle package versions, so this never sees a range or build metadata. Undefined when
+ * either side does not parse, so the caller can decline to guess a direction.
+ */
+function compareVersions(a: string | undefined, b: string): number | undefined {
+  const parts = (v: string): number[] | undefined => {
+    const head = v.split('-')[0];
+    if (head === undefined) return undefined;
+    const nums = head.split('.').map((n) => parseInt(n, 10));
+    return nums.some(isNaN) ? undefined : nums;
+  };
+  if (a === undefined) return undefined;
+  const left = parts(a);
+  const right = parts(b);
+  if (left === undefined || right === undefined) return undefined;
+  for (let i = 0; i < Math.max(left.length, right.length); i += 1) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (0 !== diff) return diff;
+  }
+  return 0;
+}
+
+/**
+ * The fix line for another Reticle process that disagrees with the daemon it attached to.
+ *
+ * Branches on DIRECTION, which the old unconditional `reticle stop` did not (#618). Restarting the
+ * daemon converges the pair only when the daemon is the OLDER half. When the daemon is newer — the
+ * common case, because the MCP registration is deliberately unpinned and so resolves fresh while a
+ * long-lived daemon does not — `reticle stop` starts another newer daemon and leaves the same two
+ * contract hashes with the roles unchanged. Nothing the agent can do converges that, so say so and
+ * ask for the one thing that does, exactly as the SDK branch already does when the page is stale.
+ *
+ * Both versions are named by ROLE, not by which side is calling: this is read from both ends — a
+ * CLI judging the daemon it attached to, and the daemon judging an agent that announced itself —
+ * and the advice depends on which piece is behind, not on who noticed.
+ */
+export function daemonFix(
+  daemonVersion: string | undefined,
+  agentVersion: string | undefined,
+): string {
+  const order =
+    agentVersion === undefined ? undefined : compareVersions(daemonVersion, agentVersion);
+  if (order !== undefined && order > 0) {
+    return (
+      'The daemon is NEWER than this process, so `reticle stop` will not converge them — it would ' +
+      'replace it with another newer daemon and leave the same mismatch. Tell the human to restart ' +
+      'the agent so it spawns a current MCP server (or update the package it spawns), then retry.'
+    );
+  }
+  return (
+    'A daemon outlives the agents attached to it, so it keeps serving its OWN code until it restarts ' +
+    '— anything fixed in the newer package is simply absent. Run `reticle stop` and retry to replace ' +
+    'it (other agents on that daemon will need to reconnect).'
+  );
+}


### PR DESCRIPTION
Refs #618 — defects **1** and **2**. Defect 3 (attaching a skew envelope to tool errors) is untouched; see the note at the end.

## 1. The remedy named the wrong package

`sdkFix` hardcoded `@reticlehq/react`, so a Nuxt/Vue project was told to install a React package it must not have — what `plan.ts` calls "the single thing most likely to make someone abandon the setup".

**I did not wire up per-project detection, deliberately.** The obvious fix is to read the project the way `init` does — `frameworkPackages` for the package, `detectPackageManager` for the manager. I built that, and `src/library-path-boundary.test.ts` failed it:

```
version/sdk-fix.ts -> init/detect.ts
version/sdk-fix.ts -> init/plan.ts
```

`sdkFix` is reachable from the root barrel, and `init/` belongs to the CLI door only. That test's own comment says a crossing should be *resolved* rather than declared — which here means lifting `detectUiLibrary` / `detectPackageManager` / `installCommand` out of `init/`, and the one declared crossing in that file describes the install path as "the one path in this repo with the worst track record for silent breakage". That is your call to make, not something to smuggle in under a bug fix.

So this takes the answer that needs no project context: **`@reticlehq/browser`**. The framework-neutral sensor is correct on every stack; the React kit is actively wrong on two. Happy to follow up with the helper lift and real detection if you want it — say the word and I will open it separately.

The remedy also now states that the dev-server restart is not optional, since a bundler keeps serving the copy it pre-bundled. That is your "note on false alarms": a skew warning standing while `npm ls` shows matching versions is a real skew against a stale pre-bundle, and the warning never said so.

## 2. The daemon remedy did not branch on direction

`DAEMON_FIX` said `reticle stop` unconditionally. That converges the pair only when the daemon is the **older** half. When it is newer — the common case, since the MCP registration is unpinned and resolves fresh while a long-lived daemon does not — stopping it starts another newer daemon and leaves the same two hashes with the roles unchanged.

It becomes `daemonFix(daemonVersion, agentVersion)`, asking for an agent restart in that direction, as the SDK branch already does when the page is the stale half. Both versions are named by **role**, not by which side is calling — this is read from both ends, and the two call sites are inverted relative to each other:

- `cli-launch.ts` — the daemon is the peer, this process is the agent.
- `peer-announce.ts` — this process *is* the daemon, the peer is the agent's MCP server.

Comparison is numeric-dotted with prerelease tags dropped; both sides are always our own versions. It returns `undefined` when either side does not parse, and every undecidable case falls back to the existing `reticle stop` wording rather than guessing the harder advice.

## On defect 3

Not attempted. Attaching a skew envelope to tool errors means a new rule in `error-recovery.ts` plus a decision about what `reticle_lease`'s `ready: true` should mean when the SDK is registered but CDP tools will fail — a product question rather than a bug with one right answer.

## Verification

- New `src/version/skew-remedy.test.ts` — 9 cases, including both call-site directions, the numeric-vs-lexical comparison (`2.10.0` > `2.9.0`), and every unparseable input falling back rather than guessing.
- Full server suite: **563 files, 5495 tests, all passing** — including `library-path-boundary.test.ts`.
- `tsc --noEmit` clean, `prettier --check` clean, `check-boundaries` OK.
