### PR TITLE
fix(server): a presence predicate is not satisfied by a hollow match (#797)

### DIFF
--- a/packages/server/src/events/predicate-eval.ts
+++ b/packages/server/src/events/predicate-eval.ts
@@ -74,6 +74,16 @@ export interface EvalResult {
   observed?: string;
   expected?: string;
   assertion?: string;
+  /**
+   * A qualification on a verdict that stands. Not a failure and not an inconclusive: the predicate
+   * was answered, and something about HOW it was answered would change how a reader weighs it.
+   *
+   * Today this carries the hollow-match warnings from a presence check (#797): a role-only clause
+   * satisfied by a nameless live-region container reads as "an error is displayed" and proves
+   * nothing, but failing it would break every legitimate assertion on a genuinely unnamed element.
+   * Saying so is the honest middle.
+   */
+  caveat?: string;
 }
 
 export function str(value: unknown): string | undefined {

--- a/packages/server/src/events/predicate-presence-hollow.test.ts
+++ b/packages/server/src/events/predicate-presence-hollow.test.ts
@@ -1,0 +1,173 @@
+/**
+ * A presence predicate must not be satisfiable with nothing on screen (#797).
+ *
+ * `{ kind: "element", role: "alert" }` and a bare `text` clause are the natural way to ask "did an
+ * error appear", and both were answerable without anything appearing:
+ *
+ *  - a toast library's permanently-mounted, unnamed `role="alert"` live region never leaves the DOM
+ *    and is visible, so the role-only clause was a permanent green;
+ *  - dialog content present-but-hidden before a click satisfied a text clause, so the click was
+ *    graded `already_true` and never actually graded.
+ *
+ * These tests pin the two halves of the answer: hidden-only matches stop passing, nameless-only
+ * matches keep passing and say what they rested on.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  asRef,
+  ElementState,
+  ReticleCommand,
+  type CommandResult,
+  type ElementDescriptor,
+  type ElementQuery,
+  type MatchResult,
+  type ReticleEvent,
+} from '@reticlehq/core';
+import { evaluatePredicate, type PredicateSession } from './predicate.js';
+
+function alert(ref: string, name: string, visible: boolean): ElementDescriptor {
+  return { ref: asRef(ref), role: 'alert', name, states: [], visible, text: name };
+}
+
+/** The reported page: a real error toast beside the library's always-present empty container. */
+const NAMED_TOAST = alert('e116', 'Invalid login credentials', true);
+/** The live region itself: always mounted, visible, and unnamed. */
+const EMPTY_LIVE_REGION = alert('e113', '', true);
+/** Dialog copy that is in the DOM before the click, but not shown. */
+const HIDDEN_HEADING: ElementDescriptor = {
+  ref: asRef('e200'),
+  role: 'heading',
+  name: 'Delete account?',
+  states: [],
+  visible: false,
+  text: 'Delete account?',
+};
+
+/**
+ * Returns whatever it was seeded with, honouring only `state` filtering the way the browser does,
+ * so a test can hand the evaluator exactly the DOM the report describes.
+ */
+class PageSession implements PredicateSession {
+  constructor(
+    private readonly page: readonly ElementDescriptor[],
+    /** Set below `page.length` to model a match the browser truncated. */
+    private readonly reportedCount?: number,
+  ) {}
+
+  command(name: string, args: Record<string, unknown> = {}): Promise<CommandResult> {
+    if (name !== ReticleCommand.MATCH) {
+      return Promise.resolve({ kind: 'command_result', id: 'x', ok: true, result: {} });
+    }
+    const query = (args['query'] ?? {}) as ElementQuery;
+    const state = args['state'] as string | undefined;
+    let matched = this.page.filter(
+      (element) =>
+        (undefined === query.role || element.role === query.role) &&
+        (undefined === query.name || element.name === query.name) &&
+        (undefined === query.text || (element.text ?? '').includes(query.text)),
+    );
+    if (ElementState.VISIBLE === state) matched = matched.filter((element) => element.visible);
+    const result: MatchResult = {
+      matched: matched.length > 0,
+      count: this.reportedCount ?? matched.length,
+      elements: matched,
+    };
+    return Promise.resolve({ kind: 'command_result', id: 'x', ok: true, result });
+  }
+  eventsSince(): ReticleEvent[] {
+    return [];
+  }
+  onEvent(): () => void {
+    return () => undefined;
+  }
+  elapsed(): number {
+    return 0;
+  }
+}
+
+describe('a presence match nobody can see is not an appearance', () => {
+  it('fails a text clause answered only by hidden content', async () => {
+    const session = new PageSession([HIDDEN_HEADING]);
+    const result = await evaluatePredicate(session, {
+      kind: 'text',
+      contains: 'Delete account?',
+    });
+    expect(result.pass, 'hidden-only content has not appeared').toBe(false);
+    expect(result.assertion).toBe('element.visible');
+    expect(result.failureReason).toContain('visible');
+  });
+
+  it('names the escape hatch, so presence-regardless-of-visibility stays available', async () => {
+    const session = new PageSession([HIDDEN_HEADING]);
+    const result = await evaluatePredicate(session, { kind: 'text', contains: 'Delete account?' });
+    expect(result.failureReason).toContain('state: "present"');
+  });
+
+  it('passes the same clause when the caller states the intent', async () => {
+    const session = new PageSession([HIDDEN_HEADING]);
+    const result = await evaluatePredicate(session, {
+      kind: 'element',
+      query: { text: 'Delete account?' },
+      state: ElementState.PRESENT,
+    });
+    expect(result.pass, 'a stated state is not second-guessed').toBe(true);
+  });
+
+  it('still passes when one of several matches is visible', async () => {
+    const session = new PageSession([
+      HIDDEN_HEADING,
+      { ...HIDDEN_HEADING, ref: asRef('e201'), visible: true },
+    ]);
+    const result = await evaluatePredicate(session, { kind: 'text', contains: 'Delete account?' });
+    expect(result.pass).toBe(true);
+    expect(result.caveat, 'a named visible match needs no qualification').toBeUndefined();
+  });
+
+  it('does not claim every match is hidden when the browser truncated the list', async () => {
+    // 12 matched, 1 described. "All of them are hidden" is not a claim this evidence supports, and
+    // a wrong failure sends an agent to fix working code.
+    const session = new PageSession([HIDDEN_HEADING], 12);
+    const result = await evaluatePredicate(session, { kind: 'text', contains: 'Delete account?' });
+    expect(result.pass).toBe(true);
+  });
+});
+
+describe('a role-only clause satisfied by an unnamed container says so', () => {
+  it('passes but qualifies the verdict when the only match is the empty live region', async () => {
+    const session = new PageSession([EMPTY_LIVE_REGION]);
+    const result = await evaluatePredicate(session, { kind: 'element', query: { role: 'alert' } });
+    expect(
+      result.pass,
+      'unnamed roles are legitimate; failing would break correct assertions',
+    ).toBe(true);
+    expect(result.caveat, 'the hollow match must be reported').toBeDefined();
+    expect(result.caveat).toContain('unnamed');
+  });
+
+  it('does not qualify a verdict once a real named alert is on screen', async () => {
+    const session = new PageSession([NAMED_TOAST, EMPTY_LIVE_REGION]);
+    const result = await evaluatePredicate(session, { kind: 'element', query: { role: 'alert' } });
+    expect(result.pass).toBe(true);
+    expect(result.caveat, 'a named match answered the clause').toBeUndefined();
+  });
+
+  it('does not qualify a verdict when the query itself discriminates', async () => {
+    const session = new PageSession([{ ...EMPTY_LIVE_REGION, name: 'Saved' }]);
+    const result = await evaluatePredicate(session, {
+      kind: 'element',
+      query: { role: 'alert', name: 'Saved' },
+    });
+    expect(result.pass).toBe(true);
+    expect(result.caveat).toBeUndefined();
+  });
+
+  it('reports the hollow match rather than failing it, so absence checks are untouched', async () => {
+    const session = new PageSession([EMPTY_LIVE_REGION]);
+    const result = await evaluatePredicate(session, {
+      kind: 'element',
+      query: { role: 'alert' },
+      absent: true,
+    });
+    expect(result.pass, 'the container IS there, so an absence check correctly fails').toBe(false);
+  });
+});

--- a/packages/server/src/events/predicate-presence.ts
+++ b/packages/server/src/events/predicate-presence.ts
@@ -1,0 +1,84 @@
+/**
+ * Deciding a presence match that found something -- and saying when what it found is hollow.
+ *
+ * Extracted from `predicate.ts` so the evaluator's switch stays readable; the reasoning for the two
+ * different treatments lives on `presenceVerdict` below.
+ */
+import type { ElementQuery, ElementState, MatchResult } from '@reticlehq/core';
+import type { EvalResult } from './predicate-eval.js';
+
+/**
+ * Decide a presence match that found something, and say when what it found is hollow.
+ *
+ * `element` and `text` are the most idiomatic way to ask "did an error appear", and both are
+ * satisfiable without anything appearing (#797):
+ *
+ *  - A toast library mounts a permanently-present, unnamed `role="alert"` live region. It never
+ *    leaves the DOM and it is `visible`, so `{ kind: "element", role: "alert" }` is a permanent
+ *    green on any app using one — with zero errors on screen.
+ *  - A dialog's content is in the DOM but hidden before the click, so a `text` clause returns
+ *    `already_true` and the action it was meant to grade is never actually graded.
+ *
+ * The two get different treatment on purpose, because the confidence in each differs:
+ *
+ *  - **Hidden-only matches FAIL.** An appearance check answered entirely by nodes nobody can see
+ *    has not observed an appearance. A caller who genuinely means presence-regardless-of-visibility
+ *    already has a way to say so — `state: "present"`, or `state: "hidden"` — and this only changes
+ *    the DEFAULT, which is what the report asks for.
+ *  - **Nameless-only matches PASS, with a caveat.** Plenty of roles are legitimately unnamed
+ *    (`progressbar`, a decorative `separator`), so failing here would break correct assertions to
+ *    catch an incorrect one. The verdict stands and says what it rested on.
+ *
+ * Both checks are skipped when the caller passed a `state`: they said what they meant by "there",
+ * and second-guessing a stated intent is how a tool earns a reputation for surprises.
+ */
+export function presenceVerdict(
+  match: MatchResult,
+  query: ElementQuery,
+  subject: string,
+  state: ElementState | undefined,
+): EvalResult {
+  const described = match.elements;
+  // `elements` is a described PREFIX of `count` (see the residual note above). With matches the
+  // browser never described, "every match is hidden" and "every match is nameless" are claims the
+  // evidence does not support -- and a wrong FAILURE here is worse than the false green, because it
+  // sends an agent to fix working code. Pass, as before.
+  if (state !== undefined || 0 === described.length || match.count > described.length) {
+    return { pass: true, evidence: described };
+  }
+
+  const visible = described.filter((element) => element.visible);
+  if (0 === visible.length) {
+    const plural = 1 === described.length ? 'it is' : 'none is';
+    return {
+      pass: false,
+      failureReason:
+        `${String(described.length)} element(s) matched ${subject} but ${plural} visible — ` +
+        'an appearance check answered by hidden nodes has not seen anything appear. ' +
+        'Pass `state: "present"` to accept a match regardless of visibility',
+      observed: `${String(described.length)} hidden element(s) matching ${subject}`,
+      expected: `a visible element matching ${subject}`,
+      assertion: 'element.visible',
+      evidence: described,
+    };
+  }
+
+  // A role-only clause is the hollow shape: the caller named a role and nothing else, and every
+  // node that answered it is unnamed. `role="alert"` satisfied only by an empty live-region
+  // container is the reported case. When the query itself carries a name or text, a nameless match
+  // cannot have answered it, so there is nothing to warn about.
+  const discriminating =
+    undefined !== query.name || undefined !== query.text || undefined !== query.testid;
+  const namedVisible = visible.filter((element) => element.name.trim().length > 0);
+  if (!discriminating && 0 === namedVisible.length) {
+    return {
+      pass: true,
+      evidence: described,
+      caveat:
+        `matched ${String(visible.length)} visible element(s) for ${subject}, all unnamed — ` +
+        'a live-region or landmark container that is always present satisfies this clause with ' +
+        'nothing on screen. Add `name` (or a `text` clause) to assert what was actually shown',
+    };
+  }
+  return { pass: true, evidence: described };
+}

--- a/packages/server/src/events/predicate.ts
+++ b/packages/server/src/events/predicate.ts
@@ -20,6 +20,7 @@ import type { ExpectedLink } from '../capsule/divergence.js';
 import { isAmbient, ambientKeyOf, type AmbientCounts } from '../journal/ambient.js';
 import { evalRoute } from './predicate-route.js';
 import { describeSuperseded } from './observed-in-window.js';
+import { presenceVerdict } from './predicate-presence.js';
 import {
   PredicateSchema,
   matchValue,
@@ -189,7 +190,7 @@ async function evalElement(
       evidence: { scopeMissing: true },
     };
   }
-  if (match.matched) return { pass: true, evidence: match.elements };
+  if (match.matched) return presenceVerdict(match, query, subject, state);
 
   // The near-miss diagnostic below costs one or two EXTRA MATCH round-trips. It only enriches a FAILED
   // verdict, and a wait loop's interim rechecks read nothing but `pass` — so on the poll path (diagnose


### PR DESCRIPTION
Closes #797.

## Both halves of the report, and why they need different answers

The issue describes two false greens. They look like one problem but need opposite treatment, and the reported evidence is what separates them.

**A — the always-present live region.** `{"ref":"e113","role":"alert","name":"","visible":true}`. Note `visible: true`: this container is *not* hidden, so a visibility rule alone would not have caught it. What makes it hollow is that it is **unnamed** and permanent.

**B — hidden dialog content.** Present in the DOM before the click, so a `text` clause returned `already_true` and the action was never graded.

So:

| | treatment | why |
|---|---|---|
| hidden-only match | **fails** | an appearance check answered by nodes nobody can see has not seen an appearance |
| nameless-only match | **passes, with a `caveat`** | `progressbar`, a decorative `separator` and plenty of other roles are legitimately unnamed — failing would break correct assertions to catch an incorrect one |

The issue's own wording asks for exactly this asymmetry: presence "should not satisfy an appearance check" (expectation 1, a hard rule) versus "at minimum, note in the result that a nameless match was included" (expectation 2, a report).

## The escape hatch already existed

`ElementState.PRESENT` and `ElementState.HIDDEN` are in the vocabulary today. A caller who genuinely wants presence-regardless-of-visibility passes `state: "present"`, and the new failure message names that. This changes the **default**, which is what the report asks for ("if a caller wants presence-regardless-of-visibility that should be explicit"), and adds no new predicate fields.

Both new checks are skipped entirely when the caller passed a `state` — they already said what they meant by "there".

## The truncation guard, which matters more than it looks

`MatchResult.elements` is a described *prefix* of `count`. When 12 elements matched and 1 was described, "every match is hidden" is a claim the evidence does not support. Asserting it would produce a wrong **failure**, which is worse than the false green it replaces: a failure names a component and sends an agent to fix working code. Both checks bail to the old behaviour when `count > elements.length`, and `test_does_not_claim_every_match_is_hidden_when_the_browser_truncated_the_list` pins it.

## Deliberately out of scope

Expectation 3 — "say when the matched node was already there, unchanged since before the action" — needs the pre-action DOM, which `evalElement` does not receive; it is a change to the act/wait plumbing rather than to predicate evaluation. I left it out rather than half-implement it from the post-action match alone. Happy to take it as a follow-up if you want it split that way.

## New surface

`EvalResult.caveat?: string` — a qualification on a verdict that *stands*. Distinct from `inconclusive` (nothing was proven) and from `failureReason` (proven false): the predicate was answered, and how it was answered would change how a reader weighs it.

## Verification

```
pnpm typecheck                                                   # clean
pnpm lint                                                        # clean
pnpm format                                                      # clean
pnpm --filter @reticlehq/server exec vitest run src/events/predicate-presence-hollow.test.ts   # 9 passed
pnpm --filter @reticlehq/server exec vitest run src/events src/tools                           # 173 files, 1857 passed
```

No existing test changed. `presenceVerdict` sits in its own module because folding it into `predicate.ts` pushed that file past the repo's 1000-line `max-lines` cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)