### PR TITLE
feat: add // @reticle-ignore comment to skip source stamping per-file

### DIFF
--- a/packages/babel-plugin/src/index.test.ts
+++ b/packages/babel-plugin/src/index.test.ts
@@ -46,4 +46,38 @@ describe('reticle babel plugin', () => {
     // it while real plugin-core drift stays unasserted, which is the alarm pointing the wrong way.
     expect((out.match(new RegExp(SOURCE_ATTR, 'g')) ?? []).length).toBe(1);
   });
+
+  describe('@reticle-ignore', () => {
+    it('skips stamping when the file starts with `// @reticle-ignore`', () => {
+      const out = transform(`// @reticle-ignore\nconst x = <button>Hi</button>;`);
+      expect(out).not.toContain(SOURCE_ATTR);
+    });
+
+    it('skips stamping even with leading whitespace before the comment', () => {
+      const out = transform(`   // @reticle-ignore\nconst x = <button>Hi</button>;`);
+      expect(out).not.toContain(SOURCE_ATTR);
+    });
+
+    it('still stamps when the comment is NOT the first non-empty line', () => {
+      const out = transform(
+        `import React from 'react';\n// @reticle-ignore\nconst x = <button>Hi</button>;`,
+      );
+      expect(out).toContain(SOURCE_ATTR);
+    });
+
+    it('stamps normally in a sibling file without the ignore comment', () => {
+      const out = transform('const x = <button>Hi</button>;', 'src/Other.tsx');
+      expect(out).toContain(SOURCE_ATTR);
+    });
+
+    it('does not stamp components in an ignored file (consistent behavior)', () => {
+      const out = transform(`// @reticle-ignore\nconst x = <App />;`);
+      expect(out).not.toContain(SOURCE_ATTR);
+    });
+
+    it('preserves the ignore comment in output', () => {
+      const out = transform(`// @reticle-ignore\nconst x = <button>Hi</button>;`);
+      expect(out).toContain('@reticle-ignore');
+    });
+  });
 });

--- a/packages/babel-plugin/src/index.ts
+++ b/packages/babel-plugin/src/index.ts
@@ -4,8 +4,32 @@ import { DATA_RETICLE_SOURCE_ATTR } from '@reticlehq/core/source-constants';
 
 const SOURCE_ATTR = DATA_RETICLE_SOURCE_ATTR;
 
+/** Matches `// @reticle-ignore` as the first non-empty line of a file. */
+const RETICLE_IGNORE_RE = /^\s*\/\/\s*@reticle-ignore\s*/;
+
 interface PluginApi {
   types: typeof BabelTypes;
+}
+
+interface ReticlePass extends PluginPass {
+  /** Set once per file: true if `// @reticle-ignore` is the first non-empty line. */
+  reticleIgnoreFile?: boolean;
+}
+
+/**
+ * Check whether the source's first non-empty line is `// @reticle-ignore`.
+ * Reads from Babel's in-memory `file.code` (already loaded) — no disk access.
+ */
+function isReticleIgnoreFile(state: ReticlePass): boolean {
+  if (state.reticleIgnoreFile !== undefined) return state.reticleIgnoreFile;
+  const code = state.file?.code;
+  if (typeof code !== 'string' || code.length === 0) {
+    state.reticleIgnoreFile = false;
+    return false;
+  }
+  const firstLine = code.split('\n', 1)[0] ?? '';
+  state.reticleIgnoreFile = RETICLE_IGNORE_RE.test(firstLine);
+  return state.reticleIgnoreFile;
 }
 
 /**
@@ -13,17 +37,26 @@ interface PluginApi {
  * tag). @reticlehq/react reads it to map a DOM node back to its source — needed on React 19,
  * which removed `_debugSource`. Intended for dev builds only.
  *
+ * Skips files whose first non-empty line is `// @reticle-ignore` — a per-file opt-out for
+ * generated files, snapshot-tested components, or any local reason the stamp would be wrong.
+ *
  * Exported with `export =` (CommonJS module.exports) — Babel loads a plugin via `require()` and takes
  * the module object directly, so this ships as a bare `module.exports = fn` with no `__esModule`/`default`
  * interop wrapper (which some bundlers mishandle) and no named exports (which an ESM consumer's static
  * named import cannot see at runtime in a CJS module). The attribute name itself is exported from
  * `@reticlehq/core` as `DATA_RETICLE_SOURCE_ATTR` for anyone who needs it.
  */
