### PR TITLE
test(server): poll for the fixture server's port instead of sleeping a guess

### DIFF
--- a/packages/server/src/setup/node-effects.test.ts
+++ b/packages/server/src/setup/node-effects.test.ts
@@ -15,6 +15,34 @@ import {
 const isWindows = 'win32' === process.platform;
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
+/** Who is LISTENING on this port right now, as a pid list — empty when nobody is. */
+const holdersOf = (port: number): string =>
+  spawnSync('sh', ['-c', `lsof -ti:${port} -sTCP:LISTEN || true`], {
+    encoding: 'utf8',
+  }).stdout.trim();
+
+/**
+ * Wait until the port is held (or released), rather than sleeping a guess.
+ *
+ * These tests spawn a real shell, which spawns a real node, which then binds. A fixed 1,200ms for
+ * all three was fine on a developer's machine and not on a loaded runner: when it was not enough
+ * the fixture had simply not come up yet, and the assertion failed as `expected '' not to be ''` —
+ * a handover reported as broken because the machine was busy. That is the shape CLAUDE.md rules out
+ * under *Timing assertions are a bug*, and it has now cost three unrelated PRs a red CI.
+ *
+ * Polling is strictly better here: it returns as soon as the state is real, so the fast path is
+ * faster than the sleep it replaces, and the ceiling only matters when something is genuinely wrong.
+ */
+async function waitForPort(port: number, want: 'held' | 'free'): Promise<string> {
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    const held = holdersOf(port);
+    if (('held' === want) === ('' !== held)) return held;
+    if (Date.now() >= deadline) return held;
+    await sleep(50);
+  }
+}
+
 describe('the dev server this process owns', () => {
   // The promise: stopped on every ending except success. An interrupted run used to leave one
   // listening indefinitely, holding a port nobody could account for.
@@ -30,15 +58,9 @@ describe('the dev server this process owns', () => {
         process.cwd(),
         {},
       );
-      await sleep(1_200);
-      const held = (): string =>
-        spawnSync('sh', ['-c', `lsof -ti:${port} -sTCP:LISTEN || true`], {
-          encoding: 'utf8',
-        }).stdout.trim();
-      expect(held(), 'the fixture server never came up').not.toBe('');
+      expect(await waitForPort(port, 'held'), 'the fixture server never came up').not.toBe('');
       server.stop();
-      await sleep(700);
-      expect(held(), 'stopping left the port held by an orphan').toBe('');
+      expect(await waitForPort(port, 'free'), 'stopping left the port held by an orphan').toBe('');
     },
     15_000,
   );
@@ -53,15 +75,20 @@ describe('the dev server this process owns', () => {
         process.cwd(),
         {},
       );
-      await sleep(1_200);
+      expect(await waitForPort(port, 'held'), 'the fixture server never came up').not.toBe('');
       server.handOver();
       server.stop();
+      // A real pause, not a poll: this asserts the server is STILL there, so it has to be given a
+      // chance to die first. Polling for "still held" would pass on its first tick and prove nothing.
       await sleep(400);
-      const held = spawnSync('sh', ['-c', `lsof -ti:${port} -sTCP:LISTEN || true`], {
-        encoding: 'utf8',
-      }).stdout.trim();
-      expect(held, 'a handed-over server must survive').not.toBe('');
-      for (const pid of held.split('\n')) process.kill(Number(pid), 'SIGKILL');
+      const survivors = holdersOf(port);
+      // Killed BEFORE the assertion, so a failure cannot leak the listener this test deliberately
+      // kept alive: an assertion that throws would skip the cleanup underneath it, and the next run
+      // would find 59232 held and fail for a reason belonging to this one.
+      for (const pid of survivors.split('\n').filter(Boolean)) {
+        process.kill(Number(pid), 'SIGKILL');
+      }
+      expect(survivors, 'a handed-over server must survive').not.toBe('');
     },
     15_000,
   );

--- a/packages/server/src/tools/heavy-browser-tests-declare-a-timeout.test.ts
+++ b/packages/server/src/tools/heavy-browser-tests-declare-a-timeout.test.ts
@@ -206,8 +206,13 @@ function loopBody(text: string, headOpen: number): string | null {
  * `session-end` is the one worth naming: it creates `DEFAULT_SESSION_RETENTION + 5` directories and
  * writes a file into each, which is more per-iteration IO than the 40-record loop that actually
  * broke Windows CI and prompted this issue.
+ *
+ * 13th: `setup/node-effects.test.ts`. It now polls `lsof` for a port to be bound instead of sleeping
+ * a fixed 1,200ms and hoping — which is the same defect this rule exists for, one layer down, and
+ * had failed three unrelated PRs as `expected '' not to be ''`. The poll is the IO loop; both tests
+ * in that file already declare `15_000`, so it satisfies the rule and only this count moved.
  */
-const EXPECTED_IO_LOOP_FILES = 12;
+const EXPECTED_IO_LOOP_FILES = 13;
 
 function testFiles(dir: string): string[] {
   const out: string[] = [];


### PR DESCRIPTION
`node-effects.test.ts` has now failed three unrelated PRs. It is not their code, and it is not the handover it claims to be testing.

## What it does

```ts
server.start(`node -e "…listen(${port})"`, …);
await sleep(1_200);
expect(held(), 'the fixture server never came up').not.toBe('');
```

A shell spawns a node, which then binds — and 1,200ms is the budget for all three. When the runner is slow the fixture simply has not come up yet, and the failure reads:

```
→ a handed-over server must survive: expected '' not to be ''
```

which says the handover broke. It did not; nothing had started yet. On #751 that landed on a PR whose entire diff is in `packages/browser/src/observers/console.ts` and cannot reach this file.

## Reproduced, not assumed

I could not make the current test fail on this machine even with every core loaded — it is faster than a loaded runner, which is the whole problem. So I reproduced the **mechanism** instead: dropping that sleep to 1ms on the unmodified test gives the exact CI string —

```
→ the fixture server never came up: expected '' not to be ''
```

Same assertion, same shape, differing only in which test reaches it first.

## The fix

Poll for the port instead of sleeping at it. `waitForPort(port, 'held' | 'free')` returns as soon as the state is real, so the fast path is *faster* than the sleep it replaces — the first test drops from ~1.9s to ~160ms — and the 10s ceiling only matters when something is genuinely wrong.

The one sleep I kept is deliberate and commented: the handover test asserts the server is **still** alive, so it has to be given a chance to die first. Polling for "still held" would pass on its first tick and prove nothing.

## Two things found on the way

- **The cleanup now runs before its assertion.** It kills the survivor the test deliberately kept alive; with the kill *after* the `expect`, a failure skipped it and left :59232 held — so the next run failed for a reason belonging to the previous one. I know this because my own throwaway repro leaked exactly that orphan on :59231 and turned the next full-suite run red.
- **`heavy-browser-tests-declare-a-timeout` caught this change**, which is the guard working: the new poll is an IO-in-a-loop, so its pinned count goes 12 → 13, with the reason recorded next to it. Both tests in the file already declare `15_000`, so the rule itself was already satisfied.

Verified: the file passes 5/5 consecutive runs and under full CPU load; the whole server suite is green at 6,539.