### PR TITLE
fix(snapshot): stop an empty tree reading as an empty page on a hidden one

### DIFF
--- a/packages/browser/src/dom/snapshot-hidden-page.test.ts
+++ b/packages/browser/src/dom/snapshot-hidden-page.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { SnapshotMode } from '@reticlehq/core';
+import { buildSnapshot } from './snapshot.js';
+
+/**
+ * An empty tree must not read as an empty page (#672).
+ *
+ * Reported from the field: inside a lease, `reticle_snapshot` returned `{ tree: "", nodes: 0 }` for
+ * BOTH `interactive` and `full` on a fully rendered page, while `reticle_query({ by: "role" })` on
+ * that same page found 44 buttons and 12 textboxes — every one of them `visible: false`. It cost the
+ * reporter about six tool calls and a large console dump to establish that the page was fine and the
+ * snapshot was wrong, and the flow then had to be driven off query refs.
+ *
+ * `leanSkipped` already answers this for leanness and is lean-only by construction, so `full` had no
+ * explanation available to it at all. These pin the count that gives it one — and, as much, pin what
+ * must NOT be counted, because a number that appears on every ordinary page tells a reader nothing
+ * on the one page that needs it.
+ */
+describe('hiddenSkipped — an empty tree that says why', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('counts a display:none subtree that emptied the tree', () => {
+    document.body.innerHTML = '<div style="display:none"><button>One</button></div>';
+    const r = buildSnapshot({ mode: SnapshotMode.FULL });
+
+    expect(r.nodes).toBe(0);
+    expect(r.tree).toBe('');
+    expect(r.hiddenSkipped).toBe(1);
+  });
+
+  it('counts an aria-hidden subtree', () => {
+    document.body.innerHTML = '<div aria-hidden="true"><button>One</button></div>';
+
+    expect(buildSnapshot({ mode: SnapshotMode.FULL }).hiddenSkipped).toBe(1);
+  });
+
+  it('counts a subtree hidden by the hidden attribute', () => {
+    document.body.innerHTML = '<div hidden><button>One</button></div>';
+
+    expect(buildSnapshot({ mode: SnapshotMode.FULL }).hiddenSkipped).toBe(1);
+  });
+
+  it('answers for `full`, the mode leanSkipped cannot speak to', () => {
+    // The half of the report that had no diagnostic at all: `leanSkipped` is only set in a lean
+    // mode, so a full snapshot of a wholly hidden page returned "" and nothing else.
+    document.body.innerHTML = '<div aria-hidden="true"><button>One</button></div>';
+    const r = buildSnapshot({ mode: SnapshotMode.FULL });
+
+    expect(r.leanSkipped).toBeUndefined();
+    expect(r.hiddenSkipped).toBe(1);
+  });
+
+  it('is absent, not zero, on a healthy page', () => {
+    // Absence is the signal, exactly as it is for leanSkipped and visibleDialogs: a field that is
+    // always present is one a reader stops reading.
+    document.body.innerHTML = '<div><button>One</button></div>';
+    const r = buildSnapshot({ mode: SnapshotMode.FULL });
+
+    expect(r.nodes).toBeGreaterThan(0);
+    expect(r.hiddenSkipped).toBeUndefined();
+  });
+
+  it('does not count the tags the tree is supposed to omit', () => {
+    // <script>/<style> are absent from every snapshot ever taken and explain nothing about a page.
+    // Counting them would put a number on every ordinary page and make it mean nothing on this one.
+    document.body.innerHTML =
+      '<script>var a = 1;</script><style>.a{color:red}</style><div><button>One</button></div>';
+    const r = buildSnapshot({ mode: SnapshotMode.FULL });
+
+    expect(r.nodes).toBeGreaterThan(0);
+    expect(r.hiddenSkipped).toBeUndefined();
+  });
+
+  it('counts the subtree root once, not the elements underneath it', () => {
+    // A hidden root is never descended into, so the elements below it are never seen to be counted.
+    // Stated here so the number is read as what it is rather than as an element count.
+    document.body.innerHTML =
+      '<div aria-hidden="true"><button>One</button><button>Two</button><input></div>';
+
+    expect(buildSnapshot({ mode: SnapshotMode.FULL }).hiddenSkipped).toBe(1);
+  });
+
+  it('counts each hidden sibling separately', () => {
+    document.body.innerHTML =
+      '<div aria-hidden="true"><button>One</button></div>' +
+      '<div style="display:none"><button>Two</button></div>' +
+      '<div hidden><button>Three</button></div>';
+
+    expect(buildSnapshot({ mode: SnapshotMode.FULL }).hiddenSkipped).toBe(3);
+  });
+});
+
+/**
+ * The overlay explainer must not fail closed in its own failure case.
+ *
+ * `overlayHidingPage` picked the modal with `isVisible`, which is the right primary test — it tells
+ * an open modal from a closed one left in the DOM. But in the state #672 describes, EVERY node
+ * computes hidden, the modal with them, so the one function that explains an empty tree went silent
+ * exactly when the tree was emptiest. The reporter's dialog had just opened and was in the React
+ * tree; the snapshot offered no explanation for its absence.
+ *
+ * The candidate's own visibility was never the evidence. The evidence is every other child of body
+ * carrying `aria-hidden="true"`, which is a focus trap's signature, and that gate is unchanged.
+ */
+describe('overlayHidingPage when the modal itself computes hidden (#672)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('still explains the empty page when the modal does not compute visible', () => {
+    document.body.innerHTML =
+      '<div aria-hidden="true"><button>Buy now</button></div>' +
+      '<div style="opacity:0"><div role="dialog" aria-label="Confirm"><button>OK</button></div></div>';
+    const { status } = buildSnapshot({ mode: SnapshotMode.FULL });
+
+    expect(status.overlayHidingPage).toBeDefined();
+  });
+
+  it('still requires the rest of the page to be aria-hidden', () => {
+    // The gate that carries the actual evidence. Without it the fallback would explain any page
+    // holding a closed dialog as an overlay problem, which is a confident wrong answer.
+    document.body.innerHTML =
+      '<div><button>Buy now</button></div>' +
+      '<div style="opacity:0"><div role="dialog" aria-label="Confirm"><button>OK</button></div></div>';
+    const { status } = buildSnapshot({ mode: SnapshotMode.FULL });
+
+    expect(status.overlayHidingPage).toBeUndefined();
+  });
+
+  it('prefers a visible modal when there is one', () => {
+    document.body.innerHTML =
+      '<div aria-hidden="true"><button>Buy now</button></div>' +
+      '<div><div role="dialog" aria-label="Confirm"><button>OK</button></div></div>';
+    const { status } = buildSnapshot({ mode: SnapshotMode.FULL });
+
+    expect(status.overlayHidingPage).toBeDefined();
+  });
+});

