### PR TITLE
docs(server): document the HTTP/SSE transport and pin it as public surface

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ Everything here is published to [docs.reticle.sh](https://docs.reticle.sh) by `d
 | [for-agents.md](for-agents.md) | how to fetch these docs as Markdown or `llms.txt` |
 | [architecture.md](architecture.md) | how it works, and why it is built this way |
 | [platform-integration.md](platform-integration.md) | Vite, Next, Remix, Astro, plain HTML |
+| [http-transport.md](http-transport.md) | driving the tools over plain HTTP/SSE, for clients that cannot reload MCP |
 | [desktop.mdx](desktop.mdx) | Electron and Tauri in full: setup, IPC, screenshots, headless, troubleshooting |
 | [frameworks.mdx](frameworks.mdx) | what is supported, what is wired-but-unverified, and the wiring |
 | [state-management.mdx](state-management.mdx) | zustand, Redux, and eight adapters |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -62,7 +62,12 @@
               },
               {
                 "group": "Working with agents",
-                "pages": ["multi-agent-testing", "human-control", "platform-integration"]
+                "pages": [
+                  "multi-agent-testing",
+                  "human-control",
+                  "platform-integration",
+                  "http-transport"
+                ]
               },
               {
                 "group": "When it goes wrong",

--- a/docs/http-transport.md
+++ b/docs/http-transport.md
@@ -1,0 +1,164 @@
+---
+title: 'HTTP transport'
+description: 'Drive the full reticle_* tool surface over plain HTTP and SSE, from a client that cannot hot-reload MCP tools or that is not an MCP client at all.'
+icon: 'plug'
+---
+
+Most clients reach Reticle over stdio: they spawn `reticle mcp`, and the tools appear in the agent's surface. That has one property you cannot always live with. **Many clients read their MCP tool list once, at startup**. If the daemon was not running when the client launched, the `reticle_*` tools are absent for the rest of that session, and the fix is to restart the client.
+
+The daemon also speaks MCP over HTTP, on the same port as everything else. Nothing has to reload for a client to reach it, so this is the transport for scripted runs, CI, a language with no MCP client library, and any editor that will not pick up tools mid-session.
+
+It is the same tool surface. Not a subset, not a simplified one. `reticle_snapshot`, `reticle_act_and_wait`, `reticle_assert` and the rest behave exactly as they do over stdio, because they are the same server behind a different transport.
+
+## The two endpoints
+
+| Method | Path | What it does |
+| --- | --- | --- |
+| `GET` | `/mcp/sse` | Opens a session. The response is an SSE stream that stays open, and every reply the server sends comes back on it. |
+| `POST` | `/mcp/message?sessionId=<id>` | Sends one JSON-RPC message into an open session. |
+
+The daemon listens on port **4400** by default (`RETICLE_PORT`, or `reticle serve --port N`). Run `reticle status` to confirm which port is live.
+
+## The handshake
+
+The one shape worth reading before you write any code: **the POST does not answer your request.** It replies `202 Accepted` with no result in it, and the actual JSON-RPC reply arrives on the SSE stream you opened first. A client that waits on the POST body waits forever.
+
+1. `GET /mcp/sse`. Hold the response open.
+2. The first frame is the endpoint announcement, and it carries the session id:
+
+   ```
+   event: endpoint
+   data: /mcp/message?sessionId=6f1c2b7e-1f4a-4a8e-9d5f-3f7a1b2c3d4e
+   ```
+
+   Use that `data` value verbatim as the path you POST to. Do not build it yourself: the session id is minted per connection.
+
+3. `POST` the `initialize` request there, then the `notifications/initialized` notification.
+4. `POST` `tools/list`, `tools/call`, and anything else. Match each reply to its request by the JSON-RPC `id`, off the SSE stream.
+
+When the daemon shuts down it writes a shutdown frame on the stream before the socket closes, so a client can tell a planned stop from a dropped connection.
+
+## Errors
+
+| Status | Meaning | What to do |
+| --- | --- | --- |
+| `400 missing sessionId` | The POST had no `sessionId` query parameter. | Use the path from the `endpoint` frame. |
+| `404 session not found` | That session is not open, usually because the SSE stream dropped. | Reconnect to `/mcp/sse` and handshake again. |
+| `503 MCP server not ready` | The daemon is up but the MCP server is not attached yet. | Retry. Unlike a `404`, the endpoint is real and coming. |
+
+`404` and `400` are kept apart on purpose: reconnecting fixes one and nothing about the other.
+
+## Authorization
+
+Two tiers, the same ones the WebSocket bridge uses.
+
+**Local clients need no token.** A request is trusted when its peer address, its `Host` header, and its `Origin`/`Referer` (when present) are all loopback. All three are required, because a DNS-rebound page reaches the daemon _as_ a loopback peer while carrying the attacker's `Host`, so peer address alone would not be a check.
+
+**Anything else must present the pairing token**, which is required whenever you bind beyond loopback with `RETICLE_HOST`. Either form works:
+
+```
+Authorization: Bearer <token>
+```
+
+```
+/mcp/sse?token=<token>
+```
+
+Set it with `RETICLE_TOKEN`. With no token configured, the daemon binds loopback-only and non-local requests are refused outright rather than falling back to trust.
+
+## A minimal client
+
+No MCP library. Node's standard library is enough. This opens a session, lists the tools, and takes a snapshot.
+
+```js
+import http from 'node:http';
+
+const PORT = 4400;
+let endpoint = null;
+let next = 1;
+const pending = new Map();
+
+// 1. Open the stream and keep it open. Every reply arrives here.
+http.get({ port: PORT, path: '/mcp/sse', agent: false }, (res) => {
+  let buffer = '';
+  res.setEncoding('utf8');
+  res.on('data', (chunk) => {
+    buffer += chunk;
+    const frames = buffer.split('\n\n');
+    buffer = frames.pop();
+    for (const frame of frames) {
+      const event = /^event: (.*)$/m.exec(frame)?.[1] ?? 'message';
+      const data = /^data: (.*)$/m.exec(frame)?.[1] ?? '';
+      if (event === 'endpoint') {
+        endpoint = data; // "/mcp/message?sessionId=…", used verbatim
+        start();
+        continue;
+      }
+      const message = JSON.parse(data);
+      pending.get(message.id)?.(message); // match the reply to its request by id
+      pending.delete(message.id);
+    }
+  });
+});
+
+// 2. POST a request; resolve when its reply comes back on the stream.
+function send(method, params) {
+  const id = next++;
+  const body = JSON.stringify({ jsonrpc: '2.0', id, method, params });
+  return new Promise((resolve) => {
+    pending.set(id, resolve);
+    const req = http.request(
+      {
+        port: PORT,
+        path: endpoint,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      },
+      (res) => res.resume(), // 202 Accepted; the answer is on the SSE stream
+    );
+    req.end(body);
+  });
+}
+
+async function start() {
+  await send('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'my-client', version: '1.0.0' },
+  });
+
+  const notify = http.request(
+    { port: PORT, path: endpoint, method: 'POST', headers: { 'Content-Type': 'application/json' } },
+    (res) => res.resume(),
+  );
+  notify.end(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }));
+
+  const listed = await send('tools/list', {});
+  console.log(listed.result.tools.map((t) => t.name).join(', '));
+
+  const snapshot = await send('tools/call', { name: 'reticle_snapshot', arguments: {} });
+  console.log(snapshot.result.content[0].text);
+}
+```
+
+To watch the raw frames instead, `curl` is enough for the first half:
+
+```bash
+curl -N http://127.0.0.1:4400/mcp/sse
+```
+
+Then, from a second shell, POST to the path that stream printed:
+
+```bash
+curl -X POST 'http://127.0.0.1:4400/mcp/message?sessionId=<id>' \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+The `202` comes back here; the tool list appears in the first shell.
+
+## What this does not change
+
+The transport carries the tools. It does not replace the rest of the setup. The app still has to be instrumented and connected, and `reticle_sessions` is still what tells you whether a session is there to drive. A verdict reached over HTTP is a verdict reached the usual way: only `verified: "yes"` is a pass.
+
+The endpoints, the handshake, the three status codes and the `202`-then-SSE shape are pinned by `packages/server/src/mcp-http-transport.test.ts`, which drives them over raw HTTP with no client library, so the contract this page describes fails the build if it changes.

--- a/packages/server/src/mcp-http-transport.test.ts
+++ b/packages/server/src/mcp-http-transport.test.ts
@@ -1,0 +1,286 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { MCP_MESSAGE_PATH, MCP_SSE_PATH } from '@reticlehq/core';
+import { createSharedServer, type SharedServer } from './http-server.js';
+
+/**
+ * The daemon's HTTP/SSE MCP transport, pinned as public surface (#690).
+ *
+ * A reporter who could not use the `reticle_*` tools — their client loads MCP tools only at startup —
+ * found `/mcp/sse` + `/mcp/message`, wrote their own client against it, and drove the whole tool
+ * surface over plain HTTP, video capture included. It works. It was also undocumented, and an
+ * undocumented endpoint is free to break: nothing in the gate would have noticed the endpoint path,
+ * the handshake shape or the status codes changing under them.
+ *
+ * These drive it the way that reporter had to — RAW HTTP and hand-parsed SSE frames, no SDK client.
+ * That is deliberate. A test written with `Client` from the SDK would survive a rename of the wire
+ * contract, because both halves would move together; the whole value of this file is that it fails
+ * when the bytes a hand-written client depends on change. It is the executable half of
+ * `docs/http-transport.md`, and every literal below appears there.
+ */
+
+let shared: SharedServer | undefined;
+
+afterEach(async () => {
+  await shared?.close();
+  shared = undefined;
+});
+
+function listen(server: SharedServer): Promise<number> {
+  return new Promise((resolve) => {
+    server.httpServer.listen(0, '127.0.0.1', () => {
+      resolve((server.httpServer.address() as AddressInfo).port);
+    });
+  });
+}
+
+/** A real McpServer — not a stand-in — so the handshake below is the one an agent performs. */
+async function mcpServerWithPing(): Promise<McpServer> {
+  const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+  const server = new McpServer({ name: 'reticle-test', version: '0' });
+  server.registerTool('ping', { description: 'answers pong' }, () => ({
+    content: [{ type: 'text' as const, text: 'pong' }],
+  }));
+  return server;
+}
+
+interface SseFrame {
+  event: string;
+  data: string;
+}
+
+/**
+ * One open SSE session, with the frames it has received so far.
+ *
+ * Frames are accumulated rather than awaited one at a time: a JSON-RPC reply can land before the
+ * caller starts listening for it, and a test that raced that would be flaky in exactly the way this
+ * repo refuses to ship.
+ */
+interface SseSession {
+  waitFor: (match: (f: SseFrame) => boolean, timeoutMs?: number) => Promise<SseFrame>;
+  close: () => void;
+}
+
+function openSse(port: number, path: string = MCP_SSE_PATH): Promise<SseSession> {
+  return new Promise((resolve, reject) => {
+    // `agent: false` gives this its own socket: an SSE response never ends, so a pooled one would
+    // block every later request in the test behind it.
+    const req = http.get({ host: '127.0.0.1', port, path, agent: false }, (res) => {
+      const frames: SseFrame[] = [];
+      const waiters: { match: (f: SseFrame) => boolean; resolve: (f: SseFrame) => void }[] = [];
+      let buffer = '';
+      res.setEncoding('utf8');
+      res.on('data', (chunk: string) => {
+        buffer += chunk;
+        // SSE frames are separated by a blank line. Whatever follows the last separator is a partial
+        // frame and stays in the buffer until the rest of it arrives.
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop() ?? '';
+        for (const part of parts) {
+          let event = 'message';
+          const data: string[] = [];
+          for (const line of part.split('\n')) {
+            if (line.startsWith('event:')) event = line.slice('event:'.length).trim();
+            else if (line.startsWith('data:')) data.push(line.slice('data:'.length).trim());
+          }
+          const frame: SseFrame = { event, data: data.join('\n') };
+          frames.push(frame);
+          for (let i = waiters.length - 1; i >= 0; i -= 1) {
+            const waiter = waiters[i];
+            if (waiter !== undefined && waiter.match(frame)) {
+              waiter.resolve(frame);
+              waiters.splice(i, 1);
+            }
+          }
+        }
+      });
+      resolve({
+        waitFor: (match, timeoutMs = 5000) =>
+          new Promise<SseFrame>((settle, fail) => {
+            const already = frames.find(match);
+            if (already !== undefined) {
+              settle(already);
+              return;
+            }
+            const timer = setTimeout(
+              () => fail(new Error('no SSE frame matched within the budget')),
+              timeoutMs,
+            );
+            waiters.push({
+              match,
+              resolve: (f) => {
+                clearTimeout(timer);
+                settle(f);
+              },
+            });
+          }),
+        close: () => req.destroy(),
+      });
+    });
+    req.on('error', reject);
+  });
+}
+
+function post(port: number, path: string, body: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port,
+        path,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let out = '';
+        res.setEncoding('utf8');
+        res.on('data', (c: string) => (out += c));
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body: out }));
+      },
+    );
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+const rpc = (id: number, method: string, params?: unknown): string =>
+  JSON.stringify({ jsonrpc: '2.0', id, method, ...(params === undefined ? {} : { params }) });
+
+const INITIALIZE = {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'raw-http-client', version: '0' },
+};
+
+/** The JSON-RPC id carried by a frame, or undefined for a notification or a non-JSON frame. */
+function idOf(frame: SseFrame): number | undefined {
+  try {
+    const parsed: unknown = JSON.parse(frame.data);
+    const id = (parsed as { id?: unknown }).id;
+    return 'number' === typeof id ? id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function startDaemon(): Promise<number> {
+  shared = createSharedServer();
+  const server = await mcpServerWithPing();
+  shared.attachMcp(() => server);
+  return listen(shared);
+}
+
+/** Open a session and complete the initialize exchange, returning the path to POST to. */
+async function handshake(port: number): Promise<{ sse: SseSession; endpoint: string }> {
+  const sse = await openSse(port);
+  const frame = await sse.waitFor((f) => 'endpoint' === f.event);
+  await post(port, frame.data, rpc(1, 'initialize', INITIALIZE));
+  await sse.waitFor((f) => 1 === idOf(f));
+  await post(
+    port,
+    frame.data,
+    JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+  );
+  return { sse, endpoint: frame.data };
+}
+
+describe('the SSE handshake', () => {
+  it('answers the connect with an endpoint frame naming the message path and a session id', async () => {
+    const port = await startDaemon();
+    const sse = await openSse(port);
+
+    const frame = await sse.waitFor((f) => 'endpoint' === f.event);
+    // The whole contract a hand-written client starts from: where to POST, and which session it is.
+    expect(frame.data.startsWith(MCP_MESSAGE_PATH)).toBe(true);
+    const sessionId = new URL(frame.data, 'http://127.0.0.1').searchParams.get('sessionId');
+    expect(sessionId).not.toBeNull();
+    expect(sessionId).not.toBe('');
+
+    sse.close();
+  });
+
+  it('answers the POST 202 and carries the JSON-RPC reply back over the stream', async () => {
+    // The shape that surprises people writing a client: the POST is only an acknowledgement, and the
+    // actual reply arrives on the SSE stream opened earlier.
+    const port = await startDaemon();
+    const sse = await openSse(port);
+    const endpoint = await sse.waitFor((f) => 'endpoint' === f.event);
+
+    const accepted = await post(port, endpoint.data, rpc(1, 'initialize', INITIALIZE));
+    expect(accepted.status).toBe(202);
+
+    const reply = await sse.waitFor((f) => 1 === idOf(f));
+    const parsed = JSON.parse(reply.data) as { result?: { serverInfo?: { name?: string } } };
+    expect(parsed.result?.serverInfo?.name).toBe('reticle-test');
+
+    sse.close();
+  });
+
+  it('lists and calls a tool over plain HTTP, with no MCP client library', async () => {
+    const port = await startDaemon();
+    const { sse, endpoint } = await handshake(port);
+
+    await post(port, endpoint, rpc(2, 'tools/list'));
+    const listed = await sse.waitFor((f) => 2 === idOf(f));
+    const tools = (JSON.parse(listed.data) as { result: { tools: { name: string }[] } }).result
+      .tools;
+    expect(tools.map((t) => t.name)).toContain('ping');
+
+    await post(port, endpoint, rpc(3, 'tools/call', { name: 'ping', arguments: {} }));
+    const called = await sse.waitFor((f) => 3 === idOf(f));
+    const content = (JSON.parse(called.data) as { result: { content: { text?: string }[] } }).result
+      .content;
+    expect(content[0]?.text).toBe('pong');
+
+    sse.close();
+  });
+});
+
+describe('the transport refuses what it cannot route', () => {
+  it('rejects a POST with no sessionId', async () => {
+    const port = await startDaemon();
+    const res = await post(port, MCP_MESSAGE_PATH, rpc(1, 'tools/list'));
+
+    expect(res.status).toBe(400);
+    expect(res.body).toContain('missing sessionId');
+  });
+
+  it('rejects a POST for a session that is not open', async () => {
+    // Distinct from the 400 on purpose: "you did not say which session" and "that session is gone"
+    // send a client to different fixes, and reconnecting only helps the second.
+    const port = await startDaemon();
+    const res = await post(
+      port,
+      `${MCP_MESSAGE_PATH}?sessionId=00000000-0000-0000-0000-000000000000`,
+      rpc(1, 'tools/list'),
+    );
+
+    expect(res.status).toBe(404);
+    expect(res.body).toContain('session not found');
+  });
+
+  it('answers 503 while no MCP server is attached yet', async () => {
+    // A daemon that is up but not yet wired. Worth its own status: a client that retries recovers
+    // from this one, where a 404 would tell it the endpoint does not exist at all.
+    shared = createSharedServer();
+    const port = await listen(shared);
+    const res = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+      http
+        .get({ host: '127.0.0.1', port, path: MCP_SSE_PATH, agent: false }, (r) => {
+          let body = '';
+          r.setEncoding('utf8');
+          r.on('data', (c: string) => (body += c));
+          r.on('end', () => resolve({ status: r.statusCode ?? 0, body }));
+        })
+        .on('error', reject);
+    });
+
+    expect(res.status).toBe(503);
+    expect(res.body).toContain('MCP server not ready');
+  });
+});


### PR DESCRIPTION
Closes #690.

The issue asks for three things: document the endpoints, give a minimal client, and add a check so the endpoints cannot silently disappear. All three are here.

## The page

`docs/http-transport.md`, published under **Guides → Working with agents**, next to the other "integrating a client" pages.

It leads with the thing that catches everyone writing a client for the first time, because I hit it myself while writing the test:

> **the POST does not answer your request.** It replies `202 Accepted` with no result in it, and the actual JSON-RPC reply arrives on the SSE stream you opened first. A client that waits on the POST body waits forever.

Then the handshake step by step, the auth tiers, the three refusal statuses, a ~40-line Node client that uses no MCP library, and a `curl` pair for watching the raw frames. Every fact on the page is read off the source rather than assumed: the default port from `RETICLE_DEFAULT_PORT`, the token forms from `requestToken` (`Authorization: Bearer` or `?token=`), the three-part loopback test from `authorized`, and the shutdown frame from `announceShutdown`.

## The check

`packages/server/src/mcp-http-transport.test.ts`, six cases, ~600ms.

It drives the transport over **raw HTTP with hand-parsed SSE frames**, not through the SDK's `Client`. That is the whole point rather than an inconvenience: a test written with `Client` would keep passing through a rename of the wire contract, because both halves would move together. This one fails when the bytes a hand-written client depends on change, which is the failure the issue is actually about.

Against a real `McpServer` (not a stand-in), it pins:

- the `endpoint` frame, that it names `/mcp/message`, and that it carries a session id
- the POST answering `202` while the reply comes back on the stream
- a full `initialize` → `notifications/initialized` → `tools/list` → `tools/call` round trip, asserting the tool answers
- `400 missing sessionId`, `404 session not found`, `503 MCP server not ready`

The `400`/`404` split gets its own case with the reason written down, since reconnecting fixes one and nothing about the other, and a client that cannot tell them apart retries the wrong one.

The page names the test file and the test file names the page, so the two cannot drift apart quietly.

## Notes

- Registered in `docs/README.md` and `docs.json`; `docs-index-coverage` holds it like every other page. That gate also taught me the house rule on em dashes, which the page now respects.
- Gates green: `format:check`, `lint` 17/17, `typecheck` 22/22, server suite 6338 passing. `init/format-generated.test.ts` fails identically on a clean `main` on this Windows box and is unrelated.

**One thing I deliberately did not do.** The issue says to "treat it as public surface", and I have documented it and pinned it, but I have not written a stability guarantee into the page. Whether this transport is now something you promise not to break is a product decision, and it is yours rather than mine. If you want that sentence in there, tell me the strength you want and I will add it.
