### PR TITLE
chore(init): move the workspace redirect out of run.ts

### DIFF
--- a/packages/server/src/init/run.ts
+++ b/packages/server/src/init/run.ts
@@ -15,13 +15,8 @@ import { projectIdOf, rememberProjectOnDisk } from '../project/remember-project.
 import { detect, Framework, namesAPackageManager, type DetectInput, UiLibrary } from './detect.js';
 import { wasMcpRegistered } from './mcp-registered.js';
 import { pickAstroHost } from './astro-host.js';
-import {
-  findWorkspaceApps,
-  NEXT_CONFIG_CANDIDATES,
-  PACKAGE_JSON,
-  VITE_CONFIG_CANDIDATES,
-} from './workspace-apps.js';
-import { chooseWorkspaceApp } from './app-choice.js';
+import { NEXT_CONFIG_CANDIDATES, PACKAGE_JSON, VITE_CONFIG_CANDIDATES } from './workspace-apps.js';
+import { redirectToWorkspaceApp } from './workspace-redirect.js';
 import { isConnectStep } from './connect-steps.js';
 import { CURSOR_RULE_PATH, RETICLE_MD_PATH } from './agent-rules.js';
 import { CRA_ENV_PATH } from './cra.js';
@@ -766,90 +761,6 @@ function classifyInitFailure(failed: ReadonlySet<string>): string {
   return InitFailure.OTHER;
 }
 
