### PR TITLE
fix(session): a refused dial is not an uninstalled app (#685)

### DIFF
--- a/packages/server/src/session/no-session-next-action.ts
+++ b/packages/server/src/session/no-session-next-action.ts
@@ -51,6 +51,20 @@ interface NextActionFacts {
    * that works.
    */
   previouslyConnected?: boolean;
+  /**
+   * A page reached this daemon and was REFUSED on the pairing token.
+   *
+   * Positive evidence, and the only fact here that proves the app is both running and instrumented:
+   * nothing dials the bridge but an SDK, so a refused hello means the wiring works and the daemon
+   * would not serve it. That happens whenever an IDE registers the MCP server GLOBALLY -- the daemon
+   * starts with a cwd of `/` or `$HOME`, finds no `.reticle.json` there, and refuses every page
+   * while `doctor` run from the app directory reports the project wired (#685).
+   *
+   * Without it, `initialized: false` plus a listening port reads as "the app may carry no SDK" and
+   * the action handed back is `reticle init` -- over a config that already works, which is the one
+   * action that cannot help and can overwrite it.
+   */
+  authRefused?: boolean;
 }
 
 /** `reticle init`, the only command here that is Reticle's own and so cannot be wrong. */
@@ -158,6 +172,26 @@ export function nextActionFor(facts: NextActionFacts): NoSessionNextAction {
   // a second port is the exact confusion the probe exists to prevent.
   const ports = facts.listening.join(', ');
   const only = 1 === facts.listening.length ? facts.listening[0] : undefined;
+
+  // A refused dial outranks the absence of a local config, for the same reason `previouslyConnected`
+  // does: it is positive evidence about the app, and `initialized` only ever answers "is there a
+  // `.reticle.json` in the ONE directory this daemon stands in". A globally-registered daemon stands
+  // in `/` or `$HOME`, so that answer is no for every project it serves -- and every page it turns
+  // away is proof that the project it turned away is wired.
+  if (!facts.initialized && true === facts.authRefused) {
+    return {
+      action: NoSessionAction.OPEN_APP,
+      ...(only === undefined ? {} : { port: only }),
+      reason:
+        `a page dialled this daemon and was refused on the pairing token, so the app IS running ` +
+        `and instrumented (${ports} listening) — this is a SCOPE problem, not an install problem. ` +
+        'This daemon was started outside the project (an IDE that registers the MCP server ' +
+        'globally starts it in `/` or your home directory), so it has no `.reticle.json` to match ' +
+        'the page against. Do NOT run `reticle init`: the config it would write is already correct ' +
+        'somewhere else. Take a context you own instead with reticle_lease {action:"acquire", url, ' +
+        "projectId}, or restart the daemon from the app's own directory.",
+    };
+  }
 
   if (!facts.initialized && true !== facts.previouslyConnected) {
     return {

--- a/packages/server/src/session/no-session-watch.ts
+++ b/packages/server/src/session/no-session-watch.ts
@@ -26,6 +26,7 @@ import { stallUptime } from './stall-clock.js';
 import type { SessionManager } from './session-manager.js';
 import { probeDaemon } from '../mcp/mcp-proxy.js';
 import { findOccupiedSiblings } from '../cli/sibling-ports.js';
+import { WS_CLOSE_REASON } from '../bridge/bridge.js';
 
 /** Slow enough to be free, fast enough that a dev server started 15s ago is already reflected. */
 const REFRESH_MS = 15_000;
@@ -256,6 +257,21 @@ export function startNoSessionWatch(options: NoSessionWatchOptions): () => void 
   const timer = setInterval(refresh, REFRESH_MS);
   timer.unref();
 
+  /**
+   * Did the most recent bridge-initiated close refuse a page on its token?
+   *
+   * The bridge records it (`noteClosure(WS_CLOSE_REASON.AUTH_FAILED)`) and nothing read it as a
+   * DIAGNOSIS. It is the one fact that proves an app is running and instrumented: only an SDK dials
+   * the bridge, so a refused hello means the wiring works and this daemon would not serve it.
+   *
+   * Called optionally because this watch is constructed against a structural slice of the manager,
+   * and several callers pass a double that predates `lastClosure`. A manager that cannot answer has
+   * recorded no refusal, which falls through to the behaviour that was there before -- the safe
+   * direction for a fact whose only job is to SUPPRESS an `init` suggestion.
+   */
+  const lastCloseWasAuthFailure = (): boolean =>
+    options.sessions.lastClosure?.()?.reason === WS_CLOSE_REASON.AUTH_FAILED;
+
   const nextAction = (scope: ProjectScopeFacts): NoSessionNextAction => {
     const split = splitBrain();
     return nextActionFor({
@@ -263,6 +279,9 @@ export function startNoSessionWatch(options: NoSessionWatchOptions): () => void 
       initialized: scope.initialized,
       ...(scope.configsElsewhere === undefined ? {} : { configsElsewhere: scope.configsElsewhere }),
       previouslyConnected: connectedBefore(),
+      // Read when asked, like every other fact here: a page can dial at any moment, and a daemon
+      // that cached "nothing has been refused" at boot would keep saying so.
+      authRefused: lastCloseWasAuthFailure(),
       ...(split === undefined ? {} : { splitBrain: split }),
       listening,
       // Read when asked, like everything else here: a `package.json` can gain a dev script, and a

--- a/packages/server/src/session/refused-dial-is-not-an-uninstalled-app.test.ts
+++ b/packages/server/src/session/refused-dial-is-not-an-uninstalled-app.test.ts
@@ -1,0 +1,160 @@
+/**
+ * #685: a globally-registered MCP server runs outside the project, and every symptom points
+ * somewhere other than the cause.
+ *
+ * The daemon starts with a cwd of `/` or `$HOME`, finds no `.reticle.json` there, and refuses every
+ * page on the pairing token — while `doctor`, run from the app directory, reports the project wired.
+ * `reticle_sessions` then told the agent to run `reticle init` on a project that is already
+ * instrumented. One reporter burned a turn re-running init over a working config.
+ *
+ * The daemon already RECORDED the refusal (`noteClosure(WS_CLOSE_REASON.AUTH_FAILED)`). Nothing read
+ * it as a diagnosis.
+ */
+import { describe, expect, it } from 'vitest';
+import { NoSessionAction } from '@reticlehq/core';
+import { nextActionFor } from './no-session-next-action.js';
+
+const LISTENING = [5173];
+
+describe('a refused dial proves the app is instrumented', () => {
+  it('does not tell an agent to init over a config that already works', () => {
+    const next = nextActionFor({
+      everConnected: false,
+      initialized: false,
+      listening: LISTENING,
+      dev: undefined,
+      authRefused: true,
+    });
+
+    expect(next.action).not.toBe(NoSessionAction.RUN_INIT);
+    expect(next.action).toBe(NoSessionAction.OPEN_APP);
+  });
+
+  it('says why: the app is running and instrumented, the daemon is out of scope', () => {
+    const next = nextActionFor({
+      everConnected: false,
+      initialized: false,
+      listening: LISTENING,
+      dev: undefined,
+      authRefused: true,
+    });
+
+    expect(next.reason).toContain('refused on the pairing token');
+    expect(next.reason).toContain('SCOPE problem');
+    expect(next.reason).toContain('not an install problem');
+  });
+
+  it('tells the agent explicitly NOT to run init', () => {
+    // The wrong action here is not merely unhelpful — `init` can overwrite the config that works.
+    const next = nextActionFor({
+      everConnected: false,
+      initialized: false,
+      listening: LISTENING,
+      dev: undefined,
+      authRefused: true,
+    });
+
+    expect(next.reason).toContain('Do NOT run `reticle init`');
+    expect(next.command).toBeUndefined();
+  });
+
+  it('hands over the two things that DO work', () => {
+    const next = nextActionFor({
+      everConnected: false,
+      initialized: false,
+      listening: LISTENING,
+      dev: undefined,
+      authRefused: true,
+    });
+
+    expect(next.reason).toContain('reticle_lease');
+    expect(next.reason).toContain("the app's own directory");
+  });
+
+  it('carries the listening port when there is exactly one', () => {
+    const next = nextActionFor({
+      everConnected: false,
+      initialized: false,
+      listening: [5173],
+      dev: undefined,
+      authRefused: true,
+    });
+    expect(next.port).toBe(5173);
+  });
+});
+
+describe('the branches it must not disturb', () => {
+  it('still says run init when nothing has dialled at all', () => {
+    // No refusal means no evidence the app carries an SDK — the original diagnosis stands.
+    const next = nextActionFor({
+      everConnected: false,
+      initialized: false,
+      listening: LISTENING,
+      dev: undefined,
+    });
+
+    expect(next.action).toBe(NoSessionAction.RUN_INIT);
+  });
+
+  it('still says run init when the fact is explicitly false', () => {
+    const next = nextActionFor({
+      everConnected: false,
+      initialized: false,
+      listening: LISTENING,
+      dev: undefined,
+      authRefused: false,
+    });
+
+    expect(next.action).toBe(NoSessionAction.RUN_INIT);
+  });
+
+  it('leaves a locally-initialized project alone', () => {
+    const next = nextActionFor({
+      everConnected: false,
+      initialized: true,
+      listening: LISTENING,
+      dev: undefined,
+      authRefused: true,
+    });
+
+    expect(next.action).not.toBe(NoSessionAction.RUN_INIT);
+    expect(next.reason).not.toContain('SCOPE problem');
+  });
+
+  it('still reports a daemon split first, which outranks everything', () => {
+    const next = nextActionFor({
+      everConnected: false,
+      initialized: false,
+      listening: LISTENING,
+      dev: undefined,
+      authRefused: true,
+      splitBrain: 'another daemon on 4401 serves this project',
+    });
+
+    expect(next.action).toBe(NoSessionAction.DAEMON_SPLIT);
+  });
+
+  it('still reopens for a project that connected earlier', () => {
+    const next = nextActionFor({
+      everConnected: true,
+      initialized: false,
+      listening: LISTENING,
+      dev: undefined,
+      authRefused: true,
+    });
+
+    expect(next.action).toBe(NoSessionAction.REOPEN_APP);
+  });
+
+  it('still starts the dev server when nothing is listening', () => {
+    const next = nextActionFor({
+      everConnected: false,
+      initialized: false,
+      listening: [],
+      dev: undefined,
+      authRefused: true,
+    });
+
+    expect(next.action).toBe(NoSessionAction.START_DEV_SERVER);
+  });
+});


### PR DESCRIPTION
#685 — item 3, the diagnosis split. Items 1 and 2 are the plumbing half; see the end.

## The evidence was already there

Several IDEs register the MCP server **globally**, so the daemon starts with a cwd of `/` or `$HOME`. It finds no `.reticle.json`, refuses every page on the pairing token, and `reticle_sessions` tells the agent to run `reticle init` — on a project that is already instrumented, while `doctor` run from the app directory reports it wired. *"One reporter burned a turn re-running init over a working config."*

The daemon **already recorded** the refusal — `noteClosure(WS_CLOSE_REASON.AUTH_FAILED)` on the auth-failure path in `bridge.ts`, readable through `lastClosure()`. Nothing read it as a *diagnosis*.

## Why it outranks the missing config

A refused dial is the one fact available here that proves the app is both **running and instrumented**: nothing dials the bridge but an SDK, so a refused hello means the wiring works and this daemon would not serve it.

That is the same argument `previouslyConnected` already makes in this file — `initialized` only ever answers *"is there a `.reticle.json` in the ONE directory this daemon stands in"*, and a globally-registered daemon stands somewhere that is no project at all.

## What the new branch says

- the app **is** running and instrumented, with the listening ports
- this is a **scope** problem, not an install problem
- **do not run `reticle init`** — the config it would write is already correct somewhere else, and `init` can overwrite it
- carries **no `command`**, so there is nothing to run by reflex
- hands over the two things that work: `reticle_lease {action:"acquire", url, projectId}`, or restarting the daemon from the app's own directory

## Nothing above or below it moves

Each guarded by its own test: a daemon split still outranks everything; a project that connected before still reopens; nothing listening still starts the dev server; an initialized project is unaffected; and **with no refusal recorded the original `init` diagnosis stands exactly as before**.

`lastClosure` is called optionally — this watch is built against a structural slice of the manager and several existing callers pass a double that predates the method. A manager that cannot answer has recorded no refusal, which falls through to the previous behaviour: the safe direction for a fact whose only job is to *suppress* an `init` suggestion.

## Tests

11 cases in `refused-dial-is-not-an-uninstalled-app.test.ts`. **4 fail on `main`** (checked by stashing the source): `Tests 4 failed | 7 passed` → `11 passed`.

```
vitest run src/session/ src/cli/ src/tools/   # 1968 passed
tsc --noEmit / eslint src/session              # clean
```
(`published-skill-artifacts.test.ts` cannot resolve `yaml` and fails identically on `main`)

## Not in this PR

Item 1 (a globally-registered daemon authenticating any project in `~/.reticle/projects.json` off the hello's `projectId`) and item 2 (resolving artifact paths from the project root — the remaining half of #443). Both are real plumbing changes to auth and path resolution; this is the one that stops the agent being sent to fix something that is not broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)