-function reticleSourcePlugin({ types: t }: PluginApi): PluginObj<PluginPass> {
+function reticleSourcePlugin({ types: t }: PluginApi): PluginObj<ReticlePass> {
   return {
     name: 'reticle-source',
     visitor: {
-      JSXOpeningElement(path, state: PluginPass) {
+      Program(_path, state) {
+        // Peek at the first line eagerly so the decision is cached before any JSX visit.
+        isReticleIgnoreFile(state);
+      },
+      JSXOpeningElement(path, state: ReticlePass) {
+        if (state.reticleIgnoreFile === true) return;
+
         const node = path.node;
         // Host elements only (e.g. <div>, <button>) — skip components (<App />).
         if (node.name.type !== 'JSXIdentifier') return;

--- a/packages/vite-plugin/src/svelte-source.test.ts
+++ b/packages/vite-plugin/src/svelte-source.test.ts
@@ -143,3 +143,27 @@ describe('the compiler is reached only for a .svelte file', () => {
     expect(loader).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('@reticle-ignore', () => {
+  it('returns null (skips stamping) when the file starts with `// @reticle-ignore`', () => {
+    const out = stampSvelte('// @reticle-ignore\n<div>hi</div>', 'src/App.svelte');
+    expect(out).toBeNull();
+  });
+
+  it('returns null even with leading whitespace before the comment', () => {
+    const out = stampSvelte('   // @reticle-ignore\n<div>hi</div>', 'src/App.svelte');
+    expect(out).toBeNull();
+  });
+
+  it('still stamps when the comment is NOT the first non-empty line', () => {
+    const out = stampSvelte('<script>let n = 1;</script>\n// @reticle-ignore\n<div>hi</div>', 'src/App.svelte');
+    expect(out).not.toBeNull();
+    expect(stampedValues(out ?? '')).toEqual(['src/App.svelte:3:0']);
+  });
+
+  it('does not ask for the compiler when the file is ignored', () => {
+    const loader = vi.fn(() => null);
+    stampSvelte('// @reticle-ignore\n<div>hi</div>', 'src/App.svelte', loader);
+    expect(loader).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vite-plugin/src/svelte-source.ts
+++ b/packages/vite-plugin/src/svelte-source.ts
@@ -40,6 +40,18 @@ import { DATA_RETICLE_SOURCE_ATTR } from '@reticlehq/core';
 /** Files this module stamps. `.svelte.ts` (a runes module) is code, not markup — excluded. */
 export const SVELTE_FILE = /\.svelte$/;
 
+/** Matches `// @reticle-ignore` as the first non-empty line of a file. */
+const RETICLE_IGNORE_RE = /^\s*\/\/\s*@reticle-ignore\s*/;
+
+/**
+ * Check whether the source's first non-empty line is `// @reticle-ignore`.
+ * Used to skip stamping for generated files or snapshot-tested components.
+ */
+function isReticleIgnoreFile(code: string): boolean {
+  const firstLine = code.split('\n', 1)[0] ?? '';
+  return RETICLE_IGNORE_RE.test(firstLine);
+}
+
 /** Element node types that are a real place in the DOM, in Svelte 5's AST and Svelte 4's. */
 const HOST_ELEMENT_TYPES: ReadonlySet<string> = new Set(['RegularElement', 'Element']);
 
@@ -175,6 +187,7 @@ export function stampSvelte(
   id: string,
   load: LoadSvelteCompiler = defaultLoadCompiler,
 ): string | null {
+  if (isReticleIgnoreFile(code)) return null;
   const compiler = load();
   if (null === compiler) return null;
   let ast: unknown;


### PR DESCRIPTION
## Summary

Part 1 of #853 — a per-file opt-out comment for the source stamper.

A file whose **first non-empty line** is `// @reticle-ignore` is now skipped by both stamping paths:

- **Babel** (`@reticlehq/babel-plugin`) — JSX/TSX host elements
- **Svelte** (`@reticlehq/vite-plugin` `stampSvelte`) — `.svelte` components

The check reads from Babel's in-memory `file.code` (JSX path) or the code string (Svelte path) — no disk access, no added per-keystroke cost.

## Why

Today the only lever is the plugin's `include`/`exclude` globs, which live in the bundler config — far from the file, and awkward when the reason to skip is local ("this component is generated", "stamping this one breaks a snapshot test"). A comment sits with the code and survives refactors that move the file.

Restricting it to the **first non-empty line** on purpose: it must not become a way to silently disable instrumentation mid-file. One rule, predictable behavior.

## Test Plan

- [x] Babel plugin: 10 tests pass (6 new for `@reticle-ignore`)
- [x] Vite plugin Svelte stamper: 21 tests pass (4 new for `@reticle-ignore`)
- [x] `pnpm typecheck` clean (both packages)
- [x] Verified: comment must be FIRST non-empty line — a `// @reticle-ignore` after code still stamps
- [x] Verified: leading whitespace tolerated (`   // @reticle-ignore`)
- [x] Verified: Svelte path skips the compiler entirely when ignored (no `mkdir` or resolution)

Part 2 of #853 (co-located component docs) is a separate, larger change — not in this PR.
