### PR TITLE
chore(release): v2.13.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "reticle",
       "source": "./plugin",
       "description": "Verify a running web app from the inside. Installs the Reticle skill and registers the Reticle MCP server.",
-      "version": "2.13.0",
+      "version": "2.13.1",
       "category": "testing",
       "tags": ["mcp", "verification", "testing", "web"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
+## [2.13.1] — 2026-09-02
+
+### Fixed
+
+- **`@reticlehq/server` — `init` no longer gives up on a cold Windows dev server that is still starting.** Silence from the dev server means it is wedged, and the budget for that was a flat 45 seconds. On Windows that is inside the window a first `npm run dev` spends optimising dependencies before the bundler prints its first line, so `init` reported "the dev server neither printed a URL nor bound a port", exited 1, and left an install failed on an app that was perfectly healthy — found by the install gate, which started the same scaffold immediately afterwards and connected to it. Windows now allows three minutes of quiet; every other platform is unchanged. Only the quiet budget moved: the overall ceiling is untouched, and a launcher that exits is still dead immediately, so this buys patience for a server that is starting and none at all for one that is broken.
+
 ## [2.13.0] — 2026-09-02
 
 ### Added

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/api",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "private": true,
   "description": "Demo backend for exercising Reticle against real-world behaviors (auth, errors, eventual consistency, LLM, uploads).",
   "type": "module",

--- a/apps/atlas/package.json
+++ b/apps/atlas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/atlas",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "private": true,
   "description": "The hard fixture: a logistics console with server-authoritative state, push updates, virtualization and a branching flow — built to find what Reticle cannot see.",
   "type": "module",

--- a/apps/bench-app/package.json
+++ b/apps/bench-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/bench-app",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "private": true,
   "description": "Complex dashboard fixture with injectable bugs — the app under test for the Playwright-vs-Reticle benchmark.",
   "type": "module",

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/e2e",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "private": true,
   "type": "module",
   "description": "Committed end-to-end batteries: the web battery boots api+bench-app+next-smoke and drives Reticle in a real headless browser; the desktop battery starts a real Electron main process and a packaged Tauri binary. The product regression safety net.",

--- a/apps/electron-smoke/package.json
+++ b/apps/electron-smoke/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/electron-smoke",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "private": true,
   "description": "A real Electron app (Vite + React renderer, contextBridge IPC) to smoke-test Reticle on Electron.",
   "type": "module",

--- a/apps/electron-vue-pinia/package.json
+++ b/apps/electron-vue-pinia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apps-electron-vue-pinia",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "private": true,
   "description": "An Electron application with Vue and TypeScript",
   "main": "./out/main/index.js",

--- a/apps/examples/astro/package.json
+++ b/apps/examples/astro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@reticlehq/example-astro",
   "private": true,
-  "version": "2.13.0",
+  "version": "2.13.1",
   "type": "module",
   "description": "Minimal Astro app with a React island — verifies Reticle via a dev-only client script.",
   "scripts": {

--- a/apps/examples/next/package.json
+++ b/apps/examples/next/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@reticlehq/example-next",
   "private": true,
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Minimal Next.js (App Router) app — verifies Reticle via withReticle + a dev-only client connect.",
   "scripts": {
     "dev": "next dev --webpack -p 5302",

--- a/apps/examples/react/package.json
+++ b/apps/examples/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@reticlehq/example-react",
   "private": true,
-  "version": "2.13.0",
+  "version": "2.13.1",
   "type": "module",
   "description": "Minimal Vite + React app — verifies Reticle integration via the reticle() Vite plugin.",
   "scripts": {

--- a/apps/examples/remix/package.json
+++ b/apps/examples/remix/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@reticlehq/example-remix",
   "private": true,
-  "version": "2.13.0",
+  "version": "2.13.1",
   "type": "module",
   "description": "Minimal React Router 7 (Remix) app — verifies Reticle via a dev-only client connect (SSR, no plugin injection).",
   "scripts": {

--- a/apps/large-dom-bench/package.json
+++ b/apps/large-dom-bench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/large-dom-bench",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "private": true,
   "description": "A deliberately large, non-virtualized DOM (thousands of nodes) used to measure the token wedge: full-snapshot cost vs a targeted verify loop.",
   "type": "module",

--- a/apps/next-smoke/package.json
+++ b/apps/next-smoke/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/next-smoke",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "private": true,
   "description": "A real Next.js (app router, React 19) app to smoke-test Reticle on Next.",
   "scripts": {

--- a/apps/tauri-smoke/package.json
+++ b/apps/tauri-smoke/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/tauri-smoke",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "private": true,
   "description": "A real Tauri v2 app (Vite + React frontend, Rust commands over invoke) to smoke-test Reticle on Tauri.",
   "type": "module",

--- a/apps/vibe-builder-demo/package.json
+++ b/apps/vibe-builder-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/vibe-builder-demo",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -32,7 +32,7 @@
   "navigation": {
     "versions": [
       {
-        "version": "2.13.0",
+        "version": "2.13.1",
         "default": true,
         "tabs": [
           {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reticle-monorepo",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "private": true,
   "description": "Reticle — the proof layer for AI agents. Observe and verify a running web app over MCP, no screenshots.",
   "packageManager": "pnpm@10.33.2",

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/babel-plugin",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Babel plugin that stamps data-reticle-source=\"file:line:col\" on JSX host elements so @reticlehq/react can map a DOM node to its source (works on React 19, which dropped _debugSource).",
   "type": "commonjs",
   "license": "Apache-2.0",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/browser",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Reticle browser SDK — installs observers, builds semantic snapshots, executes actions, talks to the bridge.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/core",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "The Reticle foundation: the shared wire contract — types, zod schemas, constants, messages, and the isomorphic kernel that every Reticle package (browser SDK, server, kits, test harness) imports. Depends only on zod.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/electron",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Reticle adapter for Electron: makes main-process IPC observable and the window screenshottable, from the two places the renderer cannot reach.",
   "type": "module",
   "exports": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/eslint-plugin",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Reticle ESLint plugin — keeps the signal layer self-enforcing (mutation-without-signal).",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/next",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Next.js helper for Reticle: keeps SWC, adds source-file mapping via a dev-only webpack pre-loader (data-reticle-source).",
   "license": "Apache-2.0",
   "author": "Reticle contributors",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/react",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Reticle React adapter — maps a DOM ref to its component stack and source file via the fiber tree.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/server",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Reticle bridge + MCP server. Hosts the browser WS endpoint and exposes MCP tools to the coding agent.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/tauri/Cargo.lock
+++ b/packages/tauri/Cargo.lock
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "reticle-tauri"
-version = "2.13.0"
+version = "2.13.1"
 dependencies = [
  "block2",
  "cairo-rs",

--- a/packages/tauri/Cargo.toml
+++ b/packages/tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reticle-tauri"
-version = "2.13.0"
+version = "2.13.1"
 edition = "2021"
 description = "Reticle screenshots and headless mode for a Tauri app"
 license = "MIT"

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/test",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Reticle test runner: reticleTest spec registry + a runner that drives Reticle tools without MCP/stdio.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reticlehq/vite-plugin",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Vite plugin for Reticle: dev-only source-map stamping plus auto-injected reticle.connect(). apply:'serve' guarantees it never ships to production.",
   "type": "module",
   "license": "Apache-2.0",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reticle",
   "displayName": "Reticle",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Verify a running web app from the inside. Installs the Reticle skill and registers the Reticle MCP server so the agent can look, act, observe and assert against the real app.",
   "author": {
     "name": "Reticle contributors",

--- a/plugin/SKILL.md
+++ b/plugin/SKILL.md
@@ -3,7 +3,7 @@ name: reticle
 description: Install, instrument and verify this running web app from the inside (DOM, network, routing, console and framework state) instead of screenshots or guessing. Drives one real flow end to end and returns a verdict with the file:line to fix. Use when the user asks to set up or install Reticle, when a user-facing change needs proving before you call it done, when a test passes but the UI is broken, or when the user types /reticle.
 license: Apache-2.0
 metadata:
-  version: 2.13.0
+  version: 2.13.1
   homepage: https://www.reticle.sh
   repository: https://github.com/reticlehq/reticle
 ---

--- a/skills/agentic-tdd/SKILL.md
+++ b/skills/agentic-tdd/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-tdd
 description: Test-driven development for behaviour a unit test cannot reach, by writing the expectation against the running app before writing the code. Declare the consequence first, watch it fail, implement, watch it pass. Use when building a user-facing feature, when the user asks for TDD on UI or full-stack work, when a unit test cannot express the outcome that matters, or when you want a red-green loop that runs against the real app instead of mocks.
 license: Apache-2.0
 metadata:
-  version: 2.13.0
+  version: 2.13.1
   homepage: https://www.reticle.sh
   repository: https://github.com/reticlehq/reticle
 ---

--- a/skills/audit-my-app/SKILL.md
+++ b/skills/audit-my-app/SKILL.md
@@ -3,7 +3,7 @@ name: audit-my-app
 description: Sweep a whole running web app for what is broken, without writing a script or knowing the codebase. Clicks every reachable control and reports dead buttons, console errors, failed requests, and places where the API and the screen disagree. Use on an unfamiliar codebase, before a release, after a big merge or dependency bump, when the user asks for a smoke test or a health check, or when someone says "just check everything still works".
 license: Apache-2.0
 metadata:
-  version: 2.13.0
+  version: 2.13.1
   homepage: https://www.reticle.sh
   repository: https://github.com/reticlehq/reticle
 ---

--- a/skills/debug-broken-ui/SKILL.md
+++ b/skills/debug-broken-ui/SKILL.md
@@ -3,7 +3,7 @@ name: debug-broken-ui
 description: Find out why something in a running web app does not work, when the console is empty and the code looks correct. Reads the click, the request, the store and the console together and returns the file:line to open. Use when a button does nothing, a form will not submit, data will not load, a page renders blank or stale, a modal will not close, or the user says "it's broken" and the code review says it is fine.
 license: Apache-2.0
 metadata:
-  version: 2.13.0
+  version: 2.13.1
   homepage: https://www.reticle.sh
   repository: https://github.com/reticlehq/reticle
 ---

--- a/skills/design-system-compliance/SKILL.md
+++ b/skills/design-system-compliance/SKILL.md
@@ -3,7 +3,7 @@ name: design-system-compliance
 description: Check that the UI you actually rendered uses the design system, by reading computed styles in the running app against the project's design tokens. Catches hardcoded hex colors, off-palette backgrounds, invisible or unusable controls, and animations that never ran. Use after building or restyling a component, when a design review is wanted, when a UI looks slightly off but nobody can say why, or when a design system exists and nothing checks whether the code follows it.
 license: Apache-2.0
 metadata:
-  version: 2.13.0
+  version: 2.13.1
   homepage: https://www.reticle.sh
   repository: https://github.com/reticlehq/reticle
 ---

--- a/skills/drive-desktop-app/SKILL.md
+++ b/skills/drive-desktop-app/SKILL.md
@@ -3,7 +3,7 @@ name: drive-desktop-app
 description: Drive and verify an Electron or Tauri desktop app from the inside, including the main-process and Rust IPC calls a browser tool cannot see. Use when a desktop app needs testing, when a feature works in the browser but not in the packaged app, when an IPC or invoke call needs proving, when a desktop screenshot or visual diff is wanted, or when you need a headless run of a desktop UI in CI.
 license: Apache-2.0
 metadata:
-  version: 2.13.0
+  version: 2.13.1
   homepage: https://www.reticle.sh
   repository: https://github.com/reticlehq/reticle
 ---

--- a/skills/false-green-tests/SKILL.md
+++ b/skills/false-green-tests/SKILL.md
@@ -3,7 +3,7 @@ name: false-green-tests
 description: 'Find out why the tests pass but the app is broken. Catches false greens: a green suite over a feature that does not work, a mocked API standing in for a real one, an assertion that holds no matter what the app does, a click handler wired to nothing. Use when the suite is green and the user says it is broken, when a test never fails, when coverage looks fine but bugs still ship, or before trusting a passing run you did not watch.'
 license: Apache-2.0
 metadata:
-  version: 2.13.0
+  version: 2.13.1
   homepage: https://www.reticle.sh
   repository: https://github.com/reticlehq/reticle
 ---

--- a/skills/fix-what-i-pointed-at/SKILL.md
+++ b/skills/fix-what-i-pointed-at/SKILL.md
@@ -3,7 +3,7 @@ name: fix-what-i-pointed-at
 description: Pick up the bugs a human flagged by pointing at them in the running app, each arriving with the element, the note they typed, and the source file and line. Use when the user says they marked or flagged something, when starting a session on an app someone has been clicking through, when a designer or PM has left feedback in the UI, or when the user describes a problem as "that button there" without saying which file.
 license: Apache-2.0
 metadata:
-  version: 2.13.0
+  version: 2.13.1
   homepage: https://www.reticle.sh
   repository: https://github.com/reticlehq/reticle
 ---

--- a/skills/install-and-verify/SKILL.md
+++ b/skills/install-and-verify/SKILL.md
@@ -3,7 +3,7 @@ name: install-and-verify
 description: Verify that a web app change actually works by driving the running app from the inside (DOM, network, routing, console, framework state) instead of screenshots or guessing. Use after any user-facing change, when a fix is claimed but unproven, when a test passes but the UI is broken, or when you need a real verdict rather than "looks right". Also use to install and wire up Reticle in a project that does not have it yet.
 license: Apache-2.0
 metadata:
-  version: 2.13.0
+  version: 2.13.1
   homepage: https://www.reticle.sh
   repository: https://github.com/reticlehq/reticle
 ---

--- a/skills/replay-user-flows/SKILL.md
+++ b/skills/replay-user-flows/SKILL.md
@@ -3,7 +3,7 @@ name: replay-user-flows
 description: Turn a user journey you just clicked through into a saved regression check that re-runs deterministically, with no model in the loop and no test code to write. Use when you have driven the same flow twice, when the user wants regression coverage without a Playwright suite, when a refactor needs proving against every existing journey, or when re-verifying by hand is costing a full drive every time.
 license: Apache-2.0
 metadata:
-  version: 2.13.0
+  version: 2.13.1
   homepage: https://www.reticle.sh
   repository: https://github.com/reticlehq/reticle
 ---

--- a/skills/test-error-states/SKILL.md
+++ b/skills/test-error-states/SKILL.md
@@ -3,7 +3,7 @@ name: test-error-states
 description: Force the states a happy-path run never reaches (a failing API, an empty list, a slow request, a timeout, an expired session, a toast that auto-dismisses) and check the UI actually handles them. Use when error handling was written but never run, when a loading or empty state needs verifying, when a bug only happens on a slow connection, or when a timer, poll, debounce or retry needs testing without sleeping.
 license: Apache-2.0
 metadata:
-  version: 2.13.0
+  version: 2.13.1
   homepage: https://www.reticle.sh
   repository: https://github.com/reticlehq/reticle
 ---

--- a/skills/verify-ui-change/SKILL.md
+++ b/skills/verify-ui-change/SKILL.md
@@ -3,7 +3,7 @@ name: verify-ui-change
 description: Check that a change to a web app actually works in the running app before calling it done. Drives the real page and returns a pass/fail verdict with the request that fired, the state that moved, and the file:line to fix. Use after editing a component, a form, a route, or an API call; when you have said "fixed" but have not opened the app; when the user asks "does it actually work?"; or when a change looks right on screen and you cannot prove it.
 license: Apache-2.0
 metadata:
-  version: 2.13.0
+  version: 2.13.1
   homepage: https://www.reticle.sh
   repository: https://github.com/reticlehq/reticle
 ---

--- a/skills/verify-unattended/SKILL.md
+++ b/skills/verify-unattended/SKILL.md
@@ -3,7 +3,7 @@ name: verify-unattended
 description: 'Install, instrument and verify a web app end to end without pausing for a human. Use in an autonomous or goal-mode agent, in CI, or in any client that asks for approval on every command: it never says "restart your client" or "open a browser", because it takes a route that needs neither. Prefer the normal install-and-verify skill when a human is present and can answer.'
 license: Apache-2.0
 metadata:
-  version: 2.13.0
+  version: 2.13.1
   homepage: https://www.reticle.sh
   repository: https://github.com/reticlehq/reticle
 ---


### PR DESCRIPTION
Patch release. One user-facing fix, already merged to main as `c65b2e89`; this is the version bump, changelog and lockstep sweep on top of it.

### Why a patch rather than waiting

`v2.13.0` is published to npm. The commit immediately after the tag fixes a **Windows install failure**: the flat 45-second "silence means hung" budget fires while a cold `npm run dev` is still optimising dependencies, so `reticle init` reports *"the dev server neither printed a URL nor bound a port"* and exits 1 on an app that is perfectly healthy. The install gate found it by starting the same scaffold straight afterwards and connecting to it.

That is the exact failure class the gate exists to catch, on the shipped artifact, so it does not wait for the next minor.

### Scope

- 15 artifacts bumped in lockstep: root + 10 workspace packages, `Cargo.toml` + `Cargo.lock`, plugin manifest, marketplace entry, plugin skill + 12 published skills.
- The `reticle-tauri = "2.13"` pin in the three docs pages is a minor pin, correctly untouched.
- No contract change, no new surface, no behaviour change off Windows.

### Gates

`format:check` · `lint` · `typecheck` · `test:unit` · `lint:docs` · `test:e2e` **36/36** · `claude plugin validate` · all 13 skills discoverable via `npx skills`.

The version-lockstep guards in `test:unit` (`crate-version-lockstep`, `docs-version-drift`, plugin version, skill frontmatter) all pass, which is what proves the sweep was complete rather than my having listed the files correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzFWBTEj28aTCv77jTGrLs