### PR TITLE
test(server): the handshake-cap test raced its own hello timeout

### DIFF
--- a/packages/server/src/bridge/bridge.security.test.ts
+++ b/packages/server/src/bridge/bridge.security.test.ts
@@ -396,16 +396,24 @@ describe('Bridge security boundary', () => {
   });
 
   it('caps and expires unauthenticated pending handshakes', async () => {
+    // The hello timeout has to outlast the SECOND connect, not merely be short. At 50ms this raced
+    // on a loaded runner: `idle` expired before `excess` finished connecting, which freed the one
+    // pending slot, so `excess` was ACCEPTED and later closed 1008 (hello timeout) instead of 1013
+    // (too many pending). The assertion then read `expected 1008 to be 1013` — a real cap reported
+    // as broken because the machine was slow, which is the failure mode a duration-based test has.
+    // A second is far longer than a loopback connect and still expires well inside the test.
     const limited = await makeBridge({
       maxPendingConnections: 1,
-      helloTimeoutMs: 50,
+      helloTimeoutMs: 1_000,
     });
     const idle = await openSocket(limited.port);
     const idleClosed = waitForClose(idle);
 
     const excess = await openSocket(limited.port);
     const excessClosed = waitForClose(excess);
+    // Refused by the cap while `idle` still holds the slot — not by its own timeout.
     expect(await excessClosed).toBe(1013);
+    // And the slot is not held for ever: the idle handshake still expires on its own.
     expect(await idleClosed).toBe(1008);
     expect(limited.bridge.sessions.count()).toBe(0);
   });


### PR DESCRIPTION
`caps and expires unauthenticated pending handshakes` fails on the macOS runner with:

```
AssertionError: expected 1008 to be 1013
 ❯ src/bridge/bridge.security.test.ts:408:32
```

**Why.** The bridge was configured with `maxPendingConnections: 1` and `helloTimeoutMs: 50`. The test opens `idle` (taking the one pending slot), then opens `excess` and asserts it is refused with 1013 (too many pending handshakes). On a loaded runner the second connect takes longer than 50ms, so `idle` has already expired and RELEASED the slot — `excess` is accepted, sits there, and closes 1008 (hello timeout) on its own.

So the cap works; the test was asserting against the clock. It reads as "the pending-connection cap is broken" and fires only under parallel load, which is to say only in CI — the shape [CLAUDE.md](../blob/main/CLAUDE.md) calls out under *Timing assertions are a bug*.

**Fix.** Give the hello timeout a second, so it comfortably outlasts a loopback connect. Both assertions are unchanged and both still mean what they said: `excess` is refused **by the cap** while `idle` holds the slot, and `idle` still expires on its own afterwards. The test is not made timing-free — the ordering it checks is real — but the margin is now three orders of magnitude over the thing it races.

Found while merging #765, whose macOS job this failed twice; the diff there does not touch the bridge.