### PR TITLE
fix(tools): bound a blocking wait by what the client will wait for, not by us

### DIFF
--- a/packages/server/src/tools/blocking-wait-ceiling.test.ts
+++ b/packages/server/src/tools/blocking-wait-ceiling.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_BLOCKING_WAIT_MS,
+  MAX_TIMEOUT_MS,
+  timeoutMsSchema,
+} from './numeric-bounds.js';
+
+/**
+ * An advertised bound has to be one we can actually honour.
+ *
+ * `timeout_ms` accepted up to 120s while the MCP SDK's default request timeout is 60s, and clients
+ * configure it lower. A caller who believed the advertised bound and asked for 90s got a TRANSPORT
+ * error at 60s: no verdict, no near-miss diagnosis, nothing to act on. The wait was honoured right
+ * up to the moment the only thing that could report it had gone (#601).
+ *
+ * The ceiling is therefore below the SDK default, not at it. The margin is what lets Reticle's own
+ * "timed out, here is the near miss" answer beat the client's abort.
+ */
+describe('a blocking wait is bounded by what the client will wait for', () => {
+  it('refuses a wait longer than an MCP client will hold the request open', () => {
+    expect(timeoutMsSchema.safeParse(90_000).success).toBe(false);
+    expect(timeoutMsSchema.safeParse(60_000).success).toBe(false);
+  });
+
+  it('leaves room for the answer to arrive before the client gives up', () => {
+    // At exactly 60s the verdict races the abort and loses: the reply has to be produced,
+    // serialised and written after the wait ends. The margin is the point of the constant.
+    expect(MAX_BLOCKING_WAIT_MS).toBeLessThan(60_000);
+  });
+
+  it('still accepts the ceiling itself and the ordinary budgets', () => {
+    // A ceiling that refuses its own value turns a documented bound into a lie in the other
+    // direction, and 4000 is the default assert budget.
+    expect(timeoutMsSchema.safeParse(MAX_BLOCKING_WAIT_MS).success).toBe(true);
+    expect(timeoutMsSchema.safeParse(4_000).success).toBe(true);
+  });
+
+  it('keeps `timeout_ms: 0` legal — it means evaluate once, not "wait forever"', () => {
+    expect(timeoutMsSchema.safeParse(0).success).toBe(true);
+  });
+
+  it('does not lower the ceiling for arguments the caller does NOT block on', () => {
+    // Only a wait the request is held open for is bounded by the client's patience. Folding the
+    // two together would shrink unrelated bounds in the name of a transport constraint they
+    // never touch.
+    expect(MAX_TIMEOUT_MS).toBeGreaterThan(MAX_BLOCKING_WAIT_MS);
+  });
+});

--- a/packages/server/src/tools/blocking-wait-ceiling.test.ts
+++ b/packages/server/src/tools/blocking-wait-ceiling.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  MAX_BLOCKING_WAIT_MS,
-  MAX_TIMEOUT_MS,
-  timeoutMsSchema,
-} from './numeric-bounds.js';
+import { MAX_BLOCKING_WAIT_MS, MAX_TIMEOUT_MS, timeoutMsSchema } from './numeric-bounds.js';
 
 /**
  * An advertised bound has to be one we can actually honour.

--- a/packages/server/src/tools/numeric-bounds.ts
+++ b/packages/server/src/tools/numeric-bounds.ts
@@ -21,10 +21,31 @@ import { RING_BUFFER_DEFAULTS, TRANSPORT_LIMITS } from '@reticlehq/core';
 export const MAX_RESULT_COUNT = RING_BUFFER_DEFAULTS.MAX_EVENTS;
 
 /**
- * Hard cap on a wait. The default assert budget is 4s; two minutes is already a hung session.
+ * Hard cap on a numeric millisecond argument that does NOT block the caller's request.
  * `timeout_ms: 0` stays legal — it means evaluate once, do not wait.
  */
 export const MAX_TIMEOUT_MS = 120_000;
+
+/**
+ * Hard cap on a wait the CALLER BLOCKS ON, which is a different ceiling from the one above.
+ *
+ * A blocking wait is bounded by the client's patience, not by ours. The MCP SDK's default request
+ * timeout is 60s and clients configure it lower; we advertised 120s. A caller who believed the
+ * advertised bound and asked for 90s got a TRANSPORT error at 60s — not a Reticle verdict, not a
+ * near-miss diagnosis, nothing to act on. The wait was honoured right up to the point where the
+ * only thing that could report it had gone.
+ *
+ * So the ceiling is set below the SDK default rather than at it: the margin is what lets Reticle's
+ * own "timed out, here is the near miss" answer beat the client's abort. A refused argument is a
+ * bad ceiling costing one round trip; an accepted one that cannot be delivered costs the drive.
+ *
+ * This does not make long waits possible, and is not meant to — it makes the ADVERTISED bound one
+ * that can actually be honoured. A caller that genuinely needs to outlast this polls: several short
+ * waits, each of which returns a verdict. See #601 for the bounded-wait cursor that would let one
+ * call do it properly.
+ */
+const MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+export const MAX_BLOCKING_WAIT_MS = MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS - 5_000;
 
 /**
  * `capDepth` at this many levels is already past any store an agent can read.
@@ -60,7 +81,7 @@ export const cursorSchema = z.number().finite().int().nonnegative();
 /**
  * A wait budget in ms. 0 means evaluate now (documented on assert). Negative cannot be honoured.
  */
