### PR TITLE
feat(server): add opt-in seedStorage to reticle_lease (#599)

### DIFF
--- a/apps/e2e/gate-harness.mjs
+++ b/apps/e2e/gate-harness.mjs
@@ -165,7 +165,11 @@ export async function freePortSafely(port, { onNote = () => {} } = {}) {
 function kill(pids, hard) {
   for (const pid of pids) {
     try {
-      process.kill(Number(pid), hard ? 'SIGKILL' : 'SIGTERM');
+      if ('win32' === process.platform) {
+        killTree(pid);
+      } else {
+        process.kill(Number(pid), hard ? 'SIGKILL' : 'SIGTERM');
+      }
     } catch {
       // Already gone between the listing and the signal. Fine.
     }

--- a/apps/e2e/install-gate.mjs
+++ b/apps/e2e/install-gate.mjs
@@ -806,7 +806,7 @@ async function driveScaffold(scaffold, index) {
     try {
       report = run(
         'node',
-        [CLI, 'init', '--port', String(SELF_TEST ? bridgePort + 1 : bridgePort), '--no-mcp'],
+        [CLI, 'init', '--port', String(SELF_TEST ? bridgePort + 1 : bridgePort), '--no-mcp', '--no-drive'],
         initFrom,
         {
           npm_config_registry: REGISTRY,
@@ -1123,6 +1123,23 @@ async function driveScaffold(scaffold, index) {
 console.log('\n=== INSTALL GATE: pristine apps, installed into, opened, and asked to connect ===');
 if (SELF_TEST) console.log('   (self-test: every scaffold is mis-wired and MUST fail)');
 await sweepBatteryOrphans([], { onNote: (n) => console.log(`   · ${n}`) });
+
+// Free ports used by either the real run or a preceding self-test (which runs first in CI in the
+// same job). On Windows, where detached daemons outlive process termination, an un-freed daemon
+// from self-test (e.g. port 4855) stays listening and tricks subsequent scaffolds into probing it.
+const allGatePorts = new Set([REGISTRY_PORT]);
+for (const offset of [0, SELF_TEST_PORT_OFFSET]) {
+  for (let i = 0; i < SCAFFOLDS.length; i++) {
+    const b = Number(process.env.INSTALL_GATE_PORT ?? '4788') + offset + i * 2;
+    allGatePorts.add(b);
+    allGatePorts.add(b + 1);
+    const a = Number(process.env.INSTALL_GATE_APP_PORT ?? '4820') + offset + i * 2;
+    allGatePorts.add(a);
+  }
+}
+for (const port of allGatePorts) {
+  await freePortSafely(port);
+}
 
 const chosen = SCAFFOLDS.filter((s) => ONLY === undefined || s.id === ONLY);
 if (chosen.length === 0) {

--- a/packages/browser/src/observers/storage.test.ts
+++ b/packages/browser/src/observers/storage.test.ts
@@ -57,6 +57,44 @@ describe('readStorage', () => {
       if (realLocal) Object.defineProperty(window, 'localStorage', realLocal);
     }
   });
+
+  it('redacts secret-shaped values (e.g. JWT) even under benign key names', () => {
+    const jwtSecret =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+    const apiKeySecret = 'sk_test_mocktoken1234567890abcdef';
+
+    localStorage.setItem('custom_app_cache', jwtSecret);
+    sessionStorage.setItem('cached_payload', `prefix-${apiKeySecret}-suffix`);
+    document.cookie = `benign_cookie=${jwtSecret}`;
+
+    const snap = readStorage() as StorageSnapshot;
+    expect(snap.local['custom_app_cache']).toBe('[REDACTED]');
+    expect(snap.local['custom_app_cache']).not.toContain(jwtSecret);
+
+    expect(snap.session['cached_payload']).toBe('prefix-[REDACTED]-suffix');
+    expect(snap.session['cached_payload']).not.toContain(apiKeySecret);
+
+    expect(snap.cookies['benign_cookie']).toBe('[REDACTED]');
+    expect(snap.cookies['benign_cookie']).not.toContain(jwtSecret);
+  });
+
+  it('preserves legitimate near-miss values that merely resemble a secret', () => {
+    const nearMiss1 = 'eyJshort'; // not a 3-part base64 JWT
+    const nearMiss2 = 'sk_unknown_prefix_12345'; // not live/test
+    const legitimateText = 'standard-user-profile-description';
+    const validJson = JSON.stringify({ count: 42, label: 'items_in_cart' });
+
+    localStorage.setItem('description', legitimateText);
+    localStorage.setItem('cart_json', validJson);
+    localStorage.setItem('near_miss_data', nearMiss1);
+    sessionStorage.setItem('fake_key', nearMiss2);
+
+    const snap = readStorage() as StorageSnapshot;
+    expect(snap.local['description']).toBe(legitimateText);
+    expect(snap.local['cart_json']).toBe(validJson);
+    expect(snap.local['near_miss_data']).toBe(nearMiss1);
+    expect(snap.session['fake_key']).toBe(nearMiss2);
+  });
 });
 
 /**

--- a/packages/browser/src/observers/storage.ts
+++ b/packages/browser/src/observers/storage.ts
@@ -1,5 +1,5 @@
 import { EventType, REDACTED_VALUE, StorageArea } from '@reticlehq/core';
-import { isSensitiveKey } from '../security/serialization.js';
+import { isSensitiveKey, scrubKnownSecrets } from '../security/serialization.js';
 import { observeSafely, observeValue, type Emit, type Teardown } from './types.js';
 
 /** The three readable client-side storage areas. httpOnly cookies are invisible to JS by design. */
@@ -25,7 +25,9 @@ function readArea(storage: Storage | null): Record<string, string> {
     const key = storage.key(i);
     if (null === key) continue;
     // Redact credential-bearing keys (token/session/password/…) so auth state never leaks verbatim.
-    out[key] = isSensitiveKey(key) ? REDACTED_VALUE : (storage.getItem(key) ?? '');
+    // Also scrub high-confidence secret shapes (e.g. JWTs) from values under benign keys.
+    const val = storage.getItem(key) ?? '';
+    out[key] = isSensitiveKey(key) ? REDACTED_VALUE : scrubKnownSecrets(val);
   }
   return out;
 }
@@ -49,11 +51,13 @@ function readCookies(): Record<string, string> {
       out[key] = REDACTED_VALUE;
       continue;
     }
+    let val = '';
     try {
-      out[key] = decodeURIComponent(part.slice(eq + 1).trim());
+      val = decodeURIComponent(part.slice(eq + 1).trim());
     } catch {
-      out[key] = part.slice(eq + 1).trim();
+      val = part.slice(eq + 1).trim();
     }
+    out[key] = scrubKnownSecrets(val);
   }
   return out;
 }
@@ -78,7 +82,7 @@ export function readStorage(area?: string): StorageSnapshot | Record<string, str
 /** Redact a value when its key is credential-bearing — the same rule the pull path applies. */
 function redactFor(key: string, value: string | null): string | undefined {
   if (null === value) return undefined;
-  return isSensitiveKey(key) ? REDACTED_VALUE : value;
+  return isSensitiveKey(key) ? REDACTED_VALUE : scrubKnownSecrets(value);
 }
 
 type SetItemFn = (this: Storage, key: string, value: string) => void;

--- a/packages/core/src/event-payloads.ts
+++ b/packages/core/src/event-payloads.ts
@@ -52,6 +52,44 @@ export type ScrollDirection = (typeof ScrollDirection)[keyof typeof ScrollDirect
 export const StorageArea = { LOCAL: 'local', SESSION: 'session', COOKIE: 'cookies' } as const;
 export type StorageArea = (typeof StorageArea)[keyof typeof StorageArea];
 
+/**
+ * A single cookie to seed before initial navigation.
+ */
+export const SeedCookieSchema = z.object({
+  name: z.string().describe('Cookie name.'),
+  value: z.string().describe('Cookie value.'),
+  domain: z.string().optional().describe('Cookie domain. Defaults to the navigation URL domain.'),
+  path: z.string().optional().describe('Cookie path. Defaults to "/".'),
+  url: z.string().optional().describe('Cookie URL. Defaults to the navigation URL.'),
+  httpOnly: z.boolean().optional().describe('Whether the cookie is httpOnly.'),
+  secure: z.boolean().optional().describe('Whether the cookie is secure.'),
+  sameSite: z.enum(['Strict', 'Lax', 'None']).optional().describe('SameSite policy.'),
+  expires: z.number().optional().describe('Unix timestamp in seconds for cookie expiration.'),
+});
+export type SeedCookie = z.infer<typeof SeedCookieSchema>;
+
+export const SeedCookiesSchema = z.union([z.record(z.string()), z.array(SeedCookieSchema)]);
+export type SeedCookies = z.infer<typeof SeedCookiesSchema>;
+
+/**
+ * Client storage and session state to seed into an isolated context before the first navigation.
+ * Matches the three storage areas Reticle already observes (localStorage, sessionStorage, cookies).
+ */
+export const SeedStorageSchema = z.object({
+  local: z
+    .record(z.string())
+    .optional()
+    .describe('Key-value pairs to seed into window.localStorage before first navigation.'),
+  session: z
+    .record(z.string())
+    .optional()
+    .describe('Key-value pairs to seed into window.sessionStorage before first navigation.'),
+  cookies: SeedCookiesSchema.optional().describe(
+    'Cookies to seed before first navigation: a name-value record scoped to the lease URL or an array of cookie objects.',
+  ),
+});
+export type SeedStorage = z.infer<typeof SeedStorageSchema>;
+
 const elementLabel = z.object({ role: z.string().optional(), name: z.string().optional() });
 
 /**

--- a/packages/server/src/events/predicate.ts
+++ b/packages/server/src/events/predicate.ts
@@ -78,6 +78,11 @@ export interface PredicateSession {
    * Optional: a fake that never throttles simply omits it.
    */
   throttled?(): boolean;
+  /**
+   * Set when a required application precondition (e.g. seedStorage) was not established.
+   * Optional: a fake that never tests preconditions simply omits it.
+   */
+  preconditionFailure?(): string | undefined;
 }
 
 /**
@@ -386,8 +391,12 @@ function annotateThrottledMiss(
   result: EvalResult,
 ): EvalResult {
   if (result.pass) return result;
-  if (true !== session.throttled?.()) return result;
   if (result.inconclusive !== undefined) return result;
+  const preconditionFailure = session.preconditionFailure?.();
+  if (preconditionFailure !== undefined) {
+    return { ...result, inconclusive: preconditionFailure };
+  }
+  if (true !== session.throttled?.()) return result;
   if (failureRestsOnSeeing(predicate)) return result;
   return { ...result, inconclusive: THROTTLED_STARVED_NOTE };
 }

--- a/packages/server/src/events/predicate.ts
+++ b/packages/server/src/events/predicate.ts
@@ -78,10 +78,7 @@ export interface PredicateSession {
    * Optional: a fake that never throttles simply omits it.
    */
   throttled?(): boolean;
-  /**
-   * Set when a required application precondition (e.g. seedStorage) was not established.
-   * Optional: a fake that never tests preconditions simply omits it.
-   */
+  /** Precondition failure reason (e.g. seedStorage), if any. */
   preconditionFailure?(): string | undefined;
 }
 

--- a/packages/server/src/pool/browser-pool.test.ts
+++ b/packages/server/src/pool/browser-pool.test.ts
@@ -10,6 +10,7 @@ import {
   type Launcher,
   type PooledBrowser,
   type PooledContext,
+  type PooledCookie,
   type PooledDialog,
   type PooledPage,
 } from './browser-pool.js';
@@ -20,8 +21,11 @@ class FakePage implements PooledPage {
   failNav = false;
   dismissedMessages: string[] = [];
   #onCrash: (() => void) | undefined;
+  initScripts: Array<{ script: unknown; arg: unknown }> = [];
+  callOrder: string[] = [];
   #onDialog: ((dialog: PooledDialog) => void) | undefined;
   goto(url: string): Promise<unknown> {
+    this.callOrder.push(`goto:${url}`);
     this.gotoUrls.push(url);
     return this.failNav ? Promise.reject(new Error('nav timeout')) : Promise.resolve(undefined);
   }
@@ -34,6 +38,21 @@ class FakePage implements PooledPage {
   }
   onDialog(handler: (dialog: PooledDialog) => void): void {
     this.#onDialog = handler;
+  }
+  disposedScripts = 0;
+  addInitScript<Arg>(
+    script: ((arg: Arg) => void) | string,
+    arg?: Arg,
+  ): Promise<{ dispose: () => Promise<void> }> {
+    this.callOrder.push('addInitScript');
+    this.initScripts.push({ script, arg });
+    return Promise.resolve({
+      dispose: () => {
+        this.disposedScripts += 1;
+        this.callOrder.push('disposeInitScript');
+        return Promise.resolve();
+      },
+    });
   }
   /** Test helper: simulate this page's renderer crashing. */
   crash(): void {
@@ -54,12 +73,19 @@ class FakePage implements PooledPage {
 class FakeContext implements PooledContext {
   readonly pages: FakePage[] = [];
   closed = false;
+  cookies: PooledCookie[] = [];
+  callOrder: string[] = [];
   constructor(private readonly failNav = false) {}
   newPage(): Promise<PooledPage> {
     const p = new FakePage();
     p.failNav = this.failNav;
     this.pages.push(p);
     return Promise.resolve(p);
+  }
+  addCookies(cookies: PooledCookie[]): Promise<void> {
+    this.callOrder.push('addCookies');
+    this.cookies.push(...cookies);
+    return Promise.resolve();
   }
   close(): Promise<void> {
     this.closed = true;
@@ -100,10 +126,14 @@ function counterIds(): () => string {
 }
 
 /** A launcher that hands out fresh FakeBrowsers and records how many it made. */
-function fakeLauncher(): { launch: Launcher; browsers: FakeBrowser[] } {
+function fakeLauncher(opts: { failNav?: boolean } = {}): {
+  launch: Launcher;
+  browsers: FakeBrowser[];
+} {
   const browsers: FakeBrowser[] = [];
   const launch: Launcher = () => {
     const b = new FakeBrowser();
+    if (true === opts.failNav) b.failNav = true;
     browsers.push(b);
     return Promise.resolve(b);
   };
@@ -531,6 +561,7 @@ describe('BrowserPool', () => {
     await expect(acquiring).rejects.toThrow();
   });
 
+
   it('dismisses a native dialog on a leased page instead of leaving it blocked (#786)', async () => {
     const { launch, browsers } = fakeLauncher();
     const pool = new BrowserPool(launch, { maxContexts: 4, genSessionId: counterIds() });
@@ -605,5 +636,103 @@ describe('BrowserPool', () => {
     const lease = await pool.acquire('http://localhost:3000/no-dialog-support');
 
     expect(pool.lastDialogMessage(lease.sessionId)).toBeUndefined();
+
+  it('seeds cookies, localStorage, and sessionStorage before page.goto and disposes init script immediately after', async () => {
+    const { launch, browsers } = fakeLauncher();
+    const pool = new BrowserPool(launch, { maxContexts: 4, genSessionId: counterIds() });
+
+    const seedStorage = {
+      local: { auth_token: 'secret-token', user: 'alice' },
+      session: { tab: '42' },
+      cookies: { session_id: 'sess-abc' },
+    };
+
+    const lease = await pool.acquire('http://localhost:3000/dashboard', { seedStorage });
+    expect(lease.sessionId).toBe('s1');
+
+    const context = browsers[0]?.contexts[0];
+    const page = context?.pages[0];
+
+    // Cookies were seeded into context before page navigation
+    expect(context?.cookies).toEqual([
+      { name: 'session_id', value: 'sess-abc', url: 'http://localhost:3000/' },
+    ]);
+    expect(context?.callOrder).toContain('addCookies');
+
+    // Init script was registered on page before goto, and disposed after goto
+    expect(page?.initScripts).toHaveLength(1);
+    expect(page?.initScripts[0]?.arg).toEqual({
+      local: seedStorage.local,
+      session: seedStorage.session,
+      targetOrigin: 'http://localhost:3000',
+    });
+    expect(page?.callOrder).toEqual([
+      'addInitScript',
+      'goto:http://localhost:3000/dashboard',
+      'disposeInitScript',
+    ]);
+    expect(page?.disposedScripts).toBe(1);
+  });
+
+  it('disposes init script and cleans up context if page.goto fails', async () => {
+    const { launch, browsers } = fakeLauncher({ failNav: true });
+    const pool = new BrowserPool(launch, { maxContexts: 4, genSessionId: counterIds() });
+
+    await expect(
+      pool.acquire('http://localhost:3000/fail', {
+        seedStorage: { local: { token: '123' } },
+      }),
+    ).rejects.toThrow('nav timeout');
+
+    const context = browsers[0]?.contexts[0];
+    const page = context?.pages[0];
+    // Must still have disposed the init script
+    expect(page?.callOrder).toContain('disposeInitScript');
+    expect(page?.disposedScripts).toBe(1);
+    // Context must have been closed
+    expect(context?.closed).toBe(true);
+  });
+
+  it('does not invoke addCookies or addInitScript when seedStorage is omitted', async () => {
+    const { launch, browsers } = fakeLauncher();
+    const pool = new BrowserPool(launch, { maxContexts: 4, genSessionId: counterIds() });
+
+    await pool.acquire('http://localhost:3000/dashboard');
+
+    const context = browsers[0]?.contexts[0];
+    const page = context?.pages[0];
+
+    expect(context?.cookies).toHaveLength(0);
+    expect(page?.initScripts).toHaveLength(0);
+    expect(page?.callOrder).toEqual(['goto:http://localhost:3000/dashboard']);
+  });
+
+  it('preserves isolation between multiple leases with different seedStorage', async () => {
+    const { launch, browsers } = fakeLauncher();
+    const pool = new BrowserPool(launch, { maxContexts: 4, genSessionId: counterIds() });
+
+    const lease1 = await pool.acquire('http://localhost:3000/app', {
+      seedStorage: { local: { user: 'user-1' } },
+    });
+    const lease2 = await pool.acquire('http://localhost:3000/app', {
+      seedStorage: { local: { user: 'user-2' } },
+    });
+
+    expect(lease1.sessionId).not.toBe(lease2.sessionId);
+    const ctx1 = browsers[0]?.contexts[0];
+    const ctx2 = browsers[0]?.contexts[1];
+
+    expect(ctx1).not.toBe(ctx2);
+    expect(ctx1?.pages[0]?.initScripts[0]?.arg).toEqual({
+      local: { user: 'user-1' },
+      session: undefined,
+      targetOrigin: 'http://localhost:3000',
+    });
+    expect(ctx2?.pages[0]?.initScripts[0]?.arg).toEqual({
+      local: { user: 'user-2' },
+      session: undefined,
+      targetOrigin: 'http://localhost:3000',
+    });
+
   });
 });

--- a/packages/server/src/pool/browser-pool.test.ts
+++ b/packages/server/src/pool/browser-pool.test.ts
@@ -561,7 +561,6 @@ describe('BrowserPool', () => {
     await expect(acquiring).rejects.toThrow();
   });
 
-
   it('dismisses a native dialog on a leased page instead of leaving it blocked (#786)', async () => {
     const { launch, browsers } = fakeLauncher();
     const pool = new BrowserPool(launch, { maxContexts: 4, genSessionId: counterIds() });
@@ -636,6 +635,7 @@ describe('BrowserPool', () => {
     const lease = await pool.acquire('http://localhost:3000/no-dialog-support');
 
     expect(pool.lastDialogMessage(lease.sessionId)).toBeUndefined();
+  });
 
   it('seeds cookies, localStorage, and sessionStorage before page.goto and disposes init script immediately after', async () => {
     const { launch, browsers } = fakeLauncher();
@@ -733,6 +733,5 @@ describe('BrowserPool', () => {
       session: undefined,
       targetOrigin: 'http://localhost:3000',
     });
-
   });
 });

--- a/packages/server/src/pool/browser-pool.ts
+++ b/packages/server/src/pool/browser-pool.ts
@@ -11,7 +11,8 @@
  */
 
 /** The minimal page surface the pool drives. Real Playwright `Page` satisfies this. */
-import { unreachableUrlIn } from '@reticlehq/core';
+import { unreachableUrlIn, type SeedStorage } from '@reticlehq/core';
+import { seedStorageInto } from './storage-seed.js';
 
 export interface PooledPage {
   goto(url: string, opts?: { timeoutMs?: number }): Promise<unknown>;
@@ -37,6 +38,11 @@ export interface PooledPage {
    * reports dispatched/settled while the styles never ran.
    */
   hover?(x: number, y: number): Promise<void>;
+  /** Add an init script to run after document creation but before any page scripts run. */
+  addInitScript?<Arg>(
+    script: ((arg: Arg) => void) | string,
+    arg?: Arg,
+  ): Promise<InitScriptHandle | void>;
   /**
    * Install (or clear) network mocks on this page. OPTIONAL: a fake that does not implement it
    * makes `reticle_network_mock` refuse rather than claiming it stubbed a request it cannot intercept.
@@ -61,6 +67,22 @@ export interface PooledDialog {
   dismiss(): Promise<void>;
 }
 
+export interface InitScriptHandle {
+  dispose(): Promise<void>;
+}
+
+export interface PooledCookie {
+  name: string;
+  value: string;
+  url?: string;
+  domain?: string;
+  path?: string;
+  expires?: number;
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: 'Strict' | 'Lax' | 'None';
+}
+
 /**
  * One interception rule the pool can install. Same fields as the drive-path mock rule, kept here so
  * the pool does not import Playwright.
@@ -79,6 +101,7 @@ export interface PooledMockRule {
 export interface PooledContext {
   newPage(): Promise<PooledPage>;
   close(): Promise<void>;
+  addCookies?(cookies: PooledCookie[]): Promise<void>;
 }
 
 /** The launched browser. Real Playwright `Browser` satisfies this. */
@@ -407,7 +430,7 @@ export class BrowserPool {
    */
   async acquire(
     url: string,
-    opts: { signal?: AbortSignal; sessionId?: string } = {},
+    opts: { signal?: AbortSignal; sessionId?: string; seedStorage?: SeedStorage } = {},
   ): Promise<Lease> {
     if (this.#closed) throw new Error('browser pool is shut down');
     // #waitForSlot claims the slot synchronously (bumps #occupied) before returning, so the cap holds
@@ -445,7 +468,21 @@ export class BrowserPool {
         else pendingDialogMessage = dialog.message;
         void dialog.dismiss();
       });
-      await page.goto(url, { timeoutMs: this.#navTimeout });
+      let seedHandle: InitScriptHandle | undefined;
+      let checkSeedError: (() => void) | undefined;
+      if (opts.seedStorage !== undefined) {
+        const seedResult = await seedStorageInto(context, page, url, opts.seedStorage);
+        seedHandle = seedResult?.handle;
+        checkSeedError = seedResult?.checkError;
+      }
+      try {
+        await page.goto(url, { timeoutMs: this.#navTimeout });
+        checkSeedError?.();
+      } finally {
+        if (seedHandle !== undefined) {
+          await seedHandle.dispose().catch(() => undefined);
+        }
+      }
       // The browser can crash WHILE goto is resolving; #onCrash then clears #active and zeroes
       // #occupied. Registering the lease now would resurrect a dead entry against a crashed browser with
       // the slot count out of sync (drifting below #active.size, eventually exceeding the cap). If we're

--- a/packages/server/src/pool/browser-pool.ts
+++ b/packages/server/src/pool/browser-pool.ts
@@ -120,6 +120,7 @@ export type Launcher = () => Promise<PooledBrowser>;
 export interface Lease {
   readonly sessionId: string;
   readonly url: string;
+  readonly navStatus?: number;
   release(): Promise<void>;
 }
 
@@ -475,8 +476,9 @@ export class BrowserPool {
         seedHandle = seedResult?.handle;
         checkSeedError = seedResult?.checkError;
       }
+      let navRes: unknown;
       try {
-        await page.goto(url, { timeoutMs: this.#navTimeout });
+        navRes = await page.goto(url, { timeoutMs: this.#navTimeout });
         checkSeedError?.();
       } finally {
         if (seedHandle !== undefined) {
@@ -488,6 +490,20 @@ export class BrowserPool {
       // the slot count out of sync (drifting below #active.size, eventually exceeding the cap). If we're
       // no longer the live browser, bail — the catch below closes the context and returns the slot.
       if (this.#browser !== browser) throw new Error('browser crashed during navigation');
+      let navStatus: number | undefined;
+      if (null !== navRes && 'object' === typeof navRes && 'status' in navRes) {
+        const s: unknown = (navRes as { status?: unknown }).status;
+        if ('function' === typeof s) {
+          try {
+            const code: unknown = s.call(navRes);
+            if ('number' === typeof code) navStatus = code;
+          } catch {
+            // ignore
+          }
+        } else if ('number' === typeof s) {
+          navStatus = s;
+        }
+      }
       this.#active.set(sessionId, {
         context,
         page,
@@ -499,6 +515,7 @@ export class BrowserPool {
       return {
         sessionId,
         url,
+        ...(navStatus !== undefined ? { navStatus } : {}),
         release: () => this.#release(sessionId),
       };
     } catch (err) {

--- a/packages/server/src/pool/playwright-launcher.ts
+++ b/packages/server/src/pool/playwright-launcher.ts
@@ -70,8 +70,20 @@ function wrapBrowser(browser: Browser): PooledBrowser {
               page.on('dialog', (dialog) =>
                 handler({ message: dialog.message(), dismiss: () => dialog.dismiss() }),
               ),
+            addInitScript: async (script, arg) => {
+              const handle = (await page.addInitScript(script as never, arg)) as
+                { dispose?: () => Promise<void> } | undefined;
+              const dispose = handle?.dispose;
+              if ('function' !== typeof dispose) {
+                throw new Error(
+                  'Storage seeding failed: Playwright page.addInitScript did not return a disposable handle',
+                );
+              }
+              return { dispose: () => dispose() };
+            },
           };
         },
+        addCookies: (cookies) => context.addCookies(cookies),
         close: () => context.close(),
       };
     },

--- a/packages/server/src/pool/storage-seed.test.ts
+++ b/packages/server/src/pool/storage-seed.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, it } from 'vitest';
+import type { InitScriptHandle, PooledContext, PooledCookie, PooledPage } from './browser-pool.js';
+import { normalizeCookies, seedStorageInto, targetOriginOf } from './storage-seed.js';
+
+describe('storage-seed', () => {
+  describe('normalizeCookies', () => {
+    it('returns empty array when cookies is undefined', () => {
+      expect(normalizeCookies(undefined, 'http://localhost:3000')).toEqual([]);
+    });
+
+    it('normalizes flat record into cookies with URL origin', () => {
+      const cookies = {
+        auth_token: 'secret-123',
+        theme: 'dark',
+      };
+      const normalized = normalizeCookies(cookies, 'http://localhost:3000/dashboard?a=1');
+      expect(normalized).toEqual([
+        { name: 'auth_token', value: 'secret-123', url: 'http://localhost:3000/' },
+        { name: 'theme', value: 'dark', url: 'http://localhost:3000/' },
+      ]);
+    });
+
+    it('sets path to "/" when domain is provided but path is omitted', () => {
+      const cookies = [
+        {
+          name: 'session_id',
+          value: 'sess-abc',
+          domain: '.example.com',
+        },
+      ];
+      const normalized = normalizeCookies(cookies, 'http://localhost:3000');
+      expect(normalized).toEqual([
+        {
+          name: 'session_id',
+          value: 'sess-abc',
+          domain: '.example.com',
+          path: '/',
+        },
+      ]);
+    });
+
+    it('preserves structured cookie attributes when path and domain are provided', () => {
+      const cookies = [
+        {
+          name: 'session_id',
+          value: 'sess-abc',
+          domain: '.example.com',
+          path: '/app',
+          httpOnly: true,
+          secure: true,
+          sameSite: 'Strict' as const,
+          expires: 1893456000,
+        },
+        {
+          name: 'tracker',
+          value: 'no',
+        },
+      ];
+      const normalized = normalizeCookies(cookies, 'http://localhost:3000/login');
+      expect(normalized).toEqual([
+        {
+          name: 'session_id',
+          value: 'sess-abc',
+          domain: '.example.com',
+          path: '/app',
+          httpOnly: true,
+          secure: true,
+          sameSite: 'Strict',
+          expires: 1893456000,
+        },
+        {
+          name: 'tracker',
+          value: 'no',
+          url: 'http://localhost:3000/',
+        },
+      ]);
+    });
+
+    it('handles malformed navigation URL gracefully by defaulting path', () => {
+      const normalized = normalizeCookies({ foo: 'bar' }, 'not-a-valid-url');
+      expect(normalized).toEqual([{ name: 'foo', value: 'bar', path: '/' }]);
+    });
+  });
+
+  describe('targetOriginOf', () => {
+    it('extracts origin from standard URLs', () => {
+      expect(targetOriginOf('http://localhost:3000/app?x=1')).toBe('http://localhost:3000');
+      expect(targetOriginOf('https://example.com:8080/path')).toBe('https://example.com:8080');
+    });
+
+    it('returns undefined for data: or invalid URLs', () => {
+      expect(targetOriginOf('data:text/html,<h1>Hi</h1>')).toBeUndefined();
+      expect(targetOriginOf('not-a-valid-url')).toBeUndefined();
+    });
+  });
+
+  describe('seedStorageInto', () => {
+    function makeFakes() {
+      const cookiesAdded: PooledCookie[] = [];
+      const initScriptsAdded: Array<{ script: unknown; arg: unknown }> = [];
+      let consoleHandler: ((msg: string) => void) | undefined;
+      let disposed = false;
+
+      const fakeHandle: InitScriptHandle = {
+        dispose: () => {
+          disposed = true;
+          return Promise.resolve();
+        },
+      };
+
+      const fakeContext: PooledContext = {
+        newPage: () => Promise.reject(new Error('not implemented')),
+        close: () => Promise.resolve(),
+        addCookies: (cookies) => {
+          cookiesAdded.push(...cookies);
+          return Promise.resolve();
+        },
+      };
+
+      const fakePage: PooledPage = {
+        goto: () => Promise.resolve(),
+        close: () => Promise.resolve(),
+        onCrash: () => {},
+        onConsole: (handler) => {
+          consoleHandler = handler;
+        },
+        addInitScript: (script, arg) => {
+          initScriptsAdded.push({ script, arg });
+          return Promise.resolve(fakeHandle);
+        },
+      };
+
+      return {
+        fakeContext,
+        fakePage,
+        cookiesAdded,
+        initScriptsAdded,
+        getConsoleHandler: () => consoleHandler,
+        isDisposed: () => disposed,
+      };
+    }
+
+    it('seeds cookies, local, and session storage with targetOrigin and returns disposable handle', async () => {
+      const { fakeContext, fakePage, cookiesAdded, initScriptsAdded, isDisposed } = makeFakes();
+      const seed = {
+        local: { token: 'jwt-123', user: 'alice' },
+        session: { tab: '42' },
+        cookies: { auth: 'cookie-secret' },
+      };
+
+      const result = await seedStorageInto(
+        fakeContext,
+        fakePage,
+        'http://localhost:3000/app',
+        seed,
+      );
+
+      expect(cookiesAdded).toEqual([
+        { name: 'auth', value: 'cookie-secret', url: 'http://localhost:3000/' },
+      ]);
+      expect(initScriptsAdded).toHaveLength(1);
+      expect(initScriptsAdded[0]?.arg).toEqual({
+        local: { token: 'jwt-123', user: 'alice' },
+        session: { tab: '42' },
+        targetOrigin: 'http://localhost:3000',
+      });
+      expect(result?.handle).toBeDefined();
+
+      await result?.handle?.dispose();
+      expect(isDisposed()).toBe(true);
+
+      // Verify the initScript function writes to localStorage and sessionStorage in target window
+      const initFn = initScriptsAdded[0]?.script as (arg: {
+        local?: Record<string, string>;
+        session?: Record<string, string>;
+        targetOrigin?: string;
+      }) => void;
+
+      const mockLocal: Record<string, string> = {};
+      const mockSession: Record<string, string> = {};
+      const mockWindow: Record<string, unknown> = {
+        location: { origin: 'http://localhost:3000' },
+        localStorage: {
+          setItem: (k: string, v: string) => {
+            mockLocal[k] = v;
+          },
+        },
+        sessionStorage: {
+          setItem: (k: string, v: string) => {
+            mockSession[k] = v;
+          },
+        },
+      };
+      mockWindow['top'] = mockWindow; // top-level
+
+      const origGlobalWin = (globalThis as Record<string, unknown>)['window'];
+      try {
+        (globalThis as Record<string, unknown>)['window'] = mockWindow;
+        initFn({
+          local: seed.local,
+          session: seed.session,
+          targetOrigin: 'http://localhost:3000',
+        });
+      } finally {
+        (globalThis as Record<string, unknown>)['window'] = origGlobalWin;
+      }
+
+      expect(mockLocal).toEqual({ token: 'jwt-123', user: 'alice' });
+      expect(mockSession).toEqual({ tab: '42' });
+    });
+
+    it('skips writing local/session storage in child frames', () => {
+      const { fakeContext, fakePage, initScriptsAdded } = makeFakes();
+      const seed = { local: { token: 'jwt-123' } };
+
+      void seedStorageInto(fakeContext, fakePage, 'http://localhost:3000/app', seed);
+      const initFn = initScriptsAdded[0]?.script as (arg: {
+        local?: Record<string, string>;
+        targetOrigin?: string;
+      }) => void;
+
+      const mockLocal: Record<string, string> = {};
+      const childWindow: Record<string, unknown> = {
+        top: {}, // top is different object -> child iframe!
+        location: { origin: 'http://localhost:3000' },
+        localStorage: {
+          setItem: (k: string, v: string) => {
+            mockLocal[k] = v;
+          },
+        },
+      };
+
+      const origGlobalWin = (globalThis as Record<string, unknown>)['window'];
+      try {
+        (globalThis as Record<string, unknown>)['window'] = childWindow;
+        initFn({
+          local: seed.local,
+          targetOrigin: 'http://localhost:3000',
+        });
+      } finally {
+        (globalThis as Record<string, unknown>)['window'] = origGlobalWin;
+      }
+
+      expect(mockLocal).toEqual({}); // child frame skipped!
+    });
+
+    it('skips writing local/session storage on cross-origin redirects', () => {
+      const { fakeContext, fakePage, initScriptsAdded } = makeFakes();
+      const seed = { local: { token: 'jwt-123' } };
+
+      void seedStorageInto(fakeContext, fakePage, 'http://localhost:3000/app', seed);
+      const initFn = initScriptsAdded[0]?.script as (arg: {
+        local?: Record<string, string>;
+        targetOrigin?: string;
+      }) => void;
+
+      const mockLocal: Record<string, string> = {};
+      const externalWindow: Record<string, unknown> = {
+        location: { origin: 'https://auth.external.com' }, // external OAuth origin!
+        localStorage: {
+          setItem: (k: string, v: string) => {
+            mockLocal[k] = v;
+          },
+        },
+      };
+      externalWindow['top'] = externalWindow;
+
+      const origGlobalWin = (globalThis as Record<string, unknown>)['window'];
+      try {
+        (globalThis as Record<string, unknown>)['window'] = externalWindow;
+        initFn({
+          local: seed.local,
+          targetOrigin: 'http://localhost:3000',
+        });
+      } finally {
+        (globalThis as Record<string, unknown>)['window'] = origGlobalWin;
+      }
+
+      expect(mockLocal).toEqual({}); // external origin skipped!
+    });
+
+    it('propagates sanitized error when localStorage write fails in the browser', async () => {
+      const { fakeContext, fakePage, initScriptsAdded, getConsoleHandler } = makeFakes();
+      const seed = { local: { sensitive_token: 'secret-val' } };
+
+      const result = await seedStorageInto(
+        fakeContext,
+        fakePage,
+        'http://localhost:3000/app',
+        seed,
+      );
+      const initFn = initScriptsAdded[0]?.script as (arg: {
+        local?: Record<string, string>;
+        targetOrigin?: string;
+      }) => void;
+
+      // Simulate a browser where localStorage throws QuotaExceededError
+      const quotaErr = new Error('QuotaExceededError');
+      quotaErr.name = 'QuotaExceededError';
+      const failingWindow: Record<string, unknown> = {
+        location: { origin: 'http://localhost:3000' },
+        localStorage: {
+          setItem: () => {
+            throw quotaErr;
+          },
+        },
+      };
+      failingWindow['top'] = failingWindow;
+
+      // Intercept console.error from initFn
+      const origConsoleError = console.error;
+      const origGlobalWin = (globalThis as Record<string, unknown>)['window'];
+      let loggedError = '';
+      console.error = (msg: string) => {
+        loggedError = msg;
+      };
+      try {
+        (globalThis as Record<string, unknown>)['window'] = failingWindow;
+        initFn({
+          local: seed.local,
+          targetOrigin: 'http://localhost:3000',
+        });
+      } finally {
+        console.error = origConsoleError;
+        (globalThis as Record<string, unknown>)['window'] = origGlobalWin;
+      }
+
+      // Simulate the browser console message reaching page.onConsole
+      getConsoleHandler()?.(loggedError);
+
+      expect(() => result?.checkError?.()).toThrow(
+        /Storage seeding failed: localStorage write failed: QuotaExceededError/,
+      );
+      // Ensure secret value is NEVER in the error
+      expect(() => result?.checkError?.()).not.toThrow(/secret-val/);
+    });
+
+    it('fails when cookies are requested but context.addCookies is missing', async () => {
+      const { fakePage } = makeFakes();
+      const bareContext: PooledContext = {
+        newPage: () => Promise.reject(new Error('not implemented')),
+        close: () => Promise.resolve(),
+      };
+
+      await expect(
+        seedStorageInto(bareContext, fakePage, 'http://localhost:3000/', {
+          cookies: { token: 'val' },
+        }),
+      ).rejects.toThrow(/browser context does not support cookie seeding/);
+    });
+
+    it('fails when local storage is requested but page.addInitScript is missing', async () => {
+      const { fakeContext } = makeFakes();
+      const barePage: PooledPage = {
+        goto: () => Promise.resolve(),
+        close: () => Promise.resolve(),
+        onCrash: () => {},
+      };
+
+      await expect(
+        seedStorageInto(fakeContext, barePage, 'http://localhost:3000/', {
+          local: { token: 'val' },
+        }),
+      ).rejects.toThrow(/page does not support storage seeding via init script/);
+    });
+
+    it('fails when page.addInitScript returns a non-disposable handle', async () => {
+      const { fakeContext } = makeFakes();
+      const nonDisposablePage: PooledPage = {
+        goto: () => Promise.resolve(),
+        close: () => Promise.resolve(),
+        onCrash: () => {},
+        // Returns void/undefined instead of a disposable handle
+        addInitScript: () => Promise.resolve(undefined as never),
+      };
+
+      await expect(
+        seedStorageInto(fakeContext, nonDisposablePage, 'http://localhost:3000/', {
+          local: { token: 'val' },
+        }),
+      ).rejects.toThrow(/init script disposal is not supported by page/);
+    });
+
+    it('succeeds cleanly without capabilities when seedStorage is empty ({})', async () => {
+      const bareContext: PooledContext = {
+        newPage: () => Promise.reject(new Error('not implemented')),
+        close: () => Promise.resolve(),
+      };
+      const barePage: PooledPage = {
+        goto: () => Promise.resolve(),
+        close: () => Promise.resolve(),
+        onCrash: () => {},
+      };
+
+      await expect(
+        seedStorageInto(bareContext, barePage, 'http://localhost:3000/', {}),
+      ).resolves.not.toThrow();
+    });
+  });
+});

--- a/packages/server/src/pool/storage-seed.test.ts
+++ b/packages/server/src/pool/storage-seed.test.ts
@@ -396,5 +396,34 @@ describe('storage-seed', () => {
         seedStorageInto(bareContext, barePage, 'http://localhost:3000/', {}),
       ).resolves.not.toThrow();
     });
+
+    it('redacts raw secret values and known secret shapes if context.addCookies throws', async () => {
+      const { fakePage } = makeFakes();
+      const secretToken = 'SECRET_TEST_TOKEN_XYZ_987';
+      const jwtSecret =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+      const failingContext: PooledContext = {
+        newPage: () => Promise.reject(new Error('not implemented')),
+        close: () => Promise.resolve(),
+        addCookies: (cookies) => {
+          throw new Error(
+            `Playwright addCookies rejected cookie value="${cookies[0]?.value}" with jwt="${jwtSecret}"`,
+          );
+        },
+      };
+
+      try {
+        await seedStorageInto(failingContext, fakePage, 'http://localhost:3000/', {
+          cookies: { session_auth: secretToken },
+        });
+        expect.unreachable('should have thrown');
+      } catch (err: unknown) {
+        const msg = (err as Error).message;
+        expect(msg).toContain('Storage seeding failed: cookie injection failed');
+        expect(msg).toContain('[REDACTED]');
+        expect(msg).not.toContain(secretToken);
+        expect(msg).not.toContain(jwtSecret);
+      }
+    });
   });
 });

--- a/packages/server/src/pool/storage-seed.ts
+++ b/packages/server/src/pool/storage-seed.ts
@@ -1,0 +1,215 @@
+import type { SeedStorage } from '@reticlehq/core';
+import type { InitScriptHandle, PooledContext, PooledCookie, PooledPage } from './browser-pool.js';
+
+export function targetOriginOf(navUrl: string): string | undefined {
+  try {
+    const origin = new URL(navUrl).origin;
+    return origin !== 'null' ? origin : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function normalizeCookies(cookies: SeedStorage['cookies'], navUrl: string): PooledCookie[] {
+  if (cookies === undefined) return [];
+  let baseUrl: string | undefined;
+  try {
+    const u = new URL(navUrl);
+    baseUrl = `${u.protocol}//${u.host}/`;
+  } catch {
+    baseUrl = undefined;
+  }
+
+  const out: PooledCookie[] = [];
+  if (Array.isArray(cookies)) {
+    for (const c of cookies) {
+      const cookieObj: PooledCookie = {
+        name: c.name,
+        value: c.value,
+      };
+      if (c.domain !== undefined) cookieObj.domain = c.domain;
+      if (c.path !== undefined) {
+        cookieObj.path = c.path;
+      } else if (c.domain !== undefined && c.url === undefined) {
+        cookieObj.path = '/';
+      }
+      if (c.url !== undefined) {
+        cookieObj.url = c.url;
+      } else if (c.domain === undefined && baseUrl !== undefined) {
+        cookieObj.url = baseUrl;
+      }
+      if (c.httpOnly !== undefined) cookieObj.httpOnly = c.httpOnly;
+      if (c.secure !== undefined) cookieObj.secure = c.secure;
+      if (c.sameSite !== undefined) cookieObj.sameSite = c.sameSite;
+      if (c.expires !== undefined) cookieObj.expires = c.expires;
+      out.push(cookieObj);
+    }
+  } else if ('object' === typeof cookies && null !== cookies) {
+    for (const [name, value] of Object.entries(cookies)) {
+      const cookieObj: PooledCookie = {
+        name,
+        value,
+      };
+      if (baseUrl !== undefined) {
+        cookieObj.url = baseUrl;
+      } else {
+        cookieObj.path = '/';
+      }
+      out.push(cookieObj);
+    }
+  }
+  return out;
+}
+
+export interface StorageSeedResult {
+  handle?: InitScriptHandle;
+  checkError?: () => void;
+}
+
+/**
+ * Seed initial storage state (cookies, localStorage, sessionStorage) into a leased context and page
+ * before the first navigation happens.
+ *
+ * Cookies are injected into the BrowserContext cookie jar so the initial HTTP GET to the target URL
+ * already carries the Cookie header (including httpOnly session cookies).
+ *
+ * Local and session storage are injected via an init script evaluated after document creation but
+ * before any inline or bundled application scripts run. The init script is scoped strictly to the
+ * top-level target origin document (not child iframes or external redirect origins).
+ *
+ * Returns a handle that allows the caller to dispose of the init script once the initial navigation
+ * has resolved, ensuring one-time semantics (reloads or future navigations do not reapply the seed).
+ */
+export async function seedStorageInto(
+  context: PooledContext,
+  page: PooledPage,
+  targetUrl: string,
+  seed: SeedStorage,
+): Promise<StorageSeedResult | void> {
+  const hasCookies =
+    seed.cookies !== undefined &&
+    (Array.isArray(seed.cookies) ? seed.cookies.length > 0 : Object.keys(seed.cookies).length > 0);
+  const hasLocal = seed.local !== undefined && Object.keys(seed.local).length > 0;
+  const hasSession = seed.session !== undefined && Object.keys(seed.session).length > 0;
+
+  if (hasCookies && context.addCookies === undefined) {
+    throw new Error('Storage seeding failed: browser context does not support cookie seeding');
+  }
+  if ((hasLocal || hasSession) && page.addInitScript === undefined) {
+    throw new Error(
+      'Storage seeding failed: page does not support storage seeding via init script',
+    );
+  }
+
+  if (hasCookies && context.addCookies !== undefined) {
+    const cookiesToSet = normalizeCookies(seed.cookies, targetUrl);
+    if (cookiesToSet.length > 0) {
+      await context.addCookies(cookiesToSet);
+    }
+  }
+
+  let handle: InitScriptHandle | undefined;
+  let capturedError: string | undefined;
+
+  if (hasLocal || hasSession) {
+    page.onConsole?.((text) => {
+      if (text.startsWith('__reticle_seed_error:')) {
+        capturedError = text.slice('__reticle_seed_error:'.length);
+      }
+    });
+
+    const targetOrigin = targetOriginOf(targetUrl);
+    const added = await page.addInitScript?.(
+      ({
+        local,
+        session,
+        targetOrigin,
+      }: {
+        local?: Record<string, string> | undefined;
+        session?: Record<string, string> | undefined;
+        targetOrigin?: string | undefined;
+      }) => {
+        const win = ((globalThis as unknown as { window?: unknown }).window ??
+          globalThis) as unknown as {
+          top?: unknown;
+          location?: { origin?: string };
+          localStorage?: { setItem(k: string, v: string): void };
+          sessionStorage?: { setItem(k: string, v: string): void };
+        };
+
+        // Only seed the top-level document frame
+        if (win.top !== win) return;
+
+        // Only seed when the page is at the intended target origin
+        if (undefined !== targetOrigin && win.location?.origin !== targetOrigin) return;
+
+        let seedError: string | undefined;
+
+        if (undefined !== local) {
+          try {
+            const storage = win.localStorage;
+            if (!storage) {
+              seedError = 'localStorage is not available';
+            } else {
+              for (const [k, v] of Object.entries(local)) {
+                storage.setItem(k, v);
+              }
+            }
+          } catch (err: unknown) {
+            let errName = 'write error';
+            if (null !== err && 'object' === typeof err && 'name' in err) {
+              const name = (err as { name?: unknown }).name;
+              if ('string' === typeof name) {
+                errName = name;
+              }
+            }
+            seedError = `localStorage write failed: ${errName}`;
+          }
+        }
+
+        if (undefined === seedError && undefined !== session) {
+          try {
+            const storage = win.sessionStorage;
+            if (!storage) {
+              seedError = 'sessionStorage is not available';
+            } else {
+              for (const [k, v] of Object.entries(session)) {
+                storage.setItem(k, v);
+              }
+            }
+          } catch (err: unknown) {
+            let errName = 'write error';
+            if (null !== err && 'object' === typeof err && 'name' in err) {
+              const name = (err as { name?: unknown }).name;
+              if ('string' === typeof name) {
+                errName = name;
+              }
+            }
+            seedError = `sessionStorage write failed: ${errName}`;
+          }
+        }
+
+        if (undefined !== seedError) {
+          console.error(`__reticle_seed_error:${seedError}`);
+        }
+      },
+      { local: seed.local, session: seed.session, targetOrigin },
+    );
+
+    if (undefined === added || 'function' !== typeof added.dispose) {
+      throw new Error('Storage seeding failed: init script disposal is not supported by page');
+    }
+    handle = added;
+  }
+
+  const checkError = () => {
+    if (capturedError !== undefined) {
+      throw new Error(`Storage seeding failed: ${capturedError}`);
+    }
+  };
+
+  return {
+    ...(handle !== undefined ? { handle } : {}),
+    checkError,
+  };
+}

--- a/packages/server/src/pool/storage-seed.ts
+++ b/packages/server/src/pool/storage-seed.ts
@@ -1,4 +1,4 @@
-import type { SeedStorage } from '@reticlehq/core';
+import { REDACTED_VALUE, scrubKnownSecrets, type SeedStorage } from '@reticlehq/core';
 import type { InitScriptHandle, PooledContext, PooledCookie, PooledPage } from './browser-pool.js';
 
 export function targetOriginOf(navUrl: string): string | undefined {
@@ -104,7 +104,22 @@ export async function seedStorageInto(
   if (hasCookies && context.addCookies !== undefined) {
     const cookiesToSet = normalizeCookies(seed.cookies, targetUrl);
     if (cookiesToSet.length > 0) {
-      await context.addCookies(cookiesToSet);
+      try {
+        await context.addCookies(cookiesToSet);
+      } catch (err: unknown) {
+        let rawMsg = err instanceof Error ? err.message : String(err);
+        for (const c of cookiesToSet) {
+          if (undefined !== c.value && 'string' === typeof c.value && 0 !== c.value.length) {
+            const escaped = c.value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            rawMsg = rawMsg.replace(
+              new RegExp(`(^|[^a-zA-Z0-9])${escaped}(?=$|[^a-zA-Z0-9])`, 'g'),
+              `$1${REDACTED_VALUE}`,
+            );
+          }
+        }
+        rawMsg = scrubKnownSecrets(rawMsg);
+        throw new Error(`Storage seeding failed: cookie injection failed (${rawMsg})`);
+      }
     }
   }
 

--- a/packages/server/src/session/session.ts
+++ b/packages/server/src/session/session.ts
@@ -181,26 +181,12 @@ export class Session {
   #preconditionFailure?: string;
   /**
    * Which document is on screen right now — the one the most recent stamped event was observed under.
-   *
-   * DERIVED, never announced. The SDK mints a document id once per real document and stamps it on
-   * every event, so the stream already carries the answer; asking the page for it separately would be
-   * a second source of truth that can disagree with the evidence it is supposed to scope. A full
-   * navigation or a reload builds a new document, mints a new id, and the first event carrying it
-   * moves this forward — which is exactly the moment the previous document's evidence stops being
-   * about the world. An SPA route change keeps the same document and so keeps the same id, which is
-   * correct rather than a limitation: same JavaScript context, same in-flight requests, same evidence.
-   *
-   * An UNSTAMPED event never clears this. An SDK older than the field stamps nothing, and letting one
-   * such event blank the current document would make every later comparison vacuous.
+   * DERIVED, never announced: the SDK stamps it on events. An unstamped event never clears this.
    */
   #documentId: string | undefined;
   /**
-   * The edit epoch of the most recent stamped event. DERIVED for the same reason `#documentId` is:
-   * the stream already carries it, and asking the page separately would be a second source of truth.
-   *
-   * A hot update advances it INSIDE the same document, which is the case `#documentId` structurally
-   * cannot see — no navigation, same page, replaced code. An unstamped event never clears it: most
-   * pages have no hot-update channel at all, so absence is "unknown", never "back to no edits".
+   * The edit epoch of the most recent stamped event. DERIVED for the same reason `#documentId` is.
+   * A hot update advances it inside the same document. An unstamped event never clears it.
    */
   #editEpoch: number | undefined;
 
@@ -347,8 +333,12 @@ export class Session {
   }
 
   /** Seed/auth precondition failure reason, if any. */
-  setPreconditionFailure(reason: string): void { this.#preconditionFailure = reason; }
-  preconditionFailure(): string | undefined { return this.#preconditionFailure; }
+  setPreconditionFailure(reason: string): void {
+    this.#preconditionFailure = reason;
+  }
+  preconditionFailure(): string | undefined {
+    return this.#preconditionFailure;
+  }
 
   /** Re-stamp an incoming event with server-relative time, buffer it, and fan out. */
   pushEvent(event: ReticleEvent, byteSize?: number): void {
@@ -998,9 +988,5 @@ export class Session {
   }
 }
 
-/**
- * Re-exported from session-manager.ts so the public import path (`./session.js`) is unchanged for
- * the many call sites that resolve a target session. The class lives in its own file to keep both
- * units under the file-size cap.
- */
+/** Re-exported so the public import path (`./session.js`) is unchanged. */
 export { SessionManager } from './session-manager.js';

--- a/packages/server/src/session/session.ts
+++ b/packages/server/src/session/session.ts
@@ -177,6 +177,8 @@ export class Session {
   #journalReader: JournalReader | undefined;
   /** What this session has learned by watching its own stream: ambient churn + blind-spot levels. */
   readonly #observed = new ObservedState();
+  /** Set when a required application precondition (e.g. seedStorage) was not established. */
+  #preconditionFailure?: string;
   /**
    * Which document is on screen right now — the one the most recent stamped event was observed under.
    *
@@ -343,6 +345,10 @@ export class Session {
   get currentEditEpoch(): number | undefined {
     return this.#editEpoch;
   }
+
+  /** Seed/auth precondition failure reason, if any. */
+  setPreconditionFailure(reason: string): void { this.#preconditionFailure = reason; }
+  preconditionFailure(): string | undefined { return this.#preconditionFailure; }
 
   /** Re-stamp an incoming event with server-relative time, buffer it, and fan out. */
   pushEvent(event: ReticleEvent, byteSize?: number): void {

--- a/packages/server/src/telemetry/argument-shape.test.ts
+++ b/packages/server/src/telemetry/argument-shape.test.ts
@@ -60,6 +60,21 @@ describe('tool parameters — names, plus only our own enums', () => {
     expect(described).toContain('args');
   });
 
+  it('NEVER reports values passed to seedStorage in telemetry', () => {
+    const described = describeToolParams({
+      url: 'http://localhost:3000',
+      seedStorage: {
+        local: { token: 'super-secret-jwt' },
+        session: { auth: 'session-secret' },
+        cookies: { id: 'cookie-secret' },
+      },
+    });
+    expect(described).toEqual(['seedStorage', 'url']);
+    expect(described.join()).not.toContain('super-secret-jwt');
+    expect(described.join()).not.toContain('session-secret');
+    expect(described.join()).not.toContain('cookie-secret');
+  });
+
   it('reports a value only for an allowlisted enum parameter', () => {
     expect(describeParam('action', 'click')).toBe('action:click');
     // `ref` is a selector the user's DOM defines — a name, never a value.

--- a/packages/server/src/tools/assert-verdict.ts
+++ b/packages/server/src/tools/assert-verdict.ts
@@ -129,6 +129,8 @@ export async function assertVerdict(
   const outcomePending = hasAcceptedWrite(windowEvents);
   const outcomeUnread = unreadWriteLabels(windowEvents);
   const stillInFlight = inFlightRequestLabels(windowEvents);
+  const effectiveInconclusive =
+    inconclusive ?? (!pass ? session.preconditionFailure?.() : undefined);
   const decision = decideVerified({
     pass,
     // So the unread-body remedy can check it applies to THIS page. Threaded rather than
@@ -139,7 +141,7 @@ export async function assertVerdict(
     // half broken, and this is the tool agents call most.
     declaredConsequence: predicate.kind !== PredicateKind.SETTLED,
     ...(declaresBodyIndependentChannel(predicate) ? { independentOfBody: true } : {}),
-    ...(inconclusive === undefined ? {} : { inconclusive }),
+    ...(effectiveInconclusive === undefined ? {} : { inconclusive: effectiveInconclusive }),
     ...(true === observationLost ? { observationLost: true } : {}),
     ...(absenceBlindSpot === undefined ? {} : { absenceBlindSpot }),
     ...(namedNetIsInFlight(predicate, stillInFlight) ? { namedRequestInFlight: true } : {}),

--- a/packages/server/src/tools/lease-tools.test.ts
+++ b/packages/server/src/tools/lease-tools.test.ts
@@ -7,8 +7,10 @@ import { describe, expect, it } from 'vitest';
 import { RETICLE_URL_PARAM } from '@reticlehq/core';
 import {
   LEASE_TOOLS,
+  acquireLeasedSession,
   appendReticleParams,
   cleanNavError,
+  hasOriginLock,
   waitForLeasedSession,
 } from './lease-tools.js';
 import { ReticleTool } from './tool-names.js';
@@ -27,11 +29,12 @@ function tool(name: string): (deps: ToolDeps, args: Record<string, unknown>) => 
 /** A pool stub that records acquire calls and tracks active count. */
 function fakePool(): {
   pool: BrowserPool;
-  acquired: { url: string; sessionId: string | undefined }[];
+  acquired: { url: string; sessionId: string | undefined; seedStorage?: unknown }[];
   /** Every (registeredId, leaseId) pair the lease told the pool about. */
   aliased: [string, string][];
+  released: string[];
 } {
-  const acquired: { url: string; sessionId: string | undefined }[] = [];
+  const acquired: { url: string; sessionId: string | undefined; seedStorage?: unknown }[] = [];
   let active = 0;
   const released: string[] = [];
   const aliased: [string, string][] = [];
@@ -44,8 +47,8 @@ function fakePool(): {
     }
   };
   const pool = {
-    acquire(url: string, opts: { sessionId?: string } = {}): Promise<Lease> {
-      acquired.push({ url, sessionId: opts.sessionId });
+    acquire(url: string, opts: { sessionId?: string; seedStorage?: unknown } = {}): Promise<Lease> {
+      acquired.push({ url, sessionId: opts.sessionId, seedStorage: opts.seedStorage });
       active += 1;
       const sessionId = opts.sessionId ?? 'gen';
       const origin = originOf(url);
@@ -70,7 +73,7 @@ function fakePool(): {
       aliased.push([registeredId, leaseId]);
     },
   } as unknown as BrowserPool;
-  return { pool, acquired, aliased };
+  return { pool, acquired, aliased, released };
 }
 
 // A sessions stub where the leased tab is already "connected", so acquire's wait-for-ready resolves
@@ -522,5 +525,204 @@ describe('prioritising a tab that is already open', () => {
 
     expect(out['sessionId']).toBeDefined();
     expect(out['url']).toBe('http://localhost:3000/');
+  });
+});
+
+describe('reticle_lease with seedStorage', () => {
+  it('propagates seedStorage to pool.acquire and never echoes seeded values in the tool result', async () => {
+    const { pool, acquired } = fakePool();
+    const deps = { ...baseDeps, pool } as unknown as ToolDeps;
+    const seedStorage = {
+      local: { auth_token: 'secret-auth-token-12345' },
+      session: { user_session: 'secret-session-abcde' },
+      cookies: { session: 'secret-cookie-xyz99' },
+    };
+
+    const out = (await tool(ReticleTool.LEASE_ACQUIRE)(deps, {
+      url: 'http://localhost:3000/app',
+      seedStorage,
+    })) as Record<string, unknown>;
+
+    // seedStorage reached pool.acquire intact
+    expect(acquired).toHaveLength(1);
+    expect(acquired[0]?.seedStorage).toEqual(seedStorage);
+
+    // Tool output must NEVER echo the seeded values or the seedStorage object
+    expect('seedStorage' in out).toBe(false);
+    expect(JSON.stringify(out)).not.toContain('secret-auth-token-12345');
+    expect(JSON.stringify(out)).not.toContain('secret-session-abcde');
+    expect(JSON.stringify(out)).not.toContain('secret-cookie-xyz99');
+    expect(out['ready']).toBe(true);
+    expect(out['sessionId']).toBeDefined();
+  });
+
+  it('rejects malformed seedStorage without echoing raw values in the error', async () => {
+    const { pool } = fakePool();
+    const deps = { ...baseDeps, pool } as unknown as ToolDeps;
+
+    await expect(
+      tool(ReticleTool.LEASE_ACQUIRE)(deps, {
+        url: 'http://localhost:3000/',
+        seedStorage: { local: 12345 as unknown as Record<string, string> },
+      }),
+    ).rejects.toThrow(/seedStorage is invalid: local: Expected object, received number/);
+  });
+
+  it('releases an existing lease on the origin and mints fresh when seedStorage is provided', async () => {
+    const { pool, released } = fakePool();
+    const deps = { ...baseDeps, pool } as unknown as ToolDeps;
+
+    // First acquire without seedStorage
+    const first = (await tool(ReticleTool.LEASE_ACQUIRE)(deps, {
+      url: 'http://localhost:3000/',
+    })) as Record<string, unknown>;
+    const firstId = first['sessionId'] as string;
+
+    // Second acquire with seedStorage on same origin must NOT reuse firstId; it must release firstId
+    const second = (await tool(ReticleTool.LEASE_ACQUIRE)(deps, {
+      url: 'http://localhost:3000/',
+      seedStorage: { local: { token: 'new-token' } },
+    })) as Record<string, unknown>;
+    const secondId = second['sessionId'] as string;
+
+    expect(secondId).not.toBe(firstId);
+    expect(released).toContain(firstId);
+    expect(second['reused']).toBeUndefined();
+  });
+
+  it('acquireLeasedSession propagates seedStorage to pool.acquire', async () => {
+    const { pool, acquired } = fakePool();
+    const sessions = { get: () => ({ id: 'live' }), all: () => [] };
+    const seedStorage = { local: { token: 'auth-jwt' } };
+
+    await acquireLeasedSession(
+      pool,
+      sessions,
+      'http://localhost:3000/test',
+      undefined,
+      seedStorage,
+    );
+
+    expect(acquired).toHaveLength(1);
+    expect(acquired[0]?.seedStorage).toEqual(seedStorage);
+  });
+
+  it('preserves explicit empty seedStorage ({}) semantics by releasing existing lease', async () => {
+    const { pool, released } = fakePool();
+    const deps = { ...baseDeps, pool } as unknown as ToolDeps;
+
+    const first = (await tool(ReticleTool.LEASE_ACQUIRE)(deps, {
+      url: 'http://localhost:3000/',
+    })) as Record<string, unknown>;
+    const firstId = first['sessionId'] as string;
+
+    const second = (await tool(ReticleTool.LEASE_ACQUIRE)(deps, {
+      url: 'http://localhost:3000/',
+      seedStorage: {},
+    })) as Record<string, unknown>;
+    const secondId = second['sessionId'] as string;
+
+    expect(secondId).not.toBe(firstId);
+    expect(released).toContain(firstId);
+  });
+
+  it('re-throws sanitized Storage seeding failed error without masking as could not open', async () => {
+    const { pool } = fakePool();
+    pool.acquire = () =>
+      Promise.reject(
+        new Error('Storage seeding failed: localStorage write failed: QuotaExceededError'),
+      );
+    const deps = { ...baseDeps, pool } as unknown as ToolDeps;
+
+    await expect(
+      tool(ReticleTool.LEASE_ACQUIRE)(deps, {
+        url: 'http://localhost:3000/',
+        seedStorage: { local: { token: 'val' } },
+      }),
+    ).rejects.toThrow('Storage seeding failed: localStorage write failed: QuotaExceededError');
+  });
+
+  it('serializes concurrent seeded acquisitions on the same origin and cleans up lock', async () => {
+    const { pool, acquired } = fakePool();
+    const trace: string[] = [];
+    const origin = 'http://localhost:3000';
+    const originalAcquire = pool.acquire.bind(pool);
+    pool.acquire = async (url, opts) => {
+      const tag = url.includes('app1') ? 'req1' : 'req2';
+      trace.push(`${tag}:acquire-start`);
+      // Hold the lock for a moment to ensure concurrency contention
+      await new Promise((r) => setTimeout(r, 20));
+      const res = await originalAcquire(url, opts);
+      trace.push(`${tag}:acquire-end`);
+      return res;
+    };
+    const deps = { ...baseDeps, pool } as unknown as ToolDeps;
+
+    expect(hasOriginLock(origin)).toBe(false);
+
+    // Launch two concurrent seeded acquire calls for the same origin
+    const p1 = tool(ReticleTool.LEASE_ACQUIRE)(deps, {
+      url: `${origin}/app1`,
+      seedStorage: { local: { k: '1' } },
+    });
+    const p2 = tool(ReticleTool.LEASE_ACQUIRE)(deps, {
+      url: `${origin}/app2`,
+      seedStorage: { local: { k: '2' } },
+    });
+
+    // While in flight, the origin lock must be held
+    expect(hasOriginLock(origin)).toBe(true);
+
+    const [res1, res2] = await Promise.all([p1, p2]);
+
+    expect(acquired).toHaveLength(2);
+    expect(res1).toBeDefined();
+    expect(res2).toBeDefined();
+
+    // Critical assertion: req1 must have finished acquiring before req2 began acquiring!
+    expect(trace).toEqual([
+      'req1:acquire-start',
+      'req1:acquire-end',
+      'req2:acquire-start',
+      'req2:acquire-end',
+    ]);
+
+    // After completion, the origin lock must be completely cleaned up
+    expect(hasOriginLock(origin)).toBe(false);
+  });
+
+  it('cleans up origin lock and allows subsequent acquires when an acquire fails', async () => {
+    const { pool } = fakePool();
+    const origin = 'http://localhost:3000';
+    let failFirst = true;
+    const originalAcquire = pool.acquire.bind(pool);
+    pool.acquire = async (url, opts) => {
+      if (failFirst) {
+        failFirst = false;
+        throw new Error('Storage seeding failed: test failure');
+      }
+      return originalAcquire(url, opts);
+    };
+    const deps = { ...baseDeps, pool } as unknown as ToolDeps;
+
+    // First acquire fails
+    await expect(
+      tool(ReticleTool.LEASE_ACQUIRE)(deps, {
+        url: `${origin}/app`,
+        seedStorage: { local: { token: 'fail' } },
+      }),
+    ).rejects.toThrow('Storage seeding failed: test failure');
+
+    // Lock must be cleaned up despite the failure
+    expect(hasOriginLock(origin)).toBe(false);
+
+    // Second acquire on the same origin succeeds without being blocked or deadlocked
+    const second = (await tool(ReticleTool.LEASE_ACQUIRE)(deps, {
+      url: `${origin}/app`,
+      seedStorage: { local: { token: 'success' } },
+    })) as Record<string, unknown>;
+
+    expect(second['sessionId']).toBeDefined();
+    expect(hasOriginLock(origin)).toBe(false);
   });
 });

--- a/packages/server/src/tools/lease-tools.test.ts
+++ b/packages/server/src/tools/lease-tools.test.ts
@@ -4,15 +4,20 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { RETICLE_URL_PARAM } from '@reticlehq/core';
+import { RETICLE_URL_PARAM, Verified, VerifiedReason } from '@reticlehq/core';
 import {
   LEASE_TOOLS,
   acquireLeasedSession,
   appendReticleParams,
   cleanNavError,
+  evaluateSeedPrecondition,
   hasOriginLock,
+  scrubSeedFromError,
   waitForLeasedSession,
 } from './lease-tools.js';
+import { assertVerdict } from './assert-verdict.js';
+import { evaluatePredicate, type Predicate, type PredicateSession } from '../events/predicate.js';
+import type { Session } from '../session/session.js';
 import { ReticleTool } from './tool-names.js';
 import type { ToolDeps } from './tool-kit.js';
 import type { BrowserPool, Lease } from '../pool/browser-pool.js';
@@ -724,5 +729,204 @@ describe('reticle_lease with seedStorage', () => {
 
     expect(second['sessionId']).toBeDefined();
     expect(hasOriginLock(origin)).toBe(false);
+  });
+
+  describe('credential redaction & seed precondition semantics', () => {
+    it('scrubSeedFromError redacts raw secret values and known secret patterns', () => {
+      const jwt =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+      const customSecret = 'SUPER_SECRET_COOKIE_VAL_123';
+      const seed = {
+        cookies: { session: customSecret },
+        local: { token: 'LOCAL_TOKEN_999' },
+      };
+
+      const errorMsg = `Error: failed to write cookie ${customSecret} with payload ${jwt} and local LOCAL_TOKEN_999`;
+      const scrubbed = scrubSeedFromError(errorMsg, seed);
+
+      expect(scrubbed).not.toContain(customSecret);
+      expect(scrubbed).not.toContain(jwt);
+      expect(scrubbed).not.toContain('LOCAL_TOKEN_999');
+      expect(scrubbed).toContain('[REDACTED]');
+    });
+
+    it('reticle_lease acquire scrubs secret values when cookie injection fails', async () => {
+      const secretToken = 'SECRET_TEST_TOKEN_AB12';
+      const { pool } = fakePool();
+      pool.acquire = () =>
+        Promise.reject(
+          new Error(
+            `Storage seeding failed: cookie injection failed (invalid cookie: ${secretToken})`,
+          ),
+        );
+      const deps = { ...baseDeps, pool } as unknown as ToolDeps;
+
+      try {
+        await tool(ReticleTool.LEASE_ACQUIRE)(deps, {
+          url: 'http://localhost:3000/',
+          seedStorage: { cookies: { auth: secretToken } },
+        });
+        expect.unreachable('should have thrown');
+      } catch (err: unknown) {
+        const msg = (err as Error).message;
+        expect(msg).toContain('Storage seeding failed');
+        expect(msg).not.toContain(secretToken);
+        expect(msg).toContain('[REDACTED]');
+      }
+    });
+
+    it('evaluateSeedPrecondition detects 401/403 status codes', () => {
+      const failure401 = evaluateSeedPrecondition(
+        'http://localhost:3000/dashboard',
+        'http://localhost:3000/dashboard',
+        { cookies: { token: 't' } },
+        401,
+      );
+      expect(failure401).toContain('HTTP 401');
+
+      const failure403 = evaluateSeedPrecondition(
+        'http://localhost:3000/dashboard',
+        'http://localhost:3000/dashboard',
+        { cookies: { token: 't' } },
+        403,
+      );
+      expect(failure403).toContain('HTTP 403');
+    });
+
+    it('evaluateSeedPrecondition detects cross-origin redirects when storage was seeded', () => {
+      const failure = evaluateSeedPrecondition(
+        'http://localhost:3000/app',
+        'https://auth.external.com/login',
+        { local: { key: 'val' } },
+        200,
+      );
+      expect(failure).toContain('cross-origin redirect');
+      expect(failure).toContain('skipped origin-scoped storage injection');
+    });
+
+    it('evaluateSeedPrecondition detects redirect to login endpoint when requested URL was not login', () => {
+      const failure = evaluateSeedPrecondition(
+        'http://localhost:3000/dashboard',
+        'http://localhost:3000/login',
+        { cookies: { auth: 'session' } },
+        200,
+      );
+      expect(failure).toContain('redirected from /dashboard to login page (/login)');
+    });
+
+    it('evaluateSeedPrecondition accepts normal application redirects (e.g. / -> /dashboard)', () => {
+      const ok = evaluateSeedPrecondition(
+        'http://localhost:3000/',
+        'http://localhost:3000/dashboard',
+        { cookies: { auth: 'session' } },
+        200,
+      );
+      expect(ok).toBeUndefined();
+    });
+
+    it('sets precondition failure on session and propagates to assertVerdict as UNKNOWN / INCONCLUSIVE', async () => {
+      let preconditionFailure: string | undefined;
+      const fakeSession = {
+        id: 'lease-test-1',
+        url: 'http://localhost:3000/login', // redirected to login!
+        setPreconditionFailure: (reason: string) => {
+          preconditionFailure = reason;
+        },
+        preconditionFailure: () => preconditionFailure,
+        blindSpots: () => ({}),
+        queryEvents: () => Promise.resolve([]),
+        lostSince: () => false,
+        lastAct: { cursor: () => 0, source: () => undefined },
+        hasCapabilities: true,
+        command: () =>
+          Promise.resolve({ ok: true, result: { matched: false, count: 0, elements: [] } }),
+        eventsSince: () => [],
+        onEvent: () => () => {},
+        elapsed: () => 100,
+      };
+
+      const { pool } = fakePool();
+      const deps = {
+        sessions: {
+          get: () => fakeSession,
+        },
+        pool,
+      } as unknown as ToolDeps;
+
+      // Acquire with seedStorage requested for /dashboard
+      const acquireResult = (await tool(ReticleTool.LEASE_ACQUIRE)(deps, {
+        url: 'http://localhost:3000/dashboard',
+        seedStorage: { cookies: { auth: 'cookie-val' } },
+      })) as { sessionId: string };
+
+      expect(acquireResult.sessionId).toBeDefined();
+      expect(fakeSession.preconditionFailure()).toContain(
+        'redirected from /dashboard to login page (/login)',
+      );
+
+      // Evaluate an assertion on this session that fails
+      const predicate: Predicate = { kind: 'element', query: { text: 'Dashboard Welcome' } };
+      const evalRes = await evaluatePredicate(
+        fakeSession as unknown as PredicateSession,
+        predicate,
+      );
+      expect(evalRes.pass).toBe(false);
+      expect(evalRes.inconclusive).toContain('seeded authentication precondition not established');
+
+      const verdict = await assertVerdict(
+        fakeSession as unknown as Session,
+        predicate,
+        evalRes.pass,
+        evalRes.evidence,
+        0,
+        evalRes.inconclusive,
+      );
+
+      expect(verdict.decision['verified']).toBe(Verified.UNKNOWN);
+      expect(verdict.decision['verifiedReason']).toBe(VerifiedReason.INCONCLUSIVE);
+      expect(verdict.decision['because']).toContain(
+        'seeded authentication precondition not established',
+      );
+    });
+
+    it('genuine workflow failure on authenticated session produces normal FAIL (NO / ASSERTION_FAILED)', async () => {
+      const fakeSession = {
+        id: 'lease-test-2',
+        url: 'http://localhost:3000/dashboard', // stays on dashboard!
+        setPreconditionFailure: () => {},
+        preconditionFailure: () => undefined, // Precondition succeeded
+        blindSpots: () => ({}),
+        queryEvents: () => Promise.resolve([]),
+        lostSince: () => false,
+        lastAct: { cursor: () => 0, source: () => undefined },
+        hasCapabilities: true,
+        command: () =>
+          Promise.resolve({ ok: true, result: { matched: false, count: 0, elements: [] } }),
+        eventsSince: () => [],
+        onEvent: () => () => {},
+        elapsed: () => 100,
+      };
+
+      const predicate: Predicate = { kind: 'element', query: { text: 'Missing Button' } };
+      const evalRes = await evaluatePredicate(
+        fakeSession as unknown as PredicateSession,
+        predicate,
+      );
+      expect(evalRes.pass).toBe(false);
+      expect(evalRes.inconclusive).toBeUndefined();
+
+      const verdict = await assertVerdict(
+        fakeSession as unknown as Session,
+        predicate,
+        evalRes.pass,
+        evalRes.evidence,
+        0,
+        evalRes.inconclusive,
+      );
+
+      expect(verdict.decision['verified']).toBe(Verified.NO);
+      expect(verdict.decision['verifiedReason']).toBe(VerifiedReason.ASSERTION_FAILED);
+      expect(verdict.decision['because']).toBe('the declared consequence did not hold');
+    });
   });
 });

--- a/packages/server/src/tools/lease-tools.ts
+++ b/packages/server/src/tools/lease-tools.ts
@@ -224,7 +224,9 @@ export function evaluateSeedPrecondition(
 
   // Clear redirect to an authentication/login endpoint when the requested URL was not a login page
   const isAuthPath = (pathname: string): boolean =>
-    /(?:^|\/)(?:login|signin|sign-in|auth\/login|auth\/signin|session\/new)(?:$|\/)/i.test(pathname);
+    /(?:^|\/)(?:login|signin|sign-in|auth\/login|auth\/signin|session\/new)(?:$|\/)/i.test(
+      pathname,
+    );
 
   if (!isAuthPath(reqParsed.pathname) && isAuthPath(actParsed.pathname)) {
     return `seeded authentication precondition not established: redirected from ${reqParsed.pathname} to login page (${actParsed.pathname})`;
@@ -360,10 +362,12 @@ export async function acquireLeasedSession(
   if (registeredId !== undefined) pool.alias?.(registeredId, lease.sessionId);
   const effectiveId = registeredId ?? lease.sessionId;
   if (seedStorage !== undefined) {
-    const session = sessions.get(effectiveId) as {
-      url?: string;
-      setPreconditionFailure?(reason: string): void;
-    } | undefined;
+    const session = sessions.get(effectiveId) as
+      | {
+          url?: string;
+          setPreconditionFailure?(reason: string): void;
+        }
+      | undefined;
     if (session?.setPreconditionFailure !== undefined) {
       const failureReason = evaluateSeedPrecondition(
         url,
@@ -489,9 +493,7 @@ export const LEASE_ACQUIRE_TOOL: ToolDef = {
           parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', '),
           seedStorageArg,
         );
-        throw new Error(
-          `reticle_lease{action:"acquire"} seedStorage is invalid: ${issuesMsg}`,
-        );
+        throw new Error(`reticle_lease{action:"acquire"} seedStorage is invalid: ${issuesMsg}`);
       }
       validatedSeed = parsed.data;
     }

--- a/packages/server/src/tools/lease-tools.ts
+++ b/packages/server/src/tools/lease-tools.ts
@@ -21,7 +21,12 @@ import {
   watchersToNotify,
 } from '../session/lease-visibility.js';
 import { reticleStateHome } from '../daemon/daemon.js';
-import { RETICLE_URL_PARAM, RETICLE_DEFAULT_PORT } from '@reticlehq/core';
+import {
+  RETICLE_URL_PARAM,
+  RETICLE_DEFAULT_PORT,
+  SeedStorageSchema,
+  type SeedStorage,
+} from '@reticlehq/core';
 import { ReticleTool } from './tool-names.js';
 import type { ToolDef, ToolDeps } from './tool-kit.js';
 import { asString } from './tools-helpers.js';
@@ -209,7 +214,7 @@ export async function acquireLeasedSession(
   pool: {
     acquire: (
       url: string,
-      opts: { sessionId: string },
+      opts: { sessionId: string; seedStorage?: SeedStorage },
     ) => Promise<{ sessionId: string; release: () => Promise<void> }>;
     /**
      * The address this lease's page said it could not reach. Optional so a test double need not
@@ -222,9 +227,13 @@ export async function acquireLeasedSession(
   sessions: { get: (id: string) => unknown; all: () => { id: string; url?: string }[] },
   url: string,
   projectId?: string,
+  seedStorage?: SeedStorage,
 ): Promise<{ sessionId: string; release: () => Promise<void> }> {
   const sessionId = newLeaseId();
-  const lease = await pool.acquire(appendReticleParams(url, sessionId, projectId), { sessionId });
+  const lease = await pool.acquire(appendReticleParams(url, sessionId, projectId), {
+    sessionId,
+    ...(seedStorage !== undefined ? { seedStorage } : {}),
+  });
   // Resolved, not assumed — see resolveLeasedSessionId. The parallel suite replays against whatever
   // id comes back, so handing it the lease id for an app that named its own session sent every flow
   // in the run at a session that does not exist.
@@ -259,6 +268,14 @@ export async function waitForLeasedSession(
  * handler keeps that literal — the drive route dispatches through `runTool`, so it is counted like
  * any other call instead of being a second, invisible dispatch path.
  */
+// Serializes lease acquisitions on the same origin so concurrent callers (e.g. seeded replacements)
+// do not race and establish multiple overlapping contexts on that origin.
+const originAcquireLocks = new Map<string, Promise<unknown>>();
+
+export function hasOriginLock(origin: string): boolean {
+  return originAcquireLocks.has(origin);
+}
+
 export const LEASE_ACQUIRE_TOOL: ToolDef = {
   name: ReticleTool.LEASE_ACQUIRE,
   description:
@@ -271,6 +288,9 @@ export const LEASE_ACQUIRE_TOOL: ToolDef = {
       .string()
       .optional()
       .describe('Stable project id to stamp on the leased tab so the agent can scope to it.'),
+    seedStorage: SeedStorageSchema.optional().describe(
+      'Initial storage state (localStorage, sessionStorage, cookies) to seed before the first navigation (e.g. to start already authenticated).',
+    ),
   },
   outputSchema: {
     sessionId: z.string(),
@@ -327,95 +347,137 @@ export const LEASE_ACQUIRE_TOOL: ToolDef = {
       }
     }
     const projectId = asString(args['projectId']);
+    const seedStorageArg = args['seedStorage'];
+    let validatedSeed: SeedStorage | undefined;
+    if (seedStorageArg !== undefined) {
+      const parsed = SeedStorageSchema.safeParse(seedStorageArg);
+      if (!parsed.success) {
+        throw new Error(
+          `reticle_lease{action:"acquire"} seedStorage is invalid: ${parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', ')}`,
+        );
+      }
+      validatedSeed = parsed.data;
+    }
     // Sampled BEFORE acquiring: afterwards this lease is itself a session, and the point is to name
     // a tab that already existed. A human's open tab is the one they can watch, so if one is here
     // the agent should be told at the moment it is choosing — not after it has gone dark on them.
     const alreadyOpen = liveTabFor(deps, projectId);
     const origin = originOf(url);
-    const existing = origin === undefined ? undefined : pool.leaseIdOnOrigin?.(origin);
-    if (existing !== undefined && origin !== undefined) {
-      // Resolved, not looked up — the same resolver the mint path below uses, for the same reason
-      // it states: an app that names its own session registers under that name, so the id the pool
-      // holds is not always an id the other tools accept. A direct `sessions.get` missed exactly
-      // those apps and fell through to the release, which frees a LIVE lease and mints a second
-      // context — the tab-poisoning this branch exists to prevent, reached through the branch
-      // itself. It bites when the first acquire returned `ready: false`, since the mint path only
-      // aliases once its wait has resolved, so nothing recorded the app's own name (#692).
-      const resolved = resolveLeasedSessionId(deps.sessions, existing);
-      if (resolved !== undefined) {
-        // The other name this lease answers to, told to the pool exactly as the mint path tells it.
-        // A no-op when the id resolved to itself; load-bearing when it did not, because every later
-        // touch and release arrives under the id being handed back here.
-        pool.alias(resolved, existing);
-        pool.touch(existing);
-        return {
-          sessionId: resolved,
-          url,
-          ready: true,
-          reused: true,
-          expiresInMs: pool.leaseTtlMs(),
-          leased: pool.activeCount(),
-          queued: pool.queuedCount(),
-          hint: alreadyHeldHint(resolved, origin),
-          ...(alreadyOpen === undefined
-            ? {}
-            : { preferExisting: { sessionId: alreadyOpen, note: PREFER_EXISTING_NOTE } }),
-        };
-      }
-      // The lease is still held but the tab has gone — a reload dropped the session, and no session
-      // anywhere is driving it. Free the slot and mint, rather than handing back a dead id or
-      // leaving both contexts occupied.
-      await pool.release(existing);
+    const priorLock = origin !== undefined ? originAcquireLocks.get(origin) : undefined;
+    let releaseLock: (() => void) | undefined;
+    let lockPromise: Promise<void> | undefined;
+    if (origin !== undefined) {
+      lockPromise = new Promise<void>((resolve) => {
+        releaseLock = resolve;
+      });
+      originAcquireLocks.set(origin, lockPromise);
     }
-    const sessionId = newLeaseId();
-    const navUrl = appendReticleParams(url, sessionId, projectId);
-    let lease;
+    if (priorLock !== undefined) {
+      await priorLock.catch(() => undefined);
+    }
     try {
-      lease = await pool.acquire(navUrl, { sessionId });
-    } catch (err) {
-      // A raw page.goto failure is noisy and leaks the internal URL params — surface a clean,
-      // actionable message instead.
-      throw new Error(`could not open ${url} — is the app running there? (${cleanNavError(err)})`);
+      const existing = origin === undefined ? undefined : pool.leaseIdOnOrigin?.(origin);
+      if (validatedSeed !== undefined && existing !== undefined) {
+        // Caller explicitly requested storage seeding: do not reuse an existing context on this origin,
+        // release it so the new lease starts clean with the caller-provided state.
+        await pool.release(existing);
+      } else if (existing !== undefined && origin !== undefined) {
+        // Resolved, not looked up — the same resolver the mint path below uses, for the same reason
+        // it states: an app that names its own session registers under that name, so the id the pool
+        // holds is not always an id the other tools accept. A direct `sessions.get` missed exactly
+        // those apps and fell through to the release, which frees a LIVE lease and mints a second
+        // context — the tab-poisoning this branch exists to prevent, reached through the branch
+        // itself. It bites when the first acquire returned `ready: false`, since the mint path only
+        // aliases once its wait has resolved, so nothing recorded the app's own name (#692).
+        const resolved = resolveLeasedSessionId(deps.sessions, existing);
+        if (resolved !== undefined) {
+          // The other name this lease answers to, told to the pool exactly as the mint path tells it.
+          // A no-op when the id resolved to itself; load-bearing when it did not, because every later
+          // touch and release arrives under the id being handed back here.
+          pool.alias(resolved, existing);
+          pool.touch(existing);
+          return {
+            sessionId: resolved,
+            url,
+            ready: true,
+            reused: true,
+            expiresInMs: pool.leaseTtlMs(),
+            leased: pool.activeCount(),
+            queued: pool.queuedCount(),
+            hint: alreadyHeldHint(resolved, origin),
+            ...(alreadyOpen === undefined
+              ? {}
+              : { preferExisting: { sessionId: alreadyOpen, note: PREFER_EXISTING_NOTE } }),
+          };
+        }
+        // The lease is still held but the tab has gone — a reload dropped the session, and no session
+        // anywhere is driving it. Free the slot and mint, rather than handing back a dead id or
+        // leaving both contexts occupied.
+        await pool.release(existing);
+      }
+      const sessionId = newLeaseId();
+      const navUrl = appendReticleParams(url, sessionId, projectId);
+      let lease;
+      try {
+        lease = await pool.acquire(navUrl, {
+          sessionId,
+          ...(validatedSeed !== undefined ? { seedStorage: validatedSeed } : {}),
+        });
+      } catch (err) {
+        if (err instanceof Error && err.message.startsWith('Storage seeding failed')) {
+          throw err;
+        }
+        // A raw page.goto failure is noisy and leaks the internal URL params — surface a clean,
+        // actionable message instead.
+        throw new Error(
+          `could not open ${url} — is the app running there? (${cleanNavError(err)})`,
+        );
+      }
+      // Wait for the leased tab's SDK to connect so the returned sessionId is usable right away.
+      // Resolved rather than assumed: an app that names its own session registers under that name,
+      // and the id we hand back has to be the one the agent can actually drive.
+      let registeredId: string | undefined;
+      const ready = await waitForLeasedSession(() => {
+        registeredId = resolveLeasedSessionId(deps.sessions, lease.sessionId);
+        return registeredId !== undefined;
+      });
+      // Tell the pool the other name this lease answers to. Every later touch and release arrives
+      // under the id we are about to hand back, and the pool is keyed by the id it navigated with;
+      // without this the touches miss, the lease ages out despite continuous activity, and the
+      // reaper closes the context mid-flow. See BrowserPool.alias and #157.
+      if (registeredId !== undefined) pool.alias(registeredId, lease.sessionId);
+      // The lease now exists, so any HUD a human is watching has just gone dark. Say so.
+      tellWatchers(deps, projectId, AGENT_DRIVING_ELSEWHERE);
+      // ready means the SDK dialled in — not that contracts match. Carry the skew warning on acquire
+      // so the agent does not learn it only after a CDP tool invents a closed page (#688).
+      const versionSkew =
+        registeredId === undefined ? undefined : deps.sessions.get(registeredId)?.versionSkew;
+      return {
+        sessionId: registeredId ?? lease.sessionId,
+        url,
+        ready,
+        expiresInMs: pool.leaseTtlMs(),
+        leased: pool.activeCount(),
+        queued: pool.queuedCount(),
+        ...(alreadyOpen === undefined
+          ? {}
+          : {
+              preferExisting: {
+                sessionId: alreadyOpen,
+                note: PREFER_EXISTING_NOTE,
+              },
+            }),
+        ...(versionSkew === undefined ? {} : { versionSkew }),
+        ...(ready
+          ? {}
+          : { hint: await notConnectedHint(deps, url, pool.dialFailureUrl?.(lease.sessionId)) }),
+      };
+    } finally {
+      releaseLock?.();
+      if (origin !== undefined && originAcquireLocks.get(origin) === lockPromise) {
+        originAcquireLocks.delete(origin);
+      }
     }
-    // Wait for the leased tab's SDK to connect so the returned sessionId is usable right away.
-    // Resolved rather than assumed: an app that names its own session registers under that name,
-    // and the id we hand back has to be the one the agent can actually drive.
-    let registeredId: string | undefined;
-    const ready = await waitForLeasedSession(() => {
-      registeredId = resolveLeasedSessionId(deps.sessions, lease.sessionId);
-      return registeredId !== undefined;
-    });
-    // Tell the pool the other name this lease answers to. Every later touch and release arrives
-    // under the id we are about to hand back, and the pool is keyed by the id it navigated with;
-    // without this the touches miss, the lease ages out despite continuous activity, and the
-    // reaper closes the context mid-flow. See BrowserPool.alias and #157.
-    if (registeredId !== undefined) pool.alias(registeredId, lease.sessionId);
-    // The lease now exists, so any HUD a human is watching has just gone dark. Say so.
-    tellWatchers(deps, projectId, AGENT_DRIVING_ELSEWHERE);
-    // ready means the SDK dialled in — not that contracts match. Carry the skew warning on acquire
-    // so the agent does not learn it only after a CDP tool invents a closed page (#688).
-    const versionSkew =
-      registeredId === undefined ? undefined : deps.sessions.get(registeredId)?.versionSkew;
-    return {
-      sessionId: registeredId ?? lease.sessionId,
-      url,
-      ready,
-      expiresInMs: pool.leaseTtlMs(),
-      leased: pool.activeCount(),
-      queued: pool.queuedCount(),
-      ...(alreadyOpen === undefined
-        ? {}
-        : {
-            preferExisting: {
-              sessionId: alreadyOpen,
-              note: PREFER_EXISTING_NOTE,
-            },
-          }),
-      ...(versionSkew === undefined ? {} : { versionSkew }),
-      ...(ready
-        ? {}
-        : { hint: await notConnectedHint(deps, url, pool.dialFailureUrl?.(lease.sessionId)) }),
-    };
   },
 };
 

--- a/packages/server/src/tools/lease-tools.ts
+++ b/packages/server/src/tools/lease-tools.ts
@@ -22,9 +22,11 @@ import {
 } from '../session/lease-visibility.js';
 import { reticleStateHome } from '../daemon/daemon.js';
 import {
+  REDACTED_VALUE,
   RETICLE_URL_PARAM,
   RETICLE_DEFAULT_PORT,
   SeedStorageSchema,
+  scrubKnownSecrets,
   type SeedStorage,
 } from '@reticlehq/core';
 import { ReticleTool } from './tool-names.js';
@@ -104,13 +106,70 @@ export function appendReticleParams(url: string, session: string, projectId?: st
   }
 }
 
+function redactExactValue(text: string, value: string): string {
+  if (0 === value.length) return text;
+  const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return text.replace(
+    new RegExp(`(^|[^a-zA-Z0-9])${escaped}(?=$|[^a-zA-Z0-9])`, 'g'),
+    `$1${REDACTED_VALUE}`,
+  );
+}
+
+/**
+ * Scrub known secret shapes and raw seedStorage values (cookies, localStorage, sessionStorage)
+ * from an error string before it reaches daemon logs, metrics, or MCP error responses.
+ */
+export function scrubSeedFromError(text: string, seed?: unknown): string {
+  let out = scrubKnownSecrets(text);
+  if (undefined !== seed && null !== seed && 'object' === typeof seed) {
+    const s = seed as Record<string, unknown>;
+    const cookies = s['cookies'];
+    if (undefined !== cookies && null !== cookies) {
+      if (Array.isArray(cookies)) {
+        for (const c of cookies) {
+          if (undefined !== c && null !== c && 'object' === typeof c) {
+            const val = (c as Record<string, unknown>)['value'];
+            if (undefined !== val && 'string' === typeof val) {
+              out = redactExactValue(out, val);
+            }
+          }
+        }
+      } else if ('object' === typeof cookies) {
+        for (const v of Object.values(cookies as Record<string, unknown>)) {
+          if ('string' === typeof v) {
+            out = redactExactValue(out, v);
+          }
+        }
+      }
+    }
+    const local = s['local'];
+    if (undefined !== local && null !== local && 'object' === typeof local) {
+      for (const v of Object.values(local as Record<string, unknown>)) {
+        if ('string' === typeof v) {
+          out = redactExactValue(out, v);
+        }
+      }
+    }
+    const session = s['session'];
+    if (undefined !== session && null !== session && 'object' === typeof session) {
+      for (const v of Object.values(session as Record<string, unknown>)) {
+        if ('string' === typeof v) {
+          out = redactExactValue(out, v);
+        }
+      }
+    }
+  }
+  return out;
+}
+
 /**
  * Turn a raw navigation failure (Playwright's `page.goto: net::ERR_… at <url>\nCall log:…`, often
  * with ANSI codes) into a short, clean reason — so the agent/user sees "is the app running?" instead
  * of an internals-leaking wall of text.
  */
-export function cleanNavError(err: unknown): string {
-  const msg = err instanceof Error ? err.message : String(err);
+export function cleanNavError(err: unknown, seed?: SeedStorage): string {
+  const rawMsg = err instanceof Error ? err.message : String(err);
+  const msg = scrubSeedFromError(rawMsg, seed);
   // Strip ANSI color codes (ESC[…m) Playwright emits — built via fromCharCode to keep the
   // control character out of a regex literal (no-control-regex).
   const ansi = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
@@ -123,6 +182,55 @@ export function cleanNavError(err: unknown): string {
     .replace(/\s+at\s+https?:\/\/\S+.*$/, '')
     .trim()
     .slice(0, 100);
+}
+
+/**
+ * Determine if a required seedStorage application precondition failed.
+ *
+ * Checks strong signals:
+ * 1. HTTP 401/403 status on the initial navigation.
+ * 2. Cross-origin redirect when localStorage or sessionStorage was requested (skipped by origin-scoping).
+ * 3. Clear redirect to an authentication/login endpoint when the requested URL was not a login page.
+ *
+ * Normal app redirects (e.g. / → /dashboard) are valid and return undefined.
+ */
+export function evaluateSeedPrecondition(
+  requestedUrl: string,
+  actualUrl: string | undefined,
+  seed: SeedStorage,
+  navStatus?: number,
+): string | undefined {
+  if (401 === navStatus || 403 === navStatus) {
+    return `HTTP ${navStatus} returned on initial seeded navigation to ${requestedUrl}`;
+  }
+  if (actualUrl === undefined || '' === actualUrl.trim()) return undefined;
+
+  let reqParsed: URL | undefined;
+  let actParsed: URL | undefined;
+  try {
+    reqParsed = new URL(requestedUrl);
+    actParsed = new URL(actualUrl);
+  } catch {
+    return undefined;
+  }
+
+  // Cross-origin redirect when local or session storage was requested
+  const hasStorage =
+    (undefined !== seed.local && 0 < Object.keys(seed.local).length) ||
+    (undefined !== seed.session && 0 < Object.keys(seed.session).length);
+  if (hasStorage && reqParsed.origin !== actParsed.origin) {
+    return `seeded storage precondition not established: cross-origin redirect from ${reqParsed.origin} to ${actParsed.origin} skipped origin-scoped storage injection`;
+  }
+
+  // Clear redirect to an authentication/login endpoint when the requested URL was not a login page
+  const isAuthPath = (pathname: string): boolean =>
+    /(?:^|\/)(?:login|signin|sign-in|auth\/login|auth\/signin|session\/new)(?:$|\/)/i.test(pathname);
+
+  if (!isAuthPath(reqParsed.pathname) && isAuthPath(actParsed.pathname)) {
+    return `seeded authentication precondition not established: redirected from ${reqParsed.pathname} to login page (${actParsed.pathname})`;
+  }
+
+  return undefined;
 }
 
 /** A fresh, collision-resistant lease id. Uses crypto at the I/O boundary (not pure logic). */
@@ -215,7 +323,7 @@ export async function acquireLeasedSession(
     acquire: (
       url: string,
       opts: { sessionId: string; seedStorage?: SeedStorage },
-    ) => Promise<{ sessionId: string; release: () => Promise<void> }>;
+    ) => Promise<{ sessionId: string; release: () => Promise<void>; navStatus?: number }>;
     /**
      * The address this lease's page said it could not reach. Optional so a test double need not
      * implement it; the real pool always does.
@@ -230,10 +338,17 @@ export async function acquireLeasedSession(
   seedStorage?: SeedStorage,
 ): Promise<{ sessionId: string; release: () => Promise<void> }> {
   const sessionId = newLeaseId();
-  const lease = await pool.acquire(appendReticleParams(url, sessionId, projectId), {
-    sessionId,
-    ...(seedStorage !== undefined ? { seedStorage } : {}),
-  });
+  let lease;
+  try {
+    lease = await pool.acquire(appendReticleParams(url, sessionId, projectId), {
+      sessionId,
+      ...(seedStorage !== undefined ? { seedStorage } : {}),
+    });
+  } catch (err) {
+    throw new Error(
+      scrubSeedFromError(err instanceof Error ? err.message : String(err), seedStorage),
+    );
+  }
   // Resolved, not assumed — see resolveLeasedSessionId. The parallel suite replays against whatever
   // id comes back, so handing it the lease id for an app that named its own session sent every flow
   // in the run at a session that does not exist.
@@ -243,7 +358,25 @@ export async function acquireLeasedSession(
     return registeredId !== undefined;
   });
   if (registeredId !== undefined) pool.alias?.(registeredId, lease.sessionId);
-  return { sessionId: registeredId ?? lease.sessionId, release: () => lease.release() };
+  const effectiveId = registeredId ?? lease.sessionId;
+  if (seedStorage !== undefined) {
+    const session = sessions.get(effectiveId) as {
+      url?: string;
+      setPreconditionFailure?(reason: string): void;
+    } | undefined;
+    if (session?.setPreconditionFailure !== undefined) {
+      const failureReason = evaluateSeedPrecondition(
+        url,
+        session.url,
+        seedStorage,
+        lease.navStatus,
+      );
+      if (failureReason !== undefined) {
+        session.setPreconditionFailure(failureReason);
+      }
+    }
+  }
+  return { sessionId: effectiveId, release: () => lease.release() };
 }
 
 export async function waitForLeasedSession(
@@ -352,8 +485,12 @@ export const LEASE_ACQUIRE_TOOL: ToolDef = {
     if (seedStorageArg !== undefined) {
       const parsed = SeedStorageSchema.safeParse(seedStorageArg);
       if (!parsed.success) {
+        const issuesMsg = scrubSeedFromError(
+          parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', '),
+          seedStorageArg,
+        );
         throw new Error(
-          `reticle_lease{action:"acquire"} seedStorage is invalid: ${parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', ')}`,
+          `reticle_lease{action:"acquire"} seedStorage is invalid: ${issuesMsg}`,
         );
       }
       validatedSeed = parsed.data;
@@ -425,12 +562,12 @@ export const LEASE_ACQUIRE_TOOL: ToolDef = {
         });
       } catch (err) {
         if (err instanceof Error && err.message.startsWith('Storage seeding failed')) {
-          throw err;
+          throw new Error(scrubSeedFromError(err.message, validatedSeed));
         }
         // A raw page.goto failure is noisy and leaks the internal URL params — surface a clean,
         // actionable message instead.
         throw new Error(
-          `could not open ${url} — is the app running there? (${cleanNavError(err)})`,
+          `could not open ${url} — is the app running there? (${cleanNavError(err, validatedSeed)})`,
         );
       }
       // Wait for the leased tab's SDK to connect so the returned sessionId is usable right away.
@@ -446,6 +583,19 @@ export const LEASE_ACQUIRE_TOOL: ToolDef = {
       // without this the touches miss, the lease ages out despite continuous activity, and the
       // reaper closes the context mid-flow. See BrowserPool.alias and #157.
       if (registeredId !== undefined) pool.alias(registeredId, lease.sessionId);
+      const effectiveSessionId = registeredId ?? lease.sessionId;
+      const session = deps.sessions.get(effectiveSessionId);
+      if (validatedSeed !== undefined && session !== undefined) {
+        const failureReason = evaluateSeedPrecondition(
+          url,
+          session.url,
+          validatedSeed,
+          lease.navStatus,
+        );
+        if (failureReason !== undefined) {
+          session.setPreconditionFailure?.(failureReason);
+        }
+      }
       // The lease now exists, so any HUD a human is watching has just gone dark. Say so.
       tellWatchers(deps, projectId, AGENT_DRIVING_ELSEWHERE);
       // ready means the SDK dialled in — not that contracts match. Carry the skew warning on acquire

--- a/test/pool.integration.test.ts
+++ b/test/pool.integration.test.ts
@@ -11,6 +11,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
+import { chromium, type Page as PlaywrightPage } from 'playwright';
 import { BrowserPool, playwrightLauncher, type Launcher } from '@reticlehq/server';
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
@@ -81,7 +82,11 @@ describe('BrowserPool — real Chromium', () => {
     const acquires = Array.from({ length: 6 }, () => pool.acquire(url));
     let resolved = 0;
     acquires.forEach((p) => void p.then(() => (resolved += 1)));
-    await sleep(400); // let everything that CAN resolve, resolve
+    const start = Date.now();
+    while (resolved < 2 && Date.now() - start < 3000) {
+      await sleep(50);
+    }
+    await sleep(200);
 
     expect(resolved).toBe(2); // only the cap
     expect(pool.activeCount()).toBe(2);
@@ -136,6 +141,121 @@ describe('BrowserPool — real Chromium', () => {
     expect(pool.activeCount()).toBe(0);
     expect(pool.queuedCount()).toBe(0);
     expect(count()).toBeLessThanOrEqual(2); // browser reused across all 40
+    await pool.shutdown();
+  }, 15000);
+
+  it('seeds storage on initial navigation and proves one-time semantics on real Chromium reload', async () => {
+    let capturedPage: PlaywrightPage | undefined;
+    const launch: Launcher = async () => {
+      const browser = await chromium.launch({ headless: true });
+      return {
+        isConnected: () => browser.isConnected(),
+        close: () => browser.close(),
+        onDisconnected: (h) => browser.on('disconnected', h),
+        newContext: async () => {
+          const ctx = await browser.newContext();
+          return {
+            addCookies: (cookies) => ctx.addCookies(cookies),
+            close: () => ctx.close(),
+            newPage: async () => {
+              const p = await ctx.newPage();
+              capturedPage = p;
+              return {
+                goto: (u) => p.goto(u, { waitUntil: 'domcontentloaded' }),
+                close: () => p.close(),
+                onCrash: (h) => p.on('crash', h),
+                onConsole: (h) => p.on('console', (msg) => h(msg.text())),
+                addInitScript: async (script, arg) => {
+                  const handle = await p.addInitScript(script as never, arg);
+                  return { dispose: () => handle.dispose() };
+                },
+              };
+            },
+          };
+        },
+      };
+    };
+
+    const pool = new BrowserPool(launch, { maxContexts: 2, genSessionId: counter() });
+
+    const seedStorage = {
+      local: { auth_token: 'real-jwt-token-123' },
+      session: { tab_state: 'active-tab-99' },
+      cookies: { session_cookie: 'cookie-abc-456' },
+    };
+
+    // 1. Initial navigation seeds storage before application code runs
+    const lease = await pool.acquire(url, { seedStorage });
+    expect(capturedPage).toBeDefined();
+
+    const initialLocal = await capturedPage!.evaluate(() => localStorage.getItem('auth_token'));
+    const initialSession = await capturedPage!.evaluate(() => sessionStorage.getItem('tab_state'));
+    const initialCookies = await capturedPage!.context().cookies();
+
+    expect(initialLocal).toBe('real-jwt-token-123');
+    expect(initialSession).toBe('active-tab-99');
+    expect(
+      initialCookies.some((c) => c.name === 'session_cookie' && c.value === 'cookie-abc-456'),
+    ).toBe(true);
+
+    // 2. Application logs out and clears storage
+    await capturedPage!.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+    expect(await capturedPage!.evaluate(() => localStorage.getItem('auth_token'))).toBeNull();
+    expect(await capturedPage!.evaluate(() => sessionStorage.getItem('tab_state'))).toBeNull();
+
+    // 3. Real Chromium reload: init script was disposed, so the old seed MUST NOT be restored
+    await capturedPage!.reload();
+
+    const postReloadLocal = await capturedPage!.evaluate(() => localStorage.getItem('auth_token'));
+    const postReloadSession = await capturedPage!.evaluate(() =>
+      sessionStorage.getItem('tab_state'),
+    );
+
+    expect(postReloadLocal).toBeNull();
+    expect(postReloadSession).toBeNull();
+
+    // 4. Release cleans up context
+    await lease.release();
+    expect(pool.activeCount()).toBe(0);
+    await pool.shutdown();
+  });
+
+  it('detects real storage write failure, rejects acquire, cleans up context and releases slot', async () => {
+    const pool = new BrowserPool(playwrightLauncher({ headless: true }), {
+      maxContexts: 2,
+      genSessionId: counter(),
+    });
+
+    // In real Chromium, navigating to a data: URL results in an opaque origin (origin === 'null').
+    // In Chromium, attempting to access or write localStorage in an opaque origin throws a real SecurityError.
+    const failingDataUrl = 'data:text/html,<!doctype html><title>Opaque</title>';
+    const secretValue = 'super-sensitive-secret-value-999';
+
+    let errorThrown: Error | undefined;
+    try {
+      await pool.acquire(failingDataUrl, {
+        seedStorage: { local: { secret_token: secretValue } },
+      });
+    } catch (err) {
+      errorThrown = err as Error;
+    }
+
+    // 1. Browser-side failure was detected in Node
+    expect(errorThrown).toBeDefined();
+    expect(errorThrown!.message).toMatch(
+      /Storage seeding failed: localStorage write failed: SecurityError/,
+    );
+
+    // 2. Secret value is NEVER leaked in the error
+    expect(errorThrown!.message).not.toContain(secretValue);
+
+    // 3. Pool context was cleaned up and slot released
+    expect(pool.activeCount()).toBe(0);
+    expect(pool.queuedCount()).toBe(0);
+
     await pool.shutdown();
   });
 });


### PR DESCRIPTION
Implements opt-in storage seeding for `reticle_lease` in [#599](https://github.com/reticlehq/reticle/issues/599).

### What it does:
- Adds an opt-in `seedStorage` parameter to `reticle_lease{action:"acquire"}` supporting `local`, `session`, and `cookies`
- Defines strict wire schemas in `@reticlehq/core` (`SeedStorageSchema`, `SeedCookieSchema`, `SeedCookiesSchema`)
- Seeds cookies into the `BrowserContext` cookie jar before the initial HTTP GET request (supporting httpOnly session cookies)
- Injects `localStorage` and `sessionStorage` via a one-time init script that executes after document creation but strictly before application scripts execute
- Enforces strict one-time semantics: the init script handle is disposed via `handle.dispose()` immediately after the initial navigation settles; later reloads or navigations do NOT reapply the seed
- Scopes storage seeding strictly to the top-level main frame (`window.top === window`) and target application origin (`window.location.origin === targetOrigin`), preventing cross-origin leaks during redirect chains (e.g. OAuth providers) or child iframes
- Catches storage write errors (e.g. `QuotaExceededError`, `SecurityError`) and bubbles sanitized errors (`localStorage write failed: <name>`) to Node via console protocol without leaking secret keys or values
- Enforces required capabilities: fails explicitly if cookies are requested without `addCookies` support or storage is requested without `addInitScript` support; allows `{}` as a safe no-op
- Normalizes domain cookies missing paths to default `path: '/'` for Playwright compliance
- Protects concurrent acquisitions on the same origin via `originAcquireLocks`, ensuring deterministic serialization and preventing race conditions
- Forces a fresh context when `seedStorage` is provided on an origin with an existing lease, preserving clean isolation
- Guarantees zero secret leakage: seed values are never echoed in tool responses, telemetry events, or error strings
- Preserves `reticle_storage` strictly as a read-only tool

### What & why
Issue [#599](https://github.com/reticlehq/reticle/issues/599) asks for storage write capability so agents can establish authenticated application state before the initial page load. While `reticle_storage` handles reading storage, seeding credentials via post-load evaluation causes premature redirect bounces on auth-protected web applications.

The lease-level approach injects cookies directly into the context jar and evaluates storage before inline bundle scripts mount. To prevent security vulnerabilities or credential persistence across logouts, the init script is scoped to the target origin and disposed immediately following initial navigation.

Closes [#599](https://github.com/reticlehq/reticle/issues/599).

### How it was verified
1. **Real Headless Chromium Integration Tests (`test/pool.integration.test.ts`)**:
   - `seeds storage on initial navigation and proves one-time semantics on real Chromium reload`: verifies that after seeding, clearing storage (`localStorage.clear()`), and executing `page.reload()`, storage remains cleared and is NOT restored by the init script.
   - `detects real storage write failure, rejects acquire, cleans up context and releases slot`: verifies that native Chromium `SecurityError` (induced via opaque origin) is caught, sanitized, propagated to Node, tears down the context, and frees the pool slot.
2. **Server Package Unit Tests (`packages/server`)**:
   - 101 tests passing across `storage-seed.test.ts`, `browser-pool.test.ts`, `lease-tools.test.ts`, `argument-shape.test.ts`, `read-tools.storage.test.ts`, and `storage-vocabulary.test.ts`.
   - Verified concurrency ordering (`req1:acquire-start` -> `req1:acquire-end` -> `req2:acquire-start` -> `req2:acquire-end`) and lock release on failure.
3. **Core Unit Tests (`packages/core`)**:
   - 348 unit tests passing.
4. **Linting, Formatting & Boundaries**:
   - `prettier --check` passed across all modified files.
   - `node scripts/check-boundaries.mjs` passed (10 packages checked).
   - `node scripts/check-lossy-transforms.mjs` passed.
   - Strict TypeScript typechecking (`tsc -b` with `exactOptionalPropertyTypes: true`) passed across `@reticlehq/core` and `@reticlehq/server`.

### Gates run
- `pnpm format:check` — PASS
- `node scripts/check-boundaries.mjs && node scripts/check-lossy-transforms.mjs` — PASS
- `pnpm --filter @reticlehq/server typecheck && pnpm --filter @reticlehq/core typecheck` — PASS
- `pnpm exec vitest run test/pool.integration.test.ts` (Real Chromium) — PASS (6/6)
- `pnpm --filter @reticlehq/server exec vitest run ...` — PASS (101/101)
- `pnpm --filter @reticlehq/core test:unit` — PASS (348/348)
- `pnpm --filter @reticlehq/core build && pnpm --filter @reticlehq/server build` — PASS

### Checklist
- [x] Every commit is signed off (`git commit -s`)
- [x] Tests added/updated — real Chromium integration tests + full unit matrix
- [x] No `any`, no free strings, strict types with `exactOptionalPropertyTypes`
- [x] No `console.log` or internal tracking codes left in the diff — sanitized error protocol used
- [x] Each changed file is under the 1000-line cap
- [x] Security-affecting? — Yes: zero-secret-echoing guarantee verified across telemetry, tool results, and error messages
