### PR TITLE
fix(session): version skew rides the verdict, not just the session listing (#812 ask 1)

### DIFF
--- a/packages/server/src/session/session-health.ts
+++ b/packages/server/src/session/session-health.ts
@@ -34,7 +34,31 @@ export function bufferEnvelope(session: Session): BufferEnvelope {
 interface HealthEnvelope {
   session?: SessionHealth;
   warning?: string;
+  /**
+   * Present while the page's SDK and the daemon disagree on the wire contract.
+   *
+   * Skew is not a warning about the future -- it silently invalidates the verdict being returned.
+   * On a skewed link, clicks on Radix controls reported `dispatched: true`, `settled: true` and a
+   * `domMutatedWithin` in the tens of milliseconds while the app's React state never changed
+   * (#812). Nothing in that result said so, and the existing `version_skew` nudge is one-shot and
+   * lands on `reticle_sessions` / `reticle_lease` -- not on the surface an agent reads on every
+   * call.
+   */
+  skewSuspected?: string;
 }
+
+/**
+ * What a verdict taken over a skewed link is worth, said on the verdict.
+ *
+ * Deliberately not phrased as "may behave in ways neither side reports": the reporter trusted
+ * `dispatched: true, domMutatedWithin: Nms` for eight attempts across three interaction strategies
+ * before suspecting skew at all, and the same sequence worked first try once the versions
+ * converged. The sentence has to say that the fields above it cannot be believed.
+ */
+const SKEW_VERDICT_NOTE =
+  'the page SDK and the daemon disagree on the wire contract, so this result is NOT a verdict: ' +
+  'a dispatch can report dispatched/settled (and even a DOM mutation) while the app never changed ' +
+  'state. Converge the versions and re-run before concluding anything from this call';
 
 /**
  * Build the health envelope for a tool result. When the session is **nominal** (focused, not
@@ -44,10 +68,20 @@ interface HealthEnvelope {
  * so no health signal is lost — absence means healthy.
  */
 export function healthEnvelope(session: Session): HealthEnvelope {
+  // Skew rides EVERY result for as long as it holds, unlike the one-shot `version_skew` nudge.
+  // One-shot is right for "an upgrade is available" and wrong for this: the condition does not go
+  // away when it has been mentioned once, and the call it was mentioned on is rarely the call whose
+  // verdict mattered (#812).
+  const skew =
+    session.versionSkew === undefined
+      ? {}
+      : { skewSuspected: `${SKEW_VERDICT_NOTE} (${session.versionSkew})` };
   const health = session.health();
   const nominal = !health.throttled && health.focused && health.recommendation === undefined;
-  if (nominal) return {};
-  return health.throttled ? { session: health, warning: THROTTLED_WARNING } : { session: health };
+  if (nominal) return skew;
+  return health.throttled
+    ? { session: health, warning: THROTTLED_WARNING, ...skew }
+    : { session: health, ...skew };
 }
 
 /**

--- a/packages/server/src/session/skew-rides-the-verdict.test.ts
+++ b/packages/server/src/session/skew-rides-the-verdict.test.ts
@@ -1,0 +1,87 @@
+/**
+ * A verdict taken over a skewed link is not a verdict, and must say so (#812).
+ *
+ * Version skew between the page SDK and the daemon does not merely risk odd behaviour: it produced
+ * `dispatched: true`, `settled: true`, `domMutatedWithin: 12-40ms` on Radix controls whose React
+ * state never changed. Eight attempts across three interaction strategies went by before the
+ * reporter suspected skew, because the one surface an agent reads on every call said nothing.
+ *
+ * The pre-existing `version_skew` nudge is one-shot and rides `reticle_sessions` / `reticle_lease`.
+ * These tests pin the other half: while skew holds, every act/assert result carries the
+ * qualification, on the same envelope the throttled warning already uses.
+ */
+import { describe, expect, it } from 'vitest';
+import type { CommandResult } from '@reticlehq/core';
+import { UNSCRIPTABLE_TAB_RECOMMENDATION } from '@reticlehq/core';
+import { healthEnvelope } from './session-health.js';
+import { createFakeSession } from './fake-session.js';
+import type { Session } from './session.js';
+
+const SKEW = 'page SDK 2.13.1, daemon 2.14.0';
+
+function sessionWith(options: { skew?: string; throttled?: boolean } = {}): Session {
+  const throttled = true === options.throttled;
+  const command = (): Promise<CommandResult> =>
+    Promise.resolve({ kind: 'command_result', id: 'c', ok: true, result: {} });
+  const health = throttled
+    ? {
+        lastSeenMs: 0,
+        throttled: true,
+        focused: false,
+        recommendation: UNSCRIPTABLE_TAB_RECOMMENDATION,
+      }
+    : { lastSeenMs: 0, throttled: false, focused: true };
+  const session = createFakeSession(
+    {
+      elapsed: () => 0,
+      command,
+      health: () => health,
+      bufferHealth: () => ({ total: 0, dropped: 0 }),
+      throttled: () => throttled,
+    },
+    { url: 'http://localhost:5173/app' },
+  );
+  if (options.skew !== undefined) session.versionSkew = options.skew;
+  return session;
+}
+
+describe('skew is on the verdict, not only on the session listing', () => {
+  it('says nothing on a healthy, converged session', () => {
+    // The envelope stays empty when there is nothing to report: a healthy session must not pay
+    // tokens on every call, which is why absence means healthy.
+    expect(healthEnvelope(sessionWith())).toEqual({});
+  });
+
+  it('qualifies a result taken over a skewed link', () => {
+    const envelope = healthEnvelope(sessionWith({ skew: SKEW }));
+    expect(envelope.skewSuspected).toBeDefined();
+    expect(envelope.skewSuspected).toContain(SKEW);
+  });
+
+  it('says the result is not a verdict, not merely that something may misbehave', () => {
+    // The reporter trusted dispatched/settled for eight attempts. A hedge would not have stopped
+    // that; the sentence has to say the fields above it cannot be believed.
+    const note = healthEnvelope(sessionWith({ skew: SKEW })).skewSuspected ?? '';
+    expect(note).toContain('NOT a verdict');
+    expect(note).toContain('dispatched');
+  });
+
+  it('rides EVERY call while the skew holds, unlike the one-shot nudge', () => {
+    const session = sessionWith({ skew: SKEW });
+    const calls = [1, 2, 3].map(() => healthEnvelope(session).skewSuspected);
+    expect(calls.every((c) => c !== undefined)).toBe(true);
+  });
+
+  it('does not displace the throttled warning when both hold', () => {
+    const envelope = healthEnvelope(sessionWith({ skew: SKEW, throttled: true }));
+    expect(envelope.warning, 'the throttle warning still leads').toBeDefined();
+    expect(envelope.session?.throttled).toBe(true);
+    expect(envelope.skewSuspected, 'and the skew rides alongside it').toBeDefined();
+  });
+
+  it('still reports an unhealthy session when there is no skew', () => {
+    const envelope = healthEnvelope(sessionWith({ throttled: true }));
+    expect(envelope.session?.throttled).toBe(true);
+    expect(envelope.skewSuspected).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Addresses **ask 1** of #812.

## The gap, precisely

`takeVersionSkew()` is one-shot — it moves the pair from `pending` to `delivered` and never returns it again — and it surfaces on `reticle_sessions` / `reticle_lease`. So the skew banner appears once, on a listing, and the surface an agent reads on *every* call says nothing.

Meanwhile the reported behaviour is not "may behave in ways neither side reports". It is `dispatched: true`, `settled: true`, `domMutatedWithin: 12–40ms` on a control whose React state never changed — a result that is indistinguishable from success. Eight attempts, three interaction strategies, and the same sequence worked first try after converging the versions.

## The change

`healthEnvelope` now carries `skewSuspected` for as long as `session.versionSkew` is set.

That envelope is **already spliced onto every act and assert result**, so this needs no new plumbing path, and it follows the shape the codebase already uses for exactly this situation: `annotateStarvedFailure` appends a starvation note to a failed verdict on a throttled tab, because a known condition that makes a verdict untrustworthy belongs on the verdict. Skew is the same shape with a wider blast radius — it can falsify a *pass*, not just a fail.

## Two choices worth flagging

**Persistent, not one-shot.** One-shot is right for "an upgrade is available" and wrong here: the condition does not end when it has been mentioned once, and the call it was mentioned on is rarely the call whose verdict mattered. `test_rides_every_call_while_the_skew_holds` pins this.

**The wording says the result is not a verdict**, rather than hedging. A hedge is what the existing warning already said, and it did not stop the reporter trusting `dispatched: true`. The sentence names `dispatched`/`settled` specifically, because those are the fields that lied.

## What is unchanged

- A healthy, converged session still returns an **empty** envelope, so the ordinary path pays nothing and absence still means healthy.
- A throttled tab keeps its `warning` and its `session` block; skew rides alongside rather than displacing either.
- The one-shot `version_skew` nudge is untouched — it still does its job on the listing.

## Not addressed here

**Ask 2** (warn before stranding an already-connected older MCP client; a `--pin` that upgrades the daemon to the *connected* client's version). The issue itself says it belongs with #618, and it is a `restart`/`update` change rather than a verdict change — bundling them would make both harder to review.

## Verification

```
pnpm typecheck                                        # clean
pnpm lint                                             # clean
pnpm format                                           # clean
pnpm --filter @reticlehq/server exec vitest run       # 650 files, 6545 passed
```

Six new tests in `packages/server/src/session/skew-rides-the-verdict.test.ts`. No existing test changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)