### PR TITLE
feat(server): reticle_navigate takes a timeout_ms and says what the wait ended on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
+### Added
+
+- **`@reticlehq/server` — `reticle_navigate` takes a `timeout_ms`, and an unconfirmed result says what the wait ended on.** The arrival window was a fixed, unstated 5s: `navigate-arrival.ts` hard-coded it and the tool exposed nothing, so unlike `assert` / `wait_for` / `act_and_wait`, which all spend the caller's budget, nobody could tell navigate to wait longer. A Nuxt SPA reattaching under HMR was measured at 30–60s, so every navigation to it gave up while the app was still coming back and answered `confirmed: false`, which reads as a failed navigation rather than as Reticle having stopped waiting; the only escape was the blind `reticle_sessions` poll that `#612` removed everywhere else. `timeout_ms` now reaches the wait (default 5000, so nothing gets slower by accident; `0` looks once; the same bounds as the other tools), and applies to `{ reload: true }` too, since the page coming back is the same wait. `confirmed: false` carries `waitedMs`, the budget that expired, and its note names `timeout_ms` as the way to wait longer. Closes [#856](https://github.com/reticlehq/reticle/issues/856).
+
 ### Changed
 
 - **`@reticlehq/server` — a `ROUTE_CHANGE` is read through one helper (`routeOfEvent`).** Six call sites (and the journey consequence line) each picked `pathname` / `to` / `hash` out of the event by hand, so a seventh hash-router miss was a field choice away: the document pathname is `/` on every HashRouter page, the default for a packaged Electron/Tauri renderer. The helper returns both the router path and the navigable `docPath + hash`; call sites pick, they do not re-index. Closes [#727](https://github.com/reticlehq/reticle/issues/727).

--- a/docs/tools-navigate.mdx
+++ b/docs/tools-navigate.mdx
@@ -17,13 +17,14 @@ Real response, with the throttled-tab `session` and `warning` fields trimmed off
   "ok": true,
   "url": "http://localhost:4310/deployments",
   "confirmed": false,
-  "note": "ok means the navigation was DISPATCHED, not that the page arrived. The SDK is torn down by the navigation itself, so nothing here can see the new document. Call reticle_sessions to confirm a session reconnected at the new URL before acting; if none appears, the page did not load or is not instrumented."
+  "waitedMs": 5000,
+  "note": "ok means the navigation was DISPATCHED, not that the page arrived. The SDK is torn down by the navigation itself, so nothing here can see the new document, and no session reconnected at the new URL within 5000ms. A slow app may still be on its way (an SPA reattaching under HMR can take 30-60s): navigate again with a larger timeout_ms, or call reticle_sessions to confirm a session reconnected before acting; if none appears, the page did not load or is not instrumented."
 }
 ```
 
 ## `confirmed: true` when the page comes back in time
 
-The daemon waits briefly for the SDK to re-announce itself. When it does, you are told so and can act immediately without a `reticle_sessions` round trip. This is a real reload response:
+The daemon waits up to `timeout_ms` (default 5000) for the SDK to re-announce itself. When it does, you are told so and can act immediately without a `reticle_sessions` round trip. This is a real reload response:
 
 ```json
 {
@@ -40,6 +41,12 @@ Read the second sentence, which is the one that costs people a turn. `confirmed:
 A full navigation destroys the document the SDK was living in. Reticle cannot report on the new page from inside the old one, because the old one no longer exists. So it tells you what it actually knows: the navigation was dispatched.
 
 Most tools would return `ok: true` and let you assume arrival. When the page then fails to load, or loads without instrumentation, you get a confusing cascade of "element not found" errors several calls later, with nothing pointing at the real cause.
+
+`waitedMs` says which of two things you are looking at. Reticle stopped waiting at the budget it had, or the page never came back. The first is fixed by asking for more: a single-page app reattaching under HMR has been measured at 30–60s, which no default should wait for on every call, but which the caller who knows the app can grant.
+
+```json
+{ "url": "/deployments", "timeout_ms": 45000 }
+```
 
 ## The pattern after navigating
 
@@ -64,11 +71,12 @@ with [`reticle_sessions`](/tools-sessions), and only then snapshot. If no sessio
 
 ## Arguments
 
-| Argument | What it does                          |
-| -------- | ------------------------------------- |
-| `url`    | Where to go. Relative paths work      |
+| Argument | What it does |
+| --- | --- |
+| `url` | Where to go. Relative paths work |
 | `reload` | Reload in place instead of navigating |
-| `hard`   | With `reload`, bypass the cache       |
+| `hard` | With `reload`, bypass the cache |
+| `timeout_ms` | How long to wait for the page to come back before `confirmed: false`. Default 5000; 0 looks once |
 
 ## Client-side routing is different
 

--- a/packages/server/src/tools/browser-tools.ts
+++ b/packages/server/src/tools/browser-tools.ts
@@ -1,13 +1,14 @@
 import { carryReticleIdentity } from './lease-tools.js';
 import { z } from 'zod';
 import { navigateResult } from './navigate-result.js';
-import { awaitArrival } from './navigate-arrival.js';
+import { awaitArrival, ARRIVAL_TIMEOUT_MS } from './navigate-arrival.js';
 import { reloadResult } from './reload-result.js';
 import { waitForReconnect, RELOAD_RECONNECT_TIMEOUT_MS } from '../session/session-reconnect.js';
 import { ReticleCommand } from '@reticlehq/core';
 import { ReticleTool } from './tool-names.js';
-import { asString } from './tools-helpers.js';
+import { asNumber, asString } from './tools-helpers.js';
 import { sessionIdShape, commandOrThrow } from './tool-kit.js';
+import { timeoutMsSchema } from './numeric-bounds.js';
 import type { ToolDef } from './tools.js';
 
 export const BROWSER_TOOLS: ToolDef[] = [
@@ -15,7 +16,7 @@ export const BROWSER_TOOLS: ToolDef[] = [
     name: ReticleTool.NAVIGATE,
     example: { url: '/settings' },
     description:
-      'Navigate the connected browser tab to a URL, or reload it in place with { reload: true } (add { hard: true } to bypass the cache). `ok` means the navigation was DISPATCHED — the SDK is torn down by the navigation, so the page itself cannot report on it. The daemon then waits briefly for the SDK to reconnect: `confirmed:true` with a new `sessionId` means the page arrived and you can act immediately. `confirmed:false` means it did not arrive within the window — the page may be slow, uninstrumented, or not there; check reticle_sessions before acting.',
+      'Navigate the connected browser tab to a URL, or reload it in place with { reload: true } (add { hard: true } to bypass the cache). `ok` means the navigation was DISPATCHED — the SDK is torn down by the navigation, so the page itself cannot report on it. The daemon then waits up to `timeout_ms` (default 5000) for the SDK to reconnect: `confirmed:true` with a new `sessionId` means the page arrived and you can act immediately. `confirmed:false` means it did not arrive within that window (reported as `waitedMs`) — the page may be slow, uninstrumented, or not there. A slow SPA can take 30-60s to reattach: raise `timeout_ms` rather than polling reticle_sessions.',
     inputSchema: {
       url: z.string().optional().describe('The URL to navigate to. Omit when using reload.'),
       reload: z
@@ -28,6 +29,11 @@ export const BROWSER_TOOLS: ToolDef[] = [
         .boolean()
         .optional()
         .describe('With reload:true, bypass the browser cache (Cmd+Shift+R). Default: false.'),
+      timeout_ms: timeoutMsSchema
+        .optional()
+        .describe(
+          'How long to wait for the page to come back (the SDK reconnecting at the new URL, or under the same id on a reload) before answering confirmed:false. Default 5000. 0 looks once without waiting. An SPA reattaching under HMR has been measured at 30-60s — say so here instead of polling reticle_sessions.',
+        ),
       ...sessionIdShape,
     },
     outputSchema: {
@@ -39,11 +45,19 @@ export const BROWSER_TOOLS: ToolDef[] = [
       confirmed: z.boolean().optional(),
       /** The session the SDK reconnected as, when arrival was confirmed — it is a NEW id. */
       sessionId: z.string().optional(),
+      /**
+       * On confirmed:false — the budget (ms) that expired without the page coming back. Says which
+       * of "Reticle stopped waiting" and "the page never came back" you are looking at.
+       */
+      waitedMs: z.number().optional(),
       note: z.string().optional(),
     },
     handler: async (deps, args) => {
       // reload:true is the absorbed reticle_refresh — same command, one fewer advertised tool.
       if (true === args['reload']) {
+        // The reload branch has its own default, sized for a cold dev-server rebuild; the caller's
+        // budget overrides it for the same reason it overrides the arrival wait below.
+        const timeoutMs = asNumber(args['timeout_ms']) ?? RELOAD_RECONNECT_TIMEOUT_MS;
         const before = deps.sessions.resolve(asString(args['sessionId']));
         // The verdict floor moves HERE, before the page goes away. A reload destroys the document,
         // so every request that failed under the old one belongs to a page that no longer exists —
@@ -61,14 +75,14 @@ export const BROWSER_TOOLS: ToolDef[] = [
         const back = await waitForReconnect({
           current: () => deps.sessions.get(before.id),
           previous: before,
-          timeoutMs: RELOAD_RECONNECT_TIMEOUT_MS,
+          timeoutMs,
           now: deps.now,
           sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
         });
         // Not a bare `{ ok: true }`. The URL branch below already discloses that `ok` means
         // DISPATCHED — the reload branch had identical semantics and said nothing, on the path most
         // likely to need it. See reload-result.
-        return reloadResult(back);
+        return reloadResult(back, timeoutMs);
       }
       const requested = asString(args['url']);
       if (requested === undefined || 0 === requested.length)
@@ -93,9 +107,12 @@ export const BROWSER_TOOLS: ToolDef[] = [
         )) as { ok?: unknown; url?: unknown; reason?: unknown };
         // `ok` is the browser accepting the instruction, not the page arriving — see navigate-result.
         // The daemon is the only party that CAN see arrival (the SDK reconnects to it), so it looks,
-        // briefly, instead of telling the agent to go poll reticle_sessions itself.
-        const arrival = true === result.ok ? await awaitArrival(deps.sessions, url) : null;
-        return navigateResult(result, arrival);
+        // for as long as the caller said to, instead of telling the agent to go poll
+        // reticle_sessions itself. A refusal skips the wait: there is nothing to wait FOR.
+        const timeoutMs = asNumber(args['timeout_ms']) ?? ARRIVAL_TIMEOUT_MS;
+        const arrival =
+          true === result.ok ? await awaitArrival(deps.sessions, url, timeoutMs) : null;
+        return navigateResult(result, arrival, timeoutMs);
       } finally {
         session.finishAction();
       }

--- a/packages/server/src/tools/navigate-arrival.ts
+++ b/packages/server/src/tools/navigate-arrival.ts
@@ -10,13 +10,22 @@
  * Bounded and best-effort by construction: a navigation to a page that is not instrumented, or not
  * there at all, must still return promptly with `confirmed:false` rather than hanging. The clock and
  * the sleep are injected so this is testable without waiting on a real one.
+ *
+ * The bound is the CALLER'S to set. It was a fixed 5s that `reticle_navigate` did not expose, and a
+ * Nuxt SPA reattaching under HMR was measured coming back in 30–60s — so every navigation to it
+ * answered `confirmed:false` while the app was still on its way, and nothing the agent could pass
+ * would make the daemon wait. `assert` / `wait_for` / `act_and_wait` all spend the caller's
+ * `timeout_ms` (resolve-within.ts); this is the same budget applied to the same wait.
  */
 
 import type { SessionManager } from '../session/session-manager.js';
 import type { NavigateArrival } from './navigate-result.js';
 
-/** Long enough for a dev server to serve a page and the SDK to dial back; short enough to not hang. */
-const ARRIVAL_TIMEOUT_MS = 5_000;
+/**
+ * The default when the caller gives no `timeout_ms`: long enough for a dev server to serve a page
+ * and the SDK to dial back; short enough to not hang. A caller who knows the app is slower says so.
+ */
+export const ARRIVAL_TIMEOUT_MS = 5_000;
 const POLL_MS = 100;
 
 /**

--- a/packages/server/src/tools/navigate-honesty.test.ts
+++ b/packages/server/src/tools/navigate-honesty.test.ts
@@ -25,16 +25,20 @@ import { navigateResult } from './navigate-result.js';
 import { TOOLS } from './tools.js';
 import { ReticleTool } from './tool-names.js';
 
+const WAITED = 5_000;
+
 describe('navigateResult', () => {
   it('keeps ok for existing callers', () => {
-    expect(navigateResult({ ok: true, url: 'http://localhost:3000/x' })).toMatchObject({
+    expect(
+      navigateResult({ ok: true, url: 'http://localhost:3000/x' }, null, WAITED),
+    ).toMatchObject({
       ok: true,
       url: 'http://localhost:3000/x',
     });
   });
 
   it('says arrival is UNCONFIRMED, because the SDK cannot survive the navigation to report it', () => {
-    const out = navigateResult({ ok: true, url: 'http://x/y' });
+    const out = navigateResult({ ok: true, url: 'http://x/y' }, null, WAITED);
     expect(out['confirmed']).toBe(false);
     expect(String(out['note'])).toMatch(/dispatch/i);
     // And names the way to actually check.
@@ -43,14 +47,50 @@ describe('navigateResult', () => {
 
   it('does not claim dispatch when the browser refused outright', () => {
     // A refusal IS conclusive — the page never moved, so there is nothing unconfirmed about it.
-    const out = navigateResult({ ok: false, reason: 'only http(s) navigation is allowed' });
+    const out = navigateResult(
+      { ok: false, reason: 'only http(s) navigation is allowed' },
+      null,
+      WAITED,
+    );
     expect(out).toMatchObject({ ok: false, reason: 'only http(s) navigation is allowed' });
     expect(out['confirmed']).toBeUndefined();
     expect(out['note']).toBeUndefined();
+    expect(out['waitedMs']).toBeUndefined();
   });
 
   it('passes a reason through when one is given', () => {
-    expect(navigateResult({ ok: false, reason: 'url required' })['reason']).toBe('url required');
+    expect(navigateResult({ ok: false, reason: 'url required' }, null, WAITED)['reason']).toBe(
+      'url required',
+    );
+  });
+});
+
+/**
+ * `confirmed: false` used to be one word for two situations: Reticle stopped waiting, and the page
+ * never came back. A Nuxt SPA reattaching under HMR was measured at 30–60s, so against it every
+ * navigation gave up at 5s and read as a failed navigation — and there was no `timeout_ms` to say
+ * "wait longer". The unconfirmed envelope now names the budget that expired and the parameter that
+ * raises it.
+ */
+describe('an unconfirmed navigation says what the wait ended on', () => {
+  it('reports the budget that expired', () => {
+    const out = navigateResult({ ok: true, url: 'http://localhost:3000/dashboard' }, null, 30_000);
+    expect(out['waitedMs']).toBe(30_000);
+    expect(String(out['note'])).toContain('30000ms');
+  });
+
+  it('names timeout_ms as the way to wait longer', () => {
+    const out = navigateResult({ ok: true, url: 'http://localhost:3000/dashboard' }, null, WAITED);
+    expect(String(out['note'])).toContain('timeout_ms');
+  });
+
+  it('does not report a budget on a confirmed arrival — nothing expired', () => {
+    const out = navigateResult(
+      { ok: true, url: 'http://localhost:3000/dashboard' },
+      { sessionId: 's-new' },
+      WAITED,
+    );
+    expect(out['waitedMs']).toBeUndefined();
   });
 });
 
@@ -71,19 +111,20 @@ describe('confirmed reports arrival when arrival is observable', () => {
     const out = navigateResult(
       { ok: true, url: 'http://localhost:3000/dashboard' },
       { sessionId: 's-new' },
+      WAITED,
     );
     expect(out['confirmed']).toBe(true);
     expect(out['sessionId'], 'the SDK reconnects as a NEW session — name it').toBe('s-new');
   });
 
   it('stays false, with the note, when nothing arrives in the window', () => {
-    const out = navigateResult({ ok: true, url: 'http://localhost:3000/dashboard' }, null);
+    const out = navigateResult({ ok: true, url: 'http://localhost:3000/dashboard' }, null, WAITED);
     expect(out['confirmed']).toBe(false);
     expect(String(out['note'])).toContain('reticle_sessions');
   });
 
   it('a refusal is still conclusive — no confirmed, no sessionId', () => {
-    const out = navigateResult({ ok: false, reason: 'url required' }, null);
+    const out = navigateResult({ ok: false, reason: 'url required' }, null, WAITED);
     expect(out['confirmed']).toBeUndefined();
     expect(out['sessionId']).toBeUndefined();
   });
@@ -108,5 +149,38 @@ describe('the navigate description matches what navigate now returns', () => {
       tellsToPoll,
       'that instruction is now wrong whenever arrival was confirmed — the result already says so',
     ).toBe(false);
+  });
+
+  it('tells the agent the window is its own to size', () => {
+    expect(nav?.description).toContain('timeout_ms');
+  });
+});
+
+/**
+ * The 5s arrival window was fixed and unstated: `reticle_navigate` took no `timeout_ms`, so unlike
+ * `assert` / `wait_for` / `act_and_wait` — which all spend the caller's budget — nobody could tell
+ * it to wait longer. The parameter is declared with the same bounds those tools use.
+ */
+describe('reticle_navigate takes a timeout_ms', () => {
+  const timeout = TOOLS.find((t) => t.name === ReticleTool.NAVIGATE)?.inputSchema['timeout_ms'];
+
+  it('is declared', () => {
+    expect(timeout).toBeDefined();
+  });
+
+  it('stays optional — omitting it keeps the 5s default, so nothing gets slower by accident', () => {
+    expect(timeout?.safeParse(undefined).success).toBe(true);
+  });
+
+  it('takes the budget a slow SPA needs', () => {
+    expect(timeout?.safeParse(30_000).success).toBe(true);
+  });
+
+  it('takes 0 — look once, do not wait', () => {
+    expect(timeout?.safeParse(0).success).toBe(true);
+  });
+
+  it('refuses a negative budget instead of ignoring it', () => {
+    expect(timeout?.safeParse(-1).success).toBe(false);
   });
 });

--- a/packages/server/src/tools/navigate-result.ts
+++ b/packages/server/src/tools/navigate-result.ts
@@ -30,7 +30,14 @@ export function navigateResult(
    * one place that CAN answer this — the SDK reconnects to it — so making it answer removes a
    * `reticle_sessions` poll from every single navigation.
    */
-  arrival: NavigateArrival | null = null,
+  arrival: NavigateArrival | null,
+  /**
+   * The budget the daemon spent waiting for arrival, in ms. Reported on `confirmed:false` so the
+   * agent can tell "Reticle stopped waiting" from "the page never came back": the first is fixed by
+   * asking for a longer `timeout_ms`, the second is not. Without it the two read identically, and a
+   * slow SPA (30–60s to reattach under HMR) looked like a failed navigation on every call.
+   */
+  waitedMs: number,
 ): Record<string, unknown> {
   const ok = true === result.ok;
   const base: Record<string, unknown> = {
@@ -52,10 +59,13 @@ export function navigateResult(
   return {
     ...base,
     confirmed: false,
+    waitedMs,
     note:
       'ok means the navigation was DISPATCHED, not that the page arrived. The SDK is torn down by ' +
-      'the navigation itself, so nothing here can see the new document. Call reticle_sessions to ' +
-      'confirm a session reconnected at the new URL before acting; if none appears, the page did ' +
-      'not load or is not instrumented.',
+      'the navigation itself, so nothing here can see the new document, and no session reconnected ' +
+      `at the new URL within ${waitedMs}ms. A slow app may still be on its way (an SPA reattaching ` +
+      'under HMR can take 30-60s): navigate again with a larger timeout_ms, or call reticle_sessions ' +
+      'to confirm a session reconnected before acting; if none appears, the page did not load or is ' +
+      'not instrumented.',
   };
 }

--- a/packages/server/src/tools/navigate-timeout.test.ts
+++ b/packages/server/src/tools/navigate-timeout.test.ts
@@ -1,0 +1,81 @@
+/**
+ * `timeout_ms` reaches the wait.
+ *
+ * The parameter is the fix for an arrival window nobody could size (a fixed 5s, against an SPA
+ * measured reattaching in 30–60s). A parameter the schema accepts and the handler then drops would
+ * be the silent-ignore failure this repo refuses everywhere else — the agent asked for something,
+ * did not get it, and was told nothing. So this drives the handler, not the helper.
+ *
+ * The session map changes between LOOKS, and the budget is proven by how many times the daemon
+ * looked — never by elapsed time, which is a statement about the machine.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { BROWSER_TOOLS } from './browser-tools.js';
+import { ReticleTool } from './tool-names.js';
+import { LastAct } from '../session/last-act.js';
+import type { CommandResult } from '@reticlehq/core';
+import type { Session, SessionManager } from '../session/session.js';
+import type { ToolDeps } from './tools.js';
+
+const FROM = 'http://localhost:3000/';
+const TO = 'http://localhost:3000/dashboard';
+
+function fakeSession(id: string, url: string): Session {
+  const stub: Partial<Session> = {
+    id,
+    url,
+    elapsed: () => 0,
+    lastAct: new LastAct(),
+    beginAction: () => 'a1',
+    finishAction: () => undefined,
+    // The browser accepts every instruction; whether the page ARRIVES is the map's business below.
+    command: (): Promise<CommandResult> =>
+      Promise.resolve({ kind: 'command_result', id: 'c', ok: true, result: { ok: true, url: TO } }),
+  };
+  return stub as Session;
+}
+
+/** Just enough deps for the navigate handler: a map where the new session appears on the Nth look. */
+function fakeDeps(arrivesOnLook: number): { deps: ToolDeps; looks: () => number } {
+  const before = fakeSession('s-old', FROM);
+  const after = fakeSession('s-new', TO);
+  let look = 0;
+  const sessions: Partial<SessionManager> = {
+    resolve: () => before,
+    // The reload branch asks whether a DIFFERENT object holds the id now. Same object: not back.
+    get: () => before,
+    all: () => {
+      look++;
+      return look >= arrivesOnLook ? [after] : [];
+    },
+  };
+  return {
+    deps: { sessions: sessions as SessionManager, now: () => 0 } as unknown as ToolDeps,
+    looks: () => look,
+  };
+}
+
+const nav = BROWSER_TOOLS.find((t) => t.name === ReticleTool.NAVIGATE);
+
+describe('reticle_navigate spends the caller’s timeout_ms on arrival', () => {
+  it('timeout_ms: 0 looks once and answers, naming the budget it did not have', async () => {
+    const { deps, looks } = fakeDeps(2);
+    const out = await nav?.handler(deps, { url: TO, timeout_ms: 0 });
+    expect(out).toMatchObject({ ok: true, confirmed: false, waitedMs: 0 });
+    expect(looks(), 'a zero budget is one look, not a wait').toBe(1);
+  });
+
+  it('a budget keeps the daemon looking until the page comes back', async () => {
+    const { deps, looks } = fakeDeps(2);
+    const out = await nav?.handler(deps, { url: TO, timeout_ms: 1_000 });
+    expect(out).toMatchObject({ ok: true, confirmed: true, sessionId: 's-new' });
+    expect(looks()).toBe(2);
+  });
+
+  it('applies to a reload too — the page coming back is the same wait', async () => {
+    const { deps } = fakeDeps(Number.POSITIVE_INFINITY);
+    const out = await nav?.handler(deps, { reload: true, timeout_ms: 0 });
+    expect(out).toMatchObject({ ok: true, confirmed: false, waitedMs: 0 });
+  });
+});

--- a/packages/server/src/tools/reload-result.test.ts
+++ b/packages/server/src/tools/reload-result.test.ts
@@ -16,21 +16,27 @@ import { reloadResult } from './reload-result.js';
 
 describe('what a reload reports', () => {
   it('is not confirmed — ok means dispatched, and the page has not come back yet', () => {
-    const out = reloadResult();
+    const out = reloadResult(false, 5000);
     expect(out.ok).toBe(true);
     expect(out.confirmed).toBe(false);
   });
 
   it('says what to do about it, in the same terms the URL branch uses', () => {
     // An agent that reads `ok: true` and acts immediately is the failure this prevents.
-    expect(String(reloadResult().note)).toContain('reticle_sessions');
+    expect(String(reloadResult(false, 5000).note)).toContain('reticle_sessions');
+  });
+
+  it('names the budget that expired, so "stopped waiting" reads differently from "never came back"', () => {
+    expect(reloadResult(false, 5000).waitedMs).toBe(5000);
   });
 
   it('confirms the reload once the page has re-announced itself', () => {
     // The tool now WAITS for the reconnect (see session-reconnect), so the common case is a
     // confirmed one — and the agent must not be sent to re-select a session that is already live.
-    const out = reloadResult(true);
+    const out = reloadResult(true, 5000);
     expect(out.confirmed).toBe(true);
     expect(String(out.note)).not.toContain('reticle_sessions');
+    // Nothing expired, so there is no budget to report.
+    expect(out.waitedMs).toBeUndefined();
   });
 });

--- a/packages/server/src/tools/reload-result.ts
+++ b/packages/server/src/tools/reload-result.ts
@@ -27,8 +27,13 @@ const RELOAD_RECONNECTED_NOTE =
   'the page came back and re-announced itself under the same session id, so this session is live ' +
   'again — no re-selection needed. Anything captured before the reload is gone with the old document.';
 
-export function reloadResult(reconnected = false): Record<string, unknown> {
+/**
+ * `waitedMs` is the budget that expired, reported on `confirmed:false` for the same reason the URL
+ * branch reports it (navigate-result.ts): so "Reticle stopped waiting" is distinguishable from "the
+ * page never came back", and the fix — a larger `timeout_ms` — is visible in the result.
+ */
+export function reloadResult(reconnected: boolean, waitedMs: number): Record<string, unknown> {
   return reconnected
     ? { ok: true, confirmed: true, note: RELOAD_RECONNECTED_NOTE }
-    : { ok: true, confirmed: false, note: RELOAD_NOTE };
+    : { ok: true, confirmed: false, waitedMs, note: RELOAD_NOTE };
 }


### PR DESCRIPTION
## What & why

`reticle_navigate`'s arrival window was a fixed, unstated 5s (`ARRIVAL_TIMEOUT_MS` in `navigate-arrival.ts`) and the tool took no `timeout_ms`, so unlike `assert` / `wait_for` / `act_and_wait` (which spend the caller's budget via `resolveSessionWithin`, #612) nobody could tell it to wait longer. Against a Nuxt SPA measured reattaching under HMR in 30–60s, every navigation gave up while the app was still coming back and answered `{ ok: true, confirmed: false }`, which reads as a failed navigation rather than as Reticle having stopped waiting.

- `reticle_navigate` now accepts `timeout_ms` (same `timeoutMsSchema` bounds as the other tools; default stays 5000 so nothing gets slower by accident; `0` looks once). It reaches `awaitArrival`, and also the `{ reload: true }` branch's `waitForReconnect`, since a declared parameter the handler silently drops is the failure this repo refuses elsewhere.
- Same two narrowings as `resolveSessionWithin`: the wait only runs where it can help (a refused navigation skips it), and expiry keeps the original diagnosis (the existing note) rather than replacing it with a stopwatch reading.
- An unconfirmed result now says what the wait ended on: `waitedMs` carries the budget that expired, and the note names it and points at `timeout_ms`. That is what lets an agent tell "Reticle stopped waiting" from "the page never came back".
- `ARRIVAL_TIMEOUT_MS` is exported so the handler and the default share one number; `navigateResult` / `reloadResult` take the budget explicitly rather than defaulting it.

Docs (`docs/tools-navigate.mdx`) and `CHANGELOG.md` updated.

Closes #856

## How it was verified

- `navigate-timeout.test.ts` (new) drives the `reticle_navigate` handler with a session map that changes between looks: `timeout_ms: 0` looks exactly once and answers `confirmed: false, waitedMs: 0`; a budget keeps the daemon looking until the session appears; the reload branch honours it too. Asserts look counts, never elapsed time.
- `navigate-honesty.test.ts`: `timeout_ms` is declared, optional, accepts 0 and 30000, refuses a negative; the unconfirmed envelope reports `waitedMs` and names `timeout_ms`; a confirmed arrival carries no `waitedMs`; the description mentions `timeout_ms`.
- `reload-result.test.ts`: `waitedMs` on the unconfirmed reload, absent on the confirmed one.
- The new schema assertions and `waitedMs` assertions fail on `main` (RED → GREEN).

## Gates run

- [x] `pnpm lint && pnpm typecheck && pnpm test:unit` (~2 min — **always**)
- [ ] `pnpm test:e2e` (~8 min) — _touched the tool surface_ — not run locally; leaving to CI
- [ ] `pnpm gate:install` (~15 min)
- [ ] `pnpm test:e2e:desktop` (~3 min)
- [ ] None of the above tiers apply to this change

## Checklist

- [x] **Every commit is signed off** (`git commit -s`)
- [x] Tests added/updated (RED → GREEN); the change is covered by a test that would fail without it
- [x] No `any`, no free strings (wire strings live in `@reticlehq/core`), no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 1000-line cap
- [x] Docs and `CHANGELOG.md` updated (entry under `[Unreleased]`)
- [x] Not security-affecting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
