### PR TITLE
fix(server): stop a net miss claiming a startup request never happened

### DIFF
--- a/packages/server/src/events/predicate-eval.ts
+++ b/packages/server/src/events/predicate-eval.ts
@@ -397,6 +397,36 @@ function unobservedChannelReason(
   );
 }
 
+/**
+ * Appended to a zero-match `net` negative whose window starts at SDK attach.
+ *
+ * Every event's `t` is stamped `performance.now() - #start`, where `#start` is taken when the SDK
+ * is constructed, so `t` is never negative and a window with `since === 0` begins AT attach — never
+ * before it. Whatever the page did between navigation start and attach left no event at all, so
+ * "no matching call" over such a window cannot be told apart from "the call was made while nothing
+ * was watching yet".
+ *
+ * The gap is routine rather than exotic: a `fetch` from an effect in a root provider, or a classic
+ * `<script>` at the end of `<body>`, fires before a deferred module script has run. Reported from
+ * the field, the verdict then read as proof the request was never made, and reporters went looking
+ * for the defect in code that was working — restarting dev servers and re-reading providers to
+ * establish the request was invisible rather than absent.
+ *
+ * Same argument as DOCUMENT_ONLY_SUFFIXES one axis over: that one is a channel Reticle does not
+ * watch, this is a stretch of TIME it was not yet watching.
+ *
+ * The grade is deliberately NOT downgraded to `inconclusive`. A missing API call is the finding this
+ * oracle exists to make, and it is the strongest grade available for the startup class — session
+ * restore, feature flags, bootstrap config — which is exactly the class that silently breaks on
+ * reload. Every window an action opens carries `since > 0` and is untouched. What changes is only
+ * what the negative CLAIMS: it stops asserting the request never happened, and names the assertion
+ * that can settle it, because the state such a request produces IS observable after attach.
+ */
+const PRE_ATTACH_CAVEAT =
+  ' — note that this window starts where the SDK attached, and requests made before that are never ' +
+  'captured, so a miss here cannot tell a call that was never made apart from one made before the ' +
+  'page connected; if the call is expected during startup, assert on the state it produces instead';
+
 export function evalNet(
   events: ReticleEvent[],
   p: Extract<Predicate, { kind: typeof PredicateKind.NET }>,
@@ -542,13 +572,20 @@ export function evalNet(
         assertion: 'net.count',
       };
     }
