### PR TITLE
fix(tools): let the tool surface itself carry a rename, not just an error string

### DIFF
--- a/packages/server/src/tools/dynamic-tools.test.ts
+++ b/packages/server/src/tools/dynamic-tools.test.ts
@@ -60,6 +60,46 @@ describe('buildDynamicTools — the dynamic profile meta-tools', () => {
   });
 
   /**
+   * A renamed tool has to be reachable FROM THE SURFACE, not only from an error string.
+   *
+   * Guidance in the wild still names `reticle_crawl`. `reticle_run` has answered that name with its
+   * replacement for a while, but the tool asked to DISCOVER tools said "unknown tool" — the wrong
+   * answer in the one place an agent goes to resolve a name it is unsure of — and the catalogue
+   * omitted the old name entirely, which reads as "no such capability" rather than "renamed".
+   *
+   * Instructions written against a previous version are a permanent fact of the product, so this is
+   * not about `reticle_crawl`: it is about every tool that has been merged or will be.
+   */
+  it('reticle_tools names the replacement for a retired tool, not "unknown tool"', async () => {
+    const tools = buildDynamicTools(fakeTools);
+    const discover = tools.find((t) => t.name === ReticleTool.TOOLS);
+    const out = (await discover?.handler(NO_DEPS, { names: [ReticleTool.CRAWL] })) as {
+      tools: { name: string; error?: string; tool?: string; action?: string }[];
+    };
+    const crawl = out.tools.find((t) => ReticleTool.CRAWL === t.name);
+    expect(crawl?.error).not.toBe('unknown tool');
+    expect(crawl?.tool).toBe(ReticleTool.VERIFY);
+    expect(crawl?.action).toBe('crawl');
+    expect(crawl?.error).toContain(ReticleTool.VERIFY);
+  });
+
+  it('the catalog carries the tombstones, so a rename is discoverable without guessing it', async () => {
+    const tools = buildDynamicTools(fakeTools);
+    const discover = tools.find((t) => t.name === ReticleTool.TOOLS);
+    const out = (await discover?.handler(NO_DEPS, {})) as {
+      retired: Record<string, string>;
+      tools: { name: string }[];
+    };
+    expect(out.retired[ReticleTool.CRAWL]).toContain(ReticleTool.VERIFY);
+    expect(out.retired[ReticleTool.CRAWL]).toContain('crawl');
+    // A name that was retired outright, with no action to pass, still says where it went.
+    expect(out.retired[ReticleTool.REFRESH]).toContain(ReticleTool.NAVIGATE);
+    // Tombstones are the names that are NO LONGER tools — a live one must not appear among them.
+    expect(out.retired).not.toHaveProperty(ReticleTool.VERIFY);
+    for (const listed of out.tools) expect(out.retired).not.toHaveProperty(listed.name);
+  });
+
+  /**
    * The surface is read by the DAEMON at startup, not by the client. Setting it in an agent's
    * environment while a daemon is already running changes nothing — which is how "standard and full
    * are the same 46 tools" got reported. The setting not taking effect must be OBSERVABLE, so the

--- a/packages/server/src/tools/dynamic-tools.ts
+++ b/packages/server/src/tools/dynamic-tools.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { ToolDef, ToolDeps } from './tools.js';
 import { runTool } from './invoke-tool.js';
 import { buildErrorPayload } from './error-recovery.js';
-import { mergedNameRedirect, mergedNameMessage } from './merged-name-redirect.js';
+import { mergedNameRedirect, mergedNameMessage, retiredToolNames } from './merged-name-redirect.js';
 import { ReticleTool } from './tool-names.js';
 import { ADVERTISE_ALL_ENV, type ToolSurfaceOrigin } from './tool-surface.js';
 import { getSessionMetrics } from '../telemetry/session-metrics.js';
@@ -128,11 +128,18 @@ export function buildDynamicTools(allTools: ToolDef[], profile?: ToolSurfaceOrig
           name: t.name,
           summary: firstSentence(t.description),
         }));
+        // Names that USED to be tools, against the call that replaces each. Instructions written
+        // against an earlier release are a permanent fact of the product — `reticle_crawl` is still
+        // named by guidance in the wild — and without this the catalogue is silent about them: the
+        // old name is simply absent, which reads as "no such capability" rather than "renamed".
+        // Reaching the new name then costs an error string, or never happens.
+        const retired = retiredToolNames();
         return Promise.resolve({
           total: catalog.length,
           tools: catalog,
+          retired,
           ...profileBlock,
-          next: `All ${catalog.length} tools above are callable, advertised or not. Load full params with reticle_tools { names:[…] }, then call reticle_run { tool, args }.`,
+          next: `All ${catalog.length} tools above are callable, advertised or not. Load full params with reticle_tools { names:[…] }, then call reticle_run { tool, args }. \`retired\` maps names that are no longer tools to the call that replaced each.`,
         });
       }
       // The grammar rides ONLY on a `names:[…]` reply that asked for a tool taking a predicate, so
@@ -144,9 +151,20 @@ export function buildDynamicTools(allTools: ToolDef[], profile?: ToolSurfaceOrig
       return Promise.resolve({
         tools: names.map((n) => {
           const t = byName.get(n);
-          return t === undefined
+          if (t !== undefined)
+            return { name: n, description: t.description, params: paramInfo(t.inputSchema) };
+          // `reticle_run` has answered a merged name with its replacement for a while; the tool
+          // asked to DISCOVER tools still said "unknown tool", which is the wrong answer in the one
+          // place an agent goes to resolve a name it is unsure of. Same redirect, same derivation.
+          const moved = mergedNameRedirect(n);
+          return moved === undefined
             ? { name: n, error: 'unknown tool' }
-            : { name: n, description: t.description, params: paramInfo(t.inputSchema) };
+            : {
+                name: n,
+                error: mergedNameMessage(n, moved),
+                tool: moved.tool,
+                ...(moved.action === undefined ? {} : { action: moved.action }),
+              };
         }),
         ...(carriesPredicate ? { predicateGrammar: predicateGrammar() } : {}),
       });

--- a/packages/server/src/tools/merged-name-redirect.ts
+++ b/packages/server/src/tools/merged-name-redirect.ts
@@ -58,6 +58,29 @@ export function mergedNameRedirect(name: string): MergedNameRedirect | undefined
   return BY_OLD_NAME.get(name);
 }
 
+/**
+ * Every retired name against the call that replaces it — the tombstones, as one block.
+ *
+ * The redirect above answers an agent that already guessed the old name. This answers the one that
+ * is reading the surface to find out what exists, and is the case a redirect cannot reach: nothing
+ * in the catalogue says `reticle_crawl` became `reticle_verify { action: "crawl" }`, so instructions
+ * written against an earlier release lead either to an error string or to nothing at all.
+ *
+ * Derived from the same two declarations as `BY_OLD_NAME`, for the same reason: a hand-written
+ * migration list is one merge away from being wrong, and wrong is worse than absent here — the agent
+ * retries into it.
+ */
+export function retiredToolNames(): Readonly<Record<string, string>> {
+  const tombstones: Record<string, string> = {};
+  for (const [old, redirect] of BY_OLD_NAME) {
+    tombstones[old] =
+      redirect.action === undefined
+        ? `retired; ${redirect.note ?? `use ${redirect.tool}`}`
+        : `retired; use ${redirect.tool} { action: "${redirect.action}" }`;
+  }
+  return tombstones;
+}
+
 /** The sentence handed to an agent that called `name`. */
 export function mergedNameMessage(name: string, redirect: MergedNameRedirect): string {
   return redirect.action === undefined


### PR DESCRIPTION
Fixes #605.

Guidance in the wild still names `reticle_crawl`. `reticle_run` has answered a merged name with its replacement for a while — but `reticle_tools`, the tool an agent calls to **discover** tools, still answered `unknown tool`. That is the wrong answer in the one place somebody goes to resolve a name they are unsure of, and it is the tool that is supposed to know.

The catalogue was worse than wrong, it was silent: the old name is simply *absent* from it, which reads as "no such capability" rather than "renamed". So an agent working from older instructions reached the new name through an error string, or not at all.

## Both halves now answer

- **`names: [...]`** consults `mergedNameRedirect` before giving up, the way `reticle_run` already does — same redirect, same derivation, so the two meta-tools stop disagreeing about the same name. A name Reticle does not own is still `unknown tool`.
- **The no-argument catalogue** carries a `retired` block mapping each dead name to the call that replaced it, and `next` says what it is:

  ```
  reticle_crawl → retired; use reticle_verify { action: "crawl" }
  reticle_refresh → retired; reloading was absorbed into reticle_navigate { reload: true }
  ```

Derived from `MERGE_PLANS` and `RETIRED_FROM_SURFACE` like everything else in that file, so the next merge is covered the day it lands rather than the day someone notices. That is the general point the issue makes — instructions written against a previous version are a permanent fact of the product — so this is not about `reticle_crawl` specifically.

## Tests

Two added to the existing `dynamic-tools` suite, as the issue suggested:

- a retired name resolves to its replacement, with the action to pass, instead of `unknown tool`
- the catalogue's tombstones name the replacement (both the merged and the retired-outright shapes) and never list a live tool

Confirmed red before the change.

## Note on scope

Only the first half of #556's sibling concern is touched here — this is purely the discovery surface. The three retired `ToolDef`s that issue names are already gone from `main`.

## Gates

`pnpm lint`, `pnpm typecheck`, `pnpm format:check` green; `packages/server` tools suites 1152 passed.