### PR TITLE
feat(tools): act_sequence addresses a step by target, like every other act tool

### DIFF
--- a/packages/server/src/tools/act-preflight.ts
+++ b/packages/server/src/tools/act-preflight.ts
@@ -34,11 +34,15 @@ export function assertSequenceSteps(steps: readonly unknown[]): void {
   steps.forEach((raw, i) => {
     const step = 'object' === typeof raw && null !== raw ? (raw as Record<string, unknown>) : {};
     if ('string' === typeof step['ref'] && step['ref'].length > 0) return;
-    const usedTarget = step['target'] !== undefined;
+    // `target` is addressed too, resolved per step through the same resolver `reticle_act` uses.
+    // This used to refuse it with an explanation, which was the honest half-fix: the asymmetry it
+    // explained still cost a round trip per field, which is the exact cost this tool exists to
+    // remove (#702).
+    if (step['target'] !== undefined) return;
     throw new Error(
-      `step ${String(i)} has no \`ref\`${usedTarget ? ' (it has `target`, which this tool does not take)' : ''}. ` +
-        'Sequence steps are addressed by ref: resolve them with reticle_query or reticle_snapshot first, ' +
-        'or use reticle_act / reticle_act_and_wait, which do accept `target`. ' +
+      `step ${String(i)} has neither \`ref\` nor \`target\`. ` +
+        'Address a step by ref (from reticle_query or reticle_snapshot) or by target ' +
+        '(e.g. { testid } or { role, name }). ' +
         'Nothing was acted on — the whole sequence is refused so a bad step cannot leave the earlier ones half-applied.',
     );
   });

--- a/packages/server/src/tools/act-sequence-steps.test.ts
+++ b/packages/server/src/tools/act-sequence-steps.test.ts
@@ -7,24 +7,31 @@
  *
  * Found by driving this project's own dashboard, where exactly that happened — the form submitted an
  * empty email and the failure surfaced three screens later as a mystery 401.
+ *
+ * A `target` step is now ACTED ON rather than refused (#702): the refusal was the honest half-fix,
+ * and the asymmetry it explained still cost a round trip per field. What must never come back is the
+ * original defect — a step this tool cannot address being skipped while the call reports success —
+ * so the cases below moved from "refuses target" to "refuses a step it cannot address at all".
  */
 import { describe, expect, it } from 'vitest';
 import { assertSequenceSteps } from './act-preflight.js';
 import { describeStepResult } from './act-sequence-retry.js';
 
 describe('refusing a sequence that cannot act', () => {
-  it('refuses a step written with `target` instead of `ref`', () => {
+  it('accepts a step addressed by `target`, which it now resolves', () => {
     expect(() =>
       assertSequenceSteps([{ target: { testid: 'auth-email' }, action: 'fill' }]),
-    ).toThrow(/target/);
+    ).not.toThrow();
   });
 
-  it('says where to put a target instead, rather than only refusing', () => {
+  it('names BOTH ways to address a step when one has neither', () => {
+    // The recovery has to name the option the caller did not use, or the message only says no.
     try {
-      assertSequenceSteps([{ target: { testid: 'x' }, action: 'click' }]);
+      assertSequenceSteps([{ action: 'click' }]);
       expect.unreachable('should have thrown');
     } catch (e) {
-      expect((e as Error).message).toContain('reticle_act_and_wait');
+      expect((e as Error).message).toContain('ref');
+      expect((e as Error).message).toContain('target');
     }
   });
 
@@ -33,7 +40,7 @@ describe('refusing a sequence that cannot act', () => {
       assertSequenceSteps([
         { ref: 'e1', action: 'fill' },
         { ref: 'e2', action: 'fill' },
-        { target: { testid: 'x' }, action: 'click' },
+        { action: 'click' },
       ]),
     ).toThrow(/step 2/);
   });
@@ -50,8 +57,18 @@ describe('refusing a sequence that cannot act', () => {
     expect(() => assertSequenceSteps([])).toThrow(/no steps/);
   });
 
-  it('refuses a step with an empty ref', () => {
-    expect(() => assertSequenceSteps([{ ref: '', action: 'click' }])).toThrow(/no `ref`/);
+  it('refuses a step with an empty ref and no target', () => {
+    // An empty string is not an address. It reached the browser as `ref: ''` and came back as
+    // "ref '' no longer resolves to an element", which sends the reader looking for a re-render.
+    expect(() => assertSequenceSteps([{ ref: '', action: 'click' }])).toThrow(/neither/);
+  });
+
+  it('accepts an empty ref when the step also carries a target', () => {
+    // `resolveActTarget` prefers a non-empty ref and falls through to the target otherwise, so a
+    // caller who sends both with an empty ref is addressed rather than refused.
+    expect(() =>
+      assertSequenceSteps([{ ref: '', target: { testid: 'x' }, action: 'click' }]),
+    ).not.toThrow();
   });
 
   it('refuses junk in the steps array', () => {

--- a/packages/server/src/tools/act-sequence-tool.ts
+++ b/packages/server/src/tools/act-sequence-tool.ts
@@ -20,7 +20,7 @@ import { asString, asRecord } from './tools-helpers.js';
 import { describeStepResult, runStepWithStaleRetry } from './act-sequence-retry.js';
 import { assertSequenceSteps } from './act-preflight.js';
 import { type ToolDef, sessionIdShape } from './tool-kit.js';
-import { actCommand } from './act-tools.js';
+import { actCommand, resolveActTarget } from './act-tools.js';
 
 export const ACT_SEQUENCE_TOOL: ToolDef = {
   name: ReticleTool.ACT_SEQUENCE,
@@ -41,7 +41,7 @@ export const ACT_SEQUENCE_TOOL: ToolDef = {
     steps: z
       .array(z.record(z.unknown()))
       .describe(
-        'Ordered list of { ref, action, args? } objects. Each step is equivalent to one reticle_act call; put confirmDangerous:true in a destructive step args object.',
+        'Ordered list of { ref | target, action, args? } objects. Each step is equivalent to one reticle_act call, and addresses its element the same way: an explicit `ref`, or a `target` query (e.g. { testid } or { role, name }) resolved in this call. put confirmDangerous:true in a destructive step args object.',
       ),
     timeout_ms: timeoutMsSchema
       .optional()
@@ -81,6 +81,21 @@ export const ACT_SEQUENCE_TOOL: ToolDef = {
       // invisible from the other — cover both when changing sequence semantics.
       for (let i = 0; i < inputSteps.length; i++) {
         const step = asRecord(inputSteps[i]);
+        // Resolve `target` per step, through the resolver `reticle_act` uses, so the two tools
+        // address an element identically. Resolved HERE rather than up front: an earlier step is
+        // what renders the element a later one names, so a batch resolved before the first
+        // dispatch would miss exactly the elements a sequence exists to reach.
+        const resolved = await resolveActTarget(session, step);
+        if ('error' === resolved.kind) {
+          stalledAt = i;
+          stepResults.push({
+            ...(step['target'] === undefined ? {} : { target: step['target'] }),
+            action: step['action'],
+            dispatched: false,
+            error: resolved.message,
+          });
+          break;
+        }
         try {
           // One retry when the ref went stale under a re-render — see act-sequence-retry.ts.
           const outcome = await runStepWithStaleRetry(
@@ -88,7 +103,7 @@ export const ACT_SEQUENCE_TOOL: ToolDef = {
               actCommand(
                 deps,
                 session,
-                { ref: step['ref'], action: step['action'], args: step['args'] ?? {} },
+                { ref: resolved.ref, action: step['action'], args: step['args'] ?? {} },
                 perStepTimeout,
               ),
             session,
@@ -98,7 +113,7 @@ export const ACT_SEQUENCE_TOOL: ToolDef = {
           if (!outcome.ok) {
             stalledAt = i;
             stepResults.push({
-              ref: step['ref'],
+              ref: resolved.ref,
               action: step['action'],
               dispatched: false,
               error: outcome.error ?? 'step failed',


### PR DESCRIPTION
## What

Sequence steps take `target`, resolved through the same resolver `reticle_act` uses.

Fixes #702, taking the option the issue prefers.

## Why the existing refusal was not enough

The clear rejection is already on `main` — a `target` step is refused with a message naming the tools that do accept one. That was the honest half-fix, and it stopped the original defect: a `target` step used to pass the schema, find no `ref`, and be **skipped while the call reported success** (an entire login journey doing nothing, found on this project's own dashboard).

But it left the asymmetry and its cost. `reticle_act` and `reticle_act_and_wait` both take `target`; only sequence steps did not, so filling three fields cost a `reticle_query` round trip per field. That is the exact cost this tool exists to remove, and the reporter's fallback was one `reticle_act` per field — i.e. not using it.

## How

`resolveActTarget` — already exported, already used by `reticle_act` — so the two tools address an element by one rule rather than two that drift.

**Resolved per step, not batched up front.** An earlier step is often what renders the element a later step names (fill → submit → click the row that appeared), so resolving every target before the first dispatch would miss exactly the elements a sequence exists to reach. It costs one query per targeted step, still inside the single round trip.

Steps with neither `ref` nor `target` are still refused **before the first dispatch**, so a bad step three cannot leave one and two applied. The message now names both ways to address a step rather than only the one the caller did not use.

The empty-ref case keeps its refusal but no longer reaches the browser as `ref: ''`, which came back as *"ref '' no longer resolves to an element"* — the symptom in this issue's title, and the reason it read as a stale ref rather than an unsupported parameter.

Only the live path changes. Replay batches one `ACT_SEQUENCE` command against compiled anchors and never resolves a target, and there is a comment in the handler about that divergence which I kept true.

## Tests

Four existing cases in `act-sequence-steps.test.ts` pinned the old refusal and are updated, not deleted — their intent (a sequence that cannot act must say so rather than skip and report success) is unchanged, so they moved from *"refuses target"* to *"refuses a step it cannot address at all"*. The file's docstring records why, so the next reader does not think the guard was weakened.

Two added: both ways to address a step are named when neither is given, and an empty `ref` **with** a target is accepted (`resolveActTarget` prefers a non-empty ref and falls through, so sending both is addressed rather than refused).

## Gates

- [x] `pnpm lint` — 17/17 (one pre-existing `bench-app` warning; my first draft tripped the repo's `yoda` rule, which is the opposite convention to the other repo I work in)
- [x] `pnpm typecheck` — 22/22
- [x] `pnpm format:check` — clean
- [x] `pnpm test:unit` — 17/17 tasks