### PR TITLE
fix(flows): a replay step retries once when its ref goes stale mid-step (#602)

### DIFF
--- a/packages/server/src/flows/flow-replay-stale-ref.test.ts
+++ b/packages/server/src/flows/flow-replay-stale-ref.test.ts
@@ -1,0 +1,177 @@
+/**
+ * A flow step whose predecessor re-rendered the page must not lose the replay (#602).
+ *
+ * The reported failure: a saved `fill` then `click` flow fails on replay with
+ * `ref 'eNNNN' no longer resolves to an element`, a DIFFERENT ref number on every attempt.
+ * `reticle_flow_heal` returns `unhealable`, and it is right to — the locator is correct, only the
+ * timing is wrong, so there is nothing to heal.
+ *
+ * Replay already re-resolves every anchor per step. The race is INSIDE one step: the fill triggers a
+ * search re-render between resolving the ref and dispatching against it. The retry therefore has to
+ * re-resolve, not merely re-send — dispatching the same stale ref twice would fail twice.
+ *
+ * `act_sequence` already solved this shape; the rule copied here is its rule exactly. Retry only for
+ * staleness, after the grace period the app already gets, so a genuinely gone element fails again
+ * immediately and no other failure ever re-runs an action.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  asRef,
+  ActionType,
+  AnchorKind,
+  DriftReason,
+  FLOW_FILE_VERSION,
+  ReticleCommand,
+  type CommandResult,
+  type ElementDescriptor,
+  type FlowFile,
+  type ReticleEvent,
+} from '@reticlehq/core';
+import { replayFlow, type FlowReplaySession } from './flow-replay.js';
+import { asString } from '../tools/tools-helpers.js';
+
+const STALE = "ref 'e1' no longer resolves to an element";
+
+function element(ref: string): ElementDescriptor {
+  return { ref: asRef(ref), role: 'button', name: 'Search', states: [], visible: true };
+}
+
+/**
+ * A page that re-renders once: the first resolve hands out `e1`, every later one hands out `e2`,
+ * and an ACT against `e1` after the re-render reports the daemon's stale-ref wording.
+ */
+class ReRenderingSession implements FlowReplaySession {
+  readonly acts: { ref: string; action: string }[] = [];
+  resolves = 0;
+  constructor(
+    /** Refs handed out in order; the last one repeats once exhausted. */
+    private readonly refs: readonly string[] = ['e1', 'e2'],
+    /** Refs the browser refuses as stale. */
+    private readonly staleRefs: ReadonlySet<string> = new Set(['e1']),
+  ) {}
+
+  command(name: string, args: Record<string, unknown> = {}): Promise<CommandResult> {
+    if (name === ReticleCommand.QUERY) {
+      const ref = this.refs[Math.min(this.resolves, this.refs.length - 1)];
+      this.resolves += 1;
+      return Promise.resolve({
+        kind: 'command_result',
+        id: 'q',
+        ok: true,
+        result: { elements: ref === undefined ? [] : [element(ref)] },
+      });
+    }
+    if (name === ReticleCommand.ACT) {
+      const ref = asString(args['ref']) ?? '';
+      this.acts.push({ ref, action: asString(args['action']) ?? '' });
+      const stale = this.staleRefs.has(ref);
+      return Promise.resolve({
+        kind: 'command_result',
+        id: 'a',
+        ok: !stale,
+        result: {},
+        ...(stale ? { error: STALE } : {}),
+      } as CommandResult);
+    }
+    return Promise.resolve({ kind: 'command_result', id: 'x', ok: true, result: {} });
+  }
+  eventsSince(): ReticleEvent[] {
+    return [];
+  }
+  onEvent(): () => void {
+    return () => undefined;
+  }
+  elapsed(): number {
+    return 0;
+  }
+}
+
+function flow(): FlowFile {
+  return {
+    version: FLOW_FILE_VERSION,
+    name: 'search',
+    steps: [
+      {
+        tool: 'reticle_act',
+        anchor: { kind: AnchorKind.TESTID, value: 'search-submit' },
+        action: ActionType.CLICK,
+      },
+    ],
+  } as unknown as FlowFile;
+}
+
+const noSleep = (): Promise<void> => Promise.resolve();
+
+async function replay(session: FlowReplaySession) {
+  return replayFlow(session, flow(), () => Promise.resolve({ pass: true }), 0, false, noSleep);
+}
+
+describe('a ref that went stale mid-step is retried against a fresh one', () => {
+  it('completes the step instead of failing the replay', async () => {
+    const session = new ReRenderingSession();
+    const [result] = await replay(session);
+    expect(result?.ok, 'the locator was right; only the timing was wrong').toBe(true);
+    expect(result?.drift, 'this is not drift — nothing to heal').toBeUndefined();
+  });
+
+  it('re-resolves before retrying, rather than re-sending the same dead ref', async () => {
+    // The property the fix rests on. Dispatching `e1` twice would fail twice, and a retry that
+    // only re-sends would look like it worked in a test that stubbed the second ACT to succeed.
+    const session = new ReRenderingSession();
+    await replay(session);
+    expect(session.acts.map((a) => a.ref)).toEqual(['e1', 'e2']);
+    expect(session.resolves, 'resolved once, then again for the retry').toBe(2);
+  });
+
+  it('does not retry an action that failed for any other reason', async () => {
+    // A tool that quietly re-runs actions turns one click into two, which is worse than the failure
+    // it was papering over.
+    class OtherFailure extends ReRenderingSession {
+      override command(name: string, args: Record<string, unknown> = {}): Promise<CommandResult> {
+        if (name === ReticleCommand.ACT) {
+          return Promise.resolve({
+            kind: 'command_result',
+            id: 'a',
+            ok: false,
+            error: 'element is disabled',
+          } as CommandResult);
+        }
+        return super.command(name, args);
+      }
+    }
+    const session = new OtherFailure();
+    const [result] = await replay(session);
+    expect(result?.ok).toBe(false);
+    expect(result?.error).toContain('disabled');
+  });
+
+  it('reports drift, not a stale ref, when the element is genuinely gone', async () => {
+    // The second resolve proves it. Reporting the stale-ref error here would send the reader after a
+    // re-render that did not happen.
+    // After the first resolve the page has nothing left to hand back.
+    const gone = new (class extends ReRenderingSession {
+      override command(name: string, args: Record<string, unknown> = {}): Promise<CommandResult> {
+        if (name === ReticleCommand.QUERY && this.resolves > 0) {
+          this.resolves += 1;
+          return Promise.resolve({
+            kind: 'command_result',
+            id: 'q',
+            ok: true,
+            result: { elements: [], hint: { presentTestids: ['search-input'] } },
+          });
+        }
+        return super.command(name, args);
+      }
+    })(['e1'], new Set(['e1']));
+    const [result] = await replay(gone);
+    expect(result?.ok).toBe(false);
+    expect(result?.drift?.reasonKind).toBe(DriftReason.TESTID_NOT_FOUND);
+  });
+
+  it('leaves a clean step at exactly one dispatch', async () => {
+    const session = new ReRenderingSession(['e2'], new Set());
+    const [result] = await replay(session);
+    expect(result?.ok).toBe(true);
+    expect(session.acts).toHaveLength(1);
+  });
+});

--- a/packages/server/src/flows/flow-replay.ts
+++ b/packages/server/src/flows/flow-replay.ts
@@ -29,6 +29,16 @@ import {
 } from './flow-step-runners.js';
 import { successToPredicate } from './flow-success.js';
 import { ReticleTool } from '../tools/tool-names.js';
+import { isStaleRefError } from '../tools/act-sequence-retry.js';
+import { waitForReaction } from '../tools/react-grace.js';
+
+/**
+ * How long a replay step waits for the render to finish before retrying a stale ref.
+ *
+ * `waitForReaction` clamps to its own 300ms grace, so this is a ceiling rather than a duration --
+ * the same shape `act_sequence` passes its per-step timeout in.
+ */
+const STALE_RETRY_BUDGET_MS = 1000;
 
 /**
  * The session surface flow-replay needs: QUERY to re-resolve a testid anchor against the live
@@ -385,6 +395,7 @@ async function runTestidStep(
   dynamic: ReadonlySet<string>,
   confirmDangerous: boolean,
   sleep: Sleep,
+  cursorBefore = 0,
 ): Promise<FlowStepResult> {
   const { refs, hint } = await resolveTestid(session, value, sleep);
   if (0 === refs.length) {
@@ -398,18 +409,51 @@ async function runTestidStep(
   }
   const ref = refs[0] ?? '';
   const note = refs.length > 1 ? ambiguousTestidNote(value) : undefined;
-  session.beginAction?.(ReticleTool.FLOW_REPLAY, { ref, action: step.action ?? '' });
-  let act;
-  try {
-    act = await session.command(ReticleCommand.ACT, {
-      ref,
-      action: step.action ?? '',
-      // `value` is the anchor's own name — the field this step types into — so a redacted fill can
-      // be supplied from RETICLE_SECRET_<FIELD> without the flow carrying the secret.
-      args: replayActionArgs(step.args, confirmDangerous, value),
-    });
-  } finally {
-    session.finishAction?.();
+  // One retry when the ref went stale between resolving it and dispatching against it.
+  //
+  // Replay already RE-RESOLVES every anchor per step, so the failure is not a drifted locator -- it
+  // is a race with the render inside a single step. `fill` triggers a search re-render, the ref
+  // resolved a moment earlier is invalidated, and the click reports `ref 'eNNNN' no longer resolves
+  // to an element` with a different number every attempt. `flow_heal` correctly returns
+  // `unhealable`: the locator is right, only the timing is wrong, and there is nothing to heal
+  // (#602).
+  //
+  // The attempt closure re-resolves the testid, so the retry dispatches against a FRESH ref rather
+  // than the stale one -- which is the whole point, and the difference from simply calling the same
+  // command twice. Everything else follows `act_sequence`'s rule exactly: retry only for staleness,
+  // after the grace period the app already gets, so a genuinely gone element fails again
+  // immediately and no other failure ever re-runs an action.
+  const dispatch = async (targetRef: string): Promise<CommandResult> => {
+    session.beginAction?.(ReticleTool.FLOW_REPLAY, { ref: targetRef, action: step.action ?? '' });
+    try {
+      return await session.command(ReticleCommand.ACT, {
+        ref: targetRef,
+        action: step.action ?? '',
+        // `value` is the anchor's own name — the field this step types into — so a redacted fill can
+        // be supplied from RETICLE_SECRET_<FIELD> without the flow carrying the secret.
+        args: replayActionArgs(step.args, confirmDangerous, value),
+      });
+    } finally {
+      session.finishAction?.();
+    }
+  };
+  let act = await dispatch(ref);
+  if (!act.ok && isStaleRefError(act.error)) {
+    await waitForReaction(session, cursorBefore, STALE_RETRY_BUDGET_MS, { sleep });
+    const fresh = await resolveTestid(session, value, sleep);
+    const freshRef = fresh.refs[0];
+    // Nothing to retry against: the element really is gone, so report the drift the second resolve
+    // proves rather than the stale-ref error, which would send the reader after a re-render.
+    if (freshRef === undefined) {
+      return {
+        step: index,
+        tool: step.tool,
+        anchor: value,
+        ok: false,
+        drift: testidDrift(value, fresh.hint),
+      };
+    }
+    act = await dispatch(freshRef);
   }
   const result: FlowStepResult = { step: index, tool: step.tool, anchor: value, ok: act.ok };
   if (!act.ok) {
@@ -600,7 +644,16 @@ export async function replayFlow(
           // and keeps its old path, where it fails legibly rather than querying a role as a testid.
           return runRoleStep(session, step, index, step.anchor, confirmDangerous, sleep);
         }
-        return runTestidStep(session, step, index, label, dynamic, confirmDangerous, sleep);
+        return runTestidStep(
+          session,
+          step,
+          index,
+          label,
+          dynamic,
+          confirmDangerous,
+          sleep,
+          cursorBefore,
+        );
       },
     );
     // Once the anchor resolved and the action ran, the step's own expect is evaluated — signal, net,


### PR DESCRIPTION
Closes #602.

## Where the race actually is

Replay **already** re-resolves every anchor per step — `runTestidStep` calls `resolveTestid` immediately before acting. So this is not a drifted locator, which is why `flow_heal` correctly returns `unhealable`: the locator is right, only the timing is wrong, and there is nothing to heal.

The race is *inside one step*: the `fill` triggers a search re-render between resolving the ref and dispatching against it. Hence a different `eNNNN` on every attempt.

## Which of the three fixes, and why

The issue offers three. I took **(3), re-resolve and retry once on a stale ref**, for the reason the issue itself gives: it is the smallest and it covers the general case rather than the fill-then-click shape. Any step whose predecessor caused a re-render has this problem, and (1) — a `wait_for` step kind — would require every affected user to know to insert one.

**The retry re-resolves, it does not re-send.** Dispatching the same dead ref twice would fail twice, so the second resolve *is* the mechanism. `test_re_resolves_before_retrying_rather_than_re_sending_the_same_dead_ref` asserts the dispatched refs are `['e1', 'e2']` and that resolution happened twice, so a fix that only re-sent would fail that test rather than pass by accident.

## Reusing the rule that already exists

`act_sequence` solved this exact shape, and `act-sequence-retry.ts` states the rule with its reasoning. Nothing new is invented here:

- retry **only** for staleness (`isStaleRefError`, keyed off the daemon's own wording);
- after the grace period `waitForReaction` already gives the app;
- so a genuinely gone element fails again immediately, and a step that failed for any other reason is never retried.

That last constraint matters: *"a tool that quietly re-runs actions would turn one click into two, which is worse than the failure it was papering over."* There is a test for it (`element is disabled` is not retried).

## One case that earns its own branch

When the second resolve finds **nothing**, the step reports `TESTID_NOT_FOUND` drift rather than the stale-ref error. The element really is gone, and reporting staleness there would send the reader after a re-render that did not happen — the same "whose fault is it" contract the rest of replay keeps.

## Verification

```
pnpm typecheck                                      # clean
pnpm lint                                           # clean
pnpm format                                         # clean
pnpm --filter @reticlehq/server exec vitest run     # 650 files, 6544 passed
```

Five new tests in `packages/server/src/flows/flow-replay-stale-ref.test.ts`, including one pinning that a clean step still dispatches exactly once. No existing test changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)