### PR TITLE
fix(events): grade bodyContains against a truncated body as undecidable, not failed

### DIFF
--- a/packages/server/src/events/predicate-eval.ts
+++ b/packages/server/src/events/predicate-eval.ts
@@ -398,6 +398,12 @@ export function evalNet(
    * a UI wiring bug that did not exist, when the defect was the value the server answered with.
    */
   let bodyMismatch: string | undefined;
+  /**
+   * The prefix of a TRUNCATED body the needle was not found in. Held apart from `bodyMismatch`
+   * because the two are different verdicts: a full body without the needle decides the assertion,
+   * a truncated one cannot (#614).
+   */
+  let truncatedBody: string | undefined;
   const matches = events.filter((e) => {
     if (e.type !== EventType.NET_REQUEST || e.t < since) return false;
     const d = e.data;
@@ -431,6 +437,15 @@ export function evalNet(
         return false;
       }
       if (!response.includes(p.bodyContains)) {
+        // A needle missing from a body we only hold the FIRST N BYTES of is undecidable, not
+        // absent: the rest of the response was never recorded, so nothing here can say whether it
+        // was in there (#614). Grading it `pass: false` with "the response value is what differed"
+        // is the inversion the honesty rules exist to prevent — an unknown reported as decided,
+        // against a response that was very likely correct.
+        if (true === d['responseBodyTruncated']) {
+          truncatedBody ??= response;
+          return false;
+        }
         bodyMismatch ??= response;
         return false;
       }
@@ -455,6 +470,18 @@ export function evalNet(
       failureReason: `a call matched but its body was not recorded, so \`bodyContains\` could not be checked — enable it where the app calls connect(): reticle({ captureNetworkBodies: true })`,
       observed: 'a matching call with no recorded body',
       expected: `a body containing ${JSON.stringify(p.bodyContains)}`,
+      assertion: 'net.bodyContains',
+    };
+  }
+  // Ranked ABOVE the mismatch branch: when both a truncated and a full body missed the needle,
+  // the honest verdict is the undecidable one. Deciding on the full body would report a failure
+  // the truncated call may well contradict.
+  if (truncatedBody !== undefined && 0 === matches.length) {
+    return {
+      pass: false,
+      inconclusive: `a call matching ${describeNetFilter(p)} was answered with a body that was TRUNCATED before it was recorded, and ${JSON.stringify(p.bodyContains)} is not in the part that was kept — so this is undecidable, not a failure. Raise the capture cap or assert on something inside the recorded prefix`,
+      observed: `the first ${String(truncatedBody.length)} characters of a truncated response body ${JSON.stringify(clipBody(truncatedBody))}`,
+      expected: `a response body containing ${JSON.stringify(p.bodyContains)}`,
       assertion: 'net.bodyContains',
     };
   }

--- a/packages/server/src/events/predicate-net-body.test.ts
+++ b/packages/server/src/events/predicate-net-body.test.ts
@@ -187,3 +187,84 @@ describe('a body mismatch reports the body, not a count of zero', () => {
     expect(r.failureReason).toContain('bodyContains');
   });
 });
