### PR TITLE
fix(setup): never create Cursor's permissions.json, which pins its run mode

### DIFF
--- a/packages/server/src/setup/approval-migration.ts
+++ b/packages/server/src/setup/approval-migration.ts
@@ -71,7 +71,7 @@ export function migrateApprovals(deps: MigrationDeps): MigrationResult {
 
   let results: ApprovalResult[] = [];
   try {
-    results = grantAutoApproval(io, { home, platform }, undefined, { onlyIfNoSupersede: true });
+    results = grantAutoApproval(io, { home, platform });
   } catch {
     return NOTHING;
   }

--- a/packages/server/src/setup/auto-approve.test.ts
+++ b/packages/server/src/setup/auto-approve.test.ts
@@ -68,25 +68,21 @@ describe('pre-approving Reticle', () => {
     expect(second[0]?.outcome).toBe(ApprovalOutcome.ALREADY);
   });
 
-  it('uses Cursor’s own allowlist spelling', () => {
+  it('never creates Cursor’s permissions file, which would pin the run mode to Allowlist', () => {
     const io = fakeIo({ '/home/u/.cursor': '' });
-    grantAutoApproval(io, WHERE, [grantById('cursor')]);
-    expect(written(io, '/home/u/.cursor/permissions.json')).toEqual({
-      mcpAllowlist: ['reticle:*'],
-    });
+    const result = grantAutoApproval(io, WHERE, [grantById('cursor')])[0];
+    expect(result?.outcome).toBe(ApprovalOutcome.DEFERRED);
+    expect(io.files['/home/u/.cursor/permissions.json']).toBeUndefined();
+    expect(result?.warn).toContain('Approvals & Execution');
   });
 
-  it('warns that a new Cursor permissions file supersedes what was approved in the app', () => {
-    const io = fakeIo({ '/home/u/.cursor': '' });
-    expect(grantAutoApproval(io, WHERE, [grantById('cursor')])[0]?.warn).toContain('ask again');
-  });
-
-  it('does not repeat that warning once the file is the user’s own', () => {
+  it('uses Cursor’s own allowlist spelling in a file the user already has', () => {
     const io = fakeIo({
       '/home/u/.cursor': '',
       '/home/u/.cursor/permissions.json': JSON.stringify({ mcpAllowlist: ['github:*'] }),
     });
     const result = grantAutoApproval(io, WHERE, [grantById('cursor')])[0];
+    expect(result?.outcome).toBe(ApprovalOutcome.GRANTED);
     expect(result?.warn).toBeUndefined();
     expect(written(io, '/home/u/.cursor/permissions.json')['mcpAllowlist']).toEqual([
       'github:*',
@@ -130,16 +126,16 @@ describe('pre-approving Reticle', () => {
   });
 
   it('reports an unwritable config instead of failing the other agents', () => {
-    const io = fakeIo({ '/home/u/.claude': '', '/home/u/.cursor': '' });
+    const io = fakeIo({ '/home/u/.claude': '', '/home/u/.gemini': '' });
     const broken: AgentWriterIo = {
       ...io,
       writeFile: (p, c) => {
-        if (p.includes('.cursor')) throw new Error('EACCES');
+        if (p.includes('.gemini')) throw new Error('EACCES');
         io.writeFile(p, c);
       },
     };
     const results = grantAutoApproval(broken, WHERE, [
-      grantById('cursor'),
+      grantById('gemini-cli'),
       grantById('claude-code'),
     ]);
     expect(results[0]?.outcome).toBe(ApprovalOutcome.FAILED);

--- a/packages/server/src/setup/auto-approve.ts
+++ b/packages/server/src/setup/auto-approve.ts
@@ -13,9 +13,12 @@
  *    defensible; the same edit made globally would hand the same pass to every other MCP server
  *    they ever install, including ones that reach the network. Their approval gate is not ours to
  *    dismantle, only ours to step out of.
- * 2. Nothing is written for an agent that is not installed. An absent agent has no Accept button to
- *    remove, and the file would be litter — Cursor's especially, since that one TAKES OVER from an
- *    allowlist we cannot read.
+ * 2. Nothing is CREATED where the file itself takes over settings we cannot read — Cursor's
+ *    permissions.json supersedes its in-app allowlist and pins the run mode to Allowlist, so a user
+ *    who ran everything without asking loses that and cannot switch back while the file exists.
+ *    Merging into one they already have is fine; making one is not, so that case is DEFERRED with
+ *    the in-app step to take instead. Nothing is written at all for an agent that is not installed:
+ *    an absent agent has no Accept button to remove.
  *
  * Codex is absent by design: its approval policy is global (`approval_policy`), so there is no
  * reticle-shaped rule to write, and its config is TOML, which this repo never rewrites. Its
@@ -41,8 +44,8 @@ export interface ApprovalGrant {
   /** Adds our rule to a parsed config, leaving everything else exactly as it was. */
   readonly grant: (current: Record<string, unknown>) => Record<string, unknown>;
   /**
-   * True where creating this file supersedes an in-app allowlist we cannot read, so the user has to
-   * be told rather than have their other servers quietly start prompting again.
+   * True where CREATING this file supersedes in-app settings we can neither read nor restore. Such
+   * a grant is only ever merged into a file the user already owns, never created.
    */
   readonly supersedesInApp?: boolean;
 }
@@ -84,8 +87,11 @@ export const APPROVAL_GRANTS: readonly ApprovalGrant[] = [
     markers: [home('.cursor')],
     rule: 'mcpAllowlist += "reticle:*"',
     // Documented: "when a key appears in permissions.json, it fully replaces the in-app allowlist
-    // for that type". Merging keeps everything already in the FILE; it cannot restore what was only
-    // ever clicked in the UI, so the user is told.
+    // for that type" — and in practice it costs more than that. A non-empty mcpAllowlist also locks
+    // the run mode to Allowlist, so a user who had Run Everything ("YOLO") on loses it and cannot
+    // turn it back on while the file exists; Cursor has acknowledged that as their bug. Merging into
+    // a file the user already made is safe — they are already in Allowlist mode. Creating one is
+    // not, so we never do: see the DEFERRED branch below.
     supersedesInApp: true,
     grant: (c) => addToList(c, null, 'mcpAllowlist', `${RETICLE_KEY}:*`),
   },
@@ -151,19 +157,6 @@ interface ApprovalWhere {
   readonly platform: keyof PlatformPaths;
 }
 
-interface ApprovalOptions {
-  /**
-   * Refuse any grant that would CREATE a file superseding an allowlist we cannot read.
-   *
-   * Set on the unattended path. Writing Cursor's permissions.json for the first time takes over
-   * from what the user approved inside the app, which is a fair trade when they just ran a command
-   * and can read the line saying so, and not a fair trade at all when a version bump did it behind
-   * them: their OTHER MCP servers would start prompting again and nothing would connect that to us.
-   * Merging into a file they already own stays safe either way.
-   */
-  readonly onlyIfNoSupersede?: boolean;
-}
-
 /**
  * Pre-approve Reticle's tools everywhere the machine has an agent that would otherwise ask.
  *
@@ -174,7 +167,6 @@ export function grantAutoApproval(
   io: AgentWriterIo,
   where: ApprovalWhere,
   grants: readonly ApprovalGrant[] = APPROVAL_GRANTS,
-  options: ApprovalOptions = {},
 ): ApprovalResult[] {
   const join = joinFor(where.platform);
   return grants.map((grant): ApprovalResult => {
@@ -184,11 +176,11 @@ export function grantAutoApproval(
     if (!installed) return { ...base, outcome: ApprovalOutcome.ABSENT };
     try {
       const existed = io.exists(file);
-      if (true === options.onlyIfNoSupersede && true === grant.supersedesInApp && !existed) {
+      if (true === grant.supersedesInApp && !existed) {
         return {
           ...base,
           outcome: ApprovalOutcome.DEFERRED,
-          warn: `creating ${file} would supersede what you approved inside ${grant.name}, which is not something to do unannounced. Run: npx @reticlehq/server init --files-only`,
+          warn: `left ${grant.name}'s approvals alone — creating ${file} would take over its in-app settings and pin the run mode to Allowlist. If ${grant.name} asks before every reticle tool call, add \`${RETICLE_KEY}:*\` under Settings → Agents → Approvals & Execution (nothing to do if you run everything already).`,
         };
       }
       // A settings file we cannot parse is left exactly as it is. Reformatting somebody's config to
@@ -200,11 +192,7 @@ export function grantAutoApproval(
       if (next === current) return { ...base, outcome: ApprovalOutcome.ALREADY };
       io.mkdirp(file.slice(0, Math.max(0, file.lastIndexOf('/'))));
       io.writeFile(file, `${JSON.stringify(next, null, INDENT)}\n`);
-      const warn =
-        true === grant.supersedesInApp && !existed
-          ? `${file} now governs which MCP tools run without asking; anything you had approved inside ${grant.name} itself will ask again until it is listed here too`
-          : undefined;
-      return { ...base, outcome: ApprovalOutcome.GRANTED, ...(undefined === warn ? {} : { warn }) };
+      return { ...base, outcome: ApprovalOutcome.GRANTED };
     } catch (err) {
       return {
         ...base,


### PR DESCRIPTION
Creating `~/.cursor/permissions.json` to pre-approve the reticle tools cost the user more than it bought them. A non-empty `mcpAllowlist` in that file locks Cursor's run mode to Allowlist: a user who had Run Everything on loses it and cannot switch back while the file exists, so every OTHER command starts asking again and the toggle in the IDE does nothing. Cursor has [acknowledged that as their bug](https://forum.cursor.com/t/permissions-json-allowlists-disable-auto-review-with-sandbox-contradicts-docs/165722/7); their [own docs](https://cursor.com/docs/reference/permissions) say the keys are independent.

There is nothing to detect our way out of — the run mode lives in the IDE's internal state, not in a file we can read — and toggling it on ourselves is the global auto-run switch this module exists to refuse.

So the grant is now merge-only. Merging into a file the user already made is safe, since owning one means they are already in Allowlist mode; creating one is not, so that case is `DEFERRED` and prints the in-app step to take instead (Settings → Agents → Approvals & Execution), which is also Cursor's own recommended workaround and a no-op for anyone running everything already. The unattended migration path had this rule already, behind an option; the option is gone because the rule is now unconditional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)