### PR TITLE
fix(cli): the port-busy refusal names the path that actually works

### DIFF
--- a/packages/server/src/cli/cli-verify.ts
+++ b/packages/server/src/cli/cli-verify.ts
@@ -326,23 +326,39 @@ async function openLiveConnection(opts: LiveOpts): Promise<VerifyConnection> {
  * worst answer available, and reached most often by the people with the fewest other options, since
  * the skill offers this command as the way to a verdict with no MCP at all.
  *
- * Three ways out, in the order they are worth trying, and the message says all three rather than
- * picking one: an agent that already has the tools should ask the daemon that is running instead of
- * starting a second one; somebody who wants this command specifically can stop the daemon; and a
- * second port works when the app is configured for it.
+ * The message says every way out rather than picking one, and it says FIRST that a busy port is the
+ * normal state rather than a fault — an install that worked leaves a daemon on it, so a reader who
+ * arrives here has done nothing wrong and should not go looking for what they broke (#689).
  *
- * Attaching to the running daemon the way `reticle drive` now does is the better answer and is not
- * this change — see cli/drive-attach.ts for the shape it should take.
+ * `reticle drive` leads, because it is the only option that works in the state most people are in
+ * when they reach this message: the client exposes no `reticle_*` tools (Codex, Cursor Cloud,
+ * Antigravity, a session whose MCP link dropped), which is exactly when the CLI is reached for. It
+ * ATTACHES to the running daemon rather than binding — see cli/drive-attach.ts — so there is nothing
+ * to stop, nothing to race, and it hands back a sessionId the daemon owns. The advice that used to
+ * lead, "ask the daemon through the tools", is the one thing that reader by construction cannot do.
+ *
+ * Stopping the daemon stays on the list and stays LAST of the working options, with the reason: the
+ * MCP proxy respawns one into the gap, so `stop` is a race the caller usually loses, and it kills
+ * the agent's own link on the way past.
+ *
+ * `verify` itself attaching, rather than needing the port at all, is the real fix and is #689's
+ * first bullet — not this change.
  */
 export function portBusyMessage(port: number): string {
   return (
     `reticle verify needs port ${String(port)} — the port your app dials — and a Reticle daemon is ` +
     'already listening on it. It did not start a second one.\n\n' +
-    '  • If you have the Reticle tools, ask the daemon that is already running instead: ' +
+    '  This is the NORMAL state after a working install, not a fault: the daemon your MCP client ' +
+    'started owns that port.\n\n' +
+    `  • Drive the app through the daemon that is already there — this needs no tools and stops ` +
+    `nothing: npx @reticlehq/server drive <url>\n` +
+    '  • If your client HAS the Reticle tools, ask that daemon directly: ' +
     'reticle_run { tool: "reticle_verify", args: { action: "change", files: ["..."] } }\n' +
-    `  • Or stop it and re-run: npx @reticlehq/server stop --port ${String(port)}\n` +
     `  • Or run both on another port, if your app is configured for it: RETICLE_PORT=<port> ` +
-    'npx @reticlehq/server verify <url>'
+    'npx @reticlehq/server verify <url>\n' +
+    `  • Stopping the daemon (npx @reticlehq/server stop --port ${String(port)}) works, but it cuts ` +
+    "your agent's MCP link and the proxy usually respawns a daemon into the gap before verify can " +
+    'bind — prefer one of the above.'
   );
 }
 

--- a/packages/server/src/cli/verify-port-busy-message.test.ts
+++ b/packages/server/src/cli/verify-port-busy-message.test.ts
@@ -1,0 +1,59 @@
+/**
+ * #689: the largest single cluster of field reports is not a defect in any tool — it is that the
+ * tools were not loaded in the client, and there was no supported way to reach a verdict.
+ *
+ * `verify` refuses because the daemon owns the port, which is precisely the state a successful
+ * install leaves you in. The refusal's first suggestion was "ask the daemon through the Reticle
+ * tools" — the one thing a reader who arrived here by construction cannot do, since not having the
+ * tools is what sent them to the CLI.
+ *
+ * `reticle drive` already ATTACHES to a running daemon rather than binding (see drive-attach.ts). It
+ * needs no tools and stops nothing, and the message did not mention it.
+ */
+import { describe, expect, it } from 'vitest';
+import { portBusyMessage } from './cli-verify.js';
+
+const message = portBusyMessage(4400);
+
+describe('the port-busy refusal', () => {
+  it('says a busy port is the normal state, not a fault', () => {
+    // A reader who arrives here has done nothing wrong and should not go looking for what they broke.
+    expect(message).toContain('NORMAL state');
+    expect(message.toLowerCase()).toContain('not a fault');
+  });
+
+  it('leads with the option that needs no tools and stops nothing', () => {
+    const drive = message.indexOf('drive <url>');
+    const tools = message.indexOf('reticle_run');
+    expect(drive).toBeGreaterThan(-1);
+    expect(drive).toBeLessThan(tools);
+  });
+
+  it('says out loud that drive attaches rather than taking the port', () => {
+    expect(message).toContain('already there');
+    expect(message).toContain('stops nothing');
+  });
+
+  it('qualifies the tools option instead of assuming the reader has them', () => {
+    // The old wording was "If you have the Reticle tools" as the FIRST option, to a reader whose
+    // problem is that they do not.
+    expect(message).toContain('If your client HAS the Reticle tools');
+  });
+
+  it('keeps stopping the daemon on the list, last, with the reason', () => {
+    const stop = message.indexOf('stop --port');
+    expect(stop).toBeGreaterThan(message.indexOf('drive <url>'));
+    expect(message).toContain('MCP link');
+    expect(message).toContain('respawns');
+  });
+
+  it('still names the port and every escape it named before', () => {
+    expect(message).toContain('4400');
+    expect(message).toContain('RETICLE_PORT');
+    expect(message).toContain('stop --port 4400');
+  });
+
+  it('is still never a bare node error', () => {
+    expect(message).not.toMatch(/EADDRINUSE|node:net/);
+  });
+});


### PR DESCRIPTION
#689 — the third bullet, and the one that can ship today.

## The wrong first suggestion

`verify` refuses because a daemon owns the port, which is *precisely the state a successful install leaves you in*. Its first suggestion was:

> • If you have the Reticle tools, ask the daemon that is already running instead: `reticle_run { … }`

That is **the one thing the reader who arrived here cannot do**. Not having the tools loaded — Codex, Cursor Cloud, Antigravity, a session whose MCP link dropped — is what sends someone to the CLI in the first place. The other two options were "stop the daemon" and "reconfigure the app onto another port".

## The path that already works, and was not mentioned

`reticle drive <url>` **attaches** to a running daemon rather than binding one. `cli/drive-attach.ts` already arbitrates this — *"A healthy daemon owns the port → ATTACH … Nothing is bound, so there is nothing to race for and no reason to run `stop`"* — and hands back a sessionId the daemon owns.

So the message now leads with it, and says out loud that it needs no tools and stops nothing.

## Two more wording changes

**A busy port is the NORMAL state**, said before the options. A reader who gets here has done nothing wrong, and the old wording left them hunting for what they broke.

**Stopping the daemon stays, last, with the reason.** It cuts the agent's own MCP link, and the proxy usually respawns a daemon into the gap before `verify` can bind — the race `drive-attach.ts` was written to delete. It was previously offered second, unqualified.

## Tests

`verify-port-busy-message.test.ts` — 7 cases. **5 fail on `main`**, checked by stashing the source:

```
Tests  5 failed | 2 passed (7)     # source reverted
Tests  7 passed (7)                # with the change
```

They pin the ordering (drive before the tools option), the "normal state" line, the qualifier on the tools option, stop being last *with* its reason, and that every escape the old message named is still named. The existing `cli-verify.test.ts` assertion passes untouched.

```
vitest run src/cli/ src/init/   # 74 files, 859 passed
tsc --noEmit / eslint src/cli    # clean
```

## Not in this PR

`verify` attaching to the running daemon instead of needing the port at all — #689's first bullet, and the real fix — plus the flow-free ad-hoc verdict. Both are design calls on the CLI's shape. This is the message somebody reads until those land, and it currently points them away from the one thing that works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)