+
+/**
+ * A truncated body cannot decide the assertion (#614).
+ *
+ * The observer caps a recorded body at MAX_BODY_CHARS and sets `responseBodyTruncated`. The grader
+ * was the one reader that ignored the flag, so a needle missing from the recorded PREFIX fell
+ * through to the hard-fail branch and reported "the request fired, the response value is what
+ * differed" — a decided verdict on an undecidable observation, against a response that was very
+ * likely correct.
+ */
+describe('evalNet — bodyContains against a truncated body', () => {
+  const TRUNCATED = netEvent(10, {
+    method: 'GET',
+    url: '/api/report',
+    status: 200,
+    ok: true,
+    responseBody: '{"rows":[{"id":1},{"id":2}',
+    responseBodyTruncated: true,
+  });
+
+  it('does not decide against a needle missing from the recorded prefix', () => {
+    const r = evalNet([TRUNCATED], {
+      kind: PredicateKind.NET,
+      urlContains: '/api/report',
+      bodyContains: 'grand_total',
+    });
+    // Not a pass — nothing here proves the needle was present either.
+    expect(r.pass).toBe(false);
+    expect(r.inconclusive).toBeDefined();
+    expect(r.inconclusive).toContain('TRUNCATED');
+    // The wording that made this a bug: it must not claim the value differed.
+    expect(r.failureReason).toBeUndefined();
+  });
+
+  it('names an action the caller can take, not just a diagnosis', () => {
+    const r = evalNet([TRUNCATED], {
+      kind: PredicateKind.NET,
+      urlContains: '/api/report',
+      bodyContains: 'grand_total',
+    });
+    expect(r.inconclusive).toContain('cap');
+  });
+
+  it('still passes when the needle IS inside the recorded prefix', () => {
+    // Truncation only blocks a NEGATIVE conclusion; a hit is a hit.
+    const r = evalNet([TRUNCATED], {
+      kind: PredicateKind.NET,
+      urlContains: '/api/report',
+      bodyContains: '"id":1',
+    });
+    expect(r.pass).toBe(true);
+  });
+
+  it('still decides against a full body, so the ordinary mismatch verdict is intact', () => {
+    const r = evalNet([REFUND], {
+      kind: PredicateKind.NET,
+      urlContains: '/api/refund',
+      bodyContains: '1187.01',
+    });
+    expect(r.pass).toBe(false);
+    expect(r.failureReason).toContain('the response value is what differed');
+    expect(r.inconclusive).toBeUndefined();
+  });
+
+  it('prefers the undecidable verdict when a truncated and a full body both miss', () => {
+    const FULL_MISS = netEvent(11, {
+      method: 'GET',
+      url: '/api/report',
+      status: 200,
+      ok: true,
+      responseBody: '{"rows":[]}',
+    });
+    const r = evalNet([TRUNCATED, FULL_MISS], {
+      kind: PredicateKind.NET,
+      urlContains: '/api/report',
+      bodyContains: 'grand_total',
+    });
+    expect(r.inconclusive).toBeDefined();
+    expect(r.failureReason).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #614.

## The inversion

`evalNet` read `responseBody` and never consulted `responseBodyTruncated`, so a needle missing from a body the observer had capped at `MAX_BODY_CHARS` fell through to the hard-fail branch and reported *"the request fired, the response value is what differed"*.

The rest of that body was never recorded. Nothing in the grader can say whether the needle was in it — so this was a decided verdict on an undecidable observation, against a response that was very likely correct. The flag is produced by the observer and already read by `event-filters.ts`; the grader was the one reader ignoring it.

## The verdict

Needle absent **and** body truncated now returns `inconclusive`, naming what was actually checked and what the caller can do:

> a call matching … was answered with a body that was TRUNCATED before it was recorded, and `"grand_total"` is not in the part that was kept — so this is undecidable, not a failure. Raise the capture cap or assert on something inside the recorded prefix

Both of those are actions. "The response value is what differed" is not.

## Two ordering decisions worth reviewing

**Ranked above the mismatch branch.** When a truncated call and a full call both miss the needle, the honest verdict is the undecidable one — deciding on the full body would report a failure the truncated call may well contradict. The two accumulators are kept separate (`truncatedBody` vs `bodyMismatch`) rather than reusing one, because they are different verdicts.

**A hit still passes.** Truncation only blocks a *negative* conclusion; a needle found inside the recorded prefix is found, and that path is untouched.

`pass` stays `false` throughout, as with the other `inconclusive` results here — nothing was proven either way.

## Tests

Five added to `src/events/predicate-net-body.test.ts`:

- the needle missing from a truncated prefix is `inconclusive`, and specifically **not** `failureReason` — the wording that made this a bug
- the message names an action, not just a diagnosis
- a needle inside the recorded prefix still passes
- a full body missing the needle still produces the ordinary mismatch verdict, unchanged
- truncated + full both missing prefers the undecidable verdict

Verified: `src/events` 42 files / 522 tests passing, `tsc --noEmit` clean, `prettier --check` clean.
