### PR TITLE
fix(core): say what a lease costs in the recommendation that offers one

### DIFF
--- a/packages/core/src/notices.ts
+++ b/packages/core/src/notices.ts
@@ -104,6 +104,20 @@ export const YIELD_WITHOUT_SESSION_NOTE =
  * through `reticle_run`, since lease is not on the default surface) and leaves `reticle drive` as
  * the human-side equivalent: an MCP-only agent has no shell, so a CLI sentence is advice it cannot
  * follow. Reticle cannot bring such a tab to front or recover it, so it names the limit instead.
+ *
+ * It also says what the escape hatch COSTS, and how sure the flag it fires on actually is. Both
+ * were missing, and both omissions were reported from the field.
+ *
+ * A lease moves every later verdict into a pooled context the human cannot see, so following the
+ * second half empties their HUD for the rest of the run and the product looks broken while working
+ * correctly. A recommendation that names only the remedy reads as though it were free — and the
+ * case where it is most expensive, a human sitting in front of the tab, is exactly the case where
+ * refocusing was available.
+ *
+ * And `throttled` is not proof the tab cannot be driven: the reporter who raised this drove the
+ * same throttled tab successfully afterwards. The flag was being read as a verdict because this
+ * sentence offered a remedy for it. Saying the drive is worth trying first costs one clause and
+ * stops the escape hatch being taken pre-emptively.
  */
 export const UNSCRIPTABLE_TAB_RECOMMENDATION =
-  'tab hidden/throttled and may be un-focusable from here; refocus it, or acquire a guaranteed scriptable context yourself with `reticle_run { tool: "reticle_lease", action: "acquire", url }` (a human can equivalently run `reticle drive <url>`)';
+  'tab hidden/throttled and may be un-focusable from here — though throttled does not mean undriveable, so trying the drive first is reasonable. If it fails: refocus the tab, or acquire a guaranteed scriptable context yourself with `reticle_run { tool: "reticle_lease", action: "acquire", url }` (a human can equivalently run `reticle drive <url>`). Leasing opens a context the human CANNOT watch — their HUD stays empty for the rest of the run — so prefer refocusing their tab if they are sitting in front of it.';

--- a/packages/core/src/throttle-recommendation.test.ts
+++ b/packages/core/src/throttle-recommendation.test.ts
@@ -1,0 +1,40 @@
+/**
+ * The throttle recommendation has to disclose what its own advice costs.
+ *
+ * It read: "tab hidden/throttled and may be un-focusable from here; refocus it, or acquire a
+ * guaranteed scriptable context yourself with `reticle_lease`". Following the second half moves
+ * every later verdict into a pooled context the human CANNOT see — their HUD stays empty for the
+ * rest of the run, and the product looks broken while working correctly. The sentence offered that
+ * as though it were free.
+ *
+ * The same report also drove the "throttled" tab successfully afterwards. The flag is not a
+ * verdict, and it was being read as one because this sentence answered it with a remedy.
+ *
+ * Both are wording, and wording is exactly the kind of thing that gets tidied back out. These pin
+ * the two disclosures by meaning rather than by quoting the sentence, so it stays editable.
+ */
+import { describe, expect, it } from 'vitest';
+import { UNSCRIPTABLE_TAB_RECOMMENDATION } from './notices.js';
+
+describe('the unscriptable-tab recommendation', () => {
+  it('still names both escape hatches', () => {
+    // The agent-side one first — an MCP-only agent has no shell, so the CLI is the human's route.
+    expect(UNSCRIPTABLE_TAB_RECOMMENDATION).toContain('reticle_lease');
+    expect(UNSCRIPTABLE_TAB_RECOMMENDATION).toContain('reticle drive');
+    expect(UNSCRIPTABLE_TAB_RECOMMENDATION).toContain('refocus');
+  });
+
+  it('says a lease costs the human their view of the run', () => {
+    expect(UNSCRIPTABLE_TAB_RECOMMENDATION).toMatch(/cannot watch|cannot see|CANNOT watch/i);
+  });
+
+  it('prefers refocusing when the human is present, rather than leaving the choice unweighted', () => {
+    expect(UNSCRIPTABLE_TAB_RECOMMENDATION).toMatch(/prefer refocusing/i);
+  });
+
+  it('says throttled is not proof the tab cannot be driven', () => {
+    // Without this the flag reads as a verdict, and the escape hatch gets taken pre-emptively on a
+    // tab that would have driven fine.
+    expect(UNSCRIPTABLE_TAB_RECOMMENDATION).toMatch(/does not mean undriveable/i);
+  });
+});


### PR DESCRIPTION
Fixes #606.

The recommendation read:

> tab hidden/throttled and may be un-focusable from here; refocus it, or acquire a guaranteed scriptable context yourself with `reticle_lease`

Following the second half moves every later verdict into a pooled context the human **cannot see**. Their HUD stays empty for the rest of the run and the product looks broken while working correctly. The sentence offered that as though it were free — and the case where it costs the most, a human sitting in front of the tab, is exactly the case where refocusing was available.

The same reporter went on to drive that "throttled" tab successfully. So the flag is not proof the tab is undriveable, and it was being read as one *because* this sentence answered it with a remedy rather than with what it is: a hint.

## Change

Wording only, as the issue specifies — no behaviour change, both escape hatches still named, agent-side first:

> tab hidden/throttled and may be un-focusable from here — **though throttled does not mean undriveable, so trying the drive first is reasonable.** If it fails: refocus the tab, or acquire a guaranteed scriptable context yourself with `reticle_run { tool: "reticle_lease", action: "acquire", url }` (a human can equivalently run `reticle drive <url>`). **Leasing opens a context the human CANNOT watch — their HUD stays empty for the rest of the run — so prefer refocusing their tab if they are sitting in front of it.**

## Tests

Four, pinning the disclosures **by meaning rather than by quoting the sentence**. Wording is exactly the kind of thing that gets tidied back out later, and a test that quoted the string would fail on any rewrite instead of on the one that drops the disclosure — which is the only failure worth having.

Every existing assertion references `UNSCRIPTABLE_TAB_RECOMMENDATION` rather than its literal text, so nothing else needed touching.

## Gates

`pnpm lint`, `pnpm format:check` and `pnpm test:unit` green (server 565 files, browser 130 files, core all passing).