### PR TITLE
fix(browser): the console channel sees CSP violations

### DIFF
--- a/packages/browser/src/observers/console.test.ts
+++ b/packages/browser/src/observers/console.test.ts
@@ -151,3 +151,60 @@ describe('browser-emitted resource failures reach the console channel', () => {
     expect(events.filter((e) => e.type === EventType.ERROR_UNCAUGHT)).toHaveLength(0);
   });
 });
+
+describe('CSP violations reach the console channel', () => {
+  let teardown: Teardown | undefined;
+  afterEach(() => {
+    teardown?.();
+    teardown = undefined;
+  });
+
+  /**
+   * `securitypolicyviolation` as the browser dispatches it. Constructed rather than provoked: a
+   * real violation needs a CSP header the test environment cannot set, and the shape is what the
+   * listener reads.
+   */
+  const dispatchViolation = (violatedDirective: string, blockedURI: string): void => {
+    const event = new Event('securitypolicyviolation', { bubbles: true, cancelable: false });
+    Object.assign(event, { violatedDirective, blockedURI });
+    document.dispatchEvent(event);
+  };
+
+  it('reports a blocked subresource that no console method ever sees', () => {
+    const { emit, events } = collect();
+    teardown = installConsole(emit);
+
+    dispatchViolation('script-src', 'https://cdn.example.test/analytics.js');
+
+    const errors = events.filter((e) => e.type === EventType.CONSOLE_ERROR);
+    expect(errors, 'DevTools prints this; an absent-console assertion must not pass').toHaveLength(
+      1,
+    );
+    expect(String(errors[0]?.data['message'])).toContain('analytics.js');
+    expect(String(errors[0]?.data['message'])).toContain('script-src');
+    expect(errors[0]?.data['kind']).toBe('securitypolicyviolation');
+    expect(errors[0]?.data['source']).toBe('https://cdn.example.test/analytics.js');
+  });
+
+  it('names inline content rather than reporting a blocked empty string', () => {
+    // `blockedURI` is '' for inline script/style, which is the common script-src violation. A bare
+    // interpolation would read "blocked " and say nothing about what was refused.
+    const { emit, events } = collect();
+    teardown = installConsole(emit);
+
+    dispatchViolation('script-src', '');
+
+    const error = events.find((e) => e.type === EventType.CONSOLE_ERROR);
+    expect(String(error?.data['message'])).toContain('inline content');
+    expect(error?.data).not.toHaveProperty('source');
+  });
+
+  it('stops reporting after teardown', () => {
+    const { emit, events } = collect();
+    installConsole(emit)();
+
+    dispatchViolation('img-src', 'https://example.test/pixel.gif');
+
+    expect(events.filter((e) => e.type === EventType.CONSOLE_ERROR)).toHaveLength(0);
+  });
+});

--- a/packages/browser/src/observers/console.ts
+++ b/packages/browser/src/observers/console.ts
@@ -106,11 +106,35 @@ export function installConsole(emit: Emit): Teardown {
       ...(stack === undefined ? {} : { stack }),
     });
   };
+  /**
+   * A CSP violation is not a console call, and the browser never routes it through one.
+   *
+   * DevTools prints it, so a human reading the page sees dozens of them while
+   * `reticle_assert({ kind: "console", level: "error", absent: true })` returns a confident pass.
+   * That is a false green in the one place the product's claim rests, and
+   * `securitypolicyviolation` exists precisely so a page can observe what the browser refused.
+   *
+   * `blockedURI` is empty for inline content, which is the common case for a script-src violation;
+   * it is named rather than reported as a blocked empty string.
+   */
+  const onViolation = (event: SecurityPolicyViolationEvent): void => {
+    emit(EventType.CONSOLE_ERROR, {
+      message:
+        `Content Security Policy directive: ${event.violatedDirective} blocked ` +
+        `${0 === event.blockedURI.length ? 'inline content' : event.blockedURI}`,
+      kind: 'securitypolicyviolation',
+      ...(0 === event.blockedURI.length ? {} : { source: event.blockedURI }),
+    });
+  };
   // Capture phase: element `error` events do not bubble, so this is the only registration that
   // sees a failed subresource. Uncaught script errors reach a capturing window listener too, so one
   // registration covers both.
   window.addEventListener('error', onError, true);
   window.addEventListener('unhandledrejection', onRejection);
+  // Dispatched on `document` and it bubbles, so a window listener sees it; registered in the
+  // capture phase alongside the others so a page that stops propagation on `document` cannot hide
+  // one from us.
+  window.addEventListener('securitypolicyviolation', onViolation, true);
 
   return () => {
     for (const [method, original] of originals) {
@@ -120,5 +144,6 @@ export function installConsole(emit: Emit): Teardown {
     }
     window.removeEventListener('error', onError, true);
     window.removeEventListener('unhandledrejection', onRejection);
+    window.removeEventListener('securitypolicyviolation', onViolation, true);
   };
 }


### PR DESCRIPTION
## What

A CSP violation is not a console call. The browser blocks the resource, DevTools prints a red line, and nothing passes through `console.error` — so `reticle_assert({ kind: "console", level: "error", absent: true })` returns a confident pass on a page a human can see is full of errors. That is a false green in the one place the product's claim rests.

`securitypolicyviolation` exists precisely so a page can observe what the browser refused. This listens for it and emits `CONSOLE_ERROR`.

## Details

- Registered in the capture phase alongside the other two listeners, so a page that stops propagation on `document` cannot hide one.
- `blockedURI` is `''` for inline script/style — the common `script-src` case. The message names "inline content" rather than reading "blocked " and saying nothing, and `source` is omitted rather than set to an empty string.
- Torn down with the rest.

## Rebuilt on current main

The original branch also fixed resource-load failures (`<img>`/`<script>` `error` events that do not bubble). That half landed independently on main in the capture-phase `error` listener, so it is gone from here — this PR is only the residual CSP work, on top of main.

## Verification

`pnpm lint && pnpm typecheck && pnpm test:unit` green. Three new tests in `console.test.ts`; with the listener registration removed, two of them fail, so they are load-bearing rather than decorative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)