-    return evalExactCount({
+    const counted = evalExactCount({
       matched: matches.length,
       want: p.count,
       noun: 'network call(s)',
       filter: describeNetFilter(p),
       assertion: 'net.count',
     });
+    // Same blind head, second door: "saw 0" over a whole-session window is the same claim the
+    // presence branch makes, and just as unable to see a startup call. A `count: 0` assertion is
+    // left alone on purpose — it PASSES here, and turning that green into a non-pass is a grade
+    // change, not a wording one.
+    return 0 === matches.length && 0 === since && counted.failureReason !== undefined
+      ? { ...counted, failureReason: `${counted.failureReason}${PRE_ATTACH_CAVEAT}` }
+      : counted;
   }
   const hit = matches[0];
   if (hit === undefined && targetsUnobservedChannel(p) && !sawSubresources) {
@@ -566,7 +603,7 @@ export function evalNet(
     ? { pass: true, evidence: netEvidence(hit.data) }
     : {
         pass: false,
-        failureReason: `no network call matched ${JSON.stringify(p)}`,
+        failureReason: `no network call matched ${JSON.stringify(p)}${0 === since ? PRE_ATTACH_CAVEAT : ''}`,
         // Same reasoning as the signal miss: "no matching call" cannot be told apart from "the app
         // made no calls at all", and those need different fixes.
         observed: observedNetCalls(events, p.urlContains),

--- a/packages/server/src/events/predicate-net-pre-attach.test.ts
+++ b/packages/server/src/events/predicate-net-pre-attach.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { EventType } from '@reticlehq/core';
+import type { ReticleEvent } from '@reticlehq/core';
+import { evalNet } from './predicate-eval.js';
+import { PredicateKind } from './predicate.js';
+
+/**
+ * A request made before the SDK attached must not be graded as a request that never happened.
+ *
+ * Event `t` is stamped `performance.now() - #start`, `#start` being taken when the SDK is
+ * constructed. So `t` is never negative, and a window with no `since` starts AT attach: everything
+ * the page did between navigation start and attach left no event to find. Reported from the field
+ * (#667) on several stacks — two `fetch`es from an effect in a provider mounted in `app/layout.tsx`
+ * never appeared across many hard reloads, and a classic `<script>` at the end of `<body>` lost its
+ * calls to a deferred module script under CSP. Later calls were captured perfectly in both.
+ *
+ * The verdict read `verified: "no" — no network call matched urlContains "/api/v1/auth/me"`, which
+ * is a claim about the app rather than about the observer, and it is convincing enough that one
+ * reporter re-read their provider and restarted their dev server before working out the request was
+ * invisible rather than absent.
+ *
+ * What is asserted here is deliberately narrow. The negative keeps its grade — a missing API call is
+ * the finding this oracle exists to make, and startup is the class that most needs it — so these
+ * tests pin BOTH halves: the sentence stops overclaiming, and nothing about the failure weakens.
+ */
+function netEvent(t: number, data: Record<string, unknown>): ReticleEvent {
+  return { type: EventType.NET_REQUEST, t, data } as ReticleEvent;
+}
+
+/** A call captured well after attach, so the observer is demonstrably alive in every case below. */
+const LATER_CALL = netEvent(400, { method: 'GET', url: '/api/v1/poll', status: 200, ok: true });
+
+const BLIND_HEAD = 'before that are never captured';
+
+describe('evalNet — the window between navigation and SDK attach', () => {
+  it('stops a whole-session miss claiming the request was never made', () => {
+    const r = evalNet([LATER_CALL], {
+      kind: PredicateKind.NET,
+      urlContains: '/api/v1/auth/me',
+    });
+
+    expect(r.pass).toBe(false);
+    expect(r.failureReason).toContain(BLIND_HEAD);
+  });
+
+  it('points at the assertion that can settle it', () => {
+    // The recovery matters as much as the caveat: the state such a request produces IS observable
+    // after attach, and without somewhere to go the caller is left with a verdict and no next step.
+    const r = evalNet([], { kind: PredicateKind.NET, urlContains: '/api/v1/auth/me' });
+
+    expect(r.failureReason).toContain('assert on the state it produces');
+  });
+
+  it('keeps the negative a failure rather than downgrading it to inconclusive', () => {
+    // The half that must NOT change. `inconclusive` lands the verdict on `unknown`, and doing that
+    // to every startup assertion would cost the strongest grade for session restore, feature flags
+    // and bootstrap config — the class the issue is about — to fix the wording of a sentence.
+    const r = evalNet([LATER_CALL], { kind: PredicateKind.NET, urlContains: '/api/v1/auth/me' });
+
+    expect(r.inconclusive).toBeUndefined();
+    expect(r.assertion).toBe('net.present');
+    expect(r.expected).toContain('/api/v1/auth/me');
+  });
+
+  it('leaves a window an action opened alone, since it cannot contain the blind head', () => {
+    // `act_and_wait` stamps `since` at the moment it acts, which is necessarily after attach. The
+    // caveat there would be false, and would blunt the ordinary "your click fired no request" miss.
+    const r = evalNet([LATER_CALL], {
+      kind: PredicateKind.NET,
+      urlContains: '/api/v1/auth/me',
+      since: 200,
+    });
+
+    expect(r.pass).toBe(false);
+    expect(r.failureReason).not.toContain(BLIND_HEAD);
+  });
+
+  it('says nothing on a match', () => {
+    const r = evalNet([LATER_CALL], { kind: PredicateKind.NET, urlContains: '/api/v1/poll' });
+
+    expect(r.pass).toBe(true);
+    expect(r.failureReason).toBeUndefined();
+  });
+
+  it('carries the same caveat into a count assertion that saw nothing', () => {
+    // The identical claim through a second door: "saw 0" over a whole-session window is as blind to
+    // a startup call as "no network call matched" is.
+    const r = evalNet([LATER_CALL], {
+      kind: PredicateKind.NET,
+      urlContains: '/api/v1/auth/me',
+      count: 2,
+    });
+
+    expect(r.pass).toBe(false);
+    expect(r.assertion).toBe('net.count');
+    expect(r.failureReason).toContain(BLIND_HEAD);
+  });
+
+  it('does not caveat a count that saw the wrong number of calls it could see', () => {
+    // Matches exist, so the observer plainly caught this traffic; the cardinality is the finding.
+    const r = evalNet([LATER_CALL], {
+      kind: PredicateKind.NET,
+      urlContains: '/api/v1/poll',
+      count: 3,
+    });
+
+    expect(r.pass).toBe(false);
+    expect(r.failureReason).not.toContain(BLIND_HEAD);
+  });
+
+  it('leaves a `count: 0` absence assertion passing, which is the known gap', () => {
+    // Documented rather than fixed. This green is reached the same blind way, so it can assert an
+    // absence it never observed — but turning it red is a change of GRADE, not of wording, and it
+    // would flip existing green suites. Named here so the limit is visible in the test file rather
+    // than only in a discussion.
+    const r = evalNet([LATER_CALL], {
+      kind: PredicateKind.NET,
+      urlContains: '/api/v1/auth/me',
+      count: 0,
+    });
+
+    expect(r.pass).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #667.

Takes the first of the three fixes the issue lists, which it ranks as "a one-line honesty fix that recovers most of the cost". The other two make the requests *observable*; this one stops Reticle claiming they did not happen.

## Why `since === 0` is exactly the condition

The issue words the trigger as "the window starts at or before SDK attach". That turns out to be checkable with no new wire data, because the SDK already defines its own zero:

```ts
// packages/browser/src/reticle.ts
this.#start = performance.now();          // taken when the SDK is constructed
...
t: Math.round(performance.now() - this.#start),
```

Every event's `t` is measured from attach, so `t` is never negative, and a window with no `since` begins **at** attach — never before it. Whatever the page did between navigation start and attach left no event to find. So `0 === since` *is* "the window starts at attach", precisely, and a window an action opened necessarily carries `since > 0`.

That boundary is what keeps the change safe: `act_and_wait` windows are untouched, so the ordinary "your click fired no request" miss reads exactly as it did before.

## What changes

`evalNet`'s zero-match negative stops overclaiming:

> no network call matched `{"urlContains":"/api/v1/auth/me"}` — note that this window starts where the SDK attached, and requests made before that are never captured, so a miss here cannot tell a call that was never made apart from one made before the page connected; if the call is expected during startup, assert on the state it produces instead

The recovery is part of it. The state such a request produces *is* observable after attach, so the caller is not left with a verdict and nowhere to go — which is the cost the issue describes, one reporter re-reading their provider and restarting their dev server before working out the request was invisible rather than absent.

The same caveat rides the `count` branch, where "saw 0" over a whole-session window is the identical claim through a second door.

## What deliberately does not change

**The grade.** This does not set `inconclusive`. The issue's own complaint is that the bug "removes the strongest verdict grade for an entire class of behaviour — session restore, feature flags, bootstrap config", and downgrading every startup assertion to `unknown` would remove that grade too, just from the other direction. A missing API call is the finding this oracle exists to make. What was wrong was the sentence, so the sentence is what moved.

This is `DOCUMENT_ONLY_SUFFIXES` one axis over — and its comment already says what this PR is for:

> it did not make these requests observable, it stopped Reticle claiming they did not happen.

That one is a channel Reticle does not watch; this is a stretch of time it was not yet watching.

## One thing I found and left alone

A `count: 0` assertion over a whole-session window reaches its green the same blind way — it can assert an absence it never observed, which is a false **green** rather than a false red. It is pinned in the tests as a known gap rather than fixed, because turning it non-passing is a change of grade that would flip existing green suites, and that is your call rather than mine. Happy to send it separately if you want it.

Related but out of scope here: #668 is the eviction case for `absent: true`, which is a different mechanism reaching a similar-looking wrong answer.

## Tests

`packages/server/src/events/predicate-net-pre-attach.test.ts`, a sibling of the existing `predicate-net-unobserved.test.ts` since it is the same argument on a different axis. Eight cases, half of them pinning what must **not** move — the grade stays `pass: false` with `inconclusive` undefined, `since > 0` windows carry no caveat, a match says nothing, and a count that saw the wrong number of calls it *could* see is not excused.

Mutation-checked: reverting only the two call sites reddens exactly three tests (both presence cases and the count case) and leaves the five guard tests green, which is the split you want — the guards assert unchanged behaviour, so the bug must not disturb them.

Gates run in order on Windows: `format:check`, `lint` (17/17), `typecheck` (22/22), `test:unit`. The 107 tests across `predicate-net-pre-attach`, `predicate-net-unobserved` and `predicate.test.ts` pass together, so nothing in the existing net surface shifted. Two file-scanning suites (`docs-index-coverage`, the telemetry doc scan) hit the 5s timeout under full parallel load on this machine and pass in isolation on a clean `main` — unrelated to this change, but flagging it rather than leaving you to wonder.

`predicate-eval.ts` lands at 971 lines, still under the 1000 cap.
