### PR TITLE
fix(cli): give `verify` the --session-id flag its own error tells you to pass

### DIFF
--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -245,6 +245,43 @@ describe('parseCliArgs', () => {
     });
   });
 
+  // The ambiguity error `sessions.resolve` throws when several tabs are connected reads "pass
+  // sessionId to target one" — and the verify parser used to reject every flag that could carry
+  // one, so the only action the message prescribed was one the CLI could not perform. The
+  // workaround was closing tabs until the ambiguity went away.
+  it('verify <url> --session-id targets one of several connected tabs', () => {
+    expect(parseCliArgs(['verify', URL, '--session-id', 's-42'], PORT)).toEqual({
+      kind: 'verify',
+      url: URL,
+      headless: true,
+      sessionId: 's-42',
+      port: PORT,
+    });
+  });
+
+  it('verify --session-id with no id names the flag', () => {
+    expect(parseCliArgs(['verify', URL, '--session-id'], PORT)).toEqual({
+      kind: 'error',
+      message: '--session-id needs a value',
+    });
+  });
+
+  it('verify carries --session-id alongside the other flags', () => {
+    expect(
+      parseCliArgs(
+        ['verify', URL, '--session-id', 's-42', '--headed', '--port', '4411', '--timeout', '9000'],
+        PORT,
+      ),
+    ).toEqual({
+      kind: 'verify',
+      url: URL,
+      headless: false,
+      sessionId: 's-42',
+      timeoutMs: 9000,
+      port: 4411,
+    });
+  });
+
   it('init with no flags defaults to mcp + install on, no dry run, no port', () => {
     expect(parseCliArgs(['init'], PORT)).toEqual({
       kind: 'init',

--- a/packages/server/src/cli/cli-parse.ts
+++ b/packages/server/src/cli/cli-parse.ts
@@ -37,7 +37,7 @@ export const CLI_USAGE = `usage:  npx @reticlehq/server <command>   (or \`reticl
   reticle status [--port N]
   reticle doctor [--port N]                            (one command to diagnose setup: Chromium, daemon, port)
   reticle open  [url] [--port N]                        (show the app: reuse the connected tab, else open one)
-  reticle verify <url> [--port N] [--headed] [--timeout N] [--storage-state <file>]  (one-shot: drive the URL, verify saved flows, exit 0=pass)
+  reticle verify <url> [--port N] [--headed] [--timeout N] [--storage-state <file>] [--session-id <id>]  (one-shot: drive the URL, verify saved flows, exit 0=pass)
   reticle affected [--since <ref>] [file...]           (which saved flows must re-verify for the changed files)
   reticle gate [--since <ref>] [file...]               (exit non-zero unless passing artifacts cover the affected flows)
   reticle watch [url]                                  (on save, report which saved flows must re-verify)
@@ -177,6 +177,7 @@ export const HTTP_PORT_FLAG = '--http-port';
 export const HTTP_TOKEN_FLAG = '--http-token';
 const TIMEOUT_FLAG = '--timeout';
 const STORAGE_STATE_FLAG = '--storage-state';
+const SESSION_ID_FLAG = '--session-id';
 
 export type CliResult =
   | {
@@ -225,6 +226,7 @@ export type CliResult =
       port: number;
       timeoutMs?: number;
       storageState?: string;
+      sessionId?: string;
     }
   | { kind: 'affected'; files: string[]; since?: string }
   | { kind: 'hunt'; dir: string }
@@ -399,18 +401,21 @@ type VerifySuffix =
       port: number;
       timeoutMs?: number;
       storageState?: string;
+      sessionId?: string;
     }
   | { kind: 'error'; message: string };
 
 /**
- * Parse `verify <url> [--port N] [--headed] [--timeout N] [--storage-state <file>]`. The first
- * non-flag token is the preview URL. `defaultPort` is already env + `.reticle.json` + 4400.
+ * Parse `verify <url> [--port N] [--headed] [--timeout N] [--storage-state <file>]
+ * [--session-id <id>]`. The first non-flag token is the preview URL. `defaultPort` is already
+ * env + `.reticle.json` + 4400.
  */
 function parseVerifySuffix(args: string[], defaultPort: number): VerifySuffix {
   let headless = true;
   let url: string | undefined;
   let timeoutMs: number | undefined;
   let storageState: string | undefined;
+  let sessionId: string | undefined;
   let port = defaultPort;
   let i = 0;
   while (i < args.length) {
@@ -437,6 +442,11 @@ function parseVerifySuffix(args: string[], defaultPort: number): VerifySuffix {
       const v = args[i];
       if (v === undefined) return missingValue(STORAGE_STATE_FLAG);
       storageState = v;
+    } else if (arg === SESSION_ID_FLAG) {
+      i++;
+      const v = args[i];
+      if (v === undefined) return missingValue(SESSION_ID_FLAG);
+      sessionId = v;
     } else if (arg.startsWith('--')) {
       return unknownArgument(arg);
     } else if (url === undefined) {
@@ -454,6 +464,7 @@ function parseVerifySuffix(args: string[], defaultPort: number): VerifySuffix {
     port,
     ...(timeoutMs !== undefined ? { timeoutMs } : {}),
     ...(storageState !== undefined ? { storageState } : {}),
+    ...(sessionId !== undefined ? { sessionId } : {}),
   };
 }
 
@@ -681,6 +692,7 @@ export function parseCliArgs(
         port: r.port,
         ...(r.timeoutMs !== undefined ? { timeoutMs: r.timeoutMs } : {}),
         ...(r.storageState !== undefined ? { storageState: r.storageState } : {}),
+        ...(r.sessionId !== undefined ? { sessionId: r.sessionId } : {}),
       };
     }
     case CAPSULES_COMMAND:

--- a/packages/server/src/cli/cli-verify.ts
+++ b/packages/server/src/cli/cli-verify.ts
@@ -193,6 +193,8 @@ interface LiveOpts {
    *  (--port / RETICLE_PORT / .reticle.json), or a custom-port app never connects. */
   port: number;
   storageState?: string;
+  /** Which connected tab to verify, when the app has more than one open on this port. */
+  sessionId?: string;
 }
 
 /** Split a drive URL into its origin + whether it's loopback — decides token/injection pairing. */
@@ -238,7 +240,7 @@ async function openLiveConnection(opts: LiveOpts): Promise<VerifyConnection> {
     ...(opts.storageState !== undefined ? { storageState: opts.storageState } : {}),
   });
   const deps = buildVerifyDeps(running, opts.reticleRoot, opts.now);
-  const runner = new ReticleRunner(createRunnerPort(deps));
+  const runner = new ReticleRunner(createRunnerPort(deps, opts.sessionId));
   return {
     sessionReady: (timeoutMs) => waitForSession(deps.sessions, timeoutMs, opts.now),
     listFlows: () => deps.flows.list(),
@@ -302,6 +304,7 @@ export function handleVerify(parsed: {
   headless: boolean;
   timeoutMs?: number;
   storageState?: string;
+  sessionId?: string;
   /** Bridge port — parseCliArgs already resolves --port / RETICLE_PORT / .reticle.json into this. */
   port: number;
 }): void {
@@ -318,6 +321,7 @@ export function handleVerify(parsed: {
         now,
         port: parsed.port ?? RETICLE_DEFAULT_PORT,
         ...(parsed.storageState !== undefined ? { storageState: parsed.storageState } : {}),
+        ...(parsed.sessionId !== undefined ? { sessionId: parsed.sessionId } : {}),
       }),
     out: (line) => process.stdout.write(`${line}\n`),
     fail: (line) => process.stderr.write(`${line}\n`),


### PR DESCRIPTION
Fixes #597.

With more than one tab connected, `reticle verify` fails with:

```
multiple sessions connected — pass sessionId to target one: …
```

`parseVerifySuffix` accepted only `--headed`, `--port`, `--timeout` and `--storage-state`, and rejected everything else as an unknown argument — so the one action the message prescribed was the one action the CLI could not perform. `--help` named no session option either. The only way out was closing tabs until the ambiguity resolved itself.

## Approach

The issue offers two fixes and prefers the flag. That is also the smaller one, because the far end of the plumbing already exists: `createRunnerPort(deps, sessionId?)` takes the argument, and its doc comment says *"Pass sessionId to disambiguate when several tabs are open."* `cli-verify.ts` called it with one argument because nothing upstream could produce a second.

So this adds the missing links only:

- `--session-id` in `parseVerifySuffix`, alongside the flags already there
- threaded through the `verify` command → `handleVerify` → `openLiveConnection` → that existing `createRunnerPort` argument
- listed in the usage line, since the issue notes `--help` was silent about it too — the flag should be discoverable *before* you hit the error, not only after

## Tests

Three in `cli.test.ts`, beside the existing `--storage-state` pair:

- `verify <url> --session-id s-42` parses and carries the id
- `--session-id` with no value names the flag (the shared missing-value wording)
- it composes with `--headed`, `--port` and `--timeout` rather than being positional-order dependent

Confirmed red before the change — the parser previously answered `unknown argument --session-id`, which is the defect stated as a test.

## Gates

`pnpm lint`, `pnpm typecheck`, `pnpm format:check` green; CLI suites 280 passed.