### PR TITLE
fix(server): spend the caller's timeout_ms waiting for a session, not refusing at t=0

### DIFF
--- a/packages/server/src/session/session-manager.ts
+++ b/packages/server/src/session/session-manager.ts
@@ -18,6 +18,20 @@ interface ResolveScope {
   url?: string;
 }
 
+/**
+ * Thrown by `resolve` for the one refusal that TIME can fix: nothing is connected at all.
+ *
+ * Every other refusal is a fact about sessions that already exist — an unknown id, two candidate
+ * tabs, a session outside the scoped project — and waiting turns an instant accurate answer into the
+ * same answer N seconds later. This one is the app not being back YET, which is what a caller
+ * passing `timeout_ms` is asking to wait through (see `resolveWaitingForSession`).
+ *
+ * A subclass rather than a message check: the message here is frequently REPLACED by a richer
+ * diagnosis from `#noSessionHint`, so there is no stable text to match on, and matching the default
+ * wording would silently stop waiting exactly when the daemon knows most about why.
+ */
+export class NoSessionConnectedError extends Error {}
+
 /** The scheme://host:port of a URL, or undefined if it can't be parsed. Used to compare origins. */
 export function originOf(url: string | undefined): string | undefined {
   if (url === undefined) return undefined;
@@ -387,7 +401,7 @@ export class SessionManager {
         closure === undefined
           ? ''
           : ` NOTE: the bridge REFUSED or closed a connection recently — "${closure.reason}". The app is probably still running and trying to connect: it was turned away, and the SDK does not retry after a policy close. The reason above names the fix — do not go looking for a stopped dev server.`;
-      throw new Error(`${hint ?? NO_SESSION_CONNECTED_ERROR}${refusal}`);
+      throw new NoSessionConnectedError(`${hint ?? NO_SESSION_CONNECTED_ERROR}${refusal}`);
     }
     // Scope to the agent's active project FIRST, so a stray tab from another app/origin (e.g. a
     // leftover dashboard on a different port) is structurally unselectable — it never enters the

--- a/packages/server/src/session/session-wait.test.ts
+++ b/packages/server/src/session/session-wait.test.ts
@@ -1,0 +1,91 @@
+/**
+ * `timeout_ms` was inert when there was no session yet.
+ *
+ * `reticle_assert`, `reticle_wait_for` and `reticle_act_and_wait` resolved a session as their FIRST
+ * statement, so `resolve`'s no-session error was raised before the timeout argument was read. A
+ * caller that said "wait up to N seconds for this to hold" was refused in under a millisecond
+ * because the app was not back YET, and the only workaround was polling `reticle_sessions` blind —
+ * the same wait, done by hand, one round trip at a time.
+ *
+ * The distinction these pin is which refusals are worth waiting through. "Nothing is connected" is
+ * the app not being back yet. "Two tabs are connected" or "that id is unknown" are facts about
+ * sessions that already exist, and waiting only delays an answer that was already correct.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { resolveWaitingForSession } from './session-wait.js';
+import { NoSessionConnectedError, type SessionManager } from './session-manager.js';
+import type { Session } from './session.js';
+
+const SESSION = { id: 's-1' } as Session;
+
+/** A manager whose `resolve` refuses `failures` times, then succeeds. */
+function connectsAfter(failures: number, error: () => Error): SessionManager {
+  let calls = 0;
+  const resolve = (): Session => {
+    calls += 1;
+    if (calls <= failures) throw error();
+    return SESSION;
+  };
+  return { resolve, calls: () => calls } as unknown as SessionManager;
+}
+
+const noSession = (): Error => new NoSessionConnectedError('nothing is connected');
+const ambiguous = (): Error =>
+  new Error('multiple sessions connected — pass sessionId to target one');
+
+describe('a wait spends the budget it was given', () => {
+  it('returns the session that arrives during the timeout', async () => {
+    const sessions = connectsAfter(3, noSession);
+
+    const session = await resolveWaitingForSession(sessions, 5_000);
+
+    expect(session).toBe(SESSION);
+  });
+
+  it('refuses at once when the caller asked to wait for nothing', async () => {
+    // timeout_ms 0 is a documented mode — evaluate now, do not wait — so it must stay instant.
+    const sessions = connectsAfter(1, noSession);
+
+    await expect(resolveWaitingForSession(sessions, 0)).rejects.toThrow('nothing is connected');
+    expect((sessions as unknown as { calls: () => number }).calls()).toBe(1);
+  });
+
+  it('gives up with resolve\'s own diagnosis, not a thinner "timed out"', async () => {
+    // The daemon replaces this message with a real diagnosis when it has one — which of the three
+    // causes this is. A wait that swallowed it would discard the most useful thing on the call.
+    const sessions = connectsAfter(Number.MAX_SAFE_INTEGER, () =>
+      Object.assign(new NoSessionConnectedError('the app is not dialling this daemon'), {}),
+    );
+
+    await expect(resolveWaitingForSession(sessions, 250)).rejects.toThrow(
+      'the app is not dialling this daemon',
+    );
+  });
+});
+
+describe('only the refusal that TIME can fix is waited through', () => {
+  it('re-throws an ambiguity immediately — a second tab is not a slow connect', async () => {
+    // Waiting here would turn an instant, accurate answer into the same answer N seconds later.
+    const sessions = connectsAfter(1, ambiguous);
+
+    await expect(resolveWaitingForSession(sessions, 30_000)).rejects.toThrow(
+      'multiple sessions connected',
+    );
+    expect((sessions as unknown as { calls: () => number }).calls()).toBe(1);
+  });
+
+  it('does not busy-loop: it polls, rather than hammering resolve', async () => {
+    vi.useFakeTimers();
+    try {
+      const sessions = connectsAfter(Number.MAX_SAFE_INTEGER, noSession);
+      const pending = resolveWaitingForSession(sessions, 1_000).catch(() => undefined);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await pending;
+
+      // 1s of budget at a 100ms poll is ~11 attempts, not thousands.
+      expect((sessions as unknown as { calls: () => number }).calls()).toBeLessThan(20);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/server/src/session/session-wait.ts
+++ b/packages/server/src/session/session-wait.ts
@@ -1,0 +1,55 @@
+/**
+ * Spend a caller's `timeout_ms` waiting for the app to come back, instead of refusing instantly.
+ *
+ * `reticle_assert`, `reticle_wait_for` and `reticle_act_and_wait` all resolved a session as their
+ * FIRST statement, so `resolve`'s no-session error was raised before the timeout argument was even
+ * read. A caller that said "wait up to 30s for this to hold" was refused in under a millisecond
+ * because the app was not back yet — and the documented workaround was polling `reticle_sessions`
+ * blind, which is this same wait with the waiting done by hand, one round trip at a time.
+ *
+ * Measured against the case that motivates it: a Nuxt SPA with HMR active reattaches in 30–60s.
+ * Anything that refuses at t=0 is guaranteed to miss it.
+ */
+import { NoSessionConnectedError, type SessionManager } from './session-manager.js';
+import type { Session } from './session.js';
+
+/**
+ * How often to look for a session that has not arrived yet.
+ *
+ * A connect is a websocket handshake, not a computation: checking costs a `Map` lookup, while
+ * checking too slowly adds dead time to every reconnect an agent sits through.
+ */
+const SESSION_ARRIVAL_POLL_MS = 100;
+
+const sleep = (ms: number): Promise<void> => new Promise((resume) => setTimeout(resume, ms));
+
+/**
+ * Resolve a session, waiting up to `timeoutMs` for a first one to connect.
+ *
+ * Only `NoSessionConnectedError` is waited through. Every other refusal `resolve` raises is about
+ * sessions that already exist and is re-thrown at once, because no amount of waiting changes it.
+ *
+ * The final attempt's error is what reaches the caller, so a session that never arrives still gets
+ * `resolve`'s full diagnosis — which names which of the three causes this is — rather than a thinner
+ * "timed out" that throws that diagnosis away.
+ *
+ * @param sessions The manager to resolve against.
+ * @param timeoutMs Budget for a session to appear. `<= 0` is exactly the old behaviour.
+ * @param sessionId Optional explicit target, passed straight through to `resolve`.
+ */
+export async function resolveWaitingForSession(
+  sessions: SessionManager,
+  timeoutMs: number,
+  sessionId?: string,
+): Promise<Session> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      return sessions.resolve(sessionId);
+    } catch (error) {
+      const waitable = error instanceof NoSessionConnectedError && Date.now() < deadline;
+      if (!waitable) throw error;
+    }
+    await sleep(SESSION_ARRIVAL_POLL_MS);
+  }
+}

--- a/packages/server/src/tools/act-tools.ts
+++ b/packages/server/src/tools/act-tools.ts
@@ -1,5 +1,6 @@
 import { normalizeQueryArgs } from './query-shape.js';
 import type { Session } from '../session/session.js';
+import { resolveWaitingForSession } from '../session/session-wait.js';
 import { resolveTargetRef, type TargetResolution } from './resolve-target.js';
 /**
  * Action tools — reticle_act, reticle_act_sequence, reticle_act_and_wait. Split out of tools.ts to keep
@@ -477,7 +478,14 @@ export const ACT_TOOLS: ToolDef[] = [
       ...pausedOutputShape,
     },
     handler: async (deps, args) => {
-      let session = deps.sessions.resolve(asString(args['sessionId']));
+      // Resolved with the caller's budget in hand so a reconnecting app is waited for rather than
+      // refused because it is not back YET. `timeout` is re-read below with the other arguments;
+      // this one is needed before anything can be resolved. See resolveWaitingForSession.
+      let session = await resolveWaitingForSession(
+        deps.sessions,
+        asNumber(args['timeout_ms']) ?? DEFAULT_ASSERT_TIMEOUT_MS,
+        asString(args['sessionId']),
+      );
       const acted = session;
       const actedSessionId = session.id;
       // Live-control: refuse to drive the page (no act, no predicate eval) while paused.

--- a/packages/server/src/tools/assert-waits-for-session.test.ts
+++ b/packages/server/src/tools/assert-waits-for-session.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The wiring half of the inert-`timeout_ms` defect.
+ *
+ * `session-wait.test.ts` pins what the wait DOES. This pins that the tools reach it at all: each
+ * handler resolved a session as its first statement, so the no-session error was raised before the
+ * timeout argument had been read. The bug was the ORDER of two lines, and only a test that drives
+ * the tool can see the order — a helper can be perfect and still be called too late.
+ *
+ * The manager here refuses once, the way a daemon does while an app is still reconnecting, then
+ * answers. A handler that resolves before reading `timeout_ms` fails on the first refusal.
+ */
+import { describe, it, expect } from 'vitest';
+import { LastAct } from '../session/last-act.js';
+import { PredicateKind, ReticleCommand, SessionState, type CommandResult } from '@reticlehq/core';
+import { TOOLS, type ToolDeps } from './tools.js';
+import { ReticleTool } from './tool-names.js';
+import { NoSessionConnectedError } from '../session/session-manager.js';
+import type { Session, SessionManager } from '../session/session.js';
+
+/** Deps whose `resolve` refuses `refusals` times before the app reconnects. */
+function depsConnectingAfter(refusals: number): ToolDeps {
+  const stub: Partial<Session> = {
+    id: 'demo',
+    command: (name: string): Promise<CommandResult> =>
+      Promise.resolve({
+        kind: 'command_result',
+        id: 'c',
+        ok: true,
+        result:
+          name === ReticleCommand.MATCH
+            ? {
+                matched: true,
+                count: 1,
+                elements: [{ ref: 'e1', role: 'button', name: 'X', states: [], visible: true }],
+              }
+            : {},
+      }),
+    eventsSince: () => [],
+    // The waiting path subscribes; the predicate here is already true, so it never fires.
+    onEvent: () => () => undefined,
+    throttled: () => false,
+    health: () => ({ lastSeenMs: 0, throttled: false, focused: true }),
+    bufferHealth: () => ({ total: 0, dropped: 0 }),
+    recordAction: () => 'a1',
+    lastAct: new LastAct(),
+    queryEvents: () => Promise.resolve([]),
+    blindSpots: () => ({}),
+    getState: () => SessionState.ACTIVE,
+    drainInbox: () => [],
+  };
+  let calls = 0;
+  const sessions: Partial<SessionManager> = {
+    resolve: () => {
+      calls += 1;
+      if (calls <= refusals) throw new NoSessionConnectedError('nothing is connected');
+      return stub as Session;
+    },
+  };
+  return { sessions: sessions as SessionManager } as ToolDeps;
+}
+
+function toolNamed(name: string) {
+  const tool = TOOLS.find((t) => t.name === name);
+  if (tool === undefined) throw new Error(`no ${name} tool`);
+  return tool;
+}
+
+const PRESENT = { kind: PredicateKind.ELEMENT, query: { role: 'button', name: 'X' } };
+
+describe('a tool given timeout_ms waits for the app to reconnect', () => {
+  it('reticle_assert reaches a verdict instead of refusing at t=0', async () => {
+    const deps = depsConnectingAfter(2);
+
+    const out = (await toolNamed(ReticleTool.ASSERT).handler(deps, {
+      predicate: PRESENT,
+      timeout_ms: 5_000,
+    })) as Record<string, unknown>;
+
+    expect(out['verified']).toBeDefined();
+  });
+
+  it('reticle_wait_for reaches a verdict instead of refusing at t=0', async () => {
+    const deps = depsConnectingAfter(2);
+
+    const out = (await toolNamed(ReticleTool.WAIT_FOR).handler(deps, {
+      predicate: PRESENT,
+      timeout_ms: 5_000,
+    })) as Record<string, unknown>;
+
+    // wait_for answers with the raw verdict rather than assert's `verified` wording.
+    expect(out['pass']).toBe(true);
+  });
+
+  it('reticle_assert with timeout_ms 0 still refuses at once', async () => {
+    // The documented no-wait mode: evaluate now. It must not start waiting just because a wait
+    // became possible -- that would turn an instant answer into a hang on a genuinely dead app.
+    const deps = depsConnectingAfter(1);
+
+    await expect(
+      toolNamed(ReticleTool.ASSERT).handler(deps, { predicate: PRESENT, timeout_ms: 0 }),
+    ).rejects.toThrow('nothing is connected');
+  });
+});

--- a/packages/server/src/tools/observe-tools.ts
+++ b/packages/server/src/tools/observe-tools.ts
@@ -66,6 +66,7 @@ import {
 } from '../intent/inline-intent.js';
 import { bodiesNotCaptured } from '../honesty/uncaptured-bodies.js';
 import { withControl } from '../session/control-envelope.js';
+import { resolveWaitingForSession } from '../session/session-wait.js';
 import { asString, asNumber, asRecord } from './tools-helpers.js';
 import { type ToolDef, intentArg, sessionIdShape, commandOrThrow } from './tool-kit.js';
 import { gradeOfPredicate } from './assert-grade.js';
@@ -334,17 +335,19 @@ export const OBSERVE_TOOLS: ToolDef[] = [
         ),
     },
     handler: async (deps, args) => {
-      const session = deps.sessions.resolve(asString(args['sessionId']));
+      const timeout = asNumber(args['timeout_ms']) ?? DEFAULT_ASSERT_TIMEOUT_MS;
+      // Spend the caller's budget waiting for the app to come back, rather than refusing because it
+      // is not back YET — see resolveWaitingForSession.
+      const session = await resolveWaitingForSession(
+        deps.sessions,
+        timeout,
+        asString(args['sessionId']),
+      );
       // `until` is act_and_wait's name for this — see alias-args.ts.
       const predicate = parsePredicate(aliasParam(args, 'predicate', ['until'])['predicate']);
       // Honesty: explicit since wins; else default to the last act's cursor; else the whole buffer.
       const since = asNumber(args['since']) ?? session.lastAct.cursor() ?? 0;
-      const verdict = await waitForPredicate(
-        session,
-        predicate,
-        asNumber(args['timeout_ms']) ?? DEFAULT_ASSERT_TIMEOUT_MS,
-        since,
-      );
+      const verdict = await waitForPredicate(session, predicate, timeout, since);
       // match reticle_assert — wrap with control + session health (throttle matters most while blocking)
       // and the buffer envelope, so a verdict reached over an evicted window says so.
       return withControl(session, {
@@ -456,10 +459,17 @@ export const OBSERVE_TOOLS: ToolDef[] = [
         ),
     },
     handler: async (deps, args) => {
-      const session = deps.sessions.resolve(asString(args['sessionId']));
+      const timeout = asNumber(args['timeout_ms']) ?? 0;
+      // Spend the caller's budget waiting for the app to come back, rather than refusing because it
+      // is not back YET. With no timeout this is exactly the old call — an assertion that asked to
+      // wait for nothing still refuses at once. See resolveWaitingForSession.
+      const session = await resolveWaitingForSession(
+        deps.sessions,
+        timeout,
+        asString(args['sessionId']),
+      );
       // `until` is act_and_wait's name for this — see alias-args.ts.
       const predicate = parsePredicate(aliasParam(args, 'predicate', ['until'])['predicate']);
-      const timeout = asNumber(args['timeout_ms']) ?? 0;
       // Honesty: explicit since wins; else default to the last act's cursor; else the whole buffer.
       const since = asNumber(args['since']) ?? session.lastAct.cursor() ?? 0;
       // Declared BEFORE the verdict, so the undeclared-change read below finds it open and stays


### PR DESCRIPTION
Fixes #612.

`reticle_assert`, `reticle_wait_for` and `reticle_act_and_wait` each resolved a session as their **first statement**, so `resolve`'s no-session error was raised before `timeout_ms` had been read. A caller that said "wait up to 30s for this to hold" was refused in under a millisecond because the app was not back *yet* — and the documented workaround, polling `reticle_sessions`, is this same wait done by hand, one round trip at a time. The budget was the only instruction the caller gave.

## Which refusals are worth waiting through

Only the one that time can fix. "Nothing is connected" is the app not being back yet. An unknown `sessionId`, two candidate tabs, or a session outside the scoped project are facts about sessions that **already exist** — waiting there turns an instant, accurate answer into the same answer N seconds later.

Telling them apart needs the condition to be identifiable, and the message is not: `#noSessionHint` frequently *replaces* it with a richer diagnosis, so a message check would stop waiting exactly when the daemon knows most about why nothing is connected. `resolve` now throws a `NoSessionConnectedError` for that one branch — still an `Error`, same message, every existing `catch` unaffected — and the wait matches on the type.

## Why a free function rather than a `SessionManager` method

Not only to spare the fixtures. Waiting is a policy of the tools that *accept* a timeout, not of the registry, and keeping `resolve` synchronous keeps the ~40 call sites that cannot wait honest about it. The last attempt's error propagates, so an app that never comes back still gets `resolve`'s full diagnosis rather than a thinner "timed out" that throws it away.

`timeout_ms: 0` is unchanged and still refuses at once — it is the documented evaluate-now mode, and waiting there would turn an instant answer into a hang against a genuinely dead app.

## Tests

Two layers, because a helper can be correct and still be called too late — the defect was the order of two lines.

- **`session-wait.test.ts`** — what the wait does: returns a session arriving inside the budget; re-throws an ambiguity immediately without spending any of it; keeps `resolve`'s diagnosis on expiry; polls rather than busy-loops.
- **`assert-waits-for-session.test.ts`** — drives the tools against a manager that refuses twice, the way a daemon does mid-reconnect. Both reach a verdict; `timeout_ms: 0` still refuses.

Confirmed red before the change (the two tool-level cases fail; the `timeout_ms: 0` guard passes both ways, which is the point of it).

## Out of scope

`reticle_navigate`'s fixed 5s reattach budget. The issue notes it as reachable by the same argument, but it is a different call with its own default and belongs in its own change.

## Gates

`pnpm lint`, `pnpm typecheck`, `pnpm format:check` and `pnpm test:unit` all green (server 5517 passed, core 321 passed).