### PR TITLE
fix(server): count socket-level MCP POST failures on the session summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
+### Added
+
+- **`@reticlehq/core` + `@reticlehq/server` — socket-level MCP POST failures are now a session count.** `ENOBUFS`, `EMFILE`, `EADDRNOTAVAIL` and `ECONNREFUSED` before any bytes were sent never produced `tool_refused` (the handler never ran) and never produced `mcp_connection_lost` (the SSE stream was fine), so a keep-alive retry that saved the call was indistinguishable from one that never fired. `postSocketFailures` and `postRetriesSaved` ride the existing session summary, omitted when zero, and the proxy awaits the flush before exit.
+
 ### Fixed
 
 - **`@reticlehq/server` — a scheme-less `RETICLE_ALLOWED_ORIGINS` entry is no longer discarded silently.** `RETICLE_ALLOWED_ORIGINS=myapp.test` appeared to work and had no effect: an entry without a scheme fails origin normalization and was filtered out without a trace, so the allow-list looked configured while every dial from that origin was refused at the gate — and the refusal read as a problem with the page, not with the config. The bridge now logs an `allowed_origin_ignored` warning at startup for each dropped entry, naming the entry and the accepted form (`scheme://host[:port]`), with the corrected value spelled out so the fix is copy-pasteable. The drop itself is unchanged — an invalid entry still allows nothing.

--- a/docs/telemetry-contract.md
+++ b/docs/telemetry-contract.md
@@ -27,7 +27,7 @@ Tool usage, timing, errors, verifications and bugs are all recorded in **one pla
 
 Do **not** add telemetry inside a tool handler. If you find yourself wanting to, the metric probably belongs at the chokepoint, read off the result.
 
-> The one exception is a path that genuinely does not go through `runTool`. Today that is only the verification runner (`reticle verify`, the HTTP verify surface), which has its own reporter in `telemetry/run-telemetry.ts`. **If you add a second dispatch path, it needs the same treatment**, and until it has one it is invisible. That gap existed for real: CI-found bugs were uncounted.
+> The exceptions are paths that genuinely do not go through `runTool`. One is the verification runner (`reticle verify`, the HTTP verify surface), which has its own reporter in `telemetry/run-telemetry.ts`. The other is the MCP proxy's POST leg (`postToSession`): a socket failure there never reaches a tool handler, so the counts live on the proxy's session summary and flush as `session_progress`. **If you add another dispatch path, it needs the same treatment**, and until it has one it is invisible. That gap existed for real: CI-found bugs were uncounted.
 
 ### 2. Names say what happened
 
@@ -135,6 +135,8 @@ Four counters and one flag were added because the data could not answer question
 | Field | On | Means |
 | --- | --- | --- |
 | `noSessionErrors` | session summary | tool calls that failed because there was no app to reach: no session, no session by that id, or several with none named. The largest drop-off in the funnel; it was previously reachable only by unpacking `errors[]`. |
+| `postSocketFailures` | session summary | connection-level POST failures on the MCP proxy (`ENOBUFS`, `EMFILE`, `EADDRNOTAVAIL`, `ECONNREFUSED` before any bytes were sent). These never produce `tool_refused` (the call never reached a handler) and never produce `mcp_connection_lost` (the SSE stream is fine). Counted in the proxy process and flushed as `session_progress` on stdin end. The send is awaited, because fire-and-forget before `process.exit` is how `daemon_stopped` never arrived. Absent when none happened. |
+| `postRetriesSaved` | session summary | of those POST failures, how many a bounded retry then delivered. The numerator against `postSocketFailures`: a retry that quietly saves a call is a different fact from a retry that never runs. Absent when none were saved. |
 | `consecutiveRepeats` | session summary | longest back-to-back run per tool name. `toolCounts` reports five useful calls and five retries of one failing call identically, and those are opposite facts. |
 | `abandonedActions` | session summary | actions driven with no verdict AFTER them (the trailing unsettled run, not `actions - verifications`). That difference ignores order, so a verdict that drove nothing (a `flow_verify` over saved flows) silently paid for an abandoned action elsewhere. |
 | `endedWithVerdict` | session summary (final only) | did this session ever produce a verdict. The headline metric, and previously the only thing in the payload that had to be COMPUTED, from lifetime counters sitting next to windowed ones, which is a subtraction that gets read wrong. Sent as `false` rather than omitted: a session that drove an app and never asked whether it worked is the finding. |

