### PR TITLE
fix(babel-plugin): stamp only tags that are actually DOM

### DIFF
--- a/packages/babel-plugin/src/dom-tags.ts
+++ b/packages/babel-plugin/src/dom-tags.ts
@@ -1,0 +1,272 @@
+/**
+ * The lowercase JSX tags that are actually DOM elements.
+ *
+ * "Lowercase means host element" was the rule, and it is true only for React DOM. React is a
+ * reconciler interface, not a renderer: react-three-fiber, react-pdf, ink and friends define their
+ * own lowercase intrinsics, and those host instances are not nodes and do not take attributes.
+ *
+ * R3F is the case that bit. Its `applyProps` treats any prop containing a dash as a PIERCED
+ * PROPERTY PATH, so `data-reticle-source` is walked as `data` -> `reticle` -> `source`; there is no
+ * `data` object on a three.js instance, and it throws from inside the commit phase. Unhandled there,
+ * the whole React tree unmounts to a white screen — and because it needs an element UPDATE rather
+ * than a mount, it fires long after the app looked fine.
+ *
+ * So the check is an ALLOWLIST, not a heuristic. The set of custom-reconciler intrinsics is
+ * unbounded and cannot be enumerated; the set of HTML and SVG tags can. Getting it wrong in the
+ * conservative direction costs one source pointer on an exotic element. Getting it wrong the other
+ * way costs the user their entire app.
+ *
+ * WHAT THIS DOES NOT COVER, stated rather than implied: a handful of three.js class names collide
+ * with real DOM tags — `line` is both `<line>` in SVG and `THREE.Line`, and `audio` is both. A tag
+ * name alone cannot separate them, and a lexical "is it under a <Canvas>" walk only sees the file
+ * it is transforming, so a scene component in its own file would still slip through. The complete
+ * answer for a three.js app is `reticle({ sourceMapping: false })`, which `reticle init` now writes
+ * on its own when it finds react-three-fiber in the manifest.
+ */
+
+/** Every HTML element name, including the deprecated ones a real codebase still contains. */
+const HTML_TAGS = [
+  'a',
+  'abbr',
+  'address',
+  'area',
+  'article',
+  'aside',
+  'audio',
+  'b',
+  'base',
+  'bdi',
+  'bdo',
+  'big',
+  'blockquote',
+  'body',
+  'br',
+  'button',
+  'canvas',
+  'caption',
+  'center',
+  'cite',
+  'code',
+  'col',
+  'colgroup',
+  'data',
+  'datalist',
+  'dd',
+  'del',
+  'details',
+  'dfn',
+  'dialog',
+  'div',
+  'dl',
+  'dt',
+  'em',
+  'embed',
+  'fieldset',
+  'figcaption',
+  'figure',
+  'font',
+  'footer',
+  'form',
+  'frame',
+  'frameset',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'head',
+  'header',
+  'hgroup',
+  'hr',
+  'html',
+  'i',
+  'iframe',
+  'img',
+  'input',
+  'ins',
+  'kbd',
+  'keygen',
+  'label',
+  'legend',
+  'li',
+  'link',
+  'main',
+  'map',
+  'mark',
+  'marquee',
+  'menu',
+  'menuitem',
+  'meta',
+  'meter',
+  'nav',
+  'nobr',
+  'noframes',
+  'noscript',
+  'object',
+  'ol',
+  'optgroup',
+  'option',
+  'output',
+  'p',
+  'param',
+  'picture',
+  'pre',
+  'progress',
+  'q',
+  'rp',
+  'rt',
+  'ruby',
+  's',
+  'samp',
+  'script',
+  'search',
+  'section',
+  'select',
+  'slot',
+  'small',
+  'source',
+  'span',
+  'strike',
+  'strong',
+  'style',
+  'sub',
+  'summary',
+  'sup',
+  'table',
+  'tbody',
+  'td',
+  'template',
+  'textarea',
+  'tfoot',
+  'th',
+  'thead',
+  'time',
+  'title',
+  'tr',
+  'track',
+  'u',
+  'ul',
+  'var',
+  'video',
+  'wbr',
+];
+
+/**
+ * SVG element names. Included because SVG is DOM — a `data-*` attribute on `<path>` is as valid as
+ * one on `<div>`, and an app whose UI is a chart would otherwise lose every source pointer in it.
+ *
+ * The camelCase members (`clipPath`, `linearGradient`, …) are real JSX intrinsics in React DOM and
+ * are matched exactly, so the lookup below cannot be case-folded.
+ */
+const SVG_TAGS = [
+  'animate',
+  'animateMotion',
+  'animateTransform',
+  'circle',
+  'clipPath',
+  'defs',
+  'desc',
+  'ellipse',
+  'feBlend',
+  'feColorMatrix',
+  'feComponentTransfer',
+  'feComposite',
+  'feConvolveMatrix',
+  'feDiffuseLighting',
+  'feDisplacementMap',
+  'feDistantLight',
+  'feDropShadow',
+  'feFlood',
+  'feFuncA',
+  'feFuncB',
+  'feFuncG',
+  'feFuncR',
+  'feGaussianBlur',
+  'feImage',
+  'feMerge',
+  'feMergeNode',
+  'feMorphology',
+  'feOffset',
+  'fePointLight',
+  'feSpecularLighting',
+  'feSpotLight',
+  'feTile',
+  'feTurbulence',
+  'filter',
+  'foreignObject',
+  'g',
+  'image',
+  'line',
+  'linearGradient',
+  'marker',
+  'mask',
+  'metadata',
+  'mpath',
+  'path',
+  'pattern',
+  'polygon',
+  'polyline',
+  'radialGradient',
+  'rect',
+  'set',
+  'stop',
+  'svg',
+  'switch',
+  'symbol',
+  'text',
+  'textPath',
+  'tspan',
+  'use',
+  'view',
+];
+
+/**
+ * MathML, for completeness: also DOM, also takes `data-*`. Small enough that omitting it would be a
+ * deliberate blind spot rather than a saving.
+ */
+const MATHML_TAGS = [
+  'annotation',
+  'annotation-xml',
+  'maction',
+  'math',
+  'merror',
+  'mfrac',
+  'mi',
+  'mmultiscripts',
+  'mn',
+  'mo',
+  'mover',
+  'mpadded',
+  'mphantom',
+  'mprescripts',
+  'mroot',
+  'mrow',
+  'ms',
+  'mspace',
+  'msqrt',
+  'mstyle',
+  'msub',
+  'msubsup',
+  'msup',
+  'mtable',
+  'mtd',
+  'mtext',
+  'mtr',
+  'munder',
+  'munderover',
+  'semantics',
+];
+
+const DOM_TAGS: ReadonlySet<string> = new Set([...HTML_TAGS, ...SVG_TAGS, ...MATHML_TAGS]);
+
+/**
+ * Whether `tag` names a DOM element that will accept an arbitrary `data-*` attribute.
+ *
+ * Custom elements are deliberately included: a tag containing a dash is a valid custom element per
+ * the HTML spec, it IS a DOM node, and `data-*` on it is ordinary. That rule cannot collide with a
+ * custom reconciler's intrinsics, which are bare identifiers (`mesh`, `group`, `box`).
+ */
+export function isDomTag(tag: string): boolean {
+  return DOM_TAGS.has(tag) || (tag.includes('-') && !tag.startsWith('-'));
+}

