### PR TITLE
fix(events): a same-document hash jump is not a blank destination

### DIFF
--- a/packages/server/src/events/contradictions.test.ts
+++ b/packages/server/src/events/contradictions.test.ts
@@ -336,6 +336,49 @@ describe('the route moved and nothing was rendered for it', () => {
   });
 
   /**
+   * A skip link is an accessibility primitive, and "did my skip link work" is a reasonable thing to
+   * verify. It reported `unknown` plus a spurious contradiction: a same-document hash navigation
+   * renders nothing BY DEFINITION, so this rule accused every one of arriving nowhere while the
+   * landmark it jumped to was present the whole time (#704).
+   */
+  const hashJump = (from: string, to: string): ReticleEvent =>
+    ev(EventType.ROUTE_CHANGE, { from, to, pathname: '/docs', hash: to.slice(to.indexOf('#')) });
+
+  it('stays silent for a same-document hash jump', () => {
+    expect(
+      kinds([hashJump('https://app.test/docs', 'https://app.test/docs#main-content'), attrOnly()]),
+    ).not.toContain(ContradictionKind.ROUTE_RENDERED_NOTHING);
+  });
+
+  it('still fires when the path moved as well as the hash', () => {
+    // A different document that rendered nothing is the bug this rule exists for; carrying a hash
+    // must not buy an exemption from it.
+    expect(
+      kinds([hashJump('https://app.test/docs', 'https://app.test/guide#intro'), attrOnly()]),
+    ).toContain(ContradictionKind.ROUTE_RENDERED_NOTHING);
+  });
+
+  it('still fires when the URL did not change at all', () => {
+    // A same-URL replace that rendered nothing genuinely arrived nowhere, and has no hash to jump
+    // to — the exemption must not swallow it.
+    expect(
+      kinds([hashJump('https://app.test/docs#a', 'https://app.test/docs#a'), attrOnly()]),
+    ).toContain(ContradictionKind.ROUTE_RENDERED_NOTHING);
+  });
+
+  it('still fires when a hash jump is followed by a real navigation that rendered nothing', () => {
+    // EVERY route change in the window has to be same-document, or a skip link at the start of a
+    // window would exempt whatever came after it.
+    expect(
+      kinds([
+        hashJump('https://app.test/docs', 'https://app.test/docs#main-content'),
+        routeChange(),
+        attrOnly(),
+      ]),
+    ).toContain(ContradictionKind.ROUTE_RENDERED_NOTHING);
+  });
+
+  /**
    * The window below is COPIED FROM A MEASUREMENT, not invented: three ordinary sidebar navigations
    * on the bench app, read back through reticle_observe. Every one of them emitted
    *

--- a/packages/server/src/events/contradictions.ts
+++ b/packages/server/src/events/contradictions.ts
@@ -468,7 +468,19 @@ function findWindowContradictions(
   // A navigation that neither fetches nor renders arrived nowhere. Distinct from a dead control:
   // the control worked, the DESTINATION is empty — which is why every "did the click do something"
   // heuristic passes it, a route change being unambiguously something.
-  const routed = events.some((e) => e.type === EventType.ROUTE_CHANGE);
+  const routeEvents = events.filter((e) => e.type === EventType.ROUTE_CHANGE);
+  const routed = routeEvents.length > 0;
+  // A same-document hash navigation renders nothing BY DEFINITION, so this rule accused every one
+  // of arriving nowhere. A skip link — `href="#main-content"`, an accessibility primitive — reported
+  // `unknown` / route-rendered-nothing while the landmark it jumped to was present the whole time
+  // and a `reticle_assert({ role: "main" })` immediately after returned yes (#704).
+  //
+  // Its observable consequences are `location.hash`, focus and scroll position; a DOM mutation is
+  // not among them, and demanding one asks the page for evidence it has no reason to produce.
+  //
+  // EVERY route change in the window has to be same-document: a hash jump followed by a real
+  // navigation that rendered nothing is still the bug this rule is for.
+  const sameDocumentOnly = routed && routeEvents.every((e) => isHashOnlyNavigation(e));
   // `dom.text` counts as rendered, and it has to: React reconciles a destination IN PLACE far more
   // often than it adds nodes. Measured on three ordinary sidebar navigations of the bench app — every
   // one emitted { dom.attr:2, dom.text:2, render.commit, state.change } and ZERO dom.added/removed,
@@ -488,7 +500,7 @@ function findWindowContradictions(
   const fetched = events.some(
     (e) => e.type === EventType.NET_REQUEST || e.type === EventType.NET_PENDING,
   );
-  if (routed && !rendered && !fetched && true !== options.renderProved) {
+  if (routed && !sameDocumentOnly && !rendered && !fetched && true !== options.renderProved) {
     found.push({
       kind: ContradictionKind.ROUTE_RENDERED_NOTHING,
       claim: 'the app navigated to a new route',
@@ -701,4 +713,20 @@ function findWindowContradictions(
   // Consumer rules run LAST and over the same app-only window, so a service embedding this engine
   // adds to the verdict rather than forking the file that produces it.
   return [...found, ...runRegisteredFolds(events, options)];
+}
+
+/**
+ * Did this route change move only the fragment, within the same document?
+ *
+ * Compared on the full `from`/`to` hrefs rather than on the `hash` field alone: a navigation that
+ * changes both the path and the hash lands on a new document and must stay subject to the
+ * blank-destination rule. Requiring a hash on the destination keeps a plain same-URL replace — which
+ * genuinely rendered nothing — out of the exemption.
+ */
+function isHashOnlyNavigation(event: ReticleEvent): boolean {
+  const from = asString(event.data['from']);
+  const to = asString(event.data['to']);
+  if (from === undefined || to === undefined || from === to) return false;
+  const withoutHash = (url: string): string => url.split('#')[0] ?? url;
+  return to.includes('#') && withoutHash(from) === withoutHash(to);
 }


### PR DESCRIPTION
## What

`route-rendered-nothing` no longer fires on a same-document hash navigation.

Fixes #704.

## Why

A hash jump **renders nothing by definition**. Its observable consequences are `location.hash`, focus and scroll position — a DOM mutation is not among them. So the rule was asking the page for evidence it had no reason to produce, and every skip link came back `unknown` plus a spurious contradiction, while the landmark it jumped to was present the whole time and a `reticle_assert({ role: "main" })` immediately after returned yes.

Skip links are an accessibility primitive, so "did my skip link work" is a reasonable thing to verify, and today it has no answer.

## How, and what it deliberately still catches

Compared on the full `from`/`to` hrefs, not on the `hash` field alone:

| case | outcome | why |
|---|---|---|
| `/docs` → `/docs#main-content` | **exempt** | same document; nothing to render |
| `/docs` → `/guide#intro` | still fires | a different document that rendered nothing is the bug this rule is for; carrying a hash must not buy an exemption |
| `/docs#a` → `/docs#a` | still fires | a same-URL replace genuinely arrived nowhere, and has no hash to jump to |
| hash jump **then** a real navigation | still fires | every route change in the window must be same-document, or a skip link at the start would exempt whatever came after it |

Those last three are the tests I care about most here — the risk in this change is not failing to exempt the skip link, it is exempting a real blank destination that happened to carry a `#`.

## Tests

Five, four of them the negative controls above. The exemption case is confirmed red before the change; the other four pass both ways by design, which is the point of them.

## Gates

- [x] `pnpm lint` — 17/17 (one pre-existing `bench-app` warning)
- [x] `pnpm typecheck` — 22/22
- [x] `pnpm format:check` — clean
- [x] `pnpm test:unit` — 17/17 tasks; contradictions suite 60 passing