### PR TITLE
fix(server): pre-existing STATE bypasses alreadyTrue in act_and_wait …

### DIFF
--- a/packages/server/src/honesty/already-true.test.ts
+++ b/packages/server/src/honesty/already-true.test.ts
@@ -103,18 +103,34 @@ describe('which predicates need the before-check at all', () => {
     expect(readsDomState({ kind: 'route' })).toBe(true);
   });
 
-  it('state reads a store, which the action is supposed to change — and it IS floored', () => {
-    expect(readsDomState({ kind: 'state', path: 'cart.total' })).toBe(false);
+  /**
+   * `state` was originally assumed to be floored like event-based kinds. It is not: STATE_READ
+   * queries live in-page store memory, where no event floor applies. An action asserting a state
+   * condition that already held before dispatch passes immediately without causing any change.
+   * Evaluating before dispatch catches this as already_true.
+   */
+  it('state reads live store memory via STATE_READ without an event floor, so it needs the before-check', () => {
+    expect(readsDomState({ kind: 'state', path: 'cart.total' })).toBe(true);
+    expect(readsDomState({ kind: 'state', store: 'cart', path: 'total' })).toBe(true);
   });
 
-  it('a combinator inherits it from any branch that reads the DOM', () => {
+  it('a combinator inherits it from any branch that reads the DOM or live state', () => {
     expect(
       readsDomState({
         kind: 'allOf',
         predicates: [{ kind: 'settled' }, { kind: 'text', contains: 'Done' }],
       }),
     ).toBe(true);
+    expect(
+      readsDomState({
+        kind: 'allOf',
+        predicates: [{ kind: 'settled' }, { kind: 'state', path: 'cart.count' }],
+      }),
+    ).toBe(true);
     expect(readsDomState({ kind: 'not', predicate: { kind: 'text', contains: 'Error' } })).toBe(
+      true,
+    );
+    expect(readsDomState({ kind: 'not', predicate: { kind: 'state', path: 'error' } })).toBe(
       true,
     );
     expect(readsDomState({ kind: 'anyOf', predicates: [{ kind: 'signal', name: 'a' }] })).toBe(

--- a/packages/server/src/honesty/already-true.test.ts
+++ b/packages/server/src/honesty/already-true.test.ts
@@ -130,9 +130,7 @@ describe('which predicates need the before-check at all', () => {
     expect(readsDomState({ kind: 'not', predicate: { kind: 'text', contains: 'Error' } })).toBe(
       true,
     );
-    expect(readsDomState({ kind: 'not', predicate: { kind: 'state', path: 'error' } })).toBe(
-      true,
-    );
+    expect(readsDomState({ kind: 'not', predicate: { kind: 'state', path: 'error' } })).toBe(true);
     expect(readsDomState({ kind: 'anyOf', predicates: [{ kind: 'signal', name: 'a' }] })).toBe(
       false,
     );

--- a/packages/server/src/honesty/already-true.ts
+++ b/packages/server/src/honesty/already-true.ts
@@ -1,15 +1,17 @@
 /**
  * Which predicates can be satisfied by something that was already true before the action.
  *
- * Event-based kinds (net, signal, route, console, animation, settled) are evaluated against the
+ * Event-based kinds (net, signal, console, animation, settled) are evaluated against the
  * event buffer floored at the act's own cursor, so a stale event cannot satisfy them — that floor is
- * why `act_and_wait` can trust them at all. `state` is read through the same floored path.
+ * why `act_and_wait` can trust them at all.
  *
- * `element` and `text` read the LIVE DOM, where no floor exists. A condition that held before the
+ * `element` and `text` read the LIVE DOM, `route` can fall back to the current route, and `state` reads
+ * live store memory via STATE_READ — where no event floor applies. A condition that held before the
  * click holds after it and passes instantly, whatever the action did. Measured in the field: a click
  * asserted with `{ kind: 'text', contains: 'Parallel Routes' }` returned `verified: "yes"` in 478ms
  * against `routeChanges: 0`, because the predicate matched the nav link that was already on screen —
- * the real navigation landed 1.8 seconds later.
+ * the real navigation landed 1.8 seconds later. Similarly, a pre-existing store value (e.g. cart.count == 3)
+ * satisfies an inert action if not checked before dispatch.
  *
  * So these are the kinds worth evaluating BEFORE the act, to find out whether the green means
  * anything.
@@ -33,9 +35,15 @@ export function readsDomState(predicate: Predicate): boolean {
     // One extra query on the act path buys `already_true`, reported as UNKNOWN with the reason
     // rather than as a pass. The fallback removed a false red; this is what stops it becoming a
     // false green, and that is the trade this codebase never makes.
+    //
+    // STATE is here for the same reason: it is evaluated via STATE_READ against live in-memory stores
+    // rather than through the floored event buffer. If the store already holds the expected value
+    // before dispatch, an inert click would immediately pass post-dispatch on the pre-existing state.
+    // Evaluating before dispatch routes that pre-existing condition into already_true.
     case PredicateKind.ELEMENT:
     case PredicateKind.TEXT:
     case PredicateKind.ROUTE:
+    case PredicateKind.STATE:
       return true;
     case PredicateKind.ALL_OF:
     case PredicateKind.ANY_OF:
@@ -46,3 +54,6 @@ export function readsDomState(predicate: Predicate): boolean {
       return false;
   }
 }
+
+/** Alias reflecting that this checks live state (DOM, route fallback, and application store). */
+export const readsLiveState = readsDomState;

--- a/packages/server/src/honesty/already-true.ts
+++ b/packages/server/src/honesty/already-true.ts
@@ -54,6 +54,3 @@ export function readsDomState(predicate: Predicate): boolean {
       return false;
   }
 }
-
-/** Alias reflecting that this checks live state (DOM, route fallback, and application store). */
-export const readsLiveState = readsDomState;

--- a/packages/server/src/tools/act-state-already-true.test.ts
+++ b/packages/server/src/tools/act-state-already-true.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PredicateKind,
+  ReticleCommand,
+  SessionState,
+  Verified,
+  VerifiedReason,
+  type CommandResult,
+  type ReticleEvent,
+} from '@reticlehq/core';
+import { LastAct } from '../session/last-act.js';
+import { TOOLS, type ToolDeps } from './tools.js';
+import { ReticleTool } from './tool-names.js';
+import { BaselineStore } from '../project/baselines.js';
+import { createNodeFileSystem } from '../project/fs-port.js';
+import { RecordingStore } from '../flows/recordings.js';
+import { FlowStore } from '../flows/flows.js';
+import { ProjectStore } from '../project/project-store.js';
+import { AnnotationStore } from '../flows/annotation-store.js';
+import type { Session, SessionManager } from '../session/session.js';
+
+interface StateSessionOptions {
+  initialStore?: Record<string, unknown>;
+  onAct?: () => void;
+  settled?: boolean;
+  stateReadOk?: boolean;
+}
+
+function createStateSession(options: StateSessionOptions = {}) {
+  const {
+    initialStore = { app: { cart: { count: 3 } }, cart: { count: 3 } },
+    onAct,
+    settled = true,
+    stateReadOk = true,
+  } = options;
+
+  const commandLog: { command: string; args: unknown }[] = [];
+  let currentStore = { ...initialStore };
+
+  const command = (name: string, args: unknown): Promise<CommandResult> => {
+    commandLog.push({ command: name, args });
+    if (name === ReticleCommand.STATE_READ) {
+      if (!stateReadOk) {
+        return Promise.resolve({
+          kind: 'command_result',
+          id: 'sr_err',
+          ok: false,
+          error: 'store unreadable',
+        });
+      }
+      const recordArgs = (args ?? {}) as Record<string, unknown>;
+      if (recordArgs['store'] !== undefined && recordArgs['path'] !== undefined) {
+        // Scoped store read
+        const storeName = recordArgs['store'] as string;
+        const path = recordArgs['path'] as string;
+        const store = currentStore[storeName] as Record<string, unknown> | undefined;
+        const found = store !== undefined && path in store;
+        return Promise.resolve({
+          kind: 'command_result',
+          id: 'sr_scoped',
+          ok: true,
+          result: {
+            found,
+            value: found ? store[path] : undefined,
+            storeNames: Object.keys(currentStore),
+          },
+        });
+      }
+      return Promise.resolve({
+        kind: 'command_result',
+        id: 'sr',
+        ok: true,
+        result: {
+          stores: currentStore,
+        },
+      });
+    }
+
+    if (name === ReticleCommand.ACT) {
+      onAct?.();
+      return Promise.resolve({
+        kind: 'command_result',
+        id: 'act',
+        ok: true,
+        result: {
+          dispatched: true,
+          settled,
+          effect: { domMutatedWithin: 1 },
+        },
+      });
+    }
+
+    return Promise.resolve({
+      kind: 'command_result',
+      id: 'other',
+      ok: true,
+      result: {},
+    });
+  };
+
+  const noEvents: ReticleEvent[] = [];
+  const stub: Partial<Session> = {
+    id: 'demo-state',
+    url: 'http://localhost:5173/app',
+    elapsed: () => 1000,
+    lastAct: new LastAct(),
+    beginAction: () => 'a1',
+    finishAction: () => undefined,
+    command,
+    queryEvents: () => Promise.resolve(noEvents),
+    eventsSince: () => noEvents,
+    bufferHealth: () => ({ total: 10, dropped: 0 }),
+    lostSince: () => false,
+    blindSpots: () => ({}),
+    health: () => ({ lastSeenMs: 0, throttled: false, focused: true }),
+    throttled: () => false,
+    getState: () => SessionState.ACTIVE,
+    drainInbox: () => [],
+    inboxSize: () => 0,
+    onEvent: () => () => undefined,
+    ambientCounts: () => ({}),
+  };
+
+  const session = stub as Session;
+  const sessions: Partial<SessionManager> = { resolve: () => session };
+  const deps: ToolDeps = {
+    sessions: sessions as SessionManager,
+    baselines: new BaselineStore(),
+    recordings: new RecordingStore(),
+    flows: new FlowStore(createNodeFileSystem(), '/tmp/reticle-test/.reticle', { now: () => 0 }),
+    project: new ProjectStore(createNodeFileSystem(), '/tmp/reticle-test/.reticle', {
+      now: () => 0,
+    }),
+    annotations: new AnnotationStore(),
+    fs: createNodeFileSystem(),
+    reticleRoot: '/tmp/reticle-test/.reticle',
+    now: () => 0,
+  };
+
+  return {
+    session,
+    deps,
+    commandLog,
+    setStore: (s: Record<string, unknown>) => {
+      currentStore = s;
+    },
+  };
+}
+
+function tool(name: string) {
+  const found = TOOLS.find((t) => t.name === name);
+  if (found === undefined) throw new Error(`no ${name} tool`);
+  return found;
+}
+
+describe('#864 — pre-existing STATE bypasses alreadyTrue in act_and_wait', () => {
+  it('returns no-fault / already_true when STATE condition already holds before dispatch', async () => {
+    const { deps, commandLog } = createStateSession({
+      initialStore: { app: { cart: { count: 3 } } },
+      settled: true,
+    });
+
+    const res = (await tool(ReticleTool.ACT_AND_WAIT).handler(deps, {
+      ref: 'btn-inert',
+      action: 'click',
+      timeout_ms: 0,
+      until: {
+        kind: PredicateKind.STATE,
+        path: 'cart.count',
+        equals: 3,
+      },
+    })) as Record<string, unknown>;
+
+    // 1. Proves causal contract: pre-existing STATE does not receive causal PROVED credit
+    expect(res['verified']).toBe(Verified.NO_FAULT);
+    expect(res['verifiedReason']).toBe(VerifiedReason.ALREADY_TRUE);
+    expect(res['because']).toContain('already true before this action');
+
+    // 2. Proves baseline detection evaluated STATE before action dispatch
+    const stateReadIndex = commandLog.findIndex((c) => c.command === ReticleCommand.STATE_READ);
+    const actIndex = commandLog.findIndex((c) => c.command === ReticleCommand.ACT);
+    expect(stateReadIndex).toBeGreaterThanOrEqual(0);
+    expect(actIndex).toBeGreaterThanOrEqual(0);
+    expect(stateReadIndex).toBeLessThan(actIndex);
+  });
+
+  it('works identically for scoped / named store state', async () => {
+    const { deps, commandLog } = createStateSession({
+      initialStore: { cart: { count: 3 } },
+      settled: true,
+    });
+
+    const res = (await tool(ReticleTool.ACT_AND_WAIT).handler(deps, {
+      ref: 'btn-inert',
+      action: 'click',
+      timeout_ms: 0,
+      until: {
+        kind: PredicateKind.STATE,
+        store: 'cart',
+        path: 'count',
+        equals: 3,
+      },
+    })) as Record<string, unknown>;
+
+    expect(res['verified']).toBe(Verified.NO_FAULT);
+    expect(res['verifiedReason']).toBe(VerifiedReason.ALREADY_TRUE);
+
+    const firstStateRead = commandLog.find((c) => c.command === ReticleCommand.STATE_READ);
+    const actIndex = commandLog.findIndex((c) => c.command === ReticleCommand.ACT);
+    expect(firstStateRead).toBeDefined();
+    expect(commandLog.indexOf(firstStateRead!)).toBeLessThan(actIndex);
+  });
+
+  it('awards causal YES when STATE was not already true and changed because of the action', async () => {
+    let ctx: ReturnType<typeof createStateSession>;
+    ctx = createStateSession({
+      initialStore: { app: { cart: { count: 0 } }, cart: { count: 0 } },
+      onAct: () => {
+        // Action causes cart.count to become 3
+        ctx.setStore({ app: { cart: { count: 3 } }, cart: { count: 3 } });
+      },
+      settled: true,
+    });
+
+    const res = (await tool(ReticleTool.ACT_AND_WAIT).handler(ctx.deps, {
+      ref: 'btn-add-to-cart',
+      action: 'click',
+      timeout_ms: 0,
+      until: {
+        kind: PredicateKind.STATE,
+        path: 'cart.count',
+        equals: 3,
+      },
+    })) as Record<string, unknown>;
+
+    expect(res['verified']).toBe(Verified.YES);
+    expect(res['verifiedReason']).toBe(VerifiedReason.PROVED);
+
+    // Pre-dispatch STATE_READ saw count: 0 -> alreadyTrue was false
+    // Post-dispatch STATE_READ saw count: 3 -> pass was true
+    const stateReads = ctx.commandLog.filter((c) => c.command === ReticleCommand.STATE_READ);
+    expect(stateReads.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('preserves UNKNOWN when pre-existing STATE is true but the window never settled', async () => {
+    const { deps } = createStateSession({
+      initialStore: { app: { cart: { count: 3 } } },
+      settled: false,
+    });
+
+    const res = (await tool(ReticleTool.ACT_AND_WAIT).handler(deps, {
+      ref: 'btn-inert',
+      action: 'click',
+      timeout_ms: 0,
+      until: {
+        kind: PredicateKind.STATE,
+        path: 'cart.count',
+        equals: 3,
+      },
+    })) as Record<string, unknown>;
+
+    expect(res['verified']).toBe(Verified.UNKNOWN);
+    expect(res['verifiedReason']).toBe(VerifiedReason.ALREADY_TRUE);
+  });
+
+  it('preserves INCONCLUSIVE when store is missing rather than claiming already_true', async () => {
+    const { deps } = createStateSession({
+      initialStore: {},
+      settled: true,
+    });
+
+    const res = (await tool(ReticleTool.ACT_AND_WAIT).handler(deps, {
+      ref: 'btn-inert',
+      action: 'click',
+      timeout_ms: 0,
+      until: {
+        kind: PredicateKind.STATE,
+        path: 'cart.count',
+        equals: 3,
+      },
+    })) as Record<string, unknown>;
+
+    expect(res['verified']).toBe(Verified.UNKNOWN);
+    expect(res['verifiedReason']).toBe(VerifiedReason.INCONCLUSIVE);
+  });
+});

--- a/packages/server/src/tools/act-state-already-true.test.ts
+++ b/packages/server/src/tools/act-state-already-true.test.ts
@@ -21,7 +21,7 @@ import type { Session, SessionManager } from '../session/session.js';
 
 interface StateSessionOptions {
   initialStore?: Record<string, unknown>;
-  onAct?: () => void;
+  onAct?: (setStore: (s: Record<string, unknown>) => void) => void;
   settled?: boolean;
   stateReadOk?: boolean;
 }
@@ -34,13 +34,16 @@ function createStateSession(options: StateSessionOptions = {}) {
     stateReadOk = true,
   } = options;
 
-  const commandLog: { command: string; args: unknown }[] = [];
+  const commandLog: { command: string; args: unknown; result?: unknown }[] = [];
   let currentStore = { ...initialStore };
+  const setStore = (s: Record<string, unknown>) => {
+    currentStore = s;
+  };
 
   const command = (name: string, args: unknown): Promise<CommandResult> => {
-    commandLog.push({ command: name, args });
     if (name === ReticleCommand.STATE_READ) {
       if (!stateReadOk) {
+        commandLog.push({ command: name, args, result: { ok: false } });
         return Promise.resolve({
           kind: 'command_result',
           id: 'sr_err',
@@ -55,41 +58,48 @@ function createStateSession(options: StateSessionOptions = {}) {
         const path = recordArgs['path'] as string;
         const store = currentStore[storeName] as Record<string, unknown> | undefined;
         const found = store !== undefined && path in store;
+        const result = {
+          found,
+          value: found ? store[path] : undefined,
+          storeNames: Object.keys(currentStore),
+        };
+        commandLog.push({ command: name, args, result });
         return Promise.resolve({
           kind: 'command_result',
           id: 'sr_scoped',
           ok: true,
-          result: {
-            found,
-            value: found ? store[path] : undefined,
-            storeNames: Object.keys(currentStore),
-          },
+          result,
         });
       }
+      const result = {
+        stores: { ...currentStore },
+      };
+      commandLog.push({ command: name, args, result });
       return Promise.resolve({
         kind: 'command_result',
         id: 'sr',
         ok: true,
-        result: {
-          stores: currentStore,
-        },
+        result,
       });
     }
 
     if (name === ReticleCommand.ACT) {
-      onAct?.();
+      onAct?.(setStore);
+      const result = {
+        dispatched: true,
+        settled,
+        effect: { domMutatedWithin: 1 },
+      };
+      commandLog.push({ command: name, args, result });
       return Promise.resolve({
         kind: 'command_result',
         id: 'act',
         ok: true,
-        result: {
-          dispatched: true,
-          settled,
-          effect: { domMutatedWithin: 1 },
-        },
+        result,
       });
     }
 
+    commandLog.push({ command: name, args });
     return Promise.resolve({
       kind: 'command_result',
       id: 'other',
@@ -141,9 +151,7 @@ function createStateSession(options: StateSessionOptions = {}) {
     session,
     deps,
     commandLog,
-    setStore: (s: Record<string, unknown>) => {
-      currentStore = s;
-    },
+    setStore,
   };
 }
 
@@ -205,19 +213,20 @@ describe('#864 — pre-existing STATE bypasses alreadyTrue in act_and_wait', () 
     expect(res['verified']).toBe(Verified.NO_FAULT);
     expect(res['verifiedReason']).toBe(VerifiedReason.ALREADY_TRUE);
 
-    const firstStateRead = commandLog.find((c) => c.command === ReticleCommand.STATE_READ);
+    const firstStateReadIndex = commandLog.findIndex(
+      (c) => c.command === ReticleCommand.STATE_READ,
+    );
     const actIndex = commandLog.findIndex((c) => c.command === ReticleCommand.ACT);
-    expect(firstStateRead).toBeDefined();
-    expect(commandLog.indexOf(firstStateRead!)).toBeLessThan(actIndex);
+    expect(firstStateReadIndex).toBeGreaterThanOrEqual(0);
+    expect(firstStateReadIndex).toBeLessThan(actIndex);
   });
 
   it('awards causal YES when STATE was not already true and changed because of the action', async () => {
-    let ctx: ReturnType<typeof createStateSession>;
-    ctx = createStateSession({
+    const ctx = createStateSession({
       initialStore: { app: { cart: { count: 0 } }, cart: { count: 0 } },
-      onAct: () => {
+      onAct: (setStore) => {
         // Action causes cart.count to become 3
-        ctx.setStore({ app: { cart: { count: 3 } }, cart: { count: 3 } });
+        setStore({ app: { cart: { count: 3 } }, cart: { count: 3 } });
       },
       settled: true,
     });
@@ -238,8 +247,25 @@ describe('#864 — pre-existing STATE bypasses alreadyTrue in act_and_wait', () 
 
     // Pre-dispatch STATE_READ saw count: 0 -> alreadyTrue was false
     // Post-dispatch STATE_READ saw count: 3 -> pass was true
-    const stateReads = ctx.commandLog.filter((c) => c.command === ReticleCommand.STATE_READ);
-    expect(stateReads.length).toBeGreaterThanOrEqual(2);
+    const actIndex = ctx.commandLog.findIndex((c) => c.command === ReticleCommand.ACT);
+    expect(actIndex).toBeGreaterThanOrEqual(0);
+
+    const preActRead = ctx.commandLog
+      .slice(0, actIndex)
+      .find((c) => c.command === ReticleCommand.STATE_READ);
+    const postActRead = ctx.commandLog
+      .slice(actIndex + 1)
+      .find((c) => c.command === ReticleCommand.STATE_READ);
+
+    expect(preActRead).toBeDefined();
+    const preStores = (preActRead?.result as { stores?: Record<string, unknown> })?.stores;
+    const preCart = (preStores?.['app'] as { cart?: { count?: number } })?.cart;
+    expect(preCart?.count).toBe(0);
+
+    expect(postActRead).toBeDefined();
+    const postStores = (postActRead?.result as { stores?: Record<string, unknown> })?.stores;
+    const postCart = (postStores?.['app'] as { cart?: { count?: number } })?.cart;
+    expect(postCart?.count).toBe(3);
   });
 
   it('preserves UNKNOWN when pre-existing STATE is true but the window never settled', async () => {


### PR DESCRIPTION
Implements #864.

What it does:

- Extends readsDomState in `packages/server/src/honesty/already-true.ts` to include `PredicateKind.STATE`
- Pre-evaluates STATE predicates before action dispatch in `reticle_act_and_wait` via the existing alreadyTrue pipeline
- Routes pre-existing STATE assertions to verified: "no-fault" with verifiedReason: "`already_true`" once settled, and verified: "unknown" if unsettled
- Preserves verified: "yes" (proved) for genuine causal state transitions caused by the action
- Preserves verified: "unknown" with verifiedReason: "inconclusive" when application stores are missing or unreadable
- Updates `packages/server/src/honesty/already-true.test.ts` to assert that state predicates require pre-action checks
- Adds comprehensive regression test suite `packages/server/src/tools/act-state-already-true.test.ts` proving pre-action baseline verification and validating observed store transitions (0 -> 3)

## What & why
Issue #864 identifies a causal verification leak in reticle_act_and_wait: declaring an until condition with kind: "state" against an already-existing store value (e.g. cart.count == 3 before an inert click) passed post-dispatch and received verified: "yes" / proved.

`readsDomState(predicate)` only handled ELEMENT, TEXT, and ROUTE, falling through to false for STATE. The engine assumed STATE was floored in the event buffer, but PredicateKind.STATE evaluates via live in-page memory queries (ReticleCommand.STATE_READ). Because no event floor exists for live memory, a pre-existing condition survived through the action and passed post-dispatch, violating the causal verification contract.

This fix extends baseline detection to evaluate STATE predicates before action dispatch. If already true before the action, causal credit is withheld and the verdict takes the established ALREADY_TRUE path (no-fault if settled, unknown if unsettled).

Closes #864.

## How it was verified
Rebased on `main` and implemented on branch `fix/state-already-true`.

```bash
# Targeted honesty & regression tests
npx vitest run `src/tools/act-state-already-true.test.ts src/honesty/already-true.test.ts`  # PASS (15/15)
# Verification verdict & parity suites
npx vitest run `src/tools/act-verdict-parity.test.ts src/honesty/verified.test.ts src/honesty/false-green-caught.test.ts`  # PASS (72/72)
# Full honesty directory suite
npx vitest run src/honesty/  # PASS (25 files, 288/288 tests)
```
**Simulated regressions verified:**

- Pre-existing state holds before dispatch → returns verified: "no-fault", verifiedReason: "already_true"
- Baseline evaluation order confirmed → STATE_READ precedes ACT
- Named/scoped store read (store: 'cart', path: 'count') → returns verified: "no-fault", verifiedReason: "already_true"
- State modified by action (0 -> 3) → verified that pre-dispatch observes 0 and post-dispatch observes 3, returning verified: "yes", verifiedReason: "proved"
- Pre-existing state with unsettled window (settled: false) → returns verified: "unknown", verifiedReason: "already_true"
- Missing/unregistered store (stores: {}) → returns verified: "unknown", verifiedReason: "inconclusive"
- Existing ELEMENT, TEXT, and ROUTE predicates → untouched and passing

**Checklist**

- [x]  Every commit is signed off (git commit -s)
- [x]  Tests added/updated — unit tests and end-to-end tool regression tests added
- [x]  No any, no free strings, no non-null !
- [x]  No console.log or internal tracking codes left in the diff
- [x]  Each changed file is under the 1000-line cap
- [ ]  Docs and CHANGELOG.md updated — not user-facing
- [ ]  Security-affecting? — no