--- a/packages/babel-plugin/src/index.test.ts
+++ b/packages/babel-plugin/src/index.test.ts
@@ -47,3 +47,60 @@ describe('reticle babel plugin', () => {
     expect((out.match(new RegExp(SOURCE_ATTR, 'g')) ?? []).length).toBe(1);
   });
 });
+
+/**
+ * A lowercase JSX tag is not the same thing as a DOM element.
+ *
+ * Filed from the field, against a CAD app: `sourceMapping` is on by default, and it stamped
+ * `data-reticle-source` onto `<mesh>`, `<group>` and every other react-three-fiber intrinsic.
+ * R3F is a separate reconciler whose "host elements" are three.js objects, and `applyProps` reads
+ * ANY prop containing a dash as a pierced property path — so `data-reticle-source` is walked as
+ * `data` -> `reticle` -> `source`, finds no `data` object on the instance, and throws:
+ *
+ *   Uncaught Error: R3F: Cannot set "data-reticle-source". Ensure it is an object before setting
+ *       at applyProps (react-three-fiber.esm:434:79)
+ *       at commitUpdate (react-three-fiber.esm:8631:5)
+ *
+ * The throw is unhandled inside the commit phase, so it does not degrade the 3D viewport — it
+ * unmounts the whole React app to a white screen with no error UI. And it fires on an UPDATE, not a
+ * mount: the reporter's app ran ~20 minutes and passed ~15 verdicts before a new mesh triggered it,
+ * which made an instrumentation bug read as an application bug.
+ *
+ * The rule was "lowercase means host element". The rule is "lowercase AND a real HTML or SVG tag",
+ * because only those are guaranteed to accept an arbitrary `data-*` attribute.
+ */
+describe('non-DOM reconcilers', () => {
+  const r3f = ['mesh', 'group', 'points', 'primitive', 'bufferGeometry', 'meshStandardMaterial'];
+
+  it.each(r3f)('does not stamp <%s>, which is a three.js object and not a DOM node', (tag) => {
+    expect(transform(`const x = <${tag} />;`)).not.toContain(SOURCE_ATTR);
+  });
+
+  it('leaves an unknown bare lowercase tag alone rather than guessing it is DOM', () => {
+    // A custom reconciler's intrinsics are unbounded; an allowlist is the only side that can be
+    // enumerated. Missing a stamp costs one source pointer, stamping wrongly costs the whole app.
+    expect(transform('const x = <box />;')).not.toContain(SOURCE_ATTR);
+  });
+
+  it('still stamps a custom element, which IS a DOM node and takes data-* like any other', () => {
+    // A dash is the HTML spec's own marker for a custom element, and no reconciler's intrinsics
+    // carry one — three.js names are bare identifiers. So the dash is a safe positive signal.
+    expect(transform('const x = <sl-button />;')).toContain(SOURCE_ATTR);
+  });
+
+  it('still stamps the HTML elements the source mapping exists for', () => {
+    for (const tag of ['div', 'button', 'input', 'a', 'form', 'li', 'td']) {
+      expect(transform(`const x = <${tag} />;`)).toContain(SOURCE_ATTR);
+    }
+  });
+
+  it('stamps SVG, which is DOM and takes data-* like any other element', () => {
+    for (const tag of ['svg', 'path', 'circle', 'g']) {
+      expect(transform(`const x = <${tag} />;`)).toContain(SOURCE_ATTR);
+    }
+  });
+
+  it('does not stamp a namespaced tag — <svg:rect> is a JSXNamespacedName, not an identifier', () => {
+    expect(transform('const x = <svg:rect />;')).not.toContain(SOURCE_ATTR);
+  });
+});

