### PR TITLE
fix(cli): allow verify to target a session

### DIFF
--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -200,6 +200,23 @@ describe('parseCliArgs', () => {
     });
   });
 
+  it('verify --session-id targets one connected session', () => {
+    expect(parseCliArgs(['verify', URL, '--session-id', 's2'], PORT)).toEqual({
+      kind: 'verify',
+      url: URL,
+      headless: true,
+      sessionId: 's2',
+      port: PORT,
+    });
+  });
+
+  it('verify --session-id with no id names the flag', () => {
+    expect(parseCliArgs(['verify', URL, '--session-id'], PORT)).toEqual({
+      kind: 'error',
+      message: '--session-id needs a value',
+    });
+  });
+
   it('verify keeps the resolved default port (RETICLE_PORT / .reticle.json)', () => {
     // cli.ts already folds env + .reticle.json into parseCliArgs's defaultPort. Dropping port
     // from the verify result made handleVerify fall back to 4400 anyway, so a project on any

--- a/packages/server/src/cli/cli-parse.ts
+++ b/packages/server/src/cli/cli-parse.ts
@@ -37,7 +37,7 @@ export const CLI_USAGE = `usage:  npx @reticlehq/server <command>   (or \`reticl
   reticle status [--port N]
   reticle doctor [--port N]                            (one command to diagnose setup: Chromium, daemon, port)
   reticle open  [url] [--port N]                        (show the app: reuse the connected tab, else open one)
-  reticle verify <url> [--port N] [--headed] [--timeout N] [--storage-state <file>]  (one-shot: drive the URL, verify saved flows, exit 0=pass)
+  reticle verify <url> [--port N] [--headed] [--timeout N] [--storage-state <file>] [--session-id <id>]  (one-shot: drive the URL, verify saved flows, exit 0=pass)
   reticle affected [--since <ref>] [file...]           (which saved flows must re-verify for the changed files)
   reticle gate [--since <ref>] [file...]               (exit non-zero unless passing artifacts cover the affected flows)
   reticle watch [url]                                  (on save, report which saved flows must re-verify)
@@ -177,6 +177,7 @@ export const HTTP_PORT_FLAG = '--http-port';
 export const HTTP_TOKEN_FLAG = '--http-token';
 const TIMEOUT_FLAG = '--timeout';
 const STORAGE_STATE_FLAG = '--storage-state';
+const SESSION_ID_FLAG = '--session-id';
 
 export type CliResult =
   | {
@@ -225,6 +226,7 @@ export type CliResult =
       port: number;
       timeoutMs?: number;
       storageState?: string;
+      sessionId?: string;
     }
   | { kind: 'affected'; files: string[]; since?: string }
   | { kind: 'hunt'; dir: string }
@@ -399,11 +401,12 @@ type VerifySuffix =
       port: number;
       timeoutMs?: number;
       storageState?: string;
+      sessionId?: string;
     }
   | { kind: 'error'; message: string };
 
 /**
- * Parse `verify <url> [--port N] [--headed] [--timeout N] [--storage-state <file>]`. The first
+ * Parse `verify <url> [--port N] [--headed] [--timeout N] [--storage-state <file>] [--session-id <id>]`. The first
  * non-flag token is the preview URL. `defaultPort` is already env + `.reticle.json` + 4400.
  */
 function parseVerifySuffix(args: string[], defaultPort: number): VerifySuffix {
@@ -411,6 +414,7 @@ function parseVerifySuffix(args: string[], defaultPort: number): VerifySuffix {
   let url: string | undefined;
   let timeoutMs: number | undefined;
   let storageState: string | undefined;
+  let sessionId: string | undefined;
   let port = defaultPort;
   let i = 0;
   while (i < args.length) {
@@ -437,6 +441,11 @@ function parseVerifySuffix(args: string[], defaultPort: number): VerifySuffix {
       const v = args[i];
       if (v === undefined) return missingValue(STORAGE_STATE_FLAG);
       storageState = v;
+    } else if (arg === SESSION_ID_FLAG) {
+      i++;
+      const v = args[i];
+      if (v === undefined) return missingValue(SESSION_ID_FLAG);
+      sessionId = v;
     } else if (arg.startsWith('--')) {
       return unknownArgument(arg);
     } else if (url === undefined) {
@@ -454,6 +463,7 @@ function parseVerifySuffix(args: string[], defaultPort: number): VerifySuffix {
     port,
     ...(timeoutMs !== undefined ? { timeoutMs } : {}),
     ...(storageState !== undefined ? { storageState } : {}),
+    ...(sessionId !== undefined ? { sessionId } : {}),
   };
 }
 
@@ -681,6 +691,7 @@ export function parseCliArgs(
         port: r.port,
         ...(r.timeoutMs !== undefined ? { timeoutMs: r.timeoutMs } : {}),
         ...(r.storageState !== undefined ? { storageState: r.storageState } : {}),
+        ...(r.sessionId !== undefined ? { sessionId: r.sessionId } : {}),
       };
     }
     case CAPSULES_COMMAND:

--- a/packages/server/src/cli/cli-verify.test.ts
+++ b/packages/server/src/cli/cli-verify.test.ts
@@ -109,6 +109,18 @@ describe('runVerify', () => {
     expect(rec.closed).toBe(1);
   });
 
+  it('passes the selected session id to flow replay', async () => {
+    let selectedSessionId: string | undefined;
+    const { ports } = harness({
+      verify: (sessionId?: string) => {
+        selectedSessionId = sessionId;
+        return Promise.resolve(makeRun(RunFlowStatus.PASS));
+      },
+    });
+    await runVerify({ ...ARGS, sessionId: 's2' }, ports);
+    expect(selectedSessionId).toBe('s2');
+  });
+
   it('exits 1 when a flow fails', async () => {
     const { ports, rec } = harness({ verify: () => Promise.resolve(makeRun(RunFlowStatus.FAIL)) });
     await runVerify(ARGS, ports);

--- a/packages/server/src/cli/cli-verify.ts
+++ b/packages/server/src/cli/cli-verify.ts
@@ -70,7 +70,7 @@ export interface VerifyConnection {
   /** Resolve true once a browser session has connected, or false at timeout. */
   sessionReady(timeoutMs: number): Promise<boolean>;
   listFlows(): Promise<string[]>;
-  verify(): Promise<ReticleVerificationRun>;
+  verify(sessionId?: string): Promise<ReticleVerificationRun>;
   close(): Promise<void>;
 }
 
@@ -84,6 +84,7 @@ export interface VerifyPorts {
 interface VerifyArgs {
   url: string;
   timeoutMs: number;
+  sessionId?: string;
 }
 
 function errMessage(error: unknown): string {
@@ -117,7 +118,7 @@ export async function runVerify(args: VerifyArgs, ports: VerifyPorts): Promise<v
       ports.exit(EXIT_FAIL);
       return;
     }
-    const run = await conn.verify();
+    const run = await conn.verify(args.sessionId);
     await pushRunToCloud(run, ports); // best-effort; opt-in; never changes the verdict or exit code
     ports.out(renderRunReport(run));
     ports.exit(run.verdict.status === VerdictStatus.PASS ? EXIT_PASS : EXIT_FAIL);
@@ -238,11 +239,11 @@ async function openLiveConnection(opts: LiveOpts): Promise<VerifyConnection> {
     ...(opts.storageState !== undefined ? { storageState: opts.storageState } : {}),
   });
   const deps = buildVerifyDeps(running, opts.reticleRoot, opts.now);
-  const runner = new ReticleRunner(createRunnerPort(deps));
   return {
     sessionReady: (timeoutMs) => waitForSession(deps.sessions, timeoutMs, opts.now),
     listFlows: () => deps.flows.list(),
-    verify: async () => {
+    verify: async (sessionId) => {
+      const runner = new ReticleRunner(createRunnerPort(deps, sessionId));
       const run = await runner.verify({
         project: { name: opts.projectName, framework: RunFramework.OTHER, previewUrl: opts.url },
         agent: { id: VERIFY_AGENT_ID, kind: RunAgentKind.OEM_PIPELINE },
@@ -302,6 +303,7 @@ export function handleVerify(parsed: {
   headless: boolean;
   timeoutMs?: number;
   storageState?: string;
+  sessionId?: string;
   /** Bridge port — parseCliArgs already resolves --port / RETICLE_PORT / .reticle.json into this. */
   port: number;
 }): void {
@@ -337,7 +339,11 @@ export function handleVerify(parsed: {
       return;
     }
     await runVerify(
-      { url: parsed.url, timeoutMs: parsed.timeoutMs ?? DEFAULT_SESSION_TIMEOUT_MS },
+      {
+        url: parsed.url,
+        timeoutMs: parsed.timeoutMs ?? DEFAULT_SESSION_TIMEOUT_MS,
+        ...(parsed.sessionId !== undefined ? { sessionId: parsed.sessionId } : {}),
+      },
       ports,
     );
   })();


### PR DESCRIPTION
## What & why

With more than one browser session connected, `reticle verify` can reach the session manager's ambiguity error:

> multiple sessions connected — pass sessionId to target one

That recovery was impossible from the CLI. The live runner already accepted an optional `sessionId`, but `parseVerifySuffix` rejected `--session-id` as an unknown argument, and the help text did not advertise any way to select a session. Closing every other tab was the only workaround.

This change closes that gap rather than weakening the ambiguity error:

- adds `--session-id <id>` to `reticle verify` parsing and help output;
- carries the optional value through `parseCliArgs` → `handleVerify` → `runVerify` → `VerifyConnection.verify`;
- passes it to the existing `createRunnerPort(deps, sessionId)` selection path;
- leaves the no-flag path unchanged, so a single connected session is still selected exactly as before.

The change is intentionally limited to the CLI and its tests. It does not alter the wire contract, MCP tool surface, browser behavior, telemetry, authentication, or session-resolution rules.

Closes #597

## How it was verified

Tests were added first for the missing behavior, then made green:

- parser accepts `reticle verify <url> --session-id s2` and preserves the selected id;
- parser reports `--session-id needs a value` when the value is omitted;
- `runVerify` forwards the selected id to the verification connection;
- existing no-session-id behavior remains covered by the pre-existing verify tests.

Local verification:

- `pnpm format:check` — passed;
- `pnpm lint` — passed;
- `pnpm typecheck` — passed;
- `pnpm --filter @reticlehq/server test:unit` — 5,509 passed, 3 skipped;
- `pnpm test:bench` — 210 passed;
- focused `cli.test.ts` + `cli-verify.test.ts` — 73 passed;
- `pnpm lint:docs` — 111 passed;
- `git diff --check` — passed.

An independent pre-commit review found no security concerns or logic errors and confirmed that the optional id reaches `createRunnerPort` while preserving the no-id path.

## Gates run

- [ ] `pnpm lint && pnpm typecheck && pnpm test:unit` (~2 min — **always**) — lint and typecheck passed; the monorepo `test:unit` wrapper exceeded the local tool's 420-second execution cap, so I am not claiming this combined gate as green. The changed server package and the root benchmark suite passed separately with the counts above.
- [ ] `pnpm test:e2e` (~8 min) — _touched the tool surface, `packages/core`, an observer, or telemetry_
- [ ] `pnpm gate:install` (~15 min) — _touched `reticle init`, `vite-plugin`, `next`, or `babel-plugin`_
- [ ] `pnpm test:e2e:desktop` (~3 min) — _touched `packages/electron`, `packages/tauri`, or desktop capture_
- [x] None of the additional tiers apply to this CLI-only change

## Checklist

- [x] **Every commit is signed off** (`git commit -s`) — commit `337f19a0` contains a matching `Signed-off-by` trailer
- [x] Tests added/updated (RED → GREEN); the change is covered by tests that fail without it
- [x] No `any`, no free wire strings, and no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed source/test file is under the 1000-line cap
- [ ] Docs and `CHANGELOG.md` updated if this is user-facing — not yet present in the pushed PR diff
- [x] Security-affecting? No — this does not change auth, redaction, origin policy, trust boundaries, or data leaving the machine

## Risk

Low. `sessionId` is optional at every new boundary, and omitting `--session-id` follows the existing runner construction and session-resolution behavior. An unknown id is still rejected by the existing session manager with its established diagnostic.
