### PR TITLE
fix(flows): let flow_save name the file it writes

### DIFF
--- a/packages/server/src/flows/flow-tools.ts
+++ b/packages/server/src/flows/flow-tools.ts
@@ -138,7 +138,13 @@ export const FLOW_TOOLS: ToolDef[] = [
       flowName: z
         .string()
         .describe(
-          'Name for the flow file (saved to .reticle/flows/<flowName>.json). Use again in reticle_flow{action:"load"} / reticle_flow_replay.',
+          'Which RECORDING to save — the name reticle_record{start} was called with. This is a lookup key, not the filename: pass `saveAs` to choose that.',
+        ),
+      saveAs: z
+        .string()
+        .optional()
+        .describe(
+          'Name for the flow file (.reticle/flows/<saveAs>.json), and the name reticle_flow{action:"load"} / reticle_flow_replay take. Omit to reuse the recording name.',
         ),
       intent: z
         .string()
@@ -199,7 +205,22 @@ export const FLOW_TOOLS: ToolDef[] = [
           code: FlowErrorCode.NO_RECORDING,
         });
       }
+      // The name to save AS, which is not the name looked up above.
+      //
+      // `flowName` selects the recording; a recording is named at `record{start}`, often `default`
+      // or whatever the drive began as. Every other flow tool reads a flow name as the thing you
+      // load and replay, so a caller naming their flow at save time had no way to do it and had to
+      // `mv` the file on disk. The error message below already had to explain this ambiguity; that
+      // it needed explaining is the bug (#698).
+      const saveAs = asString(args['saveAs']);
+      if (saveAs !== undefined && !isValidFlowName(saveAs)) {
+        return Promise.resolve({
+          error: `'${saveAs}' is not a usable flow name — it becomes a filename under .reticle/flows/.`,
+          code: FlowErrorCode.INVALID_NAME,
+        });
+      }
       // fold any structured annotations (expect/dynamic/success/intent) onto the saved flow.
+      // Keyed by the RECORDING name: annotations were left against the recording, not the file.
       const success = deps.annotations.success(name);
       // The inline argument wins over an annotation left from an earlier call: it is the more recent
       // statement, and it is the one the author just typed.