-const AMBIGUOUS_HEADER =
-  'Several apps found in this workspace. Re-run `reticle init` inside the one you want:';
-
-/**
- * When the current directory is a workspace root with no app of its own, wire the app instead of the
- * root. One candidate is wired silently (there is nothing to ask about); several are listed, because
- * guessing which app someone meant is worse than one line of output.
- * Returns null when there is nothing to redirect to — the caller then proceeds here as before.
- */
-function redirectToWorkspaceApp(options: InitOptions, io: InitIo, pkg: unknown): InitResult | null {
-  if (true === options.redirected) return null;
-  const rootFiles = new Set(io.rootFiles());
-  const here = detect({
-    pkg: 'object' === typeof pkg && pkg !== null ? pkg : {},
-    configFiles: rootFiles,
-    lockfiles: new Set(),
-  });
-  // `--app` is an INSTRUCTION, and it is read before the guess below. The guess answers "where is
-  // the app?" for somebody who did not say; when somebody said, there is nothing left to infer.
-  //
-  // It used to be read after, and the check underneath returns early for any directory that looks
-  // like an app — which a JS monorepo ROOT does, because shared tooling puts `vite` in its
-  // devDependencies. So on a real pnpm+turbo monorepo (measured on nuclear, a Tauri v2 app at
-  // product scale) `reticle init --app packages/player` silently ignored the flag, installed the
-  // SDK into the root's package.json, wrote `.reticle.json` and a whole `src/reticle-dev.ts` into a
-  // repository root that has no `src/`, left `packages/player` untouched — and reported three ✓ and
-  // one ⚠. The one flag documented for this shape wired the wrong directory and said it worked.
-  //
-  // Existence is the test, not membership of the discovered list: discovery scans conventional
-  // directories, and somebody who names a path knows their own layout better than the scan does.
-  const named = options.app === undefined || '' === options.app ? undefined : options.app;
-  if (named !== undefined) {
-    const wanted = named.replace(/\/+$/, '');
-    if (io.exists(`${wanted}/${PACKAGE_JSON}`)) return enterApp(options, io, wanted, 'Wiring');
-    io.print(`--app ${named} does not name a directory with a package.json in it.`);
-    return { ok: false, applied: 0, manual: 1 };
-  }
-  if (here.framework !== Framework.HTML) return null; // this directory IS the app
-
-  const apps = findWorkspaceApps(io);
-  // An explicitly named app answers the ambiguity. Refusing to guess is right, but "re-run inside the
-  // one you want" is not something a script, a CI step, or an agent that cannot change directory can
-  // act on — so the refusal was a dead end for exactly the callers most likely to hit it.
-  const chosen = chooseWorkspaceApp(options.app, apps);
-  if (!chosen.ok) {
-    io.print(chosen.message);
-    return { ok: false, applied: 0, manual: 1 };
-  }
-  const target = chosen.app ?? (1 === apps.length ? apps[0] : undefined);
-  if (target === undefined) {
-    if (0 === apps.length) return null; // not a workspace — fall through to the normal HTML plan
-    io.print(AMBIGUOUS_HEADER);
-    for (const a of apps) io.print(`  ${a}`);
-    io.print('');
-    io.print(`Or name one without changing directory:  reticle init --app ${apps[0] ?? '<dir>'}`);
-    return { ok: false, applied: 0, manual: apps.length };
-  }
-  return enterApp(options, io, target, 'No app in this directory — wiring');
-}
-
-/**
- * Re-enter `init` scoped to one directory of a workspace.
- *
- * One implementation for both routes in — the app somebody NAMED and the app discovery found when
- * nobody did. They differ only in the sentence printed; scoping the io, moving the cwd and keeping
- * the agent root has to be identical for both, and was worth having twice for exactly as long as it
- * took to get one of them wrong.
- */
-function enterApp(options: InitOptions, io: InitIo, target: string, lead: string): InitResult {
-  io.print(`${lead} ${target}.`);
-  io.print('');
-  return runInit(
-    {
-      ...options,
-      cwd: join(options.cwd, target),
-      redirected: true,
-      // Where the human is STANDING, kept across the redirect: their agent session runs here, so
-      // this is the only place a `/reticle` command file can be found by it.
-      agentRoot: options.agentRoot ?? options.cwd,
-    },
-    io.scoped(target),
-  );
-}
-
 export function runInit(options: InitOptions, io: InitIo): InitResult {
   const result = runInitSteps(options, io);
   // The ask goes here, not in report(): report() is only the success-shaped path, and the exits that
@@ -915,7 +826,7 @@ function runInitSteps(options: InitOptions, io: InitIo): InitResult {
   //
   // `'{}'` because the redirect only needs the manifest to ask "is THIS directory the app", and a
   // directory with no package.json is definitively not.
-  const redirectedEarly = redirectToWorkspaceApp(options, io, pkgRaw ?? {});
+  const redirectedEarly = redirectToWorkspaceApp(options, io, pkgRaw ?? {}, runInit);
   if (redirectedEarly !== null) return redirectedEarly;
   if (null === pkgRaw) {
     io.print(

--- a/packages/server/src/init/workspace-redirect.ts
+++ b/packages/server/src/init/workspace-redirect.ts
@@ -1,0 +1,117 @@
+/**
+ * Workspace redirect: when `init` is run at a monorepo ROOT, wire the app rather than the root.
+ *
+ * Split out of `run.ts`, which sits one line under the 1000-line backstop — every init change that
+ * touches the orchestration now trips the cap before it can be reviewed. This is the part of that
+ * file that answers a single, separable question ("is the app somewhere else, and where?"), so it
+ * is the seam that costs nothing to move.
+ *
+ * `runInit` arrives as a parameter rather than an import: re-entering init is the whole point of a
+ * redirect, and taking it as an argument keeps this module a leaf instead of forming a cycle with
+ * the file it was cut from.
+ */
+
+import { join } from 'node:path';
+import { detect, Framework } from './detect.js';
+import { findWorkspaceApps, PACKAGE_JSON } from './workspace-apps.js';
+import { chooseWorkspaceApp } from './app-choice.js';
+import type { InitIo, InitOptions, InitResult } from './run.js';
+
+/** Re-enter `init`, scoped to one directory of the workspace. */
+export type RunInit = (options: InitOptions, io: InitIo) => InitResult;
+
+const AMBIGUOUS_HEADER =
+  'Several apps found in this workspace. Re-run `reticle init` inside the one you want:';
+
+/**
+ * When the current directory is a workspace root with no app of its own, wire the app instead of the
+ * root. One candidate is wired silently (there is nothing to ask about); several are listed, because
+ * guessing which app someone meant is worse than one line of output.
+ * Returns null when there is nothing to redirect to — the caller then proceeds here as before.
+ */
+export function redirectToWorkspaceApp(
+  options: InitOptions,
+  io: InitIo,
+  pkg: unknown,
+  runInit: RunInit,
+): InitResult | null {
+  if (true === options.redirected) return null;
+  const rootFiles = new Set(io.rootFiles());
+  const here = detect({
+    pkg: 'object' === typeof pkg && pkg !== null ? pkg : {},
+    configFiles: rootFiles,
+    lockfiles: new Set(),
+  });
+  // `--app` is an INSTRUCTION, and it is read before the guess below. The guess answers "where is
+  // the app?" for somebody who did not say; when somebody said, there is nothing left to infer.
+  //
+  // It used to be read after, and the check underneath returns early for any directory that looks
+  // like an app — which a JS monorepo ROOT does, because shared tooling puts `vite` in its
+  // devDependencies. So on a real pnpm+turbo monorepo (measured on nuclear, a Tauri v2 app at
+  // product scale) `reticle init --app packages/player` silently ignored the flag, installed the
+  // SDK into the root's package.json, wrote `.reticle.json` and a whole `src/reticle-dev.ts` into a
+  // repository root that has no `src/`, left `packages/player` untouched — and reported three ✓ and
+  // one ⚠. The one flag documented for this shape wired the wrong directory and said it worked.
+  //
+  // Existence is the test, not membership of the discovered list: discovery scans conventional
+  // directories, and somebody who names a path knows their own layout better than the scan does.
+  const named = options.app === undefined || '' === options.app ? undefined : options.app;
+  if (named !== undefined) {
+    const wanted = named.replace(/\/+$/, '');
+    if (io.exists(`${wanted}/${PACKAGE_JSON}`))
+      return enterApp(options, io, wanted, 'Wiring', runInit);
+    io.print(`--app ${named} does not name a directory with a package.json in it.`);
+    return { ok: false, applied: 0, manual: 1 };
+  }
+  if (here.framework !== Framework.HTML) return null; // this directory IS the app
+
+  const apps = findWorkspaceApps(io);
+  // An explicitly named app answers the ambiguity. Refusing to guess is right, but "re-run inside the
+  // one you want" is not something a script, a CI step, or an agent that cannot change directory can
+  // act on — so the refusal was a dead end for exactly the callers most likely to hit it.
+  const chosen = chooseWorkspaceApp(options.app, apps);
+  if (!chosen.ok) {
+    io.print(chosen.message);
+    return { ok: false, applied: 0, manual: 1 };
+  }
+  const target = chosen.app ?? (1 === apps.length ? apps[0] : undefined);
+  if (target === undefined) {
+    if (0 === apps.length) return null; // not a workspace — fall through to the normal HTML plan
+    io.print(AMBIGUOUS_HEADER);
+    for (const a of apps) io.print(`  ${a}`);
+    io.print('');
+    io.print(`Or name one without changing directory:  reticle init --app ${apps[0] ?? '<dir>'}`);
+    return { ok: false, applied: 0, manual: apps.length };
+  }
+  return enterApp(options, io, target, 'No app in this directory — wiring', runInit);
+}
+
+/**
+ * Re-enter `init` scoped to one directory of a workspace.
+ *
+ * One implementation for both routes in — the app somebody NAMED and the app discovery found when
+ * nobody did. They differ only in the sentence printed; scoping the io, moving the cwd and keeping
+ * the agent root has to be identical for both, and was worth having twice for exactly as long as it
+ * took to get one of them wrong.
+ */
+function enterApp(
+  options: InitOptions,
+  io: InitIo,
+  target: string,
+  lead: string,
+  runInit: RunInit,
+): InitResult {
+  io.print(`${lead} ${target}.`);
+  io.print('');
+  return runInit(
+    {
+      ...options,
+      cwd: join(options.cwd, target),
+      redirected: true,
+      // Where the human is STANDING, kept across the redirect: their agent session runs here, so
+      // this is the only place a `/reticle` command file can be found by it.
+      agentRoot: options.agentRoot ?? options.cwd,
+    },
+    io.scoped(target),
+  );
+}


### PR DESCRIPTION
`run.ts` is **999 lines** on main — one under the 1000-line backstop. Every `init` change that touches the orchestration now trips `max-lines` before it can be reviewed on its merits: #743 adds three lines and fails lint at 1002, and #728 lands in the same file.

Moves `redirectToWorkspaceApp` + `enterApp` (and `AMBIGUOUS_HEADER`) to `workspace-redirect.ts`. They answer one separable question — *is the app somewhere else, and where?* — which makes them the seam that costs least to move. `run.ts` goes to 915.

`runInit` is passed **as a parameter** rather than imported: re-entering init is the whole point of a redirect, and taking it as an argument keeps the new module a leaf instead of forming a cycle with the file it was cut from.

Pure move otherwise — same behaviour, same order, no test changes needed. All 618 `src/init` tests pass unchanged.