### PR TITLE
fix(server): a text miss that is really a split label says so, and names the container

### DIFF
--- a/packages/browser/src/dom/browser.test.ts
+++ b/packages/browser/src/dom/browser.test.ts
@@ -256,6 +256,45 @@ describe('query empty hint', () => {
     expect(r.hint?.presentTestids).toHaveLength(12);
   });
 
+  /**
+   * The field report this came from: a label rendered with `v-html` spans several child nodes, so
+   * `by: text` — which reads an element's OWN text nodes — matched nothing while the string was
+   * plainly on screen. The verdict was identical to "never rendered", and the drive ended in a bug
+   * report against an app that had worked.
+   */
+  it('names the container when the wanted text is split across children', () => {
+    render(
+      '<div id="row"><span>Move to </span><span>Reticle </span><span>Repro Folder</span></div>',
+    );
+    const r = runQuery({ text: 'Move to Reticle Repro Folder' });
+    expect(r.elements).toHaveLength(0);
+    expect(r.hint?.splitText).toBeDefined();
+    expect(r.hint?.splitText?.ref).toBeDefined();
+  });
+
+  it('picks the DEEPEST container, not the first one that contains the string', () => {
+    // Every ancestor up to <body> contains the string; naming <body> is not a locator.
+    render('<main><section><p id="tight"><b>Half</b><i> and half</i></p></section></main>');
+    const r = runQuery({ text: 'Half and half' });
+    const ref = r.hint?.splitText?.ref;
+    expect(ref).toBeDefined();
+    const resolved = runQuery({ scope: ref, self: true });
+    expect(resolved.elements[0]?.text).toContain('Half and half');
+  });
+
+  it('omits splitText on an ordinary text miss', () => {
+    // The string is genuinely absent — the clause must not fire, or it stops meaning anything.
+    render('<div><span>something else entirely</span></div>');
+    const r = runQuery({ text: 'not on this page at all' });
+    expect(r.hint?.splitText).toBeUndefined();
+  });
+
+  it('omits splitText when the miss was not a text search', () => {
+    render('<div><span>Save</span><span> changes</span></div>');
+    const r = runQuery({ role: 'button', name: 'Save changes' });
+    expect(r.hint?.splitText).toBeUndefined();
+  });
+
   it('reflects location in route', () => {
     history.pushState({}, '', '/cart?x=1');
     const r = runQuery({ role: 'button', name: 'nope' });

--- a/packages/browser/src/dom/query.ts
+++ b/packages/browser/src/dom/query.ts
@@ -554,6 +554,45 @@ function buildPresentRegions(query: ElementQuery): PresentRegion[] {
   return regions;
 }
 
+/**
+ * The tightest single element whose SUBTREE text carries `wanted`, when no element's OWN text does.
+ *
+ * `by: text` matches an element's direct text nodes (`directText`), so a label rendered across
+ * several child nodes — `v-html`, an inline `<span>` per word, a highlighted substring — exists on
+ * the page and matches nothing. The two channels disagree by construction: `act_and_wait` reports
+ * `appeared` by concatenating an added subtree, so the string an agent is most likely to copy into
+ * its next predicate is exactly the shape this query cannot find.
+ *
+ * That failure is indistinguishable from the element being absent, which is the expensive half: the
+ * agent reads "no element matched", concludes the app did not render, and reports a bug against
+ * correct code.
+ *
+ * Returns the DEEPEST container rather than the first, because every ancestor up to `<body>` also
+ * contains the string and naming `<body>` is not a locator. The deepest one is the tightest scope
+ * that still holds the whole string, which is the one worth pasting back.
+ */
+function splitTextOwner(container: HTMLElement, wanted: string): HTMLElement | undefined {
+  let best: HTMLElement | undefined;
+  let bestDepth = -1;
+  for (const el of elementsUnder(container)) {
+    if (isIgnored(el)) continue; // never point an agent at Reticle's own UI
+    if (!fuzzyVisibleText(el.textContent ?? '', wanted)) continue;
+    let depth = 0;
+    for (let parent = el.parentElement; parent !== null; parent = parent.parentElement) depth++;
+    if (depth > bestDepth) {
+      best = el;
+      bestDepth = depth;
+    }
+  }
+  return best;
+}
+
+/** The text this query searched for, in either spelling, or undefined when it searched by something else. */
+function wantedTextOf(query: ElementQuery): string | undefined {
+  if (query.text !== undefined) return query.text;
+  return QueryBy.TEXT === query.by ? query.value : undefined;
+}
+
 /** Diagnostic hint for a zero-match query: what testids ARE present in the searched scope. */
 function buildEmptyHint(query: ElementQuery): QueryEmptyHint {
   const container = resolveContainer(query.scope).container ?? document.body;
@@ -570,12 +609,20 @@ function buildEmptyHint(query: ElementQuery): QueryEmptyHint {
   const registered = getCapabilities().testids;
   const knownEmptyState = present.some((id) => registered.includes(id));
   const route = `${location.pathname}${location.search}`;
-  return {
+  const hint: QueryEmptyHint = {
     route,
     presentTestids: present,
     presentRegions: buildPresentRegions(query),
     knownEmptyState,
   };
+  // Only for a text search, and only when the string IS here — otherwise this is an ordinary miss
+  // and the extra clause would lengthen every failure to say nothing.
+  const wanted = wantedTextOf(query);
+  if (wanted !== undefined) {
+    const owner = splitTextOwner(container, wanted);
+    if (owner !== undefined) hint.splitText = describe(owner);
+  }
+  return hint;
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -152,6 +152,15 @@ export interface QueryEmptyHint {
   presentTestids: string[];
   /** True if a capability-registered testid is present in the scope. */
   knownEmptyState: boolean;
+  /**
+   * Present only when a TEXT search missed and the string is nonetheless on the page, split across
+   * this element's children — so no single element's own text carries it and no `by: text` query can
+   * ever match it.
+   *
+   * The descriptor is the tightest container that holds the whole string; its `ref` is a locator, so
+   * the recovery is `{ scope: <ref>, self: true }` rather than another guess at the text.
+   */
+  splitText?: ElementDescriptor;
 }
 
 /** Result of the QUERY command / reticle_query tool. `hint` present ONLY on zero matches. */

--- a/packages/server/src/events/predicate.ts
+++ b/packages/server/src/events/predicate.ts
@@ -14,6 +14,7 @@ import { log } from '../log.js';
 import { bindSpanContext } from '../trace.js';
 import { selectPath, capDepth } from '../session/state-select.js';
 import { describeTestidMiss } from './testid-near-miss.js';
+import { describeSplitTextMiss } from './split-text-miss.js';
 import { predicateToExpectedLinks } from '../capsule/predicate-to-links.js';
 import type { ExpectedLink } from '../capsule/divergence.js';
 import { isAmbient, ambientKeyOf, type AmbientCounts } from '../journal/ambient.js';
@@ -246,7 +247,12 @@ async function evalElement(
   const present = match.hint?.presentTestids ?? [];
   const alsoHere =
     query.testid === undefined ? undefined : describeTestidMiss(query.testid, present);
-  const suffix = alsoHere === undefined || '' === alsoHere ? '' : ` — ${alsoHere}`;
+  // A text miss where the string is on the page but split across children reads exactly like an
+  // element that never rendered. Naming the container is the difference between a retry and a bug
+  // report against working code. See split-text-miss.ts.
+  const splitText = describeSplitTextMiss(match.hint?.splitText);
+  const clause = splitText ?? (alsoHere === undefined || '' === alsoHere ? undefined : alsoHere);
+  const suffix = clause === undefined ? '' : ` — ${clause}`;
   return {
     pass: false,
     failureReason: `no element matched ${subject}${state === undefined ? '' : ` in state '${state}'`}${suffix}`,

--- a/packages/server/src/events/split-text-miss.test.ts
+++ b/packages/server/src/events/split-text-miss.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { describeSplitTextMiss } from './split-text-miss.js';
+
+/**
+ * The clause exists to separate two failures that produced the SAME verdict: an element that never
+ * rendered, and a label the app rendered across several children. Only the second is recoverable,
+ * and only if the message says so.
+ */
+describe('describeSplitTextMiss', () => {
+  it('says nothing when the browser found no container', () => {
+    // An ordinary miss keeps the short message. A clause that fires on every failure carries nothing.
+    expect(describeSplitTextMiss(undefined)).toBeUndefined();
+  });
+
+  it('names the container and hands back a query that resolves', () => {
+    const message = describeSplitTextMiss({ ref: 'e12', role: 'button', name: 'Move to Folder' });
+    expect(message).toContain("button 'Move to Folder'");
+    expect(message).toContain("{ scope: 'e12', self: true }");
+  });
+
+  it('states that no text query can match, not merely that this one did not', () => {
+    // The agent's next move after "no element matched" is another text guess. The message has to
+    // close that door explicitly or it buys nothing.
+    const message = describeSplitTextMiss({ ref: 'e3', role: 'listitem' });
+    expect(message).toContain('IS on the page');
+    expect(message).toContain('no text query can match');
+  });
+
+  it('falls back to a scoping instruction when the container has no ref', () => {
+    // A descriptor without a ref cannot be pasted, so the advice has to stay actionable in words.
+    const message = describeSplitTextMiss({ role: 'paragraph' });
+    expect(message).toContain('scope to that container');
+    expect(message).not.toContain('undefined');
+  });
+
+  it('describes a container with no role as an element rather than an empty string', () => {
+    const message = describeSplitTextMiss({ ref: 'e9' });
+    expect(message).toContain('element');
+    expect(message).not.toContain("''");
+  });
+
+  it('bounds the container name, so the verdict does not grow with the page', () => {
+    // The property is that the message is BOUNDED, not that it is short: asserting a byte count
+    // pins today's wording and reddens on an edit that changed nothing that matters.
+    const shorter = describeSplitTextMiss({ ref: 'e1', role: 'region', name: 'x'.repeat(200) });
+    const longer = describeSplitTextMiss({ ref: 'e1', role: 'region', name: 'x'.repeat(5000) });
+    expect(shorter).toContain('…');
+    expect(longer).toEqual(shorter);
+  });
+});

--- a/packages/server/src/events/split-text-miss.ts
+++ b/packages/server/src/events/split-text-miss.ts
@@ -1,0 +1,55 @@
+/**
+ * Turning "no element matched {text: …}" into something an agent can act on, when the string IS here.
+ *
+ * `by: text` matches an element's own text nodes. A label rendered across several children —
+ * `v-html`, one `<span>` per word, a highlighted substring — is on the page and matches nothing, and
+ * the verdict is byte-identical to the one for an element that never rendered.
+ *
+ * That equivalence is the expensive part. Reported from the field: `act_and_wait` returned
+ * `effect.appeared` containing `"Move to Reticle Repro Folder"`, the `until` predicate in the SAME
+ * call searched for that string and failed, and the drive ended in a bug report against an app that
+ * had rendered correctly. `appeared` concatenates an added subtree while `text` reads direct text
+ * only, so the channel an agent is most likely to copy from produces the one locator this query
+ * cannot resolve.
+ *
+ * Naming the container ends it in one step: `ref` is a locator, and `self: true` returns the scope
+ * element itself, so the recovery is a query the agent can paste rather than another guess.
+ */
+
+/** Enough of the label to recognise it; the message is read in a tool result, not a log. */
+const MAX_TEXT = 60;
+
+/** What the container is, in the fewest words that still identify it on the page. */
+function nameOf(owner: SplitTextOwner): string {
+  const name = owner.name !== undefined && owner.name.length > 0 ? owner.name : undefined;
+  const role = owner.role !== undefined && owner.role.length > 0 ? owner.role : 'element';
+  return name === undefined ? role : `${role} '${truncate(name)}'`;
+}
+
+function truncate(value: string): string {
+  return value.length > MAX_TEXT ? `${value.slice(0, MAX_TEXT)}…` : value;
+}
+
+/** The container descriptor the browser attaches to a missed text query. */
+export interface SplitTextOwner {
+  ref?: string;
+  role?: string;
+  name?: string;
+}
+
+/**
+ * The "…but it IS here, split across children" clause, or undefined when there is nothing to say.
+ *
+ * Undefined — not a vaguer sentence — when the browser found no container: an ordinary miss keeps the
+ * short message it already had. A clause that fires on every failure stops carrying information.
+ */
+export function describeSplitTextMiss(owner: SplitTextOwner | undefined): string | undefined {
+  if (owner === undefined) return undefined;
+  const where = nameOf(owner);
+  const scope = owner.ref !== undefined && owner.ref.length > 0 ? owner.ref : undefined;
+  const recovery =
+    scope === undefined
+      ? 'scope to that container and match it as a whole'
+      : `retry as { scope: '${scope}', self: true }`;
+  return `that text IS on the page, split across the children of ${where} — no single element's own text carries it, so no text query can match it; ${recovery}`;
+}

--- a/packages/server/src/tools/tools.ts
+++ b/packages/server/src/tools/tools.ts
@@ -405,6 +405,17 @@ export const RAW_TOOLS: ToolDef[] = [
             .describe('Structural clusters on the page — what IS here, to diagnose the miss.'),
           presentTestids: z.array(z.string()).optional(),
           knownEmptyState: z.boolean(),
+          splitText: z
+            .object({
+              ref: z.string().optional(),
+              role: z.string().optional(),
+              name: z.string().optional(),
+            })
+            .passthrough()
+            .optional()
+            .describe(
+              "Present when a TEXT search missed but the string IS on the page, split across this container's children. Retry as { scope: <ref>, self: true } — no text query can match a string no single element owns.",
+            ),
         })
         .optional()
         .describe(


### PR DESCRIPTION
## What

When a `text` query misses but the string is on the page — split across an element's children — the verdict now says so and names the container to scope to.

Fixes #607.

## Why

The issue explains the normalisation mismatch, so just the part that decided the fix: the two failures produce a **byte-identical** verdict. "This element never rendered" and "this label is spelled across three `<span>`s" both read `no element matched`, and only one of them is the app's fault.

That equivalence is what made the reported drive end where it did — a bug report against an app that had rendered correctly. `appeared` concatenates an added subtree while `text` reads direct text nodes only, so the channel an agent is most likely to copy from produces the one locator the query cannot resolve. The agent's natural next move after `no element matched` is another text guess, and every one of them fails the same way.

## How

I went with (2), and a narrower version of (1) than the issue proposes.

Marking aggregate entries in `appeared` tells a caller a string is unusable but not what to do instead, and it puts the burden on a browser-side channel that has to survive the wire and be re-read later. The failure site already holds both halves of the answer: it knows the string it was asked for, and it can ask the page whether that string exists as a concatenation under a single parent. So it names the parent instead of just refusing the locator.

- **browser** — `splitTextOwner` finds the **deepest** element whose subtree text carries the string. Deepest, not first: every ancestor up to `<body>` also contains it, and naming `<body>` is not a locator.
- **core** — `QueryEmptyHint.splitText`, the container descriptor. Attached only when a *text* search missed and the string is genuinely there.
- **server** — `describeSplitTextMiss` renders the clause, mirroring `testid-near-miss.ts`, which solved the same shape of problem for testids.

The recovery it hands back is a query that resolves rather than advice: `{ scope: <ref>, self: true }`. `scope` already accepts a ref and `self` already returns the scope element itself, so this needed no new query surface — the descriptor's `ref` is the locator.

## Tests

Ten. Four browser-side against the real DOM, six on the message.

Two of the browser cases are confirmed **red** without the change. The other two are guards that pass both ways on purpose, because the expensive failure here would be over-firing: a clause that appears on every miss stops carrying information, so there is a case pinning that an ordinary absent string stays silent, and one pinning that a non-text miss stays silent.

The first browser case is the exact `v-html` shape from the report — one label across three children. The second asserts the deepest-container rule the way it actually matters: it takes the `ref` out of the hint and feeds it back through `runQuery({ scope: ref, self: true })`, so the test proves the returned locator *resolves*, not merely that a string appeared in a message.

On the message side, one case pins that it says **no text query can match** rather than just "this one did not" — without that the advice does not close the door the agent is about to walk through again. Boundedness is asserted as a property (a 200-char and a 5000-char name produce the same output) rather than a byte count, so it does not redden on a wording change.

## Gates

- [x] `pnpm lint` — clean (one pre-existing `react-hooks/exhaustive-deps` warning in `bench-app`, untouched by this)
- [x] `pnpm typecheck` — 22/22
- [x] `pnpm test:unit` — 17/17 tasks
- [ ] `pnpm test:e2e` — **still running locally when I opened this**, not skipped. I touched `packages/core`, so the routing table asks for it and I started it; it boots the smoke apps and had not finished after ~50 minutes on this machine. Flagging that honestly rather than ticking the box — CI runs it regardless, and I will follow up here if it comes back red.

One note on scope: the hint is additive and optional, so existing `QueryEmptyHint` consumers are unaffected — `presentTestids` still populates as before, and the new clause takes precedence in the message only when it fires.