### PR TITLE
fix(honesty): treat an exact count of zero as the absence claim it is

### DIFF
--- a/packages/server/src/honesty/blind-spots.ts
+++ b/packages/server/src/honesty/blind-spots.ts
@@ -286,8 +286,19 @@ export function isStateUnwatched(spots: readonly BlindSpot[]): boolean {
 export function restsOnCompleteWindow(predicate: {
   kind: string;
   absent?: boolean;
+  count?: number;
   predicate?: unknown;
 }): boolean {
   if (PredicateKind.NOT === predicate.kind) return true;
+  // An exact cardinality of ZERO is the third spelling of an absence claim, and reading only
+  // `absent` missed it: `{ kind: "net", urlContains: "/api/auth/sign-in", count: 0 }` says "this
+  // request was never made", and the call the buffer evicted is precisely the disproof. It was
+  // graded `yes` over a window known to have lost scarce evidence — the exact false green the two
+  // clauses above exist to prevent, reached by the one spelling they did not cover (#668).
+  //
+  // Only zero. `count: 2` asserts calls were MADE and found them; events aged out elsewhere in the
+  // buffer do not unmake a positive finding, which is the same reason a plain presence assertion is
+  // left alone here.
+  if (0 === predicate.count) return true;
   return true === predicate.absent;
 }

--- a/packages/server/src/tools/assert-buffer-honesty.test.ts
+++ b/packages/server/src/tools/assert-buffer-honesty.test.ts
@@ -224,3 +224,83 @@ describe('buffer loss impeaches an absence claim, not every claim', () => {
     expect(result.verified).toBe(Verified.YES);
   });
 });
+
+/**
+ * `count: 0` is an absence claim, and the rule above did not know it (#668).
+ *
+ * `restsOnCompleteWindow` recognises `PredicateKind.NOT` and `absent: true`. It does not recognise
+ * the third spelling of the same assertion — an exact cardinality of zero — so `{ kind: "net",
+ * urlContains: "…", count: 0 }` was graded `yes` over a window the buffer had provably lost scarce
+ * evidence from. That green rests entirely on the window being complete: the evicted call is exactly
+ * the disproof, which is the definition the function's own doc comment gives for an absence claim.
+ *
+ * Reported by the second reporter on #668, in those words: `buffer.dropped` climbing well past `held`
+ * on an `absent: true` / `count: 0` assertion, unable to tell whether their "no login request fired"
+ * proof was real or an evicted-buffer artifact. They re-ran the whole flow on a fresh page to trust
+ * it — which is what a verdict costs when it cannot say how sure it is.
+ */
+describe('an exact count of zero is an absence claim (#668)', () => {
+  const noSignIn = {
+    predicate: { kind: 'net', urlContains: '/api/auth/sign-in', count: 0 },
+    timeout_ms: 0,
+  };
+
+  it('refuses a green when scarce evidence from this window was evicted', async () => {
+    const result = (await tool(ReticleTool.ASSERT).handler(
+      depsWithBuffer(0, undefined, true),
+      noSignIn,
+    )) as { pass?: boolean; verified?: string; verifiedReason?: string };
+
+    expect(result.pass).toBe(true);
+    expect(result.verified).toBe(Verified.UNKNOWN);
+    expect(result.verifiedReason).toBe(VerifiedReason.UNCLEAN_CAPTURE);
+  });
+
+  it('still grades it normally when the window is intact', async () => {
+    // The green must survive a clean window, or the fix has simply traded a false yes for a useless
+    // unknown on every absence assertion anyone writes.
+    const result = (await tool(ReticleTool.ASSERT).handler(
+      depsWithBuffer(0, undefined, false),
+      noSignIn,
+    )) as { pass?: boolean; verified?: string };
+
+    expect(result.pass).toBe(true);
+    expect(result.verified).toBe(Verified.YES);
+  });
+
+  it('leaves a NON-zero count alone, which is a positive claim', async () => {
+    // `count: 2` asserts calls were MADE. It found what it found, and events aged out elsewhere in
+    // the buffer do not unmake them — the same reason a plain positive assertion is left alone.
+    const twoCalls: ReticleEvent[] = [
+      {
+        t: 1,
+        type: EventType.NET_REQUEST,
+        sessionId: 'demo',
+        data: { method: 'POST', url: 'http://localhost/api/save', status: 200, ok: true },
+      },
+      {
+        t: 2,
+        type: EventType.NET_REQUEST,
+        sessionId: 'demo',
+        data: { method: 'POST', url: 'http://localhost/api/save', status: 200, ok: true },
+      },
+    ];
+    const result = (await tool(ReticleTool.ASSERT).handler(
+      depsWithBuffer(0, undefined, true, twoCalls),
+      { predicate: { kind: 'net', urlContains: '/api/save', count: 2 }, timeout_ms: 0 },
+    )) as { pass?: boolean; verified?: string };
+
+    expect(result.pass).toBe(true);
+    expect(result.verified).toBe(Verified.YES);
+  });
+
+  it('covers a signal count of zero too, which is the same claim on the other channel', async () => {
+    const result = (await tool(ReticleTool.ASSERT).handler(depsWithBuffer(0, undefined, true), {
+      predicate: { kind: 'signal', name: 'checkout:submitted', count: 0 },
+      timeout_ms: 0,
+    })) as { pass?: boolean; verified?: string };
+
+    expect(result.pass).toBe(true);
+    expect(result.verified).toBe(Verified.UNKNOWN);
+  });
+});


