### PR TITLE
test(server): replace regex test with behavioral parity test for abse…

### DIFF
--- a/packages/server/src/tools/act-verdict-parity.test.ts
+++ b/packages/server/src/tools/act-verdict-parity.test.ts
@@ -23,8 +23,89 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import {
+  BlindSpotKind,
+  ReticleCommand,
+  SessionState,
+  Verified,
+  VerifiedReason,
+  type CommandResult,
+  type ReticleEvent,
+} from '@reticlehq/core';
+import { TOOLS, type ToolDef, type ToolDeps } from './tools.js';
+import { ReticleTool } from './tool-names.js';
+import { LastAct } from '../session/last-act.js';
+import { BaselineStore } from '../project/baselines.js';
+import { RecordingStore } from '../flows/recordings.js';
+import { FlowStore } from '../flows/flows.js';
+import { ProjectStore } from '../project/project-store.js';
+import { AnnotationStore } from '../flows/annotation-store.js';
+import { createNodeFileSystem } from '../project/fs-port.js';
+import type { Session, SessionManager } from '../session/session.js';
 
 const src = (file: string): string => readFileSync(join(import.meta.dirname, file), 'utf8');
+
+const tool = (name: string): ToolDef => {
+  const found = TOOLS.find((t) => t.name === name);
+  if (found === undefined) throw new Error(`${name} is not on the surface`);
+  return found;
+};
+
+function createParitySessionDeps(blindSpots: Record<string, number>): ToolDeps {
+  const noEvents: ReticleEvent[] = [];
+  const command = (name: string): Promise<CommandResult> => {
+    if (name === ReticleCommand.MATCH) {
+      return Promise.resolve({
+        kind: 'command_result',
+        id: 'q1',
+        ok: true,
+        result: { matched: false, count: 0, elements: [] },
+      });
+    }
+    return Promise.resolve({
+      kind: 'command_result',
+      id: 'c1',
+      ok: true,
+      result: { dispatched: true, settled: true, effect: { domMutatedWithin: 1 } },
+    });
+  };
+  const session: Partial<Session> = {
+    id: 'demo',
+    url: 'http://localhost:5173/app',
+    elapsed: () => 1000,
+    lastAct: new LastAct(),
+    beginAction: () => 'a1',
+    finishAction: () => undefined,
+    recordAction: () => 'a1',
+    command,
+    queryEvents: () => Promise.resolve(noEvents),
+    eventsSince: () => noEvents,
+    bufferHealth: () => ({ total: 10, dropped: 0 }),
+    lostSince: () => false,
+    blindSpots: () => blindSpots,
+    health: () => ({ lastSeenMs: 0, throttled: false, focused: true }),
+    throttled: () => false,
+    getState: () => SessionState.ACTIVE,
+    drainInbox: () => [],
+    inboxSize: () => 0,
+    onEvent: () => () => undefined,
+    ambientCounts: () => ({}),
+  };
+  const sessions: Partial<SessionManager> = { resolve: () => session as Session };
+  return {
+    sessions: sessions as SessionManager,
+    baselines: new BaselineStore(),
+    recordings: new RecordingStore(),
+    flows: new FlowStore(createNodeFileSystem(), '/tmp/reticle-test/.reticle', { now: () => 0 }),
+    project: new ProjectStore(createNodeFileSystem(), '/tmp/reticle-test/.reticle', {
+      now: () => 0,
+    }),
+    annotations: new AnnotationStore(),
+    fs: createNodeFileSystem(),
+    reticleRoot: '/tmp/reticle-test/.reticle',
+    now: () => 0,
+  };
+}
 
 describe('act_and_wait and assert see the same evidence', () => {
   const act = src('act-tools.ts');
@@ -112,10 +193,26 @@ describe('act_and_wait and assert see the same evidence', () => {
     expect(assert).toMatch(/LEARNING material/);
   });
 
-  it('both paths pass absenceBlindSpot to decideVerified', () => {
-    for (const file of [act, assert]) {
-      expect(file).toMatch(/absenceBlindSpotNote\(/);
-      expect(file).toMatch(/absenceBlindSpot === undefined \? \{\} : \{ absenceBlindSpot \}/);
-    }
+  it('both paths report identical absenceBlindSpot verdicts and notes when an unobserved region is present', async () => {
+    const deps = createParitySessionDeps({ [BlindSpotKind.CLOSED_SHADOW_ROOT]: 1 });
+
+    const assertRes = (await tool(ReticleTool.ASSERT).handler(deps, {
+      predicate: { kind: 'element', query: { by: 'testid', value: 'target-row' }, absent: true },
+      timeout_ms: 0,
+    })) as Record<string, unknown>;
+
+    const actRes = (await tool(ReticleTool.ACT_AND_WAIT).handler(deps, {
+      ref: 'e1',
+      action: 'click',
+      until: { kind: 'element', query: { by: 'testid', value: 'target-row' }, absent: true },
+    })) as Record<string, unknown>;
+
+    expect(assertRes['verified']).toBe(Verified.UNKNOWN);
+    expect(assertRes['verifiedReason']).toBe(VerifiedReason.ABSENCE_BLIND_SPOT);
+
+    expect(actRes['verified']).toBe(Verified.UNKNOWN);
+    expect(actRes['verifiedReason']).toBe(VerifiedReason.ABSENCE_BLIND_SPOT);
+
+    expect(assertRes['because']).toBe(actRes['because']);
   });
 });


### PR DESCRIPTION
## What & why

Replaced the static regex source-matching test in `packages/server/src/tools/act-verdict-parity.test.ts` with a behavioral parity test that executes both `reticle_act_and_wait` and `reticle_assert` tool handlers against an unobserved DOM region (`CLOSED_SHADOW_ROOT`).

Asserts that both tools:
1. Downgrade absence assertions to `Verified.UNKNOWN`.
2. Report `VerifiedReason.ABSENCE_BLIND_SPOT`.
3. Emit identical explanatory notes (`because`).

Closes #619

## How it was verified

- Ran `pnpm --filter @reticlehq/server test` — unit test suite passed 100%.
- Verified `act-verdict-parity.test.ts` passes and accurately guards behavioral parity between both tools.

## Gates run

- [x] `pnpm lint && pnpm typecheck && pnpm test:unit` (~2 min — **always**)
- [ ] `pnpm test:e2e` (~8 min) — _touched the tool surface, `packages/core`, an observer, or telemetry_
- [ ] `pnpm gate:install` (~15 min) — _touched `reticle init`, `vite-plugin`, `next`, or `babel-plugin`_
- [ ] `pnpm test:e2e:desktop` (~3 min) — _touched `packages/electron`, `packages/tauri`, or desktop capture_
- [ ] None of the above tiers apply to this change

## Checklist

- [x] **Every commit is signed off** (`git commit -s`) — CI's DCO check fails the PR without it.
- [x] Tests added/updated (RED → GREEN); the change is covered by a test that would fail without it
- [x] No `any`, no free strings (wire strings live in `@reticlehq/core`), no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 1000-line cap
- [x] Docs and `CHANGELOG.md` updated if this is user-facing (entry under `[Unreleased]`)
- [x] Security-affecting? Auth/redaction/trust-boundary changes keep the localhost-only posture
