### PR TITLE
docs(version): stop pointing at a helper nobody wrote

### DIFF
--- a/packages/server/src/version/version-skew.ts
+++ b/packages/server/src/version/version-skew.ts
@@ -89,9 +89,14 @@ export function describeSkew(peer: PeerIdentity, self: SelfIdentity): string | u
  * The fix line for a page whose SDK disagrees with this daemon, with no project to read.
  *
  * Names the framework-neutral sensor and plain npm, because those are the answers that are never
- * actively wrong. When a project directory IS available, use `resolveSdkFix` in sdk-fix.ts, which
- * reads the real UI library and package manager — this used to hardcode `@reticlehq/react` and
- * told Vue projects to install a React package (#618).
+ * actively wrong: `@reticlehq/browser` works in a React app, and the reverse does not hold. This
+ * used to hardcode `@reticlehq/react`, so a Vue or Nuxt project was told to install a React package
+ * it must not have (#618).
+ *
+ * It has no project to read, and nothing here resolves one. Reading the real UI library and package
+ * manager would give a better line, and would belong beside the detection `init` already does —
+ * but it does not exist, and a comment pointing at a helper nobody wrote sends the next reader
+ * looking for a file that is not there.
  */
 export function sdkFix(daemonVersion: string): string {
   return (


### PR DESCRIPTION
Follow-up to #633, which was a good fix: `sdkFix` named `@reticlehq/react`, so a Vue or Nuxt project was told to install a React package it must not have.

Its comment tells readers to "use \`resolveSdkFix\` in sdk-fix.ts" for the project-aware case. Neither the function nor the file exists anywhere in this repo — `grep -rn "resolveSdkFix\|sdk-fix" packages/` returns nothing.

A dangling reference costs the next reader a search that ends in nothing, and it is a poor thing to leave in a function whose whole subject is remedies that are actually true. The idea is worth keeping, so it is stated as a gap rather than as an existing helper.

Comment only. No behaviour change; the 28 tests in `src/version` are untouched and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)