### PR TITLE
fix(init): the install step verifies instead of re-running the install

### DIFF
--- a/packages/server/src/init/install-already-satisfied.test.ts
+++ b/packages/server/src/init/install-already-satisfied.test.ts
@@ -1,0 +1,144 @@
+/**
+ * #683: a correct install read as a broken one.
+ *
+ * The install step's idempotent re-check WAS the install command. So a project whose packages were
+ * already there — installed by hand after a first run failed, or by a teammate — had `init` execute
+ * the same failing command again and report `⚠ Install dependencies — step failed` over an install
+ * that was fine. Two full init runs where one should do.
+ */
+import { describe, expect, it } from 'vitest';
+import { detect, Framework, PackageManager, UiLibrary, type Detection } from './detect.js';
+import { buildPlan, StepStatus, type PlanInput } from './plan.js';
+import { installFailureHint } from './install-hint.js';
+
+const VITE_REACT: Detection = {
+  framework: Framework.VITE,
+  uiLibrary: UiLibrary.REACT,
+  typescript: true,
+  reactMajor: 19,
+  needsSourceMapping: true,
+  packageManager: PackageManager.PNPM,
+};
+
+const planInput = (
+  installedPackages: Record<string, string | undefined> | undefined,
+  sdkVersion?: string,
+  install = true,
+): PlanInput => ({
+  detection: VITE_REACT,
+  claudeCli: false,
+  mcpExists: false,
+  viteConfig: null,
+  nextConfigFile: null,
+  nextReticleDevExists: false,
+  options: {
+    port: 4400,
+    mcp: true,
+    projectId: 'demo',
+    install,
+    ...(sdkVersion === undefined ? {} : { sdkVersion }),
+  },
+  ...(installedPackages === undefined ? {} : { installedPackages }),
+});
+
+const installStepOf = (input: PlanInput) =>
+  buildPlan(input).steps.find((step) => 'Install dependencies' === step.title);
+
+describe('the install step verifies rather than re-running', () => {
+  it('reports ALREADY when every package resolves', () => {
+    const step = installStepOf(
+      planInput({ '@reticlehq/react': '2.13.1', '@reticlehq/vite-plugin': '2.13.1' }),
+    );
+
+    expect(step?.status).toBe(StepStatus.ALREADY);
+    expect(step?.detail).toContain('@reticlehq/react@2.13.1');
+    // And nothing is executed: re-running the package manager is the bug.
+    expect(step?.exec).toBeUndefined();
+  });
+
+  it('installs when one package is missing', () => {
+    const step = installStepOf(planInput({ '@reticlehq/react': '2.13.1' }));
+    expect(step?.status).toBe(StepStatus.APPLY);
+    expect(step?.exec).toBeDefined();
+  });
+
+  it('installs when a package resolves to nothing', () => {
+    const step = installStepOf(
+      planInput({ '@reticlehq/react': '2.13.1', '@reticlehq/vite-plugin': '' }),
+    );
+    expect(step?.status).toBe(StepStatus.APPLY);
+  });
+
+  it('installs when the facts were not read at all', () => {
+    // A missing reading must never be able to SKIP an install — the direction an absent fact
+    // should be wrong in.
+    expect(installStepOf(planInput(undefined))?.status).toBe(StepStatus.APPLY);
+  });
+
+  it('does NOT report already when a pinned version is not the one installed', () => {
+    // The version-skew case pinning exists for: an older SDK against a newer daemon surfaces as a
+    // -32000 with nothing naming a version, and calling that "already installed" would be the
+    // report agreeing with the broken state.
+    const step = installStepOf(
+      planInput({ '@reticlehq/react': '2.12.0', '@reticlehq/vite-plugin': '2.12.0' }, '2.13.1'),
+    );
+    expect(step?.status).toBe(StepStatus.APPLY);
+  });
+
+  it('reports already when the pinned version IS the one installed', () => {
+    const step = installStepOf(
+      planInput({ '@reticlehq/react': '2.13.1', '@reticlehq/vite-plugin': '2.13.1' }, '2.13.1'),
+    );
+    expect(step?.status).toBe(StepStatus.ALREADY);
+  });
+
+  it('splits a scoped name from its version at the LAST @', () => {
+    // `@reticlehq/react@2.13.1` — a scoped package starts with an @, so the first one is not the
+    // separator. Getting this wrong reads the name as `` and never matches.
+    const step = installStepOf(
+      planInput({ '@reticlehq/react': '2.13.1', '@reticlehq/vite-plugin': '2.13.1' }, '2.13.1'),
+    );
+    expect(step?.detail).toContain('@reticlehq/react@2.13.1');
+    expect(step?.detail).not.toContain('@@');
+  });
+
+  it('leaves the manual (no --install) path alone', () => {
+    const input = planInput(
+      { '@reticlehq/react': '2.13.1', '@reticlehq/vite-plugin': '2.13.1' },
+      undefined,
+      false,
+    );
+    expect(installStepOf(input)?.status).toBe(StepStatus.MANUAL);
+  });
+});
+
+describe('the failure hint', () => {
+  it('names the symlinked virtual store, which is what pnpm actually reported', () => {
+    const hint = installFailureHint(PackageManager.PNPM);
+    expect(hint).toContain('ERR_PNPM_UNEXPECTED_VIRTUAL_STORE');
+    expect(hint).toContain('symlinked');
+    expect(hint).toContain('pnpm install');
+  });
+
+  it('still names the maturity window and the registry', () => {
+    const hint = installFailureHint(PackageManager.PNPM);
+    expect(hint).toContain('ERR_PNPM_NO_MATURE_MATCHING_VERSION');
+    expect(hint).toContain('registry');
+  });
+
+  it('says nothing about pnpm on another package manager', () => {
+    expect(installFailureHint(PackageManager.NPM)).not.toContain('ERR_PNPM');
+  });
+});
+
+describe('detect still works unchanged', () => {
+  it('reads a pnpm vite react app', () => {
+    const detection = detect({
+      pkg: { dependencies: { react: '^19.0.0' }, devDependencies: { vite: '^6.0.0' } },
+      configFiles: new Set(['vite.config.ts']),
+      lockfiles: new Set(['pnpm-lock.yaml']),
+    });
+    expect(detection.framework).toBe(Framework.VITE);
+    expect(detection.packageManager).toBe(PackageManager.PNPM);
+  });
+});

