### PR TITLE
feat(telemetry): instrument unknown stack diagnostic reasons and broaden workspace detection (#617)

### DIFF
--- a/docs/telemetry-events.mdx
+++ b/docs/telemetry-events.mdx
@@ -210,6 +210,7 @@ A periodic roll-up from a daemon that is still running.
 | `stack` | string, optional | Framework detected from package.json |
 | `stackSource` | `cwd` \| `workspace` | Where it was found, and therefore how much to trust its absence |
 | `stackMajor` | int, optional | Major version only. A full semver is a fingerprint |
+| `unknownStackReason` | `UnknownStackReason`, optional | `no_manifest`, `no_dependencies`, `unrecognized_deps`, `no_workspace_apps`. Why stack was undetected |
 | `size` | `ProjectSize` | `tiny`, `small`, `medium`, `large`, `huge`. A bucket answers "toy or real codebase"; an exact file count starts to identify |
 | `monorepo` | boolean, optional |  |
 | `git` | `GitState` | `none`, `local_only`, `remote` |

--- a/packages/core/src/telemetry-session.ts
+++ b/packages/core/src/telemetry-session.ts
@@ -377,6 +377,23 @@ export const ProjectSize = {
 export type ProjectSize = (typeof ProjectSize)[keyof typeof ProjectSize];
 
 /**
+ * WHY stack detection produced nothing, when `stack` is undefined on a project profile.
+ *
+ * An enum rather than a guess, so we can measure which failure mode dominates:
+ * - `no_manifest`: Neither cwd nor any workspace folder contained a readable package.json.
+ * - `no_dependencies`: Manifest exists but has no dependencies or devDependencies.
+ * - `unrecognized_deps`: Manifest exists with dependencies, but none matched STACK_BY_DEP.
+ * - `no_workspace_apps`: Monorepo root was detected, but discovery found no candidate app directories.
+ */
+export const UnknownStackReason = {
+  NO_MANIFEST: 'no_manifest',
+  NO_DEPENDENCIES: 'no_dependencies',
+  UNRECOGNIZED_DEPS: 'unrecognized_deps',
+  NO_WORKSPACE_APPS: 'no_workspace_apps',
+} as const;
+export type UnknownStackReason = (typeof UnknownStackReason)[keyof typeof UnknownStackReason];
+
+/**
  * The shape of the project and how much of Reticle it actually uses.
  *
  * `featureDepth` is the one to watch: someone running 40 saved flows with visual baselines and a
@@ -401,6 +418,14 @@ export const ProjectProfileSchema = z.object({
   stackSource: z.enum(['cwd', 'workspace']).optional(),
   /** Its MAJOR version only — "breaks on React 19" is a work item, a full semver is a fingerprint. */
   stackMajor: z.number().int().nonnegative().optional(),
+  /**
+   * WHY stack detection produced nothing, when `stack` is undefined.
+   *
+   * Distinguishes a daemon running outside the project (`no_manifest`), a monorepo where no app
+   * could be found (`no_workspace_apps`), an unrecognised/hoisted framework (`unrecognized_deps`),
+   * and an empty manifest (`no_dependencies`).
+   */
+  unknownStackReason: z.nativeEnum(UnknownStackReason).optional(),
   size: z.nativeEnum(ProjectSize).optional(),
   /** True when the repo has workspaces — monorepos exercise very different code paths. */
   monorepo: z.boolean().optional(),

--- a/packages/server/src/init/run.ts
+++ b/packages/server/src/init/run.ts
@@ -510,14 +510,41 @@ function gatherPlanInput(options: InitOptions, io: InitIo, pkgRaw: string): Plan
 /** pnpm's workspace declaration, read when present — it is authoritative about where packages live. */
 const PNPM_WORKSPACE = 'pnpm-workspace.yaml';
 /** Deps that mark a directory as a runnable web app even when it has no bundler config file. */
-const APP_DEPS = ['next', 'vite'] as const;
+const APP_DEPS = [
+  'next',
+  'vite',
+  '@sveltejs/kit',
+  'nuxt',
+  'astro',
+  '@remix-run/react',
+  '@angular/core',
+  'react',
+  'vue',
+  'svelte',
+  'solid-js',
+] as const;
+const APP_CONFIGS = [
+  ...VITE_CONFIG_CANDIDATES,
+  ...NEXT_CONFIG_CANDIDATES,
+  ...ASTRO_CONFIG_CANDIDATES,
+  'svelte.config.js',
+  'svelte.config.ts',
+  'svelte.config.mjs',
+  'svelte.config.cjs',
+  'nuxt.config.ts',
+  'nuxt.config.js',
+  'nuxt.config.mjs',
+  'remix.config.js',
+  'remix.config.ts',
+  'remix.config.mjs',
+  'angular.json',
+];
 
 function looksLikeApp(dir: string, io: Pick<InitIo, 'exists' | 'readFile'>): boolean {
   const pkgRaw = io.readFile(`${dir}/${PACKAGE_JSON}`);
   if (null === pkgRaw) return false;
-  const configs = [...VITE_CONFIG_CANDIDATES, ...NEXT_CONFIG_CANDIDATES];
-  if (configs.some((c) => io.exists(`${dir}/${c}`))) return true;
-  // `next.config` is optional in Next, so the dependency list is the other half of the signal.
+  if (APP_CONFIGS.some((c) => io.exists(`${dir}/${c}`))) return true;
+  // `next.config` and other bundler configs are optional, so the dependency list is the other half of the signal.
   return APP_DEPS.some((d) => pkgRaw.includes(`"${d}"`));
 }
 

--- a/packages/server/src/telemetry/feedback-context.test.ts
+++ b/packages/server/src/telemetry/feedback-context.test.ts
@@ -62,8 +62,41 @@ describe('detectStack finds the app when it is not in the daemon cwd', () => {
     expect(detectStack(root).stack).toBe('vite');
   });
 
-  it('reports nothing for a directory with no app anywhere — silence beats a guess', () => {
+  it('finds an Angular app in a workspace', () => {
+    write('package.json', { workspaces: ['apps/*'] });
+    write('apps/web/package.json', { dependencies: { '@angular/core': '^18.0.0' } });
+    const got = detectStack(root);
+    expect(got.stack).toBe('angular');
+    expect(got.stackMajor).toBe(18);
+    expect(got.stackSource).toBe('workspace');
+  });
+
+  it('finds a SvelteKit app in a workspace', () => {
+    write('package.json', { workspaces: ['apps/*'] });
+    write('apps/web/package.json', { dependencies: { '@sveltejs/kit': '^2.0.0' } });
+    const got = detectStack(root);
+    expect(got.stack).toBe('sveltekit');
+    expect(got.stackMajor).toBe(2);
+    expect(got.stackSource).toBe('workspace');
+  });
+
+  it('reports no_manifest for a directory with no package.json anywhere', () => {
     mkdirSync(join(root, 'src'), { recursive: true });
-    expect(detectStack(root)).toEqual({});
+    expect(detectStack(root)).toEqual({ unknownStackReason: 'no_manifest' });
+  });
+
+  it('reports no_dependencies when package.json has no deps', () => {
+    write('package.json', { name: 'empty-app' });
+    expect(detectStack(root)).toEqual({ unknownStackReason: 'no_dependencies' });
+  });
+
+  it('reports unrecognized_deps when package.json has deps not in STACK_BY_DEP', () => {
+    write('package.json', { dependencies: { express: '^4.18.0' } });
+    expect(detectStack(root)).toEqual({ unknownStackReason: 'unrecognized_deps' });
+  });
+
+  it('reports no_workspace_apps when monorepo declares workspaces but has no app packages', () => {
+    write('package.json', { workspaces: ['packages/*'] });
+    expect(detectStack(root)).toEqual({ unknownStackReason: 'no_workspace_apps' });
   });
 });

--- a/packages/server/src/telemetry/feedback-context.ts
+++ b/packages/server/src/telemetry/feedback-context.ts
@@ -12,7 +12,7 @@
 import { mcpClientIdentity, setMcpClientIdentityHook } from '../mcp/client-identity.js';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { isAbsolute, join } from 'node:path';
-import { AppRuntime, McpScope, PageDriver, type Feedback } from '@reticlehq/core';
+import { AppRuntime, McpScope, PageDriver, UnknownStackReason, type Feedback } from '@reticlehq/core';
 import { parseMajor } from '../init/detect.js';
 import { findWorkspaceApps, type InitIo } from '../init/run.js';
 
@@ -54,39 +54,75 @@ interface PackageJsonLike {
   devDependencies?: Record<string, string>;
 }
 
+interface ManifestResult {
+  stack?: string;
+  stackMajor?: number;
+  manifestFound: boolean;
+  hasDeps: boolean;
+}
+
 /**
- * The project's framework and its MAJOR version, or `{}` when package.json is absent, unreadable, or
- * names nothing we recognize. The major comes from `parseMajor` — the same range parser `reticle init`
- * uses to decide React 19 source mapping — so a range like `^15.0.0-canary.3` narrows the same way in
- * both places instead of via a second, subtly different reader.
+ * The project's framework and its MAJOR version, or `{ manifestFound: false, hasDeps: false }` when
+ * package.json is absent or unreadable. The major comes from `parseMajor` — the same range parser
+ * `reticle init` uses to decide React 19 source mapping — so a range like `^15.0.0-canary.3` narrows
+ * the same way in both places instead of via a second, subtly different reader.
  */
 function stackOfManifest(
   dir: string,
   read: (path: string) => string,
-): { stack?: string; stackMajor?: number } {
+): ManifestResult {
   let pkg: PackageJsonLike;
   try {
     pkg = JSON.parse(read(join(dir, PACKAGE_JSON))) as PackageJsonLike;
   } catch {
-    return {};
+    return { manifestFound: false, hasDeps: false };
   }
   const deps = { ...pkg.devDependencies, ...pkg.dependencies };
+  const hasDeps = Object.keys(deps).length > 0;
   for (const [dep, stack] of STACK_BY_DEP) {
     const range = deps[dep];
     if (range === undefined) continue;
     const stackMajor = parseMajor(range);
-    return { stack, ...(stackMajor !== undefined ? { stackMajor } : {}) };
+    return { stack, ...(stackMajor !== undefined ? { stackMajor } : {}), manifestFound: true, hasDeps: true };
   }
-  return {};
+  return { manifestFound: true, hasDeps };
 }
 
 export function detectStack(
   cwd: string,
   read: (path: string) => string = readFile,
-): { stack?: string; stackMajor?: number; stackSource?: 'cwd' | 'workspace' } {
+): {
+  stack?: string;
+  stackMajor?: number;
+  stackSource?: 'cwd' | 'workspace';
+  unknownStackReason?: UnknownStackReason;
+} {
   // The cwd wins when it IS an app — never redirect away from the real answer.
   const here = stackOfManifest(cwd, read);
-  if (here.stack !== undefined) return { ...here, stackSource: 'cwd' };
+  if (here.stack !== undefined) {
+    return {
+      stack: here.stack,
+      ...(here.stackMajor !== undefined ? { stackMajor: here.stackMajor } : {}),
+      stackSource: 'cwd',
+    };
+  }
+
+  let isMonorepoRoot = false;
+  try {
+    const pkgRaw = read(join(cwd, PACKAGE_JSON));
+    const parsed = JSON.parse(pkgRaw) as { workspaces?: unknown };
+    if (parsed.workspaces !== undefined) isMonorepoRoot = true;
+  } catch {
+    // no package.json or invalid json
+  }
+  if (!isMonorepoRoot) {
+    try {
+      read(join(cwd, 'pnpm-workspace.yaml'));
+      isMonorepoRoot = true;
+    } catch {
+      // no pnpm-workspace.yaml
+    }
+  }
 
   // Otherwise look for the app. The daemon's cwd is wherever the agent's client happened to launch,
   // which for a real repo is the ROOT while the app sits in `frontend/`, `web/`, or a declared
@@ -98,17 +134,51 @@ export function detectStack(
   // declared workspaces (pnpm-workspace.yaml, package.json `workspaces`) AND scans top-level
   // directories, and it was widened once already for a repo shape a user hit twice. A second
   // detector here would drift from it the first time either changed.
+  let workspaceApps: string[] = [];
   try {
-    for (const app of findWorkspaceApps(profileIo(cwd))) {
+    workspaceApps = findWorkspaceApps(profileIo(cwd));
+    for (const app of workspaceApps) {
       const found = stackOfManifest(join(cwd, app), read);
       // Reported as `workspace` so the share of projects needing discovery is measurable — that
       // number is what says whether our inference needs an agent to correct it.
-      if (found.stack !== undefined) return { ...found, stackSource: 'workspace' };
+      if (found.stack !== undefined) {
+        return {
+          stack: found.stack,
+          ...(found.stackMajor !== undefined ? { stackMajor: found.stackMajor } : {}),
+          stackSource: 'workspace',
+        };
+      }
     }
   } catch {
     // Discovery touches the filesystem; a permission error must never cost us the profile event.
   }
-  return {};
+
+  // If we found workspace apps, but none had a recognized framework:
+  if (workspaceApps.length > 0) {
+    const results = workspaceApps.map((app) => stackOfManifest(join(cwd, app), read));
+    if (results.some((r) => r.hasDeps)) {
+      return { unknownStackReason: UnknownStackReason.UNRECOGNIZED_DEPS };
+    }
+    if (results.some((r) => r.manifestFound)) {
+      return { unknownStackReason: UnknownStackReason.NO_DEPENDENCIES };
+    }
+    return { unknownStackReason: UnknownStackReason.NO_MANIFEST };
+  }
+
+  // If no workspace apps were found:
+  if (isMonorepoRoot) {
+    return { unknownStackReason: UnknownStackReason.NO_WORKSPACE_APPS };
+  }
+
+  if (here.manifestFound) {
+    return {
+      unknownStackReason: here.hasDeps
+        ? UnknownStackReason.UNRECOGNIZED_DEPS
+        : UnknownStackReason.NO_DEPENDENCIES,
+    };
+  }
+
+  return { unknownStackReason: UnknownStackReason.NO_MANIFEST };
 }
 
 /**

--- a/packages/server/src/telemetry/feedback.test.ts
+++ b/packages/server/src/telemetry/feedback.test.ts
@@ -144,12 +144,12 @@ describe('feedback context detection', () => {
     });
   });
 
-  it('returns nothing rather than guessing when package.json is unreadable', () => {
+  it('returns no_manifest rather than guessing when package.json is unreadable', () => {
     expect(
       detectStack('/p', () => {
         throw new Error('ENOENT');
       }),
-    ).toEqual({});
+    ).toEqual({ unknownStackReason: 'no_manifest' });
   });
 
   it('reads project scope from a checked-in MCP registration, user scope otherwise', () => {

--- a/packages/server/src/telemetry/project-profile.test.ts
+++ b/packages/server/src/telemetry/project-profile.test.ts
@@ -66,6 +66,19 @@ describe('project profiling', () => {
         expect(profile.featureDepth).toBe(0);
         expect(profile.featuresUsed).toEqual([]);
         expect(profile.flowCount).toBe(0);
+        expect(profile.stack).toBeUndefined();
+        expect(profile.unknownStackReason).toBe('no_manifest');
+      },
+    );
+  });
+
+  it('profiles a project with unrecognised dependencies with unknownStackReason unrecognized_deps', () => {
+    withTempProject(
+      (root) => writeFileSync(join(root, 'package.json'), JSON.stringify({ dependencies: { express: '^4.18.0' } })),
+      (root) => {
+        const profile = profileProject(root, Date.now());
+        expect(profile.stack).toBeUndefined();
+        expect(profile.unknownStackReason).toBe('unrecognized_deps');
       },
     );
   });

--- a/packages/server/src/telemetry/project-profile.ts
+++ b/packages/server/src/telemetry/project-profile.ts
@@ -187,7 +187,7 @@ export function profileProject(cwd: string, now: number): ProjectProfile {
   if (capsuleCount > 0) featuresUsed.push(FeatureFamily.BUG_CAPSULES);
   if (hasHistory) featuresUsed.push(FeatureFamily.CROSS_RUN_HISTORY);
 
-  const { stack, stackMajor, stackSource } = detectStack(cwd);
+  const { stack, stackMajor, stackSource, unknownStackReason } = detectStack(cwd);
   const ageWeeks = projectAgeWeeks(cwd, now);
   const git = gitFacts(cwd);
   return {
@@ -196,6 +196,7 @@ export function profileProject(cwd: string, now: number): ProjectProfile {
     ...(stack !== undefined ? { stack } : {}),
     ...(stackSource !== undefined ? { stackSource } : {}),
     ...(stackMajor !== undefined ? { stackMajor } : {}),
+    ...(unknownStackReason !== undefined ? { unknownStackReason } : {}),
     size: sizeBucket(countSourceFiles(cwd)),
     monorepo: isMonorepo(cwd),
     ...(ageWeeks !== undefined ? { ageWeeks } : {}),


### PR DESCRIPTION
## Description
Closes #617

This PR diagnoses and resolves why project frameworks were frequently reported as `undefined` / unknown in `ProjectProfile` telemetry by:
1. **Instrumenting Diagnostic Reasons**: Adding `UnknownStackReason` (`no_manifest`, `no_dependencies`, `unrecognized_deps`, `no_workspace_apps`) to `ProjectProfileSchema` and `detectStack()` so analytics can segment why a stack was undetected without guessing.
2. **Broadening Workspace App Discovery**: Expanding `looksLikeApp` in `findWorkspaceApps` to recognize non-Vite/Next app configs (`angular.json`, `svelte.config.*`, `nuxt.config.*`, `astro.config.*`, `remix.config.*`) and framework dependencies in monorepo packages.
3. **Updating Schema Docs & Tests**: Documenting the new field in `docs/telemetry-events.mdx` and adding test cases covering all failure modes and workspace frameworks.

---

## Changes
- **`@reticlehq/core` (`packages/core/src/telemetry-session.ts`)**:
  - Export `UnknownStackReason` enum (`no_manifest`, `no_dependencies`, `unrecognized_deps`, `no_workspace_apps`).
  - Add optional `unknownStackReason` to `ProjectProfileSchema`.
- **`@reticlehq/server` (`packages/server/src/telemetry/feedback-context.ts`)**:
  - Update `detectStack()` to classify and return `unknownStackReason` when `stack` is undefined.
- **`@reticlehq/server` (`packages/server/src/init/run.ts`)**:
  - Expand `looksLikeApp` beyond Next and Vite to support Angular, SvelteKit, Nuxt, Astro, Remix, and Solid.
- **`@reticlehq/server` (`packages/server/src/telemetry/project-profile.ts`)**:
  - Forward `unknownStackReason` to `ProjectProfile`.
- **`docs/telemetry-events.mdx`**:
  - Document `unknownStackReason` on `ProjectProfileSchema`.
- **Unit Tests**:
  - `feedback-context.test.ts`: Added tests for all 4 diagnostic reason branches and Angular/SvelteKit workspace apps.
  - `project-profile.test.ts`: Added tests verifying profile output carries `unknownStackReason`.

---

## Verification
- `pnpm build`: Clean build across all packages with zero type errors.
- `pnpm test`: All **565 test files (5,515 tests)** passed.