--- a/packages/browser/src/dom/snapshot.ts
+++ b/packages/browser/src/dom/snapshot.ts
@@ -92,6 +92,24 @@ export interface SnapshotResult {
    */
   leanSkipped?: number;
   /**
+   * How many subtrees the walk refused to enter because their ROOT was hidden — `aria-hidden`,
+   * the `hidden` attribute, or `display: none` — present only when non-zero. Counts subtree roots
+   * rather than elements, because a hidden root is never descended into and the elements beneath it
+   * are therefore never seen to be counted.
+   *
+   * The same argument as `leanSkipped`, for the cause `leanSkipped` cannot speak to. That one is
+   * lean-only by construction, so a `full` snapshot that comes back empty carries no explanation at
+   * all: `{ tree: "", nodes: 0 }` on a page holding 44 buttons, which reads as "the app broke" when
+   * what happened is that everything on it computed hidden. Reported from the field (#672) at a cost
+   * of about six tool calls and a large console dump to establish the page was fine and the snapshot
+   * was wrong.
+   *
+   * It is deliberately a count of what was SKIPPED rather than a diagnosis of why the page is
+   * hidden. The walk knows the first fact for certain and cannot know the second, and a number that
+   * is certainly true is what turns "" from a claim about the app into a pointer at the read.
+   */
+  hiddenSkipped?: number;
+  /**
    * Refs of the subtree roots the walk never entered, present ONLY when `truncated`. This is the
    * cut's own frontier: re-snapshot each with `{ scope: ref, includeRoot: true }` and the union is
    * the whole tree. Without it `truncated` says only THAT the read stopped, never WHERE, so nobody
@@ -131,12 +149,22 @@ interface SnapshotOptions {
 export const MAX_UNREAD_BRANCHES = 50;
 
 /** Cheap skips that need no computed style (tags, overlays, aria-hidden, [hidden]). */
+/**
+ * Hidden by its own MARKUP — `aria-hidden="true"` or the `hidden` attribute.
+ *
+ * Split out of `skipEarly` so the walk can tell the two kinds of skip apart. A `<script>` or
+ * Reticle's own HUD being absent from the tree explains nothing about the page; a subtree the app
+ * marked hidden is exactly what a reader of an empty tree needs to know about.
+ */
+function hiddenByMarkup(el: Element): boolean {
+  if ('true' === el.getAttribute('aria-hidden')) return true;
+  return el instanceof HTMLElement && el.hidden;
+}
+
 function skipEarly(el: Element): boolean {
   if (SKIP_TAGS.has(el.tagName.toLowerCase())) return true;
   if (isIgnored(el)) return true; // Reticle overlay + known dev overlays
-  if ('true' === el.getAttribute('aria-hidden')) return true;
-  if (el instanceof HTMLElement && el.hidden) return true;
-  return false;
+  return hiddenByMarkup(el);
 }
 
 function stateSuffix(el: Element): string {
@@ -201,6 +229,8 @@ interface WalkCtx {
   maxNodes: number;
   /** Meaningful nodes INTERACTIVE mode passed over — see the note where it is set. */
   leanSkipped: number;
+  /** Subtrees skipped because their root was hidden — see the note where it is set. */
+  hiddenSkipped: number;
   maxDepth: number;
   unread: string[];
   unreadOverflow: boolean;
@@ -247,12 +277,21 @@ function pierceChildren(parent: Element): Element[] {
 /** Emit one element (if it earns a line) and descend into it. Split out of `walk` so the completion
  * re-read can start AT a branch root — the node the truncated walk stopped just before emitting. */
 function visit(child: Element, depth: number, ctx: WalkCtx, inLive: boolean): void {
-  if (skipEarly(child)) return;
+  if (skipEarly(child)) {
+    // Only the hidden ones are counted. The others — <script>, <style>, our own HUD — are noise the
+    // tree is SUPPOSED to omit, and counting them would put a number on every ordinary page and so
+    // make the number mean nothing on the one page that needs it.
+    if (hiddenByMarkup(child)) ctx.hiddenSkipped += 1;
+    return;
+  }
   // Resolve computed style ONCE per node (the dominant snapshot cost) and thread it into both the
   // display-none skip and the layout signature — was two forced style resolutions per node.
   const view = child.ownerDocument.defaultView;
   const style = view !== null ? view.getComputedStyle(child) : null;
-  if (style !== null && 'none' === style.display) return;
+  if (style !== null && 'none' === style.display) {
+    ctx.hiddenSkipped += 1;
+    return;
+  }
   const role = getRole(child);
   const name = getAccessibleName(child);
   const interactive = INTERACTIVE.has(role);
@@ -383,6 +422,20 @@ function overlayHidingPage(root: ParentNode): string | undefined {
     '[role="dialog"], dialog[open], [aria-modal="true"]',
   );
   let modal: Element | undefined;
+  /**
+   * A candidate that is present but does NOT compute visible.
+   *
+   * The visible check is the right primary test — it is what tells an open modal from a closed one
+   * still in the DOM. But it fails CLOSED in the one state this function exists to explain: when
+   * every node on the page computes hidden, the modal computes hidden too, and the explainer for an
+   * empty tree goes silent exactly when the tree is emptiest (#672 hit this with a dialog that had
+   * just opened). A check that cannot fire in its own failure case is not a check.
+   *
+   * Falling back to it is safe because the visibility of the CANDIDATE was never the evidence. The
+   * evidence is the condition below — every other child of body carrying `aria-hidden="true"` —
+   * which is a focus trap's signature and does not happen by accident on a healthy page.
+   */
+  let hiddenCandidate: Element | undefined;
   for (const d of dialogs) {
     // Never OUR overlay. Reticle's HUD must not be able to explain the app's absence with itself:
     // that turns "the page did not render" into "an overlay is covering it", which sends the reader
@@ -392,7 +445,9 @@ function overlayHidingPage(root: ParentNode): string | undefined {
       modal = d;
       break;
     }
+    hiddenCandidate ??= d;
   }
+  modal ??= hiddenCandidate;
   if (modal === undefined) return undefined;
   const modalEl = modal;
   const outside = Array.from(document.body.children).filter((c) => !c.contains(modalEl));
@@ -439,6 +494,7 @@ export function buildSnapshot(options: SnapshotOptions = {}): SnapshotResult {
     lines: [],
     nodes: 0,
     leanSkipped: 0,
+    hiddenSkipped: 0,
     truncated: false,
     mode,
     maxNodes: options.maxNodes ?? 400,
@@ -454,6 +510,7 @@ export function buildSnapshot(options: SnapshotOptions = {}): SnapshotResult {
     nodes: ctx.nodes,
     truncated: ctx.truncated,
     ...(ctx.leanSkipped > 0 ? { leanSkipped: ctx.leanSkipped } : {}),
+    ...(ctx.hiddenSkipped > 0 ? { hiddenSkipped: ctx.hiddenSkipped } : {}),
     ...(ctx.unread.length > 0 ? { unread: ctx.unread } : {}),
     ...(ctx.unreadOverflow ? { unreadOverflow: true as const } : {}),
   };

--- a/packages/server/src/bridge/bridge.test-harness.ts
+++ b/packages/server/src/bridge/bridge.test-harness.ts
@@ -41,8 +41,20 @@ export class FakeBrowser {
   queryResolves = true;
   /** Records every command the bridge sent (for replay assertions). */
   readonly received: { name: string; args: Record<string, unknown> }[] = [];
-  /** The snapshot tree to return. Mutable so tests can vary the page between calls. */
-  snapshotResult: { tree: string; status: Record<string, unknown> } = {
+  /**
+   * The snapshot tree to return. Mutable so tests can vary the page between calls.
+   *
+   * The counters are optional because the fields they stand for are: the browser omits `nodes`-
+   * adjacent diagnostics on a page that has nothing to report, and a test asserting on one has to be
+   * able to send a payload shaped like the real thing.
+   */
+  snapshotResult: {
+    tree: string;
+    status: Record<string, unknown>;
+    nodes?: number;
+    hiddenSkipped?: number;
+    leanSkipped?: number;
+  } = {
     tree: '- button "Pay" (ref=e7)\n- dialog "Order confirmed" (ref=e12)',
     status: { route: '/checkout' },
   };

--- a/packages/server/src/tools/snapshot-hidden-note.test.ts
+++ b/packages/server/src/tools/snapshot-hidden-note.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { SnapshotMode } from '@reticlehq/core';
+import { Bridge } from '../bridge/bridge.js';
+import type { ToolDeps } from './tools.js';
+import { ReticleTool } from './tool-names.js';
+import { FakeBrowser, callTool, makeDeps, waitUntil } from '../bridge/bridge.test-harness.js';
+
+/**
+ * `{ tree: "", nodes: 0 }` is a claim about the app, and on a hidden page it is the wrong one (#672).
+ *
+ * The lean note already covers one cause of an empty tree and returns early for every mode but
+ * `interactive`, so a `full` snapshot of a page whose every node computed hidden said nothing at
+ * all. That is what was reported: 44 buttons and 12 textboxes on the page, both modes empty, and
+ * about six tool calls spent establishing that the page was fine and the snapshot was wrong.
+ *
+ * The note carries the count the browser measured and the path that still works. It deliberately
+ * does not diagnose WHY the page is hidden — the walk knows what it skipped and cannot know that.
+ */
+describe('reticle_snapshot — an empty tree on a hidden page', () => {
+  let bridge: Bridge;
+  let deps: ToolDeps;
+  let browser: FakeBrowser;
+
+  beforeAll(async () => {
+    bridge = new Bridge({ port: 0 });
+    const port = await bridge.ready;
+    deps = makeDeps(bridge);
+    browser = new FakeBrowser(port, 'demo', true);
+    await browser.open();
+    await waitUntil(() => 1 === bridge.sessions.count());
+  });
+
+  afterAll(async () => {
+    browser.close();
+    await bridge.close();
+  });
+
+  async function snapshot(mode: string): Promise<Record<string, unknown>> {
+    return (await callTool(deps, ReticleTool.SNAPSHOT, { mode })) as Record<string, unknown>;
+  }
+
+  it('says an empty full tree is not an empty page, and how many were skipped', async () => {
+    browser.snapshotResult = { tree: '', status: { route: '/app' }, nodes: 0, hiddenSkipped: 3 };
+    const result = await snapshot(SnapshotMode.FULL);
+
+    expect(String(result['note'])).toContain('NOT an empty page');
+    expect(String(result['note'])).toContain('3');
+  });
+
+  it('hands over the path that does work', async () => {
+    // The workaround the reporter found on their own and no tool description mentions.
+    browser.snapshotResult = { tree: '', status: { route: '/app' }, nodes: 0, hiddenSkipped: 3 };
+
+    expect(String((await snapshot(SnapshotMode.FULL))['note'])).toContain('reticle_query');
+  });
+
+  it('says nothing when the tree has nodes in it', async () => {
+    browser.snapshotResult = {
+      tree: '- button "Pay" (ref=e7)',
+      status: { route: '/app' },
+      nodes: 1,
+      hiddenSkipped: 3,
+    };
+
+    expect((await snapshot(SnapshotMode.FULL))['note']).toBeUndefined();
+  });
+
+  it('says nothing about an empty tree the walk skipped nothing to produce', async () => {
+    // A genuinely empty page must keep reading as one. The note exists to separate the two cases,
+    // so attaching it to both would put the tool back where it started.
+    browser.snapshotResult = { tree: '', status: { route: '/app' }, nodes: 0 };
+
+    expect((await snapshot(SnapshotMode.FULL))['note']).toBeUndefined();
+  });
+
+  it('leaves the more specific lean note in place rather than adding a second', async () => {
+    // Both causes can be true at once in `interactive`. Two explanations for one empty tree is worse
+    // than the better of them, and leanness is the one that names the mode to switch to.
+    browser.snapshotResult = {
+      tree: '',
+      status: { route: '/app' },
+      nodes: 0,
+      leanSkipped: 5,
+      hiddenSkipped: 3,
+    };
+    const note = String((await snapshot(SnapshotMode.INTERACTIVE))['note']);
+
+    expect(note).toContain('interactive ARIA role');
+    // Matched on a phrase unique to the hidden note: both notes say "NOT an empty page", which is
+    // the sentence they exist to say, so it cannot tell them apart.
+    expect(note).not.toContain('computed hidden');
+  });
+
+  it('covers interactive too when leanness has nothing to say', async () => {
+    // Lean mode reaches the same hidden page, and `leanSkipped` is 0 there because the walk never
+    // got far enough to pass anything over for leanness.
+    browser.snapshotResult = { tree: '', status: { route: '/app' }, nodes: 0, hiddenSkipped: 3 };
+
+    expect(String((await snapshot(SnapshotMode.INTERACTIVE))['note'])).toContain(
+      'NOT an empty page',
+    );
+  });
+});

--- a/packages/server/src/tools/tools.ts
+++ b/packages/server/src/tools/tools.ts
@@ -274,16 +274,19 @@ export const RAW_TOOLS: ToolDef[] = [
         mode,
       }).then((raw) =>
         withSizeCost(
-          noteEmptyLeanTree(
-            applySnapshotDelta(
-              raw,
-              {
-                sessionId: resolved.id,
-                scope: asString(args['scope']) ?? '',
-                mode,
-                diff: true === args['diff'],
-              },
-              SNAPSHOT_CACHE,
+          noteHiddenPage(
+            noteEmptyLeanTree(
+              applySnapshotDelta(
+                raw,
+                {
+                  sessionId: resolved.id,
+                  scope: asString(args['scope']) ?? '',
+                  mode,
+                  diff: true === args['diff'],
+                },
+                SNAPSHOT_CACHE,
+              ),
+              mode,
             ),
             mode,
           ),
@@ -722,6 +725,40 @@ function noteEmptyLeanTree(result: unknown, mode: string): unknown {
       `${String(skipped)} element(s) were passed over for leanness and this is NOT an empty page. ` +
       `Take reticle_snapshot { mode: "full" } instead; the controls here are addressed by text or ` +
       `by testid rather than by role.`,
+  };
+}
+
+/**
+ * An empty tree on a page full of elements is the same claim, from the other cause.
+ *
+ * `noteEmptyLeanTree` covers leanness and returns early for every other mode, so a `full` snapshot
+ * that comes back `{ tree: "", nodes: 0 }` says nothing at all — and that is the shape #672 was
+ * reported as: 44 buttons and 12 textboxes on the page, every one computing hidden, both modes
+ * empty. The reporter spent about six tool calls and a large console dump establishing the page was
+ * fine and the snapshot was wrong, then drove the flow off `reticle_query` refs, which is a
+ * workaround no tool description mentions.
+ *
+ * So the note names the count, says plainly that this is not an empty page, and hands over the path
+ * that does work. It does NOT diagnose why the page is hidden: the walk knows what it skipped and
+ * cannot know why, and a note that guessed would be the same kind of overconfident answer as the
+ * empty tree it replaces.
+ */
+function noteHiddenPage(result: unknown, mode: string): unknown {
+  if (SnapshotMode.STATUS === mode) return result;
+  const row = asRecord(result);
+  if (0 !== asNumber(row['nodes'])) return result;
+  // A note already there is the more specific one (leanness), and two explanations for one empty
+  // tree is worse than the better of them alone.
+  if (row['note'] !== undefined) return result;
+  const skipped = asNumber(row['hiddenSkipped']) ?? 0;
+  if (0 === skipped) return result;
+  return {
+    ...row,
+    note:
+      `this is NOT an empty page: ${String(skipped)} subtree(s) were skipped because their root ` +
+      `computed hidden (aria-hidden, the hidden attribute, or display:none), which is what left the ` +
+      `tree empty. If the page is plainly rendered, the visibility computation is the thing that is ` +
+      `wrong rather than the app — drive it by reticle_query refs, which do not depend on this walk.`,
   };
 }
 


### PR DESCRIPTION
Closes #672.

## First, two things the issue assumes that I could not confirm

Both are worth saying plainly, because they change where the remaining work is.

**Page visibility is not the cause.** The issue guesses "page visibility state?", so I drove the pool's own launch configuration directly — `chromium.launch` with `CHROMIUM_ANTI_THROTTLING_ARGS`, then several lease contexts in one browser, then several pages in one context, headed and headless. Every page reported `document.visibilityState === "visible"` and every element computed visible, in all six combinations. Playwright does not background its pages, so nothing in the leased path flips the document hidden.

**`reticle_snapshot` does not filter on `visible`.** `visit` never calls `isVisible` at all — it skips on `skipEarly` (SKIP_TAGS, our own HUD, `aria-hidden`, the `hidden` attribute) and on `display: none`. So the empty tree and `query`'s `visible: false` are two symptoms of one upstream cause rather than one causing the other.

I could not reproduce the underlying collapse without the reporter's app, so **this PR does not claim to fix it.** What it fixes is the part that is wrong regardless of the cause, and which is most of the reported cost.

## What this changes

### An empty tree that says why

`leanSkipped` already exists for exactly this, and its comment states the principle: *"an empty tree that says how many it passed over is no longer an empty page."* But it is lean-only by construction and `noteEmptyLeanTree` returns early for every other mode — so `mode: "full"` returning `{ tree: "", nodes: 0 }` on a page holding 44 buttons carried no explanation at all. That is the reported shape.

`hiddenSkipped` counts the subtrees the walk refused to enter because their root was `aria-hidden`, carried `hidden`, or computed `display: none`, and the tool turns a non-zero count on an empty tree into:

> this is NOT an empty page: 3 subtree(s) were skipped because their root computed hidden (aria-hidden, the hidden attribute, or display:none), which is what left the tree empty. If the page is plainly rendered, the visibility computation is the thing that is wrong rather than the app — drive it by reticle_query refs, which do not depend on this walk.

That names the workaround the reporter had to find alone. It follows the established two-part shape exactly — the browser counts, the tool builds the note — and only the hidden skips are counted: `<script>`, `<style>` and our own HUD are absent from every snapshot ever taken, and a number that appears on every ordinary page would mean nothing on the one page that needs it.

**It also produces the evidence this issue is missing.** A reporter who hits this again will be told how many subtrees were skipped and by which of the three mechanisms — which is the fact needed to fix the root cause, and the fact nobody has today.

### An explainer that could not fire in its own failure case

`overlayHidingPage` picked its modal with `isVisible`. That is the right primary test — it tells an open modal from a closed one left in the DOM — but it fails **closed** in precisely the state it exists to explain: when every node computes hidden, the modal computes hidden too, so the one function that explains an empty tree goes silent exactly when the tree is emptiest. The reporter's dialog had just opened and was visible in `reticle_console`; the snapshot offered nothing.

The fallback is safe because the candidate's visibility was never the evidence. The evidence is every other child of `body` carrying `aria-hidden="true"` — a focus trap's signature — and that gate is untouched, so this cannot explain an ordinary page holding a closed dialog. A test pins that.

Neither half diagnoses *why* a page computes hidden. The walk knows what it skipped for certain and cannot know the second thing, and a note that guessed would be the same overconfident answer as the empty tree it replaces.

## Tests

`snapshot-hidden-page.test.ts` (11) and `snapshot-hidden-note.test.ts` (6, driven through the real tool handler over the bridge harness). A deliberate share of them pin what must **not** move: absent rather than zero on a healthy page, script/style not counted, the aria-hidden gate still required, a visible modal still preferred, a genuinely empty page still reading as empty, and the more specific lean note left in place rather than a second one added beside it.

Mutation-checked, each half separately: reverting the counting or the overlay fallback reddens 7 of 11 browser tests and leaves the 4 guards green, which is the split you want.

`bridge.test-harness.ts` gains three optional counters on `snapshotResult` so a test can send a payload shaped like the real thing.

## Gates

`format:check`, `lint` (17/17), `typecheck` (22/22) green. Full package suites: `browser` 133 files / 1269 tests all pass; `server` 6338 pass. Two notes on this Windows box, both checked against a clean `main` rather than assumed: `init/format-generated.test.ts` fails identically without my changes (pre-existing), and three `project-store` cases fail only inside the full parallel run and pass 17/17 in isolation with my changes applied.

I would still like the root cause. If a reporter can share what `hiddenSkipped` says once this is in — or a page that reproduces it — that is the missing half, and I am happy to take it.