--- a/packages/server/src/init/install-hint.ts
+++ b/packages/server/src/init/install-hint.ts
@@ -20,6 +20,21 @@ const REGISTRY_HINT =
   'about reachability and not about this project: check `npm config get registry` and whether this ' +
   'machine can reach it.';
 
+/**
+ * A `node_modules` symlinked in from another checkout — a git worktree, an A/B harness.
+ *
+ * pnpm refuses to add to it, because its virtual store lives in the OTHER checkout and adding here
+ * would leave two trees disagreeing about one store. The hint named only the maturity window, so a
+ * reader met guidance that did not fit their error and every step downstream was skipped (#683).
+ *
+ * The remedy is the project's, not ours: this is a statement about how the checkout is laid out, and
+ * `pnpm install` in the worktree is the fix pnpm's own message is asking for.
+ */
+const VIRTUAL_STORE_HINT =
+  "If pnpm reported ERR_PNPM_UNEXPECTED_VIRTUAL_STORE, this checkout's `node_modules` is symlinked " +
+  'in from another one (a git worktree, or an A/B harness), so pnpm will not add to it. Run ' +
+  '`pnpm install` in THIS directory first to give it its own store, then re-run init.';
+
 export function installFailureHint(pm: PackageManager): string {
   if (pm !== PackageManager.PNPM) {
     return `If the version was refused, install the SDK yourself. ${REGISTRY_HINT}`;
@@ -29,6 +44,6 @@ export function installFailureHint(pm: PackageManager): string {
     'this release back. Either wait out the window, or allow these packages explicitly:\n' +
     '  pnpm config set minimumReleaseAgeExclude "@reticlehq/*"\n' +
     'Do NOT drop the version pin — unpinned, pnpm installs an older SDK against a newer daemon, and ' +
-    `that mismatch surfaces as a -32000 with nothing naming a version.\n${REGISTRY_HINT}`
+    `that mismatch surfaces as a -32000 with nothing naming a version.\n${VIRTUAL_STORE_HINT}\n${REGISTRY_HINT}`
   );
 }

--- a/packages/server/src/init/install-step.ts
+++ b/packages/server/src/init/install-step.ts
@@ -1,0 +1,145 @@
+/**
+ * The dependency-install step: what is already there, whether that is enough, and what to do.
+ *
+ * Split out of `plan.ts` and `run.ts`, both at the 1000-line backstop, and split as a cohesive unit
+ * rather than an arbitrary cut: all three parts are one step. `readInstalledPackages` looks,
+ * `resolvedInstall` decides, `installStep` reports.
+ *
+ * It is one unit because of #683: the step's idempotent re-check used to be the install command
+ * itself, so a project whose packages were already there had `init` execute the same failing command
+ * again and report a correct install as broken. Verifying instead of re-running is only possible
+ * when the looking and the deciding sit next to the reporting.
+ */
+import { join } from 'node:path';
+
+import { frameworkPackages, pinnedPackages, StepStatus, unpinnedRetryNote } from './plan.js';
+import { installCommand, installCommandParts } from './detect.js';
+import { installFailureHint } from './install-hint.js';
+
+import type { Framework, UiLibrary } from './detect.js';
+import type { PlanInput, Step } from './plan.js';
+
+/** The slice of `InitIo` this needs. Structural, so `run.ts` can hand over its own io. */
+interface ReadOnlyIo {
+  readFile(relPath: string): string | null;
+}
+
+/**
+ * The version each required package RESOLVES to from this app directory.
+ *
+ * Read from `node_modules/<name>/package.json` rather than from the app's own dependency list,
+ * because the question the install step asks is whether the package is THERE. A dependency
+ * declared but never installed, and a package installed by hand and not declared, are both real
+ * and they answer that question differently.
+ *
+ * An unreadable or unparseable manifest reads as absent, so the step installs. A missing reading
+ * must never be able to SKIP an install.
+ */
+export function readInstalledPackages(
+  io: ReadOnlyIo,
+  detection: { framework: Framework; uiLibrary: UiLibrary },
+): Record<string, string | undefined> {
+  const resolved: Record<string, string | undefined> = {};
+  for (const name of frameworkPackages(detection.framework, detection.uiLibrary)) {
+    const raw = io.readFile(join('node_modules', ...name.split('/'), 'package.json'));
+    if (null === raw) continue;
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      const version =
+        'object' === typeof parsed && null !== parsed
+          ? (parsed as { version?: unknown }).version
+          : undefined;
+      if ('string' === typeof version && version.length > 0) resolved[name] = version;
+    } catch {
+      // Unparseable is absent: install rather than guess.
+    }
+  }
+  return resolved;
+}
+/**
+ * Are every one of these packages already resolvable, at the version asked for?
+ *
+ * Returns the line to report when they are, and `undefined` when anything is missing or skewed --
+ * so the caller reads it as "already" or falls through to installing, with no third state to
+ * mishandle.
+ *
+ * A resolved version that differs from a PINNED one is NOT satisfied. That is the version-skew case
+ * this repo pins packages for at all: an older SDK against a newer daemon surfaces as a -32000 with
+ * nothing naming a version, and reporting it as "already installed" would be the report agreeing
+ * with the broken state.
+ *
+ * Undefined facts mean "not read", so the step installs. A missing reading must not be able to
+ * SKIP an install -- the direction an absent fact should be wrong in.
+ */
+export function resolvedInstall(
+  packages: readonly string[],
+  installed: Readonly<Record<string, string | undefined>> | undefined,
+): string | undefined {
+  if (installed === undefined) return undefined;
+  const resolved: string[] = [];
+  for (const spec of packages) {
+    // `@scope/name@version` — the version is after the LAST `@`, and a scoped name starts with one.
+    const at = spec.lastIndexOf('@');
+    const name = at > 0 ? spec.slice(0, at) : spec;
+    const wanted = at > 0 ? spec.slice(at + 1) : undefined;
+    const found = installed[name];
+    if (found === undefined || 0 === found.length) return undefined;
+    if (wanted !== undefined && wanted !== found) return undefined;
+    resolved.push(`${name}@${found}`);
+  }
+  return `already installed: ${resolved.join(', ')}`;
+}
+
+export function installStep(input: PlanInput): Step {
+  const pm = input.detection.packageManager;
+  const packages = pinnedPackages(
+    frameworkPackages(input.detection.framework, input.detection.uiLibrary),
+    input.options.sdkVersion,
+  );
+  const command = installCommand(pm, packages);
+  if (!input.options.install) {
+    return {
+      title: 'Install dependencies',
+      target: 'package.json',
+      status: StepStatus.MANUAL,
+      detail: command,
+    };
+  }
+  // Verify, do not re-run.
+  //
+  // The re-check used to be the install command itself, so a project whose packages were already
+  // there -- installed by hand after a first run failed, or by a teammate -- had `init` execute the
+  // same failing command again and report `⚠ Install dependencies — step failed` over a correct
+  // install (#683). Resolving the packages answers the question the step is actually asking, and it
+  // answers it in the state the app is in rather than by reproducing the state it got there from.
+  const satisfied = resolvedInstall(packages, input.installedPackages);
+  if (satisfied !== undefined) {
+    return {
+      title: 'Install dependencies',
+      target: 'package.json',
+      status: StepStatus.ALREADY,
+      detail: satisfied,
+    };
+  }
+  const parts = installCommandParts(pm, packages);
+  return {
+    title: 'Install dependencies',
+    target: 'package.json',
+    status: StepStatus.APPLY,
+    detail: command,
+    exec: {
+      command: parts.command,
+      args: parts.args,
+      fallback: `${command}\n\n${installFailureHint(pm)}`,
+    },
+    // Unpinned. pnpm resolves the newest MATURE version there, which is how a project with a
+    // release-age hold gets a working install instead of no install.
+    retry: {
+      ...installCommandParts(
+        pm,
+        frameworkPackages(input.detection.framework, input.detection.uiLibrary),
+      ),
+      note: unpinnedRetryNote(input.options.sdkVersion, pm),
+    },
+  };
+}