--- a/packages/babel-plugin/src/index.ts
+++ b/packages/babel-plugin/src/index.ts
@@ -1,6 +1,7 @@
 import { relative } from 'node:path';
 import type { PluginObj, PluginPass, types as BabelTypes } from '@babel/core';
 import { DATA_RETICLE_SOURCE_ATTR } from '@reticlehq/core/source-constants';
+import { isDomTag } from './dom-tags.js';
 
 const SOURCE_ATTR = DATA_RETICLE_SOURCE_ATTR;
 
@@ -27,8 +28,14 @@ function reticleSourcePlugin({ types: t }: PluginApi): PluginObj<PluginPass> {
         const node = path.node;
         // Host elements only (e.g. <div>, <button>) — skip components (<App />).
         if (node.name.type !== 'JSXIdentifier') return;
-        const first = node.name.name[0];
+        const tag = node.name.name;
+        const first = tag[0];
         if (first === undefined || first !== first.toLowerCase()) return;
+        // ...and only host elements that are DOM. React is a reconciler interface, so a lowercase
+        // intrinsic can belong to react-three-fiber, react-pdf or ink, whose host instances are not
+        // nodes. R3F reads a dashed prop as a pierced property path and throws from the commit
+        // phase, which unmounts the entire app to a white screen. See dom-tags.ts.
+        if (!isDomTag(tag)) return;
 
         const alreadyStamped = node.attributes.some(
           (attr) =>


### PR DESCRIPTION
The most severe defect in the 2026-09-08 field export. Extracted **unchanged** from `eb3e6c57` on `fix/pr-list-tells-the-truth`, where it rode along inside an onboarding commit under a PR titled about the open-PR list (#872) — invisible to any reviewer, and lost if that branch were reworked. See my comment on #872 for the suggested split.

## The defect

"Lowercase means host element" is true only for React DOM. React is a reconciler interface: react-three-fiber, react-pdf and ink define their own lowercase intrinsics, and those host instances are not nodes and do not take attributes.

R3F is the case that bit. Its `applyProps` treats any prop containing a dash as a **pierced property path**, so `data-reticle-source` is walked as `data` → `reticle` → `source`. There is no `data` object on a three.js instance, so it throws:

```
Uncaught Error: R3F: Cannot set "data-reticle-source". Ensure it is an object before setting "reticle-source".
    at applyProps (react-three-fiber.esm:434:79)
    at commitUpdate (react-three-fiber.esm:8631:5)
```

The throw is inside R3F's commit phase and unhandled, so it does not degrade the viewport — **it unmounts the entire React app to a white screen.**

## Why it is severe rather than cosmetic

- The option that causes it is **on by default**.
- It fires on an element **update**, not a mount. In the field the app imported a STEP file, ran a volume extraction and rendered geometry for ~20 minutes across ~15 passing verdicts before a newly generated mesh took it down mid-pipeline, losing all in-memory setup state.
- So `reticle init` looks clean, a session connects, verdicts pass, and the app dies much later — which reads as an application bug. The reporter initially diagnosed it as one and only found us by reading the stack trace.
- Its documentation names the **React version** as the risk axis. The actual risk axis is whether the tree contains non-DOM reconciler elements.

Net: an entire application category — CAD, simulation, 3D configurators, map and model viewers — is not merely unverifiable but actively broken by installing us.

## The approach

An **allowlist**, not a heuristic. The set of custom-reconciler intrinsics is unbounded and cannot be enumerated; the set of HTML and SVG tags can. Wrong conservatively costs one source pointer on an exotic element. Wrong the other way costs the user their entire app.

Stated rather than implied in `dom-tags.ts`: a few three.js class names collide with real DOM tags — `line` is both `<line>` in SVG and `THREE.Line`, and so is `audio`. A tag name alone cannot separate them, and a lexical "is it under a `<Canvas>`" walk only sees the file being transformed. The complete answer for a three.js app remains `reticle({ sourceMapping: false })`, which `init` now writes on its own when it finds react-three-fiber in the manifest.

## Verification

`pnpm format:check`, `pnpm lint`, `pnpm typecheck` green; 15/15 babel-plugin tests.

Not claimed: I have not driven a real react-three-fiber app against this build. The unit tests pin that the listed non-DOM intrinsics are skipped and DOM tags still stamp; the end-to-end proof that the white screen is gone is the thing #891's awkward-app corpus exists to make routine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)