### PR TITLE
fix(honesty): key the no-store-registered gap on the store registry

### DIFF
--- a/packages/server/src/honesty/instrumentation-gaps.ts
+++ b/packages/server/src/honesty/instrumentation-gaps.ts
@@ -123,7 +123,19 @@ export function gapsForAction(facts: ActionInstrumentationFacts): Instrumentatio
   //
   // Reported as the same kind, because it is the same missing thing seen from the other side, and
   // guarded so the two conditions cannot report it twice.
-  if (false === facts.hasCapabilities || (facts.stateAsked && facts.stateUnwatched)) {
+  //
+  // BOTH arms require `stateUnwatched`, which is the store registry. Keying the first on
+  // `hasCapabilities` alone made this fire on apps whose store IS registered and readable: an app
+  // that calls `registerStore()` without `registerCapabilities()` has no declaration and a perfectly
+  // good store, and got a gap saying "no state can be read from it" in the same response that
+  // carried `reticle_state { found: true }`, a populated `stateDiffs`, and `statePathsChanged`
+  // naming the store (#700). A gap contradicted by its own response tells the agent to redo work it
+  // has already done, and teaches it to distrust the whole block.
+  //
+  // The kind is NO_STORE_REGISTERED and every sentence it carries is about stores, so the store
+  // registry is what it must be keyed on. An undeclared-capabilities app with a working store is a
+  // different observation, and if it is worth reporting it needs its own kind and its own words.
+  if (facts.stateUnwatched && (false === facts.hasCapabilities || facts.stateAsked)) {
     // Same missing thing, two ways of meeting it — and the sentence has to say which. Describing an
     // assertion about state to an agent that made no such assertion is a false explanation, and a
     // gap nobody can act on is worse than no gap: it costs the trip and teaches the wrong lesson.

--- a/packages/server/src/honesty/uninstrumented-app.test.ts
+++ b/packages/server/src/honesty/uninstrumented-app.test.ts
@@ -15,6 +15,12 @@
  *
  * So a verdict drawn against an app that declared no capabilities carries the gap. Once per
  * session, like every other nudge: repeated on every call it becomes noise and gets tuned out.
+ *
+ * Both arms now also require `stateUnwatched` (#700). The fixtures below used to say
+ * `hasCapabilities: false` with `stateUnwatched: false` — an app that registered nothing, which
+ * nonetheless has a store to watch — and those two cannot both be true. That contradiction is
+ * exactly what shipped: apps calling `registerStore()` without `registerCapabilities()` were told
+ * "no state can be read from it" in the same response that read their state.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -41,7 +47,19 @@ const kinds = (facts: Parameters<typeof gapsForAction>[0]) =>
 
 describe('an app that declared no capabilities is told once', () => {
   it('reports the gap even when the agent never asked about state', () => {
-    expect(kinds({ ...declared, hasCapabilities: false })).toContain(
+    expect(kinds({ ...declared, hasCapabilities: false, stateUnwatched: true })).toContain(
+      InstrumentationGapKind.NO_STORE_REGISTERED,
+    );
+  });
+
+  /**
+   * The reported defect (#700). An app that calls `registerStore()` and not
+   * `registerCapabilities()` has no declaration and a perfectly readable store, and was told its
+   * state could not be read — beside a response carrying `reticle_state { found: true }`, a
+   * populated `stateDiffs`, and `statePathsChanged` naming the store.
+   */
+  it('stays silent when a store IS registered, however the app declared itself', () => {
+    expect(kinds({ ...declared, hasCapabilities: false, stateUnwatched: false })).not.toContain(
       InstrumentationGapKind.NO_STORE_REGISTERED,
     );
   });
@@ -51,7 +69,12 @@ describe('an app that declared no capabilities is told once', () => {
    * suspect anything first.
    */
   it('reports it on a PROVED verdict, where nothing else would raise it', () => {
-    const gaps = gapsForAction({ ...declared, hasCapabilities: false, proved: true });
+    const gaps = gapsForAction({
+      ...declared,
+      hasCapabilities: false,
+      stateUnwatched: true,
+      proved: true,
+    });
     expect(gaps.length).toBeGreaterThan(0);
   });
 });
@@ -63,13 +86,13 @@ describe('the sentence says which of the two conditions it was', () => {
    * wrong lesson about what went wrong.
    */
   it('an app that declared nothing is not told its assertion was about state', () => {
-    const [gap] = gapsForAction({ ...declared, hasCapabilities: false });
+    const [gap] = gapsForAction({ ...declared, hasCapabilities: false, stateUnwatched: true });
     expect(gap?.missing).toMatch(/declared no capabilities/i);
     expect(gap?.missing).not.toMatch(/this assertion was about state/i);
   });
 
   it('says the consequence in terms an agent can act on', () => {
-    const [gap] = gapsForAction({ ...declared, hasCapabilities: false });
+    const [gap] = gapsForAction({ ...declared, hasCapabilities: false, stateUnwatched: true });
     expect(gap?.cost).toMatch(/reticle_state will stay empty/i);
   });
 


### PR DESCRIPTION
## What

The `no-store-registered` gap now requires that no store is registered.

Fixes #700.

## The defect

It was keyed on `hasCapabilities` — a capability *declaration* — while every sentence it carries is about **stores**. So an app that calls `registerStore()` without `registerCapabilities()` has no declaration, a perfectly readable store, and was told its state could not be read. Forever.

That produced the response in the issue, which contradicts itself in three places at once:

- `reticle_state { store: "queryCache" }` → `found: true`, with real data
- `statePathsChanged: ["queryCache"]`, populated `stateDiffs`
- `instrumentationGaps: [{ kind: "no-store-registered", missing: "this app declared no capabilities at all, so no state can be read from it" }]`

Both arms now require `stateUnwatched`, which *is* the store registry.

An undeclared-capabilities app with a working store is a different observation. If it is worth reporting it needs its own kind and its own words, rather than borrowing a sentence that is false about it.

## The fixtures were the bug, written down

The four failing tests used `hasCapabilities: false` **with** `stateUnwatched: false` — an app that registered nothing, which nonetheless has a store to watch. Those cannot both be true, and that contradiction is exactly what shipped.

So they are corrected to `stateUnwatched: true` rather than the assertion being relaxed. Their intent — an under-instrumented app is told on its **first** verdict, without the agent having to suspect anything — is unchanged and still covered; the fixture now describes an app that is actually under-instrumented.

Added one for the reported case: a store registered, no declaration, **no gap**.

## Why it is worth more than one row

A gap contradicted by its own response tells the agent to redo work it has already done. Worse, it teaches it to distrust the whole `instrumentationGaps` block — and the other entries in there are the ones that are true.

## Gates

- [x] `pnpm lint` — 17/17 (one pre-existing `bench-app` warning)
- [x] `pnpm typecheck` — 22/22
- [x] `pnpm format:check` — clean
- [x] `pnpm test:unit` — 17/17 tasks; honesty suite 242 passing