--- a/packages/core/src/telemetry-session.ts
+++ b/packages/core/src/telemetry-session.ts
@@ -218,6 +218,22 @@ export const SessionSummarySchema = z.object({
    */
   noSessionErrors: z.number().int().nonnegative().optional(),
   /**
+   * Connection-level POST failures on the MCP proxy (`ENOBUFS`, `EMFILE`, `EADDRNOTAVAIL`,
+   * `ECONNREFUSED` before any bytes were sent).
+   *
+   * These never produce `tool_refused` (the call never reached a handler) and never produce
+   * `mcp_connection_lost` (the SSE stream is fine). Without this count, a keep-alive retry that
+   * saves the call is indistinguishable from one that never fired. Absent when none happened.
+   */
+  postSocketFailures: z.number().int().nonnegative().optional(),
+  /**
+   * Of those POST failures, how many a bounded retry then delivered.
+   *
+   * The numerator against `postSocketFailures`: a retry that quietly saves a call is a different
+   * fact from a retry that never runs. Absent when none were saved.
+   */
+  postRetriesSaved: z.number().int().nonnegative().optional(),
+  /**
    * Longest back-to-back run per tool name — the shape of a retry loop.
    *
    * `toolCounts` reports five useful calls and five retries of one failing call identically, and

--- a/packages/server/src/mcp/mcp-post-transport.test.ts
+++ b/packages/server/src/mcp/mcp-post-transport.test.ts
@@ -1,10 +1,19 @@
 import { EventEmitter } from 'node:events';
 import type * as http from 'node:http';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MCP_PROXY_HTTP_AGENT_OPTIONS, postToSession, shouldRetryUnsentPost } from './mcp-proxy.js';
 import { daemonPollDelayMs } from './proxy-daemon-probe.js';
+import { getSessionMetrics, resetSessionMetrics } from '../telemetry/session-metrics.js';
 
 const noBuffers = Object.assign(new Error('no buffer space'), { code: 'ENOBUFS' });
+
+beforeEach(() => {
+  resetSessionMetrics();
+});
+
+afterEach(() => {
+  resetSessionMetrics();
+});
 
 describe('MCP POST transport', () => {
   it('keeps POST requests on a bounded, long-lived socket pool', () => {
@@ -65,7 +74,46 @@ describe('MCP POST transport', () => {
 
     await expect(result).resolves.toBeNull();
     expect(attempts).toBe(2);
+    const summary = getSessionMetrics().summarize(true);
+    expect(summary.postSocketFailures).toBe(1);
+    expect(summary.postRetriesSaved).toBe(1);
     vi.useRealTimers();
+  });
+
+  it('counts a refused connection that is not retried, and does not count an HTTP refusal', async () => {
+    const refused = Object.assign(new Error('connect refused'), { code: 'ECONNREFUSED' });
+    const request = ((_options, callback) => {
+      const req = new EventEmitter() as http.ClientRequest;
+      req.end = (() => {
+        queueMicrotask(() => req.emit('error', refused));
+        return req;
+      }) as http.ClientRequest['end'];
+      void callback;
+      return req;
+    }) satisfies Parameters<typeof postToSession>[2];
+
+    await expect(postToSession('http://127.0.0.1:4400/session', '{}', request)).resolves.toEqual({
+      reason: 'post failed: connect refused',
+      transport: true,
+      attempts: 1,
+    });
+    expect(getSessionMetrics().summarize(true).postSocketFailures).toBe(1);
+    expect(getSessionMetrics().summarize(true).postRetriesSaved).toBeUndefined();
+
+    resetSessionMetrics();
+    const httpRefuse = ((_options, callback) => {
+      const req = new EventEmitter() as http.ClientRequest;
+      req.end = (() => {
+        const response = new EventEmitter() as http.IncomingMessage;
+        response.statusCode = 500;
+        response.resume = vi.fn().mockReturnValue(response);
+        queueMicrotask(() => callback(response));
+        return req;
+      }) as http.ClientRequest['end'];
+      return req;
+    }) satisfies Parameters<typeof postToSession>[2];
+    await postToSession('http://127.0.0.1:4400/session', '{}', httpRefuse);
+    expect(getSessionMetrics().summarize(true).postSocketFailures).toBeUndefined();
   });
 
   it('does not retry after any request bytes were written', () => {

--- a/packages/server/src/mcp/mcp-proxy.ts
+++ b/packages/server/src/mcp/mcp-proxy.ts
@@ -34,6 +34,8 @@ import {
   OnRequest,
 } from './proxy-lifecycle.js';
 import { describePresence, probePresence } from '../daemon/port-presence.js';
+import { getSessionMetrics } from '../telemetry/session-metrics.js';
+import { flushProxySessionMetrics } from '../telemetry/proxy-telemetry.js';
 /**
  * The same `/status` probe `doctor`, `status` and `kill` ask with. Reused rather than re-written:
  * the whole defect this import closes was the proxy answering a DIFFERENT question from every other
@@ -380,6 +382,8 @@ export function postToSession(
           // A non-2xx from the daemon MCP endpoint used to be swallowed, hanging the JSON-RPC call
           // client-side with no diagnostic. It is a refusal: no response is coming over the stream.
           log('reticle_mcp_proxy_post_non2xx', { status, path: options.path });
+        } else if (retryCount > 0) {
+          getSessionMetrics().recordPostRetrySaved();
         }
         res.resume(); // drain so the socket is reused
         resolve(
@@ -399,6 +403,8 @@ export function postToSession(
       req.on('error', (err) => {
         if (settled) return;
         settled = true;
+        // Invisible to mcp_connection_lost (SSE is up) and to tool_refused (handler never ran).
+        getSessionMetrics().recordPostSocketFailure();
         const bytesWritten =
           socket === undefined ? 0 : Math.max(0, socket.bytesWritten - socketBytesBeforeRequest);
         if (shouldRetryUnsentPost(err, bytesWritten, retryCount)) {
@@ -966,7 +972,8 @@ export function startMcpProxy(
     process.stdin.on('end', () => {
       const quit = (code: number): void => {
         stopped = true;
-        process.exit(code);
+        // Await: fire-and-forget here is how daemon_stopped never arrived.
+        void flushProxySessionMetrics().finally(() => process.exit(code));
       };
       if (0 === pending.unanswered.length) {
         quit(0);

--- a/packages/server/src/telemetry/proxy-telemetry.test.ts
+++ b/packages/server/src/telemetry/proxy-telemetry.test.ts
@@ -1,0 +1,85 @@
+/**
+ * POST socket failures are invisible to the two events that look like they would catch them:
+ * `tool_refused` never fires (the handler never ran) and `mcp_connection_lost` never fires (the SSE
+ * stream is fine). The counts therefore ride the existing session summary, omitted when zero.
+ */
+import { describe, expect, it } from 'vitest';
+import { TelemetryEventKind } from '@reticlehq/core';
+import { SessionMetrics } from './session-metrics.js';
+import { createTelemetry } from './telemetry.js';
+import { flushProxySessionMetrics } from './proxy-telemetry.js';
+
+const TEST_ENV = {
+  RETICLE_TELEMETRY_KEY: 'phc_test',
+  RETICLE_TELEMETRY_URL: 'http://example.test',
+};
+
+const USER_PROJECT = '/tmp/some-user-app';
+
+interface CapturedBatch {
+  batch: Array<{ event: string; properties: Record<string, unknown> }>;
+}
+
+describe('socket-level POST failures are countable on the session summary', () => {
+  it('counts a failure and a retry that then delivered, and omits both when none happened', () => {
+    const m = new SessionMetrics(() => 0);
+    expect(m.summarize(true).postSocketFailures).toBeUndefined();
+    expect(m.summarize(true).postRetriesSaved).toBeUndefined();
+    m.recordPostSocketFailure();
+    m.recordPostRetrySaved();
+    const s = m.summarize(true);
+    expect(s.postSocketFailures).toBe(1);
+    expect(s.postRetriesSaved).toBe(1);
+  });
+
+  it('an idle rollup is empty so a proxy that never hit the socket does not emit', () => {
+    expect(new SessionMetrics(() => 0).empty).toBe(true);
+  });
+
+  it('a rollup with only socket failures is not empty — that is the whole signal', () => {
+    const m = new SessionMetrics(() => 0);
+    m.recordPostSocketFailure();
+    expect(m.empty).toBe(false);
+  });
+});
+
+describe('the proxy flushes those counts on an existing event, and awaits the send', () => {
+  it('emits session_progress with session_postSocketFailures on the wire', async () => {
+    const calls: CapturedBatch[] = [];
+    const fetchImpl = ((_url: string, init: { body?: string }) => {
+      calls.push(JSON.parse(init.body ?? '{}') as CapturedBatch);
+      return Promise.resolve(new Response(null, { status: 200 }));
+    }) as unknown as typeof fetch;
+    const telemetry = createTelemetry({
+      version: '9.9.9',
+      env: { ...TEST_ENV, RETICLE_TELEMETRY: '1' },
+      fetchImpl,
+      cwd: USER_PROJECT,
+    });
+    const metrics = new SessionMetrics(() => 0);
+    metrics.recordPostSocketFailure();
+    metrics.recordPostRetrySaved();
+    await flushProxySessionMetrics(telemetry, metrics);
+    expect(calls).toHaveLength(1);
+    const properties = calls[0]?.batch[0]?.properties ?? {};
+    expect(calls[0]?.batch[0]?.event).toBe(TelemetryEventKind.SESSION_PROGRESS);
+    expect(properties.session_postSocketFailures, 'the count was dropped').toBe(1);
+    expect(properties.session_postRetriesSaved, 'the saved-retry count was dropped').toBe(1);
+  });
+
+  it('emits nothing when the proxy never saw a socket failure', async () => {
+    let sent = 0;
+    const fetchImpl = (() => {
+      sent += 1;
+      return Promise.resolve(new Response(null, { status: 200 }));
+    }) as unknown as typeof fetch;
+    const telemetry = createTelemetry({
+      version: '9.9.9',
+      env: { ...TEST_ENV, RETICLE_TELEMETRY: '1' },
+      fetchImpl,
+      cwd: USER_PROJECT,
+    });
+    await flushProxySessionMetrics(telemetry, new SessionMetrics(() => 0));
+    expect(sent).toBe(0);
+  });
+});

--- a/packages/server/src/telemetry/proxy-telemetry.ts
+++ b/packages/server/src/telemetry/proxy-telemetry.ts
@@ -1,0 +1,24 @@
+/**
+ * The MCP proxy's session rollup.
+ *
+ * POST socket failures (`ENOBUFS`, `EMFILE`, `ECONNREFUSED` before any bytes were sent) happen in
+ * this process, not the daemon's. `tool_refused` never fires (the handler never ran) and
+ * `mcp_connection_lost` never fires (the SSE stream is fine). Counts live on SessionMetrics here
+ * and leave as one `session_progress` — an existing kind, omitted when nothing happened.
+ *
+ * The send is awaited. Fire-and-forget microseconds before `process.exit` is how `daemon_stopped`
+ * never arrived: the POST was killed every time and nothing threw.
+ */
+import { TelemetryEventKind } from '@reticlehq/core';
+import { getSessionMetrics, type SessionMetrics } from './session-metrics.js';
+import { getTelemetry, type Telemetry } from './telemetry.js';
+
+export async function flushProxySessionMetrics(
+  telemetry: Telemetry = getTelemetry(),
+  metrics: SessionMetrics = getSessionMetrics(),
+): Promise<void> {
+  if (metrics.empty) return;
+  await telemetry.emit(TelemetryEventKind.SESSION_PROGRESS, {
+    session: metrics.summarize(true),
+  });
+}

--- a/packages/server/src/telemetry/session-metrics.ts
+++ b/packages/server/src/telemetry/session-metrics.ts
@@ -134,6 +134,12 @@ export class SessionMetrics {
    * call a tool, and of the sessions that made exactly one call, most bounced on this.
    */
   #noSessionErrors = 0;
+  /** Connection-level MCP POST failures the SSE stream cannot see. See SessionSummary. */
+  #postSocketFailures = 0;
+  #lifetimePostSocketFailures = 0;
+  /** Retries of those POSTs that then delivered. */
+  #postRetriesSaved = 0;
+  #lifetimePostRetriesSaved = 0;
   /** Longest back-to-back run per tool — a retry loop, which `toolCounts` cannot distinguish. */
   readonly #repeatRuns = new Map<string, number>();
   #lastTool: string | undefined;
@@ -335,6 +341,26 @@ export class SessionMetrics {
     });
   }
 
+  /**
+   * The MCP proxy could not POST a tool call because the TCP socket itself failed (`ENOBUFS`,
+   * `EMFILE`, `ECONNREFUSED` before any bytes left). The SSE stream is still up, so this is
+   * invisible to `mcp_connection_lost`, and the handler never ran, so it is invisible to
+   * `tool_refused`. Counted so a dashboard can see it without a new event kind.
+   */
+  recordPostSocketFailure(): void {
+    this.#postSocketFailures += 1;
+    this.#lifetimePostSocketFailures += 1;
+  }
+
+  /**
+   * A bounded retry of an unsent POST then delivered. The pair against `recordPostSocketFailure`:
+   * the retry that quietly saved a call is a different fact from the one that never ran.
+   */
+  recordPostRetrySaved(): void {
+    this.#postRetriesSaved += 1;
+    this.#lifetimePostRetriesSaved += 1;
+  }
+
   /** The agent's recent approach run + the call in flight — context for a crash report. */
   get trail(): { breadcrumb: string[]; inFlight: string | undefined } {
     return { breadcrumb: [...this.#breadcrumb], inFlight: this.#inFlight };
@@ -490,12 +516,16 @@ export class SessionMetrics {
           toolErrors: this.#lifetimeToolErrors,
           verifications: this.#lifetimeVerifications,
           bugsFound: this.#lifetimeBugsFound,
+          postSocketFailures: this.#lifetimePostSocketFailures,
+          postRetriesSaved: this.#lifetimePostRetriesSaved,
         }
       : {
           toolCalls: this.#toolCalls,
           toolErrors: this.#toolErrors,
           verifications: this.#verifications,
           bugsFound: this.#bugsFound,
+          postSocketFailures: this.#postSocketFailures,
+          postRetriesSaved: this.#postRetriesSaved,
         };
     return {
       durationMs: Math.max(0, this.#now() - this.#startedAt),
@@ -509,6 +539,8 @@ export class SessionMetrics {
       bugsFound: scalars.bugsFound,
       ...(this.#bugKinds.size > 0 ? { bugKinds: Object.fromEntries(this.#bugKinds) } : {}),
       ...(this.#noSessionErrors > 0 ? { noSessionErrors: this.#noSessionErrors } : {}),
+      ...(scalars.postSocketFailures > 0 ? { postSocketFailures: scalars.postSocketFailures } : {}),
+      ...(scalars.postRetriesSaved > 0 ? { postRetriesSaved: scalars.postRetriesSaved } : {}),
       ...(this.#repeatRuns.size > 0
         ? { consecutiveRepeats: Object.fromEntries(this.#repeatRuns) }
         : {}),
@@ -610,7 +642,9 @@ export class SessionMetrics {
       0 === this.#verifications &&
       0 === this.#toolErrors &&
       0 === this.#bugsFound &&
-      0 === this.#sdkFailures
+      0 === this.#sdkFailures &&
+      0 === this.#postSocketFailures &&
+      0 === this.#postRetriesSaved
     );
   }
 
@@ -620,6 +654,8 @@ export class SessionMetrics {
     this.#toolErrors = 0;
     this.#verifications = 0;
     this.#noSessionErrors = 0;
+    this.#postSocketFailures = 0;
+    this.#postRetriesSaved = 0;
     this.#repeatRuns.clear();
     this.#lastTool = undefined;
     this.#currentRun = 0;


### PR DESCRIPTION
## Summary
- A tool call killed by `ENOBUFS` / `EMFILE` / `EADDRNOTAVAIL` / `ECONNREFUSED` before any bytes were sent never produced `tool_refused` (the handler never ran) and never produced `mcp_connection_lost` (the SSE stream is fine), so #609's keep-alive retry could not be confirmed in the field.
- `postSocketFailures` and `postRetriesSaved` ride the existing session summary, omitted when zero. The MCP proxy records them on POST error / successful retry and awaits a `session_progress` flush on stdin end, so `process.exit` cannot kill the send the way `daemon_stopped` once was.

Closes #623

## Test plan
- [x] `pnpm --filter @reticlehq/core --filter @reticlehq/server lint`
- [x] `pnpm --filter @reticlehq/core --filter @reticlehq/server typecheck`
- [x] targeted unit: `proxy-telemetry`, `mcp-post-transport`, `telemetry-contract`, `docs-index-coverage`, `e2e-surface-drift`
- [ ] CI `verify` on this PR