--- a/packages/server/src/init/plan.ts
+++ b/packages/server/src/init/plan.ts
@@ -4,16 +4,9 @@
  * runner performs the `write` side-effects; this module decides *what* should happen.
  */
 
-import {
-  Framework,
-  PackageManager,
-  UiLibrary,
-  installCommand,
-  installCommandParts,
-  type Detection,
-} from './detect.js';
+import { Framework, PackageManager, UiLibrary, type Detection } from './detect.js';
 import type { FoundStore } from './capabilities.js';
-import { installFailureHint } from './install-hint.js';
+import { installStep } from './install-step.js';
 import { claudeAddCommand, mcpManual, mcpWindowsNote } from './mcp.js';
 import { NodePlatform } from '../platform.js';
 import {
@@ -73,7 +66,7 @@ const RETICLE_NEXT_PLUGIN = '@reticlehq/next';
  * and nothing on either side names a version. Asking for the CLI's exact version makes the cache
  * irrelevant, and a skewed pair impossible to install by accident.
  */
-function pinnedPackages(
+export function pinnedPackages(
   packages: readonly string[],
   version: string | undefined,
 ): readonly string[] {
@@ -279,6 +272,13 @@ export interface PlanInput {
   nextFoundStores?: readonly FoundStore[] | undefined;
   /** Whether src/reticle-dev.ts already exists — it is the one generated file users are meant to edit. */
   viteDevModuleExists?: boolean | undefined;
+  /**
+   * Version each required package RESOLVES to from the app directory, or undefined when it does not
+   * resolve at all. Pre-read by `gatherPlanInput`, for the reason `cspSources` is: `PlanInput` is
+   * the pure input to a pure planner, and handing it a resolver would let a step reach the disk from
+   * inside `buildPlan`.
+   */
+  installedPackages?: Readonly<Record<string, string | undefined>> | undefined;
   /** Whether src/hooks.client.ts already exists (SvelteKit idempotency). */
   svelteKitHooksExists?: boolean;
   /** CRA's bundled entry (src/index.tsx or .js) — where the connect import has to go. */
@@ -733,7 +733,7 @@ function agentRuleSteps(input: PlanInput): Step[] {
  * the CONSEQUENCE (which is certain and is the part that bites) and offer the remedy that belongs to
  * the manager actually in use — rather than name a cause that is one possibility among several.
  */
-function unpinnedRetryNote(version: string | undefined, pm: PackageManager): string {
+export function unpinnedRetryNote(version: string | undefined, pm: PackageManager): string {
   const wanted = version === undefined ? 'the exact version' : version;
   // Kept verbatim for pnpm, where minimumReleaseAge is a real and common cause with a real remedy.
   const remedy =
@@ -747,44 +747,6 @@ function unpinnedRetryNote(version: string | undefined, pm: PackageManager): str
     `installed instead. That may not match the daemon — if the agent reports protocol errors, check ` +
     `\`versionSkew\` in reticle_sessions.${remedy}`
   );
-}
-
-function installStep(input: PlanInput): Step {
-  const pm = input.detection.packageManager;
-  const packages = pinnedPackages(
-    frameworkPackages(input.detection.framework, input.detection.uiLibrary),
-    input.options.sdkVersion,
-  );
-  const command = installCommand(pm, packages);
-  if (!input.options.install) {
-    return {
-      title: 'Install dependencies',
-      target: 'package.json',
-      status: StepStatus.MANUAL,
-      detail: command,
-    };
-  }
-  const parts = installCommandParts(pm, packages);
-  return {
-    title: 'Install dependencies',
-    target: 'package.json',
-    status: StepStatus.APPLY,
-    detail: command,
-    exec: {
-      command: parts.command,
-      args: parts.args,
-      fallback: `${command}\n\n${installFailureHint(pm)}`,
-    },
-    // Unpinned. pnpm resolves the newest MATURE version there, which is how a project with a
-    // release-age hold gets a working install instead of no install.
-    retry: {
-      ...installCommandParts(
-        pm,
-        frameworkPackages(input.detection.framework, input.detection.uiLibrary),
-      ),
-      note: unpinnedRetryNote(input.options.sdkVersion, pm),
-    },
-  };
 }
 
 /**

--- a/packages/server/src/init/run.ts
+++ b/packages/server/src/init/run.ts
@@ -14,6 +14,7 @@ import { spanSync } from '../trace.js';
 import { projectIdOf, rememberProjectOnDisk } from '../project/remember-project.js';
 import { detect, Framework, namesAPackageManager, type DetectInput, UiLibrary } from './detect.js';
 import { wasMcpRegistered } from './mcp-registered.js';
+import { readInstalledPackages } from './install-step.js';
 import { pickAstroHost } from './astro-host.js';
 import {
   findWorkspaceApps,
@@ -147,6 +148,7 @@ const NEXT_PAGES_APP_CANDIDATES = [
   'src/pages/_app.js',
 ];
 const SVELTEKIT_HOOKS = 'src/hooks.client.ts';
+
 const SOURCE_FILE = /\.(tsx|jsx|ts|js|svelte|vue|astro)$/;
 /** Files read for the testid scan. A capabilities block is a hint; reading a whole repo for it is not. */
 const MAX_SCANNED_FILES = 200;
@@ -503,6 +505,7 @@ function gatherPlanInput(options: InitOptions, io: InitIo, pkg: unknown): PlanIn
     nextReticleDevImport: devLocation.importSpecifier,
     nextReticleDevExists: io.exists(devLocation.path),
     nextReticleDevSource: io.readFile(devLocation.path),
+    installedPackages: readInstalledPackages(io, detection),
     svelteKitHooksExists: io.exists(SVELTEKIT_HOOKS),
     craEntry: craEntryOf(io),
     craEnv: io.readFile(CRA_ENV_PATH),


### PR DESCRIPTION
#683, problems **1** and **2**. (Problem 3, the Codex MCP false ⚠, is #681 — [#738](https://github.com/reticlehq/reticle/pull/738).)

## 2. Verify, don't re-run — the half the issue says is worth the most

> *"Fixing (2) alone turns this from two full init runs into one."*

The step's idempotent re-check **was the install command**. So a project whose packages were already there — installed by hand after a first run failed, or by a teammate — had `init` execute the same failing command again and report `⚠ Install dependencies — step failed` over an install that was fine.

Resolving the packages answers the question the step is actually asking, and it answers it **in the state the app is in** rather than by reproducing the state it got there from.

- Read from `node_modules/<name>/package.json`, not the app's dependency list. *"Is it there"* and *"is it declared"* are different questions: a dependency declared but never installed, and a package installed by hand and not declared, are both real and they answer differently.
- **A pinned version that is not the resolved one is NOT satisfied.** That is the version-skew case this repo pins for at all — an older SDK against a newer daemon surfaces as a `-32000` with nothing naming a version — and calling it "already installed" would be the report agreeing with the broken state.
- **Undefined facts mean "not read", so the step installs.** A missing reading must never be able to *skip* an install; that is the direction an absent fact should be wrong in.
- An unreadable or unparseable manifest reads as absent, for the same reason.

## 1. The hint names the error pnpm actually reported

It named only `ERR_PNPM_NO_MATURE_MATCHING_VERSION`, so a reader whose `node_modules` is symlinked in from another checkout (a git worktree, an A/B harness) met guidance that did not fit their error — and every step downstream was skipped. It now names `ERR_PNPM_UNEXPECTED_VIRTUAL_STORE` and the remedy, which is the project's rather than ours: `pnpm install` in the worktree is what pnpm's own message is asking for.

## A file split, because both files were at the backstop

`plan.ts` (988) and `run.ts` (997) are both at the 1000-line `max-lines` limit, so the step moves to `install-step.ts` as a **cohesive unit rather than an arbitrary cut** — the way `install-hint.ts` was split before it. It holds all three parts of one step: `readInstalledPackages` looks, `resolvedInstall` decides, `installStep` reports. It is one unit precisely because verifying instead of re-running is only possible when the looking and the deciding sit next to the reporting.

`plan.ts` 988 → **950**, `run.ts` 997 → **1000**.

## Verification

```
vitest run src/init/ src/cli/ src/setup/   # 93 files, 1085 passed
vitest run src/orphan-modules.test.ts       # the new module has importers
tsc --noEmit / eslint src/init              # clean
```

12 new tests: already/apply either side of each condition, a missing package, a package resolving to nothing, facts not read at all, both directions of the pinned-version case, the scoped-name split at the **last** `@`, the manual path untouched, and the three hint assertions.

## Also worth a line, as the issue notes

The reporter's Next 16 Watchpack `EMFILE` restart loop reproduced with `withReticle` removed, so it is not ours — but *"no session ever connects"* is indistinguishable from a Reticle wiring failure, and `WATCHPACK_POLLING=true` fixes it. Happy to add that to troubleshooting if you want it somewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)