### PR TITLE
fix(honesty): gate desktop coverage on the session runtime

### DIFF
--- a/packages/server/src/honesty/blind-spots.ts
+++ b/packages/server/src/honesty/blind-spots.ts
@@ -9,6 +9,7 @@
 // honesty-side imports keep working.
 export { BlindSpotKind } from '@reticlehq/core';
 import {
+  AppRuntime,
   BlindSpotKind,
   EventType,
   ReticleEnv,
@@ -152,6 +153,41 @@ export function blindSpotsFromEvents(events: readonly ReticleEvent[]): BlindSpot
  */
 export function blindSpotsFromState(state: Readonly<Record<string, number>>): BlindSpot[] {
   return Object.entries(state).map(([kind, count]) => ({ kind: kind as BlindSpotKind, count }));
+}
+
+/**
+ * Blind spots that can only be true of a DESKTOP renderer, and the sentences that say so.
+ *
+ * `UNOBSERVED_IPC` states "this Electron renderer has no Reticle preload", and `VERDICTLESS_SEND`
+ * describes `ipcRenderer.send`. Neither can be true of a web page, and both assert their runtime as
+ * fact rather than hedging.
+ */
+const DESKTOP_ONLY_SPOTS: readonly BlindSpotKind[] = [
+  BlindSpotKind.UNOBSERVED_IPC,
+  BlindSpotKind.VERDICTLESS_SEND,
+];
+
+/**
+ * Drop desktop-only blind spots when the session is not a desktop runtime.
+ *
+ * A plain Vite + React page on `localhost:5173` was reported as an Electron renderer with
+ * unobserved `ipcRenderer.invoke` coverage, on a session whose own `adapters` correctly read
+ * `["react"]` (#701). To a reader with no IPC that says their IPC instrumentation is broken, and the
+ * reporter's stated workaround was to stop reading the coverage block at all - which costs every
+ * other caveat in it, including the one that WAS applicable to them.
+ *
+ * The SDK gates its emission on the Electron user agent, so this is a second gate rather than the
+ * only one, and deliberately: the server knows the runtime the session reported at handshake, and a
+ * claim about the runtime should be checked against the runtime rather than against a user-agent
+ * string read in the page. An older SDK reports no runtime at all, and that case is left alone -
+ * withholding a caveat we cannot rule out is the wrong direction for an honesty surface.
+ */
+export function forRuntime(
+  spots: readonly BlindSpot[],
+  runtime: string | undefined,
+): readonly BlindSpot[] {
+  if (undefined === runtime || AppRuntime.WEB !== runtime) return spots;
+  return spots.filter((s) => !DESKTOP_ONLY_SPOTS.includes(s.kind));
 }
 
 /**

--- a/packages/server/src/honesty/desktop-coverage-runtime.test.ts
+++ b/packages/server/src/honesty/desktop-coverage-runtime.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { AppRuntime, BlindSpotKind } from '@reticlehq/core';
+import { buildCoverageStatement, forRuntime } from './blind-spots.js';
+
+/**
+ * A web page must never be told its Electron IPC is unobserved (#701).
+ *
+ * A plain Vite + React session on `localhost:5173` was reported as an Electron renderer with
+ * unobserved `ipcRenderer.invoke` coverage, while `reticle_sessions` correctly showed
+ * `adapters: ["react"]` on the same session. The sentence asserts the runtime as fact — "this
+ * Electron renderer has no Reticle preload" — so to a reader with no IPC it says their IPC
+ * instrumentation is broken.
+ *
+ * The cost is not the one wrong row. The reporter's stated workaround was to stop reading the
+ * coverage block entirely and rely on network, DOM and console evidence — which throws away every
+ * other caveat in it, including the no-registered-store one that WAS applicable to them.
+ */
+describe('desktop coverage is gated on the session runtime', () => {
+  const ipc = { kind: BlindSpotKind.UNOBSERVED_IPC, count: 1 };
+  const send = { kind: BlindSpotKind.VERDICTLESS_SEND, count: 2 };
+  const state = { kind: BlindSpotKind.UNWATCHED_STATE, count: 1 };
+
+  it('drops an Electron IPC claim on a web session', () => {
+    expect(forRuntime([ipc], AppRuntime.WEB)).toEqual([]);
+  });
+
+  it('keeps it on an Electron session, which is what it is for', () => {
+    expect(forRuntime([ipc], AppRuntime.ELECTRON)).toEqual([ipc]);
+  });
+
+  it('keeps every non-desktop spot on a web session', () => {
+    // The over-correction guard. The reporter's applicable caveat was this one, and losing it
+    // while fixing the noise would trade a wrong row for a missing one.
+    expect(forRuntime([ipc, state], AppRuntime.WEB)).toEqual([state]);
+  });
+
+  it('drops the one-way IPC send note too, for the same reason', () => {
+    // `ipcRenderer.send` cannot happen on a web page either, and it describes itself as IPC.
+    expect(forRuntime([send], AppRuntime.WEB)).toEqual([]);
+  });
+
+  it('leaves an unreported runtime alone rather than guessing', () => {
+    // An older SDK reports no runtime. Withholding a caveat we cannot rule out is the wrong
+    // direction for an honesty surface: a missing warning reads as coverage that was never had.
+    expect(forRuntime([ipc], undefined)).toEqual([ipc]);
+  });
+
+  it('leaves Tauri alone, which is a desktop runtime we do not model here', () => {
+    expect(forRuntime([ipc], AppRuntime.TAURI)).toEqual([ipc]);
+  });
+
+  it('a web session with only desktop spots reports FULL coverage, not a partial one', () => {
+    // The end state that matters: after the gate there is nothing to caveat, so the block is
+    // omitted rather than rendered empty.
+    const statement = buildCoverageStatement([...forRuntime([ipc, send], AppRuntime.WEB)]);
+    expect(statement.note).toBeUndefined();
+  });
+});

--- a/packages/server/src/tools/act-tools.ts
+++ b/packages/server/src/tools/act-tools.ts
@@ -58,6 +58,7 @@ import {
   absenceBlindSpotNote,
   buildCoverageStatement,
   blindSpotsFromState,
+  forRuntime,
   transportGapNote,
   Coverage,
   impeachesCapture,
@@ -647,7 +648,7 @@ export const ACT_TOOLS: ToolDef[] = [
         // stronger than this block. Grade from the strongest asserted consequence; integrity from evictions.
         // Coverage: cross-origin frames / other blind spots the SDK reported during this window mean the
         // verdict didn't see everything — say so, never imply full coverage.
-        const spots = blindSpotsFromState(session.blindSpots());
+        const spots = forRuntime(blindSpotsFromState(session.blindSpots()), session.runtime);
         const coverage = buildCoverageStatement(spots);
         const absenceBlindSpot = absenceBlindSpotNote(until, spots);
         // Nothing subscribed ⇒ the state channel is dark, and the summary must say so rather than

--- a/packages/server/src/tools/assert-verdict.ts
+++ b/packages/server/src/tools/assert-verdict.ts
@@ -12,6 +12,7 @@ import {
   absenceBlindSpotNote,
   blindSpotsFromState,
   buildCoverageStatement,
+  forRuntime,
   Coverage,
   impeachesCapture,
   transportGapNote,
@@ -79,7 +80,9 @@ export async function assertVerdict(
   // in that session partial — including ones about a region it cannot affect. That errs toward
   // over-warning, which is the correct direction here: the failure this guards against is a green
   // that implies coverage it never had, and a needless caveat costs the agent a sentence.
-  const spots = blindSpotsFromState(session.blindSpots());
+  // Gated on the runtime the session reported, so a web page is never told its Electron IPC is
+  // unobserved (#701).
+  const spots = forRuntime(blindSpotsFromState(session.blindSpots()), session.runtime);
   const statement = buildCoverageStatement(spots);
   const absenceBlindSpot = absenceBlindSpotNote(predicate, spots);
   // Omitted entirely when coverage is full, so an intact page pays nothing and the field's PRESENCE


### PR DESCRIPTION
## What

Desktop-only blind spots are dropped when the session reported a web runtime.

Fixes #701.

## Why the one wrong row matters more than it looks

The sentence asserts the runtime as **fact** — *"this Electron renderer has no Reticle preload"* — so a reader with no IPC is being told their IPC instrumentation is broken, on a session whose own `adapters` correctly read `["react"]`.

The real cost is in the issue's last line: the reporter's workaround was to **stop reading the coverage block at all**. That throws away every other caveat in it, including the no-registered-store one that *was* applicable to them. A single confidently-wrong row is enough to make an honesty surface not worth reading, which is the failure mode this whole subsystem exists to avoid.

## How

`forRuntime` filters desktop-only spots when `session.runtime` is `AppRuntime.WEB`.

`VERDICTLESS_SEND` goes with `UNOBSERVED_IPC`: it describes `ipcRenderer.send`, which cannot happen on a web page either, and names IPC in its text.

**A second gate, not the only one.** The SDK already checks the Electron user agent before emitting (`observers/ipc.ts`). This is deliberately additive: the server knows the runtime the session declared at handshake, and a claim *about the runtime* should be checked against the runtime rather than against a user-agent string read inside the page — which is the thing that can be wrong here.

Applied at **both** places blind spots reach a verdict (`assert-verdict.ts` and `act-tools.ts`), so `act` and `assert` cannot disagree about what a session can see.

## What it deliberately does not do

- **An unreported runtime is left alone.** An older SDK sends none, and withholding a caveat we cannot rule out is the wrong direction for an honesty surface: a missing warning reads as coverage that was never had.
- **Tauri is left alone.** It is a desktop runtime, and this change is not the place to decide what IPC means there.

## Tests

Seven, including the two that guard the directions this could go wrong:

- **`keeps every non-desktop spot on a web session`** — the over-correction guard. The reporter's applicable caveat was the store one, and losing it while fixing the noise trades a wrong row for a missing one.
- **`leaves an unreported runtime alone rather than guessing`** — pins the deliberate non-change above.
- **`a web session with only desktop spots reports FULL coverage`** — the end state: after the gate there is nothing to caveat, so the block is omitted rather than rendered empty.

## Gates

- [x] `pnpm lint` — 17/17 (one pre-existing `bench-app` warning)
- [x] `pnpm typecheck` — 22/22
- [x] `pnpm format:check` — clean
- [x] `pnpm test:unit` — 17/17 tasks; the honesty suite is 248 passing