-export const timeoutMsSchema = z.number().finite().int().nonnegative().max(MAX_TIMEOUT_MS);
+export const timeoutMsSchema = z.number().finite().int().nonnegative().max(MAX_BLOCKING_WAIT_MS);
 
 /**
  * A count / cap. 0 means "return none", which is a real request. Negative is not.

--- a/packages/server/src/tools/observe-tools.ts
+++ b/packages/server/src/tools/observe-tools.ts
@@ -282,7 +282,9 @@ export const OBSERVE_TOOLS: ToolDef[] = [
       until: PredicateSchema.optional().describe("Alias for `predicate` (act_and_wait's name)."),
       timeout_ms: timeoutMsSchema
         .optional()
-        .describe('Maximum wait in milliseconds. Default: 4000.'),
+        .describe(
+          'Maximum wait in milliseconds. Default: 4000. Capped at 55000: your MCP client aborts the request before a longer wait can return, so a bound above this would be advertised and not deliverable. To outlast it, poll — several short waits, each of which returns a verdict.',
+        ),
       since: cursorSchema
         .optional()
         .describe('Cursor from a prior reticle_act — scopes the wait to events after that act.'),
@@ -380,7 +382,7 @@ export const OBSERVE_TOOLS: ToolDef[] = [
       timeout_ms: timeoutMsSchema
         .optional()
         .describe(
-          'If > 0, wait up to this many milliseconds before failing. Default: 0 (evaluate once).',
+          'If > 0, wait up to this many milliseconds before failing. Default: 0 (evaluate once). Capped at 55000: your MCP client aborts the request before a longer wait can return, so a bound above this would be advertised and not deliverable. To outlast it, poll — several short waits, each of which returns a verdict.',
         ),
       since: cursorSchema
         .optional()


### PR DESCRIPTION
## What

`timeout_ms` is now capped at 55s instead of 120s, so the advertised bound is one that can actually be honoured.

Refs #601. **This is option (1). It does not close the issue** — the bounded-wait cursor is the better answer for the timer-driven flows that are the reason anyone asks for a long timeout, and I have deliberately not pre-empted it. See the last section.

## Why 55, and why a second constant

The failure is not "the wait was too long". It is that the wait was **honoured right up to the point where the only thing that could report it had gone**. A caller who believed the advertised 120s and asked for 90s got a transport error at 60s: no verdict, no near-miss diagnosis, nothing to act on. Reticle did the work and the answer had nowhere to land.

So the ceiling sits *below* the SDK default rather than at it. At exactly 60s the verdict races the abort and loses — the reply still has to be produced, serialised and written after the wait ends, and all of that happens after the clock the client is watching has run out. The 5s margin is the point of the constant, not a rounding choice, and it is written down as `MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS - 5_000` so the relationship survives someone changing one of them.

`MAX_BLOCKING_WAIT_MS` is separate from `MAX_TIMEOUT_MS` on purpose. Only a wait **the request is held open for** is bounded by the client's patience; `delayMsSchema` and `windowMsSchema` share the old constant and are not blocking in that sense. Folding them together would shrink unrelated bounds in the name of a transport constraint they never touch, which is a silent behaviour change dressed as a fix.

## The trade, stated plainly

This **refuses** calls that are legal today. A caller asking for 90s now gets a schema rejection instead of a transport error.

I think that is the right side of the trade, and it is the same argument `numeric-bounds.ts` already opens with: a known parameter carrying a value the code cannot honour is the same failure as an unknown one. A refused argument costs one round trip and names its own fix. An accepted argument that cannot be delivered costs the drive, and reports it as a transport fault rather than as anything Reticle did.

Worth your judgement, though: if some client in the matrix is configured *above* 60s and someone is relying on a 90s wait there, this takes it away. I could not find one — the SDK default is what the matrix clients ship — but I have not driven every client in it.

## How a caller outlasts it

By polling: several short waits, each of which returns a verdict. The tool descriptions now say the ceiling **and** that recovery, so a caller meets it at the point of use rather than discovering it as a refusal.

That is a worse answer than one call that waits properly, which is exactly what (2) in the issue is for. What this change buys is that the failure mode in the meantime is an honest refusal instead of a dropped connection.

## Tests

`blocking-wait-ceiling.test.ts`, five cases: 90s and 60s are refused; the ceiling leaves room for the answer to arrive; the ceiling itself and the ordinary 4s budget are still accepted (a bound that refuses its own documented value is a lie in the other direction); `timeout_ms: 0` stays legal, since it means evaluate once rather than wait forever; and the non-blocking ceiling is unchanged.

## Gates

- [x] `pnpm lint` — 17/17 (one pre-existing `react-hooks/exhaustive-deps` warning in `bench-app`)
- [x] `pnpm typecheck` — 22/22
- [x] `pnpm test:unit` — 17/17 tasks; the tool suite is 1150 passing with no change needed to any existing bound
- [x] Tool-surface change, so `pnpm test:e2e` is the routed gate — CI runs it here; my local e2e cannot reach a daemon on this machine (noted on #655).