### PR TITLE
fix(server): surface daemon startup cause

### DIFF
--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -68,6 +68,7 @@ import {
 import { IdleShutdown, resolveIdleShutdownMs, resolveIdleCheckMs } from './daemon/idle-shutdown.js';
 import { DaemonHeartbeat, resolveHeartbeatMs } from './daemon/heartbeat.js';
 import { everServedToolCall } from './daemon/daemon-usefulness.js';
+import { DAEMON_START_FAILED_EVENT, readDaemonStartupCause } from './daemon/startup-failure.js';
 import {
   fetchStatus,
   summarizeStatus,
@@ -214,6 +215,7 @@ async function serveWithHonestExit(parsed: {
     return;
   }
   const daemonArgs = daemonSpawnArgs(parsed);
+  const startupStartedAt = Date.now();
   spawnDaemon(process.execPath, scriptPath, daemonArgs, parsed.port);
   // The child binds asynchronously and, when it cannot, exits 1 long after this process would have
   // reported success. Wait for it to ANSWER — `/status` responding is the only evidence a daemon
@@ -221,12 +223,14 @@ async function serveWithHonestExit(parsed: {
   const bound = await waitForPresence(parsed.port, PortPresence.DAEMON, SERVE_BIND_TIMEOUT_MS);
   if (!bound) {
     const settled = await probePresence(parsed.port, { tcpOpen: probeDaemon, status: fetchStatus });
+    const startupCause = readDaemonStartupCause(logPath(parsed.port), startupStartedAt);
     log('reticle_daemon_start_failed_parent', {
       port: parsed.port,
       presence: settled,
       reason: describePresence(settled, parsed.port),
       log: logPath(parsed.port),
       stateDir: stateDirProblem(reticleStateHome()) === undefined ? 'writable' : 'unwritable',
+      ...(startupCause === undefined ? {} : { cause: startupCause }),
     });
     // Name the CAUSE when we can see it. An unwritable state directory is a first-run failure mode
     // (locked-down home, read-only container mount, managed profile) that produced only "nothing is
@@ -235,7 +239,10 @@ async function serveWithHonestExit(parsed: {
     const dirProblem = stateDirProblem(reticleStateHome());
     process.stderr.write(
       dirProblem === undefined
-        ? `the daemon did not come up on :${String(parsed.port)} — ${describePresence(settled, parsed.port)}\n` +
+        ? startupCause === undefined
+          ? `the daemon did not come up on :${String(parsed.port)} — ${describePresence(settled, parsed.port)}\n` +
+            `see ${logPath(parsed.port)}\n`
+          : `the daemon did not come up on :${String(parsed.port)}.\n${startupCause}\n` +
             `see ${logPath(parsed.port)}\n`
         : `the daemon did not come up on :${String(parsed.port)}.\n${dirProblem}\n`,
     );
@@ -780,7 +787,7 @@ function handleDaemonInner(parsed: {
     })
     .catch((error: unknown) => {
       const message = error instanceof Error ? error.message : String(error);
-      log('reticle_daemon_start_failed', { error: message });
+      log(DAEMON_START_FAILED_EVENT, { error: message });
       removePid(parsed.port);
       process.exit(1);
     });

--- a/packages/server/src/cli/status-next-action.test.ts
+++ b/packages/server/src/cli/status-next-action.test.ts
@@ -89,14 +89,15 @@ describe('statusNextAction', () => {
  * server.
  */
 describe('status can say that init was never run here', () => {
-  it('names init when the project is not initialized and no daemon is up', () => {
+  it('reports the unavailable daemon before making any instrumentation claim', () => {
     const next = statusNextAction({
       running: false,
       sessionCount: 0,
       previouslyConnected: false,
       initialized: false,
     });
-    expect(next).toMatch(/init/);
+    expect(next).toMatch(/no daemon is running/);
+    expect(next).not.toMatch(/not instrumented|run `npx @reticlehq\/server init`/);
   });
 
   it('names init when the daemon IS up and nothing has connected', () => {

--- a/packages/server/src/cli/status-next-action.ts
+++ b/packages/server/src/cli/status-next-action.ts
@@ -55,20 +55,6 @@ export interface StatusFacts {
 export function statusNextAction(facts: StatusFacts): string | undefined {
   if (facts.sessionCount > 0) return undefined;
 
-  // Ahead of everything else, because it dominates: an app that was never wired cannot connect, and
-  // no advice about dev servers or ports applies until it is. `previouslyConnected` overrides it —
-  // an app CAN be wired by the Vite or Babel plugin with no `.reticle.json` at all, so a project
-  // that has connected here before is wired whatever this file says, and sending it back to `init`
-  // would be the same wrong answer in the other direction.
-  if (!facts.initialized && !facts.previouslyConnected) {
-    return (
-      'no app has ever connected for this project, and there is no Reticle config here — so the ' +
-      'tools are registered and the app itself is not instrumented. Those are two different halves ' +
-      'of the install. Run `npx @reticlehq/server init` in the app directory, then start the dev ' +
-      'server and load the page.'
-    );
-  }
-
   if (!facts.running) {
     // `running: false` reads as "Reticle is broken", and it usually means the opposite: the daemon is
     // started by an agent, on demand, and idles out when nobody is driving. A user who has not
@@ -81,6 +67,19 @@ export function statusNextAction(facts: StatusFacts): string | undefined {
       `Reticle tool, and it exits again when idle. ${wiring} Ask your agent to verify something, then ` +
       `run status again.`
     ).replace(/\s+/g, ' ');
+  }
+
+  // Only diagnose instrumentation after a live daemon makes that diagnosis possible. When the
+  // daemon is absent, claiming the app is unwired confuses missing evidence with evidence of a
+  // missing install. `previouslyConnected` overrides this branch because plugin-based wiring may
+  // connect without creating `.reticle.json`.
+  if (!facts.initialized && !facts.previouslyConnected) {
+    return (
+      'no app has ever connected for this project, and there is no Reticle config here — so the ' +
+      'tools are registered and the app itself is not instrumented. Those are two different halves ' +
+      'of the install. Run `npx @reticlehq/server init` in the app directory, then start the dev ' +
+      'server and load the page.'
+    );
   }
 
   // The daemon is up and no page has connected. `nextActionFor` owns the ranking; this passes what

--- a/packages/server/src/daemon/startup-failure.test.ts
+++ b/packages/server/src/daemon/startup-failure.test.ts
@@ -1,0 +1,51 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { readDaemonStartupCause } from './startup-failure.js';
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('readDaemonStartupCause', () => {
+  it('returns the startup error recorded by the failed daemon', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'reticle-startup-cause-'));
+    dirs.push(dir);
+    const path = join(dir, 'daemon.log');
+    const since = Date.parse('2026-09-06T15:00:00.000Z');
+    writeFileSync(
+      path,
+      [
+        JSON.stringify({
+          t: '2026-09-06T15:00:00.100Z',
+          event: 'reticle_daemon_start_failed',
+          error: 'Chromium is not installed for Playwright. Run the pinned install command.',
+        }),
+        '',
+      ].join('\n'),
+    );
+
+    expect(readDaemonStartupCause(path, since)).toBe(
+      'Chromium is not installed for Playwright. Run the pinned install command.',
+    );
+  });
+
+  it('does not surface a failure from an earlier daemon attempt', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'reticle-startup-cause-'));
+    dirs.push(dir);
+    const path = join(dir, 'daemon.log');
+    writeFileSync(
+      path,
+      `${JSON.stringify({
+        t: '2026-09-06T14:59:59.999Z',
+        event: 'reticle_daemon_start_failed',
+        error: 'stale cause',
+      })}\n`,
+    );
+
+    expect(readDaemonStartupCause(path, Date.parse('2026-09-06T15:00:00.000Z'))).toBeUndefined();
+  });
+});

--- a/packages/server/src/daemon/startup-failure.ts
+++ b/packages/server/src/daemon/startup-failure.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+
+/** The structured log event emitted when the daemon child cannot start. */
+export const DAEMON_START_FAILED_EVENT = 'reticle_daemon_start_failed';
+
+/**
+ * Return the most recent startup cause written by this launch attempt.
+ *
+ * Daemon logs are append-only across launches, so an event name alone is not enough: surfacing an
+ * older failure would confidently diagnose the wrong attempt. The parent supplies the timestamp it
+ * captured immediately before spawning and this reader ignores every earlier record. Malformed or
+ * unavailable logs are best-effort misses; the caller still has its generic fallback diagnosis.
+ */
+export function readDaemonStartupCause(path: string, sinceMs: number): string | undefined {
+  let contents: string;
+  try {
+    contents = readFileSync(path, 'utf8');
+  } catch {
+    return undefined;
+  }
+
+  const lines = contents.split('\n');
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index]?.trim();
+    if (undefined === line || 0 === line.length) continue;
+
+    let record: unknown;
+    try {
+      record = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (typeof record !== 'object' || null === record) continue;
+
+    const candidate = record as { event?: unknown; error?: unknown; t?: unknown };
+    if (candidate.event !== DAEMON_START_FAILED_EVENT) continue;
+    if (typeof candidate.t !== 'string' || typeof candidate.error !== 'string') continue;
+
+    const recordedAt = Date.parse(candidate.t);
+    const error = candidate.error.trim();
+    if (!Number.isFinite(recordedAt) || recordedAt < sinceMs || 0 === error.length) continue;
+    return error;
+  }
+  return undefined;
+}


### PR DESCRIPTION
Closes #809.

`serve` now reads the failed child daemon's structured log entry and prints the recorded startup cause, while ignoring stale failures from earlier attempts. `status` reports a missing daemon before inferring anything about app instrumentation.

Validation:
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test:unit`
