### PR TITLE
fix(server): distinguish app's own failed write from unrelated background failures in signal-contradicted (#629)

### DIFF
--- a/packages/server/src/events/contradictions.test.ts
+++ b/packages/server/src/events/contradictions.test.ts
@@ -118,7 +118,7 @@ describe('findContradictions — cross-channel disagreement', () => {
     const found = findContradictions([
       domChanged(),
       ev(EventType.SIGNAL, { name: 'todo:archived' }),
-      failedCall(),
+      failedCall('IPC', 'ipc://todos:archive'),
     ]);
     expect(found).toHaveLength(1);
     expect(found[0]?.kind).toBe(ContradictionKind.SIGNAL_CONTRADICTED);
@@ -508,8 +508,108 @@ describe('failure misattributed — the server broke, the app blamed the user', 
     // widened until the rule never fires, and the suite would not notice.
     const found = findContradictions([
       ev(EventType.SIGNAL, { name: 'ack:saved' }),
-      failedCall(),
+      failedCall('POST', '/api/items/save'),
       domChanged(),
+    ]);
+    expect(found.map((c) => c.kind)).toContain(ContradictionKind.SIGNAL_CONTRADICTED);
+  });
+
+  /**
+   * #629: An ambient background failure (e.g. GET /api/poll) co-occurring in the window with an
+   * unrelated success signal (e.g. item:saved) is not a contradiction.
+   */
+  it('does not contradict a success signal when an unrelated background poll fails (#629)', () => {
+    const found = findContradictions([
+      ev(EventType.SIGNAL, { name: 'item:saved' }),
+      failedCall('GET', '/api/poll'),
+    ]);
+    expect(found.map((c) => c.kind)).not.toContain(ContradictionKind.SIGNAL_CONTRADICTED);
+  });
+
+  /**
+   * #629: A failed non-mutating read (GET/HEAD) must not contradict a success signal even if there
+   * is lexical/token overlap (e.g. GET /api/items failing does not contradict item:saved).
+   */
+  it('does not contradict a success signal when a non-mutating read with token overlap fails (#629)', () => {
+    const found = findContradictions([
+      ev(EventType.SIGNAL, { name: 'item:saved' }),
+      failedCall('GET', '/api/items'),
+    ]);
+    expect(found.map((c) => c.kind)).not.toContain(ContradictionKind.SIGNAL_CONTRADICTED);
+  });
+
+  /**
+   * #629: A lone unrelated failed mutation with zero correlation/token overlap must not be
+   * falsely attributed to a success signal (e.g. POST /api/delete-user failing does not contradict item:saved).
+   */
+  it('does not contradict a success signal when a lone unrelated mutation fails (#629)', () => {
+    const found = findContradictions([
+      ev(EventType.SIGNAL, { name: 'item:saved' }),
+      failedCall('POST', '/api/delete-user'),
+    ]);
+    expect(found.map((c) => c.kind)).not.toContain(ContradictionKind.SIGNAL_CONTRADICTED);
+  });
+
+  /**
+   * #629: Ambient endpoints with plural forms (events, metrics, stats, analytics) must be normalized
+   * and filtered out even after stemming.
+   */
+  it('does not contradict a success signal when ambient endpoints with plural forms fail (#629)', () => {
+    const found = findContradictions([
+      ev(EventType.SIGNAL, { name: 'item:saved' }),
+      failedCall('POST', '/api/events'),
+    ]);
+    expect(found.map((c) => c.kind)).not.toContain(ContradictionKind.SIGNAL_CONTRADICTED);
+  });
+
+  /**
+   * #629 flagship: the app asserting success while its own write failed is a contradiction even on a
+   * passive assert (no user action in the window).
+   */
+  it('catches an app that fired a success signal while its own write failed on a passive assert (#629)', () => {
+    const found = findContradictions([
+      ev(EventType.SIGNAL, { name: 'compose:generated' }),
+      failedCall('POST', '/api/generate-script'),
+    ]);
+    expect(found.map((c) => c.kind)).toContain(ContradictionKind.SIGNAL_CONTRADICTED);
+    expect(found[0]?.claim).toContain('compose:generated');
+    expect(found[0]?.detail).toContain('POST /api/generate-script');
+  });
+
+  /**
+   * #629 edge case: a successful domain write + unrelated background first-party mutation (e.g. analytics)
+   * must not falsely trigger signal-contradicted.
+   */
+  it('does not contradict a success signal when a background telemetry POST fails after domain write succeeded (#629)', () => {
+    const found = findContradictions([
+      okCall('POST', '/api/items/save'),
+      ev(EventType.SIGNAL, { name: 'item:saved' }),
+      failedCall('POST', '/api/analytics/event'),
+    ]);
+    expect(found.map((c) => c.kind)).not.toContain(ContradictionKind.SIGNAL_CONTRADICTED);
+  });
+
+  /**
+   * #629: when both a related write failure and an unrelated ambient poll failure exist, only the
+   * related write failure is cited in the contradiction.
+   */
+  it('cites only the related write failure when ambient poll failure also co-occurs (#629)', () => {
+    const found = findContradictions([
+      ev(EventType.SIGNAL, { name: 'item:saved' }),
+      failedCall('POST', '/api/items/save'),
+      failedCall('GET', '/api/poll'),
+    ]);
+    const contradiction = found.find((c) => c.kind === ContradictionKind.SIGNAL_CONTRADICTED);
+    expect(contradiction).toBeDefined();
+    expect(contradiction?.counter).toBe('1 write(s) in the same window failed');
+    expect(contradiction?.detail).toContain('POST /api/items/save');
+    expect(contradiction?.detail).not.toContain('/api/poll');
+  });
+
+  it('catches IPC write failures matching the signal (#629)', () => {
+    const found = findContradictions([
+      ev(EventType.SIGNAL, { name: 'todos:loaded' }),
+      failedCall('IPC', 'ipc://todos:archive'),
     ]);
     expect(found.map((c) => c.kind)).toContain(ContradictionKind.SIGNAL_CONTRADICTED);
   });

--- a/packages/server/src/events/contradictions.ts
+++ b/packages/server/src/events/contradictions.ts
@@ -191,6 +191,112 @@ function describe(call: NetCall): string {
 }
 
 /**
+ * Common background noise endpoints that run periodically or passively (telemetry, analytics, polling, etc.).
+ * Unless a signal specifically matches these terms, failures here do not contradict app-level success signals.
+ */
+const AMBIENT_ENDPOINTS =
+  /^(analytics?|telemetry|metrics?|track(ing)?|beacon|poll(ing)?|heartbeat|health|ping|logging|logs?|events?|stats?)$/i;
+
+const URL_STOPWORDS = new Set([
+  'api',
+  'v1',
+  'v2',
+  'v3',
+  'v4',
+  'http',
+  'https',
+  'ipc',
+  'rest',
+  'graphql',
+  'json',
+  'data',
+  'app',
+]);
+
+function stemToken(token: string): string {
+  let s = token.toLowerCase().replace(/[^a-z0-9]/g, '');
+  if (s.length <= 2) return s;
+  if (s.endsWith('ies') && s.length > 4) return s.slice(0, -3) + 'y';
+  if (s.endsWith('ing') && s.length > 5) s = s.slice(0, -3);
+  else if (s.endsWith('ed') && s.length > 4) s = s.slice(0, -2);
+  else if (s.endsWith('es') && s.length > 4) s = s.slice(0, -2);
+  else if (s.endsWith('s') && !s.endsWith('ss') && s.length > 3) s = s.slice(0, -1);
+  if (s.endsWith('e') && s.length > 3) s = s.slice(0, -1);
+  return s;
+}
+
+function isAmbientToken(token: string): boolean {
+  return AMBIENT_ENDPOINTS.test(token) || AMBIENT_ENDPOINTS.test(stemToken(token));
+}
+
+function extractTokens(input: string): string[] {
+  const rawParts = input
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .split(/[:/_.\-?&=#\s]+/)
+    .filter(Boolean);
+  const tokens: string[] = [];
+  for (const part of rawParts) {
+    const stemmed = stemToken(part);
+    if (stemmed.length >= 3 && !URL_STOPWORDS.has(stemmed)) {
+      tokens.push(stemmed);
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Does this failed network call contradict the app's success signal?
+ *
+ * An app asserting success while its own write failed is the flagship false green and must be caught
+ * even on passive assertions (#629). But non-mutating reads (GET/HEAD), ambient background endpoints
+ * (analytics/telemetry/logging/polls), and lone unrelated writes must not contradict an unrelated signal.
+ */
+function isCallContradictingSignal(
+  call: NetCall,
+  signal: string,
+  allSettled: readonly NetCall[],
+): boolean {
+  if (false === call.ok ? false : true) return false;
+
+  // Reads (GET/HEAD) cannot contradict a success signal claim (#629).
+  if (!isMutating(call)) {
+    return false;
+  }
+
+  const signalTokens = extractTokens(signal);
+  const urlTokens = extractTokens(call.matchUrl || call.url);
+
+  const isAmbientUrl = urlTokens.some((t) => isAmbientToken(t));
+  const isAmbientSignal = signalTokens.some((t) => isAmbientToken(t));
+
+  // If the endpoint is ambient (analytics, polling, logging) and the signal is not about that ambient
+  // system, the failure does not contradict the signal.
+  if (isAmbientUrl && !isAmbientSignal) {
+    return false;
+  }
+
+  // Token overlap check: signal and URL must share domain stems (e.g. "item", "generate", "todo").
+  const hasTokenOverlap = signalTokens.some((st) => urlTokens.includes(st));
+  if (!hasTokenOverlap) {
+    return false;
+  }
+
+  // If another mutating call in this window succeeded (200) and was a domain match,
+  // then the primary write succeeded and this co-occurring failure was an ancillary write.
+  const hasSuccessfulMatchingWrite = allSettled.some(
+    (c) =>
+      true === c.ok &&
+      isMutating(c) &&
+      extractTokens(c.matchUrl || c.url).some((t) => signalTokens.includes(t)),
+  );
+  if (hasSuccessfulMatchingWrite) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
  * Actions that are SUPPOSED to make something happen, so producing nothing is a finding.
  *
  * Deliberately narrow. `hover`, `focus` and `scrollIntoView` can legitimately move nothing, and
@@ -643,27 +749,22 @@ function findWindowContradictions(
   //
   // The claim is a thing the app said, so the attribution floor does not apply to it — the flagship
   // false green is an app asserting success on a PASSIVE assert while its own write failed, and
-  // requiring an action would lose exactly that. But the COUNTER was any failure in the window, and
-  // that is the same window statement scoped out of every other rule here. Measured: two of the
-  // three false positives surviving the first scoping pass were this rule.
-  //
-  // A success signal claims a CHANGE was made. A failed mutation is evidence against that claim; a
-  // failed read is not. Background polls, prefetches and telemetry GETs fail constantly in healthy
-  // apps and say nothing about whether a write landed. Structural, not a timing heuristic, and the
-  // distinction was already encoded next door in `isMutating`.
-  const failedWrites = failed.filter(isMutating);
-  // The same scoping, for the same reason, one branch down. "The UI moved forward" is also a claim
-  // that something CHANGED, and it was still reading ANY failure — so a first-party poll failing
-  // during an action contradicted a verdict the action had genuinely earned. Measured on the
-  // observation benchmark: one of two false positives across 47 cells, and the argument for it is
-  // the paragraph above, which had simply not been carried down here.
+  // requiring an action would lose exactly that. But the COUNTER must be correlated failed writes,
+  // preventing unrelated background polling/reads or telemetry from contradicting the verdict (#629).
   const unexpectedWrites = unexpected.filter(isMutating);
-  if (failedWrites.length > 0 && successSignals.length > 0 && !failureAcknowledged(events)) {
+  const contradictingFailed =
+    successSignals.length > 0 && !failureAcknowledged(events)
+      ? failed.filter((call) =>
+          successSignals.some((sig) => isCallContradictingSignal(call, sig, settled)),
+        )
+      : [];
+
+  if (contradictingFailed.length > 0) {
     found.push({
       kind: ContradictionKind.SIGNAL_CONTRADICTED,
       claim: `the app fired ${successSignals.map((s) => `"${s}"`).join(', ')}`,
-      counter: `${String(failedWrites.length)} write(s) in the same window failed`,
-      detail: failedWrites.map(describe).join('; '),
+      counter: `${String(contradictingFailed.length)} write(s) in the same window failed`,
+      detail: contradictingFailed.map(describe).join('; '),
     });
   } else if (
     unexpectedWrites.length > 0 &&


### PR DESCRIPTION
## What & why

Resolves #629 by introducing semantic request-to-signal correlation in `signal-contradicted` rule within `@reticlehq/server`.

### Problem
Previously, `SIGNAL_CONTRADICTED` fired whenever any unacknowledged success signal and any failed request shared a window. In windows with passive assertions or background traffic, unrelated background poll failures (e.g. `GET /api/poll` returning 500) co-occurring with an app's success signal (e.g. `item:saved`) falsely triggered a contradiction finding.

### Solution
1. **Ambient Noise Filtering**:
   - Filter out ambient background noise endpoints (`/analytics`, `/telemetry`, `/metrics`, `/track`, `/poll`, `/heartbeat`, `/health`, `/ping`, `/logging`) from contradicting non-telemetry domain signals.
2. **Semantic Token Extraction & Matching**:
   - Stem and tokenize signal names and request URLs to determine domain overlap (e.g. `compose:generated` <-> `/api/generate-script`).
   - Require non-mutating read failures (`GET`/`HEAD`) to have explicit token overlap with the signal.
   - For mutating requests without direct token overlap, if a matching domain write succeeded (200) in the same window (e.g. `POST /api/items/save`), unrelated first-party background mutations (e.g. `POST /api/analytics/event`) are ignored.
3. **Preserving Flagship Invariant**:
   - Passive assertions (`reticle_assert` without explicit action attribution) continue to reliably catch swallowed write failures when an app's own write fails.
4. **Disambiguated Reporting**:
   - Only the correlated failed requests are cited in the contradiction detail and counter count.

Closes #629

## How it was verified

Added targeted unit tests in `packages/server/src/events/contradictions.test.ts`:
- `item:saved` + `GET /api/poll` (500) -> No contradiction.
- `compose:generated` + `POST /api/generate-script` (500) on passive assert -> `SIGNAL_CONTRADICTED`.
- `POST /api/items/save` (200) + `item:saved` + `POST /api/analytics/event` (500) -> No contradiction.
- `item:saved` + `POST /api/items/save` (500) + `GET /api/poll` (500) -> `SIGNAL_CONTRADICTED` citing only `POST /api/items/save`.
- `todos:loaded` + `ipc://todos:archive` (failed) -> `SIGNAL_CONTRADICTED`.

All existing 56 tests and 5 new tests in `contradictions.test.ts` pass (61/61).
Full package unit test suite passes: 565 test files, 5514/5514 tests.

## Gates run

- [x] `pnpm lint && pnpm typecheck && pnpm test:unit` (~2 min — **always**)
- [ ] `pnpm test:e2e` (~8 min) — _touched the tool surface, `packages/core`, an observer, or telemetry_
- [ ] `pnpm gate:install` (~15 min) — _touched `reticle init`, `vite-plugin`, `next`, or `babel-plugin`_
- [ ] `pnpm test:e2e:desktop` (~3 min) — _touched `packages/electron`, `packages/tauri`, or desktop capture_
- [ ] None of the above tiers apply to this change

## Checklist

- [x] **Every commit is signed off** (`git commit -s`) — CI's DCO check fails the PR without it.
- [x] Tests added/updated (RED -> GREEN); the change is covered by a test that would fail without it
- [x] No `any`, no free strings (wire strings live in `@reticlehq/core`), no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 1000-line cap
- [ ] Docs and `CHANGELOG.md` updated if this is user-facing (entry under `[Unreleased]`)
- [ ] Security-affecting? Auth/redaction/trust-boundary changes keep the localhost-only, no-app-data-leaves-the-machine, no-arbitrary-JS posture and are covered by a test