@@ -216,7 +237,8 @@ export const FLOW_TOOLS: ToolDef[] = [
       const emptyRefusal = emptyFlowRefusal(program.steps.length, name);
       if (emptyRefusal !== undefined) return Promise.resolve(emptyRefusal);
       const { flows, root } = flowsForSession(deps, projectId);
-      return flows.save(program, annotations, projectId).then(async (res) => {
+      const toSave = saveAs === undefined ? program : { ...program, name: saveAs };
+      return flows.save(toSave, annotations, projectId).then(async (res) => {
         if (!res.ok) return { error: flowErrorMessage(res.code), code: res.code };
         deps.annotations.clear(name);
         // Grade the saved flow's assertions so the agent learns immediately if it just saved a flow

--- a/packages/server/src/flows/tools.flows.test.ts
+++ b/packages/server/src/flows/tools.flows.test.ts
@@ -190,4 +190,87 @@ describe('reticle_flow_save / reticle_flow_load handlers', () => {
     };
     expect(loaded.steps[0]?.expect?.signal).toBe('diff:shown');
   });
+  /**
+   * `flowName` selects the RECORDING; it never named the file (#698).
+   *
+   * A recording is named at `record{start}` - often `default`, or whatever the drive began as -
+   * while every other flow tool reads a flow name as the thing you load and replay. So a caller
+   * who wanted their flow called `create-table` had no way to say so and had to `mv` it on disk.
+   * The give-away that this confused people rather than merely being undocumented: the
+   * no-recording error in this handler already had to spend a sentence explaining the difference,
+   * after it cost a real investigation.
+   */
+  it('22: reticle_flow_save saves under saveAs, and that name loads back', async () => {
+    const recordings = new RecordingStore();
+    recordings.saveCompiled(
+      program('default', [
+        {
+          tool: ReticleTool.ACT,
+          stable: true,
+          args: { by: QueryBy.TESTID, value: 'pay', action: ActionType.CLICK, args: {} },
+        },
+      ]),
+    );
+    const deps = fakeDeps(memoryFs(), recordings);
+    const saved = (await tool(ReticleTool.FLOW_SAVE).handler(deps, {
+      flowName: 'default',
+      saveAs: 'create-table',
+    })) as { name: string };
+    expect(saved.name).toBe('create-table');
+
+    // A name you cannot load with is not a name.
+    const loaded = (await tool(ReticleTool.FLOW).handler(deps, {
+      action: 'load',
+      flowName: 'create-table',
+    })) as { flowName?: string; error?: string };
+    expect(loaded.error).toBeUndefined();
+    expect(loaded.flowName).toBe('create-table');
+  });
+
+  it('23: omitting saveAs still saves under the recording name', async () => {
+    // The compatibility guard: every existing caller passes only flowName.
+    const recordings = new RecordingStore();
+    recordings.saveCompiled(
+      program('checkout', [
+        {
+          tool: ReticleTool.ACT,
+          stable: true,
+          args: { by: QueryBy.TESTID, value: 'pay', action: ActionType.CLICK, args: {} },
+        },
+      ]),
+    );
+    const deps = fakeDeps(memoryFs(), recordings);
+    const saved = (await tool(ReticleTool.FLOW_SAVE).handler(deps, {
+      flowName: 'checkout',
+    })) as { name: string };
+    expect(saved.name).toBe('checkout');
+  });
+
+  it('24: a saveAs that cannot be a filename is refused, and nothing is written', async () => {
+    // It becomes a path under .reticle/flows/, so a traversal attempt is refused by name rather
+    // than resolved into one - and refusing must not quietly save under the recording name
+    // instead, which would write a file the caller never asked for and report success.
+    const recordings = new RecordingStore();
+    recordings.saveCompiled(
+      program('default', [
+        {
+          tool: ReticleTool.ACT,
+          stable: true,
+          args: { by: QueryBy.TESTID, value: 'pay', action: ActionType.CLICK, args: {} },
+        },
+      ]),
+    );
+    const deps = fakeDeps(memoryFs(), recordings);
+    const res = (await tool(ReticleTool.FLOW_SAVE).handler(deps, {
+      flowName: 'default',
+      saveAs: '../escape',
+    })) as { code?: string };
+    expect(res.code).toBe(FlowErrorCode.INVALID_NAME);
+
+    const loaded = (await tool(ReticleTool.FLOW).handler(deps, {
+      action: 'load',
+      flowName: 'default',
+    })) as { error?: string };
+    expect(loaded.error).toBeDefined();
+  });
 });


### PR DESCRIPTION
## What

`reticle_flow_save` takes `saveAs`, which names the saved flow.

Fixes #698.

## Which of the two fixes, and why

The issue offers: honour `flowName` as the save name, **or** rename it to what it is and document that the name is fixed at `record{start}`.

I did neither exactly — because the first is a silent breaking change and the second leaves the caller unable to do the thing they wanted.

`flowName` is a **lookup key**: it selects which recording to save, and existing callers pass it that way. Redefining it as the output name would change what every current call does, quietly, with no error. So `flowName` keeps its meaning and its description now says plainly that it is a lookup key rather than a filename, and `saveAs` is the new, optional output name.

That is the union of both options: the parameter is documented as what it is, *and* the caller can name their flow.

## On refusing rather than sanitising

`saveAs` becomes a path under `.reticle/flows/`, so it goes through `isValidFlowName` — the same check the save path already applies — and a bad one is refused by name rather than resolved into a path.

The refusal deliberately does **not** fall back to saving under the recording name. That would write a file the caller never asked for and report success, which is a worse outcome than the `mv` this issue is about. There is a test for exactly that.

## Tests

Three added to the existing `tools.flows.test.ts` rather than a new file — the fixture there is ~150 lines of in-memory `FileSystemPort` and session doubles, and duplicating it to save an import is how fixtures drift.

- `saveAs` names the file, **and that name loads back** — a name you cannot load with is not a name, so the round trip is the assertion rather than the returned string
- omitting `saveAs` still saves under the recording name (the compatibility guard)
- a traversal `saveAs` is refused, **and nothing is written under the recording name either**

Two of the three are confirmed red before the change.

## Gates

- [x] `pnpm lint` — 17/17 (one pre-existing `bench-app` warning)
- [x] `pnpm typecheck` — 22/22
- [x] `pnpm format:check` — clean
- [x] `pnpm test:unit` — 17/17 tasks