### PR DESCRIPTION
Addresses the false-green half of #668, and I'd rather be precise about which half than claim the whole issue.

## The defect

`restsOnCompleteWindow` decides whether a passing verdict rests on the observation window being complete. Its own doc comment states the rule:

> Only an absence claim does. A positive assertion that passed found its evidence […] An absence claim concluded "nothing is there" — and the thing the buffer dropped is precisely the disproof.

The implementation recognised two spellings of an absence claim and missed the third:

```ts
if (PredicateKind.NOT === predicate.kind) return true;
return true === predicate.absent;
```

`{ kind: "net", urlContains: "/api/auth/sign-in", count: 0 }` says "this request was never made". It is an absence claim by that comment's own definition, and it was graded **`verified: "yes"`** over a window `lostSince` reported had lost scarce evidence — the evicted call being exactly the disproof.

That is the second reporter's case in their own words: `buffer.dropped` climbing well past `held` on an `absent: true` / `count: 0` assertion, unable to tell whether their "no login request fired" proof was real or an evicted-buffer artifact. They re-ran the whole flow on a fresh page to trust it, which is what a verdict costs when it cannot say how sure it is.

One line, `if (0 === predicate.count) return true;`, and it now reaches the machinery that was already there and already correct.

## Only zero

`count: 2` asserts calls were **made** and found them. Events aged out elsewhere in the buffer do not unmake a positive finding — the same reason a plain presence assertion is left alone here. A test pins that, because widening this to every cardinality would be the `unknown`-for-everything regression the comment warns about, from a new direction.

The impeachment still requires `lostSince(since)`, so a clean window grades exactly as before and the raw drop counter still impeaches nothing on its own. Both existing guard tests keep passing untouched.

Covers `signal.count` as well as `net.count` — the two predicates that carry a cardinality, both reached by the same gate.

## What this does NOT do, and why I stopped

The issue asks for two more things. I did not take either, and both are decisions I don't think are mine:

**Pinning matched events against eviction.** A pinned set that an armed predicate can grow has no bound of its own, so it needs a policy — what happens when pinned events alone exceed the cap, and whether a predicate that never grades leaks its pins. That is a change to the buffer's memory contract.

**Grading a failed *presence* assertion undecidable on buffer loss.** This is the first reporter's case (`act_and_wait`, the sign-in POST evicted, graded red). It is not an oversight — the act path already sets `truncated: session.lostSince(since)` with no `restsOnCompleteWindow` guard at all, because its cursor is the action's own. `reticle_assert` is guarded deliberately: `#noteScarceLoss` fires for age eviction too, so `lostSince(0)` is true on any session past 60s, and the comment records that impeaching every verdict over a caller-chosen window already made `unclean_capture` the dominant cause of `unknown` in the field once. Extending it to failed positives re-opens exactly that trade, and where the line sits is a product call about your `unknown` budget.

If you tell me which way you want either of those, I'll build it with tests.

## Tests

Four cases appended to `assert-buffer-honesty.test.ts`, which is where this rule's existing tests live and where the correction belongs beside them. Written RED first: before the fix, `net count: 0` and `signal count: 0` both returned `'yes'` where `'unknown'` was expected, and the two guard cases (clean window still green, `count: 2` still green) passed already — so the failing pair proves the fix and the passing pair proves it did not overreach.

15/15 in that file after, including the 11 that were there before.

## Gates

`format:check`, `lint` (17/17), `typecheck` (22/22) green; server suite 6334 pass. On this Windows box `init/format-generated.test.ts` fails identically on a clean `main` (pre-existing, unrelated), and two file-scanning suites time out only inside the full parallel run — I ran both in isolation against this change and they pass 18/18, which also confirms the new comments do not trip the tracking-tag scanner.
