### PR TITLE
fix(init): an app with a non-DOM React renderer is installed with the stamp off

### DIFF
--- a/packages/babel-plugin/src/dom-tags.ts
+++ b/packages/babel-plugin/src/dom-tags.ts
@@ -20,8 +20,12 @@
  * with real DOM tags — `line` is both `<line>` in SVG and `THREE.Line`, and `audio` is both. A tag
  * name alone cannot separate them, and a lexical "is it under a <Canvas>" walk only sees the file
  * it is transforming, so a scene component in its own file would still slip through. The complete
- * answer for a three.js app is `reticle({ sourceMapping: false })`, which `reticle init` now writes
- * on its own when it finds react-three-fiber in the manifest.
+ * answer for a three.js app is `reticle({ sourceMapping: false })` — which `reticle init` writes on
+ * its own when it finds one of these renderers in the manifest (see `Detection.customReconciler`).
+ *
+ * This paragraph described that as already true for a release in which it was not: nothing read the
+ * manifest, and the crash reached new installs anyway. The allowlist below is a mitigation, not the
+ * remedy; the manifest check is the remedy.
  */
 
 /** Every HTML element name, including the deprecated ones a real codebase still contains. */

--- a/packages/next/index.cjs
+++ b/packages/next/index.cjs
@@ -260,9 +260,17 @@ function sdkPackageVersion() {
 
 /**
  * @param {import('next').NextConfig} [nextConfig]
+ * @param {{ sourceMapping?: boolean }} [options] Pass `{ sourceMapping: false }` for an app that
+ *   renders through a non-DOM React reconciler — react-three-fiber, react-pdf, ink. A lowercase JSX
+ *   tag is a host element in every React renderer, but only React DOM's host instances are nodes
+ *   that take attributes. R3F reads the dashed `data-reticle-source` as a pierced property path,
+ *   walks `data` -> `reticle` on a three.js instance that has no `data`, and throws from the commit
+ *   phase — unmounting the whole tree to a white screen. The babel plugin's allowlist keeps the
+ *   stamp off `<mesh>`, and cannot help with the tags that COLLIDE: `<line>` is SVG's AND
+ *   `THREE.Line`; `<audio>` is both. Turning the stamp off costs source pointers, not the app.
  * @returns {import('next').NextConfig}
  */
-function withReticle(nextConfig = {}) {
+function withReticle(nextConfig = {}, options = {}) {
   // Production builds are untouched — this is a dev-time aid only.
   if (process.env.NODE_ENV === 'production') return nextConfig;
 
@@ -292,14 +300,16 @@ function withReticle(nextConfig = {}) {
       NEXT_PUBLIC_RETICLE_SDK_VERSION: sdkPackageVersion(),
     },
     webpack(config, ctx) {
-      config.module = config.module || { rules: [] };
-      config.module.rules = config.module.rules || [];
-      config.module.rules.push({
-        test: /\.(t|j)sx$/,
-        exclude: /node_modules/,
-        enforce: 'pre',
-        use: [{ loader: require.resolve('./loader.cjs') }],
-      });
+      if (options.sourceMapping !== false) {
+        config.module = config.module || { rules: [] };
+        config.module.rules = config.module.rules || [];
+        config.module.rules.push({
+          test: /\.(t|j)sx$/,
+          exclude: /node_modules/,
+          enforce: 'pre',
+          use: [{ loader: require.resolve('./loader.cjs') }],
+        });
+      }
       return typeof userWebpack === 'function' ? userWebpack(config, ctx) : config;
     },
   };

--- a/packages/next/index.d.ts
+++ b/packages/next/index.d.ts
@@ -1,2 +1,12 @@
 /** Wrap a Next.js config to add dev-only source-file mapping (data-reticle-source), keeping SWC. */
-export function withReticle<T = unknown>(nextConfig?: T): T;
+export function withReticle<T = unknown>(
+  nextConfig?: T,
+  options?: {
+    /**
+     * Stamp `data-reticle-source` on JSX host elements. Default true. Set false for an app that
+     * renders through a non-DOM React reconciler (react-three-fiber, react-pdf, ink), where a
+     * lowercase tag is not an element and the stamp crashes the app at commit time.
+     */
+    sourceMapping?: boolean;
+  },
+): T;

--- a/packages/next/index.test.mjs
+++ b/packages/next/index.test.mjs
@@ -76,6 +76,29 @@ describe('withReticle', () => {
     expect(rule.test.test('src/Foo.jsx')).toBe(true);
     expect(rule.test.test('src/util.ts')).toBe(false);
   });
+
+  /**
+   * A react-three-fiber app has no way to keep the rest of Reticle and drop the stamp otherwise,
+   * and the stamp crashes it: R3F reads the dashed attribute as a pierced property path, walks
+   * `data` -> `reticle` on a three.js instance that has no `data`, and throws from the commit
+   * phase, unmounting the whole tree. The user's other webpack config must survive the opt-out.
+   */
+  it('installs no loader when sourceMapping is off, and keeps the user webpack hook', () => {
+    process.env.NODE_ENV = 'development';
+    let sawUserHook = false;
+    const config = withReticle(
+      {
+        webpack(c) {
+          sawUserHook = true;
+          return c;
+        },
+      },
+      { sourceMapping: false },
+    );
+    const out = config.webpack({ module: { rules: [] } }, { dev: true });
+    expect(out.module.rules).toHaveLength(0);
+    expect(sawUserHook).toBe(true);
+  });
 });
 
 /**

--- a/packages/server/src/init/detect.test.ts
+++ b/packages/server/src/init/detect.test.ts
@@ -259,3 +259,34 @@ describe('the dependency install is quiet about things that are not ours', () =>
     }
   });
 });
+
+describe('customReconciler', () => {
+  // The whole point: a lowercase tag in these projects may not be a DOM element, and stamping one
+  // unmounts the app to a white screen from inside the commit phase.
+  it.each([
+    '@react-three/fiber',
+    'react-three-fiber',
+    '@react-pdf/renderer',
+    'ink',
+    'react-native',
+  ])('is true when %s is a dependency', (name) => {
+    expect(
+      detect(input({ pkg: { dependencies: { react: '^19.0.0', [name]: '^9.0.0' } } }))
+        .customReconciler,
+    ).toBe(true);
+  });
+
+  it('finds it in devDependencies too', () => {
+    expect(
+      detect(input({ pkg: { devDependencies: { '@react-three/fiber': '^9.0.0' } } }))
+        .customReconciler,
+    ).toBe(true);
+  });
+
+  it('is false for an ordinary React DOM app', () => {
+    expect(
+      detect(input({ pkg: { dependencies: { react: '^19.0.0', three: '^0.170.0' } } }))
+        .customReconciler,
+    ).toBe(false);
+  });
+});

--- a/packages/server/src/init/detect.ts
+++ b/packages/server/src/init/detect.ts
@@ -100,6 +100,28 @@ export interface Detection {
   reactScriptsMajor?: number | undefined;
   /** React 19 dropped _debugSource, so it needs the build-time source-map stamp. */
   needsSourceMapping: boolean;
+  /**
+   * Whether this project renders through a NON-DOM React reconciler, in which case the
+   * `data-reticle-source` stamp must be switched off for the whole app.
+   *
+   * React is a reconciler interface, not a renderer. A lowercase JSX tag is a host element in
+   * every renderer, but only in React DOM is a host element a node that takes attributes. The
+   * babel plugin's allowlist keeps the stamp off `<mesh>` and `<group>`, and it cannot help with
+   * the tags that COLLIDE: `<line>` is both SVG's and `THREE.Line`, `<audio>` is both. R3F's
+   * `applyProps` reads any dashed prop as a pierced property path, walks `data` -> `reticle` on a
+   * three.js instance that has no `data`, and throws from inside the commit phase — which unmounts
+   * the entire tree to a white screen, long after the app looked fine.
+   *
+   * A tag name alone cannot separate the two, and a lexical "is it under a <Canvas>" walk only sees
+   * the file being transformed. The manifest can: an app that depends on one of these renderers has
+   * the collision, so `init` writes `sourceMapping: false` rather than shipping a crash. The cost is
+   * source pointers on that app; the alternative cost is the app.
+   *
+   * Optional so every existing fixture keeps compiling without naming it, in the one direction a
+   * default here can be wrong safely: absent means an ordinary React DOM app, which is what an
+   * unstated fixture is. `detect` always sets it.
+   */
+  customReconciler?: boolean | undefined;
   packageManager: PackageManager;
 }
 
@@ -122,6 +144,18 @@ const ASTRO_CONFIGS = [
 function depVersion(pkg: PackageJsonLike, name: string): string | undefined {
   return pkg.dependencies?.[name] ?? pkg.devDependencies?.[name] ?? pkg.peerDependencies?.[name];
 }
+
+/**
+ * React renderers whose host instances are not DOM nodes. Presence of any one of them means a
+ * lowercase JSX tag in this project may not be an element. See `Detection.customReconciler`.
+ */
+const CUSTOM_RECONCILER_DEPS = [
+  '@react-three/fiber',
+  'react-three-fiber',
+  '@react-pdf/renderer',
+  'ink',
+  'react-native',
+];
 
 function hasAnyConfig(files: ReadonlySet<string>, candidates: readonly string[]): boolean {
   return candidates.some((c) => files.has(c));
@@ -244,6 +278,9 @@ export function detect(input: DetectInput): Detection {
       depVersion(input.pkg, 'typescript') !== undefined,
     reactMajor,
     needsSourceMapping: reactMajor !== undefined && reactMajor >= 19,
+    customReconciler: CUSTOM_RECONCILER_DEPS.some(
+      (name) => depVersion(input.pkg, name) !== undefined,
+    ),
     packageManager: detectPackageManager(input.lockfiles, input.nodeModulesMarkers ?? new Set()),
   };
 }

--- a/packages/server/src/init/next-patch.ts
+++ b/packages/server/src/init/next-patch.ts
@@ -159,25 +159,43 @@ function exportSites(source: string, head: RegExp): ExportSite[] {
  *
  * Applied back-to-front so each splice leaves the earlier offsets valid.
  */
-function wrapAll(source: string, sites: readonly ExportSite[]): string {
+function wrapAll(source: string, sites: readonly ExportSite[], secondArg: string): string {
   let out = source;
   for (const site of [...sites].sort((a, b) => b.start - a.start)) {
-    out = `${out.slice(0, site.start)}withReticle(${out.slice(site.start, site.end)})${out.slice(site.end)}`;
+    out = `${out.slice(0, site.start)}withReticle(${out.slice(site.start, site.end)}${secondArg})${out.slice(site.end)}`;
   }
   return out;
 }
 
-export function patchNextConfig(source: string): SourcePatch {
+/**
+ * The second argument to `withReticle`, or nothing at all.
+ *
+ * A Next app has no plugin call to carry `sourceMapping: false`, so the only place to say it is the
+ * config wrap itself. Omitted entirely when the stamp stays on, because an install that appends
+ * `, {}` to every config it touches is a diff against the user's file for no reason.
+ */
+function withReticleOptions(sourceMapping: boolean): string {
+  return sourceMapping ? '' : ', { sourceMapping: false }';
+}
+
+export function patchNextConfig(source: string, sourceMapping = true): SourcePatch {
   if (source.includes(RETICLE_NEXT_PACKAGE)) return { kind: PatchKind.ALREADY };
 
+  const options = withReticleOptions(sourceMapping);
   const esm = exportSites(source, ESM_DEFAULT_HEAD);
   if (esm.length > 0) {
-    return { kind: PatchKind.APPLY, code: `${NEXT_CONFIG_IMPORT}\n${wrapAll(source, esm)}` };
+    return {
+      kind: PatchKind.APPLY,
+      code: `${NEXT_CONFIG_IMPORT}\n${wrapAll(source, esm, options)}`,
+    };
   }
 
   const cjs = exportSites(source, CJS_EXPORT_HEAD);
   if (cjs.length > 0) {
-    return { kind: PatchKind.APPLY, code: `${NEXT_CONFIG_REQUIRE}\n${wrapAll(source, cjs)}` };
+    return {
+      kind: PatchKind.APPLY,
+      code: `${NEXT_CONFIG_REQUIRE}\n${wrapAll(source, cjs, options)}`,
+    };
   }
 
   return { kind: PatchKind.MANUAL, reason: NO_EXPORT_REASON };

--- a/packages/server/src/init/plan-framework.ts
+++ b/packages/server/src/init/plan-framework.ts
@@ -232,11 +232,20 @@ function viteConfigSteps(input: PlanInput, detail: string): Step[] {
         title: 'Vite plugin',
         target: 'vite.config',
         status: StepStatus.MANUAL,
-        detail: viteManual(port, input.detection.uiLibrary),
+        detail: viteManual(
+          port,
+          input.detection.uiLibrary,
+          true !== input.detection?.customReconciler,
+        ),
       },
     ];
   }
-  const patch = patchViteConfig(cfg.source, port, true === input.captureBodies);
+  const patch = patchViteConfig(
+    cfg.source,
+    port,
+    true === input.captureBodies,
+    true !== input.detection?.customReconciler,
+  );
   if (patch.kind === VitePatchKind.ALREADY) {
     return [
       {
@@ -253,7 +262,7 @@ function viteConfigSteps(input: PlanInput, detail: string): Step[] {
         title: 'Vite plugin',
         target: cfg.path,
         status: StepStatus.MANUAL,
-        detail: `${patch.reason}\n\n${viteManual(port, input.detection.uiLibrary)}`,
+        detail: `${patch.reason}\n\n${viteManual(port, input.detection.uiLibrary, true !== input.detection?.customReconciler)}`,
       },
     ];
   }
@@ -371,7 +380,7 @@ export function nextSteps(input: PlanInput): Step[] {
   const configPatch: SourcePatch =
     null === input.nextConfigSource || input.nextConfigSource === undefined
       ? { kind: PatchKind.MANUAL, reason: `no ${configFile} found` }
-      : patchNextConfig(input.nextConfigSource);
+      : patchNextConfig(input.nextConfigSource, true !== input.detection?.customReconciler);
   const layout = input.nextLayout ?? null;
   // Pages Router mounts through pages/_app, App Router through the root layout — different edits,
   // and picking by path is what stops a Pages app being handed the layout patch that cannot apply.
@@ -406,7 +415,7 @@ export function nextSteps(input: PlanInput): Step[] {
       configFile,
       configPatch,
       'wrap the export in withReticle (source mapping, dev-only)',
-      nextConfigManual(configFile),
+      nextConfigManual(configFile, true !== input.detection?.customReconciler),
     ),
     patchStep(
       'Mount ReticleDev',

--- a/packages/server/src/init/r3f-source-mapping.test.ts
+++ b/packages/server/src/init/r3f-source-mapping.test.ts
@@ -1,0 +1,99 @@
+/**
+ * A react-three-fiber app must come out of `init` with the source-map stamp OFF.
+ *
+ * This is the whole remedy, and it lives in the PLAN rather than in the babel plugin, because the
+ * plugin cannot see what the manifest can. `<line>` is SVG's `<line>` and it is `THREE.Line`; the
+ * allowlist has to let it through, and R3F then walks the dashed attribute as a pierced property
+ * path and throws from the commit phase, unmounting the app to a white screen.
+ *
+ * It is asserted on the plan's OUTPUT — the config text a user actually gets — because that is the
+ * only thing that reaches them. A correct detection that nothing writes down is the state this
+ * repo was already in: the babel plugin documented this behaviour for a release in which no code
+ * read the manifest at all.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildPlan, type PlanInput } from './plan.js';
+import { Framework, PackageManager, UiLibrary, type Detection } from './detect.js';
+
+const NEXT_CONFIG_SOURCE = `const nextConfig = {};
+export default nextConfig;
+`;
+
+const VITE_CONFIG = {
+  path: 'vite.config.ts',
+  source: `import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});
+`,
+};
+
+function input(customReconciler: boolean): PlanInput {
+  const detection: Detection = {
+    framework: Framework.VITE,
+    uiLibrary: UiLibrary.REACT,
+    typescript: true,
+    reactMajor: 19,
+    needsSourceMapping: true,
+    customReconciler,
+    packageManager: PackageManager.PNPM,
+  };
+  return {
+    detection,
+    claudeCli: true,
+    mcpExists: false,
+    viteConfig: VITE_CONFIG,
+    nextConfigFile: null,
+    nextReticleDevExists: false,
+    options: { port: 4400, mcp: true, install: false },
+  };
+}
+
+function viteStepText(plan: ReturnType<typeof buildPlan>): string {
+  return stepText(plan, 'Vite plugin');
+}
+
+function stepText(plan: ReturnType<typeof buildPlan>, title: string): string {
+  const step = plan.steps.find((s) => title === s.title);
+  if (step === undefined) throw new Error(`no ${title} step in the plan`);
+  return `${step.write?.content ?? ''}\n${step.detail ?? ''}`;
+}
+
+/**
+ * The same app on Next.js. It has no plugin call to carry the flag, so the ONLY place `init` can
+ * say it is the `withReticle` wrap it writes into next.config — and the wrap is auto-applied, so a
+ * detection that stopped at the Vite path would leave every Next R3F app crashing exactly as before.
+ */
+function nextInput(customReconciler: boolean): PlanInput {
+  return {
+    ...input(customReconciler),
+    detection: { ...input(customReconciler).detection, framework: Framework.NEXT },
+    viteConfig: null,
+    nextConfigFile: 'next.config.mjs',
+    nextConfigSource: NEXT_CONFIG_SOURCE,
+  };
+}
+
+describe('init and a non-DOM React renderer', () => {
+  it('turns the stamp off in the config it writes', () => {
+    expect(viteStepText(buildPlan(input(true)))).toContain('sourceMapping: false');
+  });
+
+  it('leaves the stamp alone for an ordinary React DOM app', () => {
+    expect(viteStepText(buildPlan(input(false)))).not.toContain('sourceMapping');
+  });
+
+  it('turns the stamp off in the next.config wrap it writes', () => {
+    const text = stepText(buildPlan(nextInput(true)), 'Next config (withReticle)');
+    expect(text).toContain('withReticle(nextConfig, { sourceMapping: false })');
+  });
+
+  it('leaves the next.config wrap bare for an ordinary React DOM app', () => {
+    const text = stepText(buildPlan(nextInput(false)), 'Next config (withReticle)');
+    expect(text).toContain('withReticle(nextConfig)');
+    expect(text).not.toContain('sourceMapping');
+  });
+});

--- a/packages/server/src/init/snippets.ts
+++ b/packages/server/src/init/snippets.ts
@@ -115,8 +115,18 @@ function frameworkPluginExample(uiLibrary: UiLibrary): string {
 export function viteManual(
   port: number | undefined,
   uiLibrary: UiLibrary = UiLibrary.UNKNOWN,
+  sourceMapping = true,
 ): string {
-  const call = port === undefined ? 'reticle()' : `reticle({ port: ${String(port)} })`;
+  const options = [
+    ...(port === undefined ? [] : [`port: ${String(port)}`]),
+    ...(sourceMapping ? [] : ['sourceMapping: false']),
+  ];
+  const call = 0 === options.length ? 'reticle()' : `reticle({ ${options.join(', ')} })`;
+  const note = sourceMapping
+    ? ''
+    : `\n\n\`sourceMapping: false\` because this app renders through a non-DOM React renderer, where a
+lowercase JSX tag is not an element. Stamping one crashes the app at commit time. You lose source
+pointers, not the app.`;
   return `Add the Reticle plugin to your Vite config:
 
   import { reticle } from '@reticlehq/vite-plugin';
@@ -126,16 +136,22 @@ export function viteManual(
   });
 
 Keep \`reticle()\` LAST so it sees the output of your other plugins. It only applies during \`vite\`
-(dev) — it is dropped from \`vite build\`.`;
+(dev) — it is dropped from \`vite build\`.${note}`;
 }
 
 /** Next.js config wrap — always printed (we never auto-rewrite next.config). */
-export function nextConfigManual(configFile: string): string {
+export function nextConfigManual(configFile: string, sourceMapping = true): string {
+  const options = sourceMapping ? '' : ', { sourceMapping: false }';
+  const note = sourceMapping
+    ? ''
+    : `\n\n\`sourceMapping: false\` because this app renders through a non-DOM React renderer, where a
+lowercase JSX tag is not an element. Stamping one crashes the app at commit time. You lose source
+pointers, not the app.`;
   return `Wrap your ${configFile} export with withReticle (keeps SWC, dev-only):
 
   import { withReticle } from '@reticlehq/next';
 
-  export default withReticle(nextConfig);`;
+  export default withReticle(nextConfig${options});${note}`;
 }
 
 /**

--- a/packages/server/src/init/vite-config.test.ts
+++ b/packages/server/src/init/vite-config.test.ts
@@ -181,3 +181,23 @@ describe('the plugin call init writes', () => {
     expect(r.code).toContain('captureNetworkBodies: true');
   });
 });
+
+describe('source mapping off for a non-DOM React renderer', () => {
+  it('writes sourceMapping: false into the call', () => {
+    const r = patchViteConfig(BASIC, undefined, false, false);
+    if (r.kind !== VitePatchKind.APPLY) throw new Error('expected apply');
+    expect(r.code).toContain('reticle({ sourceMapping: false })');
+  });
+
+  it('keeps the port and the option together, in that order', () => {
+    const r = patchViteConfig(BASIC, 4400, false, false);
+    if (r.kind !== VitePatchKind.APPLY) throw new Error('expected apply');
+    expect(r.code).toContain('reticle({ port: 4400, sourceMapping: false })');
+  });
+
+  it('says nothing when the stamp is fine, which is the default', () => {
+    const r = patchViteConfig(BASIC, 4400);
+    if (r.kind !== VitePatchKind.APPLY) throw new Error('expected apply');
+    expect(r.code).not.toContain('sourceMapping');
+  });
+});

--- a/packages/server/src/init/vite-config.ts
+++ b/packages/server/src/init/vite-config.ts
@@ -37,12 +37,28 @@ const RETICLE_MARKER = '@reticlehq/vite-plugin';
  * and reconcile-tools.ts — so the capability is discovered at the moment it is wanted, by the person
  * who wanted it, instead of being switched on before anyone has asked.
  */
-function reticlePluginCall(port: number | undefined, captureBodies: boolean): string {
+function reticlePluginCall(opts: PluginCallOptions): string {
   const options = [
-    ...(port === undefined ? [] : [`port: ${String(port)}`]),
-    ...(captureBodies ? ['captureNetworkBodies: true'] : []),
+    ...(opts.port === undefined ? [] : [`port: ${String(opts.port)}`]),
+    ...(opts.captureBodies ? ['captureNetworkBodies: true'] : []),
+    ...(opts.sourceMapping ? [] : ['sourceMapping: false']),
   ];
   return 0 === options.length ? 'reticle()' : `reticle({ ${options.join(', ')} })`;
+}
+
+/**
+ * What `init` decided to write into the call. Grouped rather than threaded positionally: two
+ * adjacent booleans through three helpers is a swap waiting to happen, and the swap is silent.
+ */
+interface PluginCallOptions {
+  port: number | undefined;
+  captureBodies: boolean;
+  /**
+   * Stamp `data-reticle-source`. Written as `sourceMapping: false` for an app whose React renderer
+   * is not React DOM — see `Detection.customReconciler`, where the whole argument lives. The plugin
+   * defaults it ON, so the only way to spare such an app is to say so in the config.
+   */
+  sourceMapping: boolean;
 }
 /** Matches the start of a `plugins: [` array literal. */
 const PLUGINS_ARRAY = /plugins\s*:\s*\[/;
@@ -84,11 +100,11 @@ function insertImport(source: string): string {
  * what a formatter rewrites, turning a one-line install into a diff against the user's own style. A
  * single-line array needs the space, or the result reads `[reticle(),react()]`.
  */
-function insertPlugin(source: string, port: number | undefined, captureBodies: boolean): string {
+function insertPlugin(source: string, call: string): string {
   return source.replace(PLUGINS_ARRAY, (match, _g, offset: number) => {
     const next = source[offset + match.length] ?? '';
     const separator = '' === next || /\s/.test(next) ? '' : ' ';
-    return `${match}${reticlePluginCall(port, captureBodies)},${separator}`;
+    return `${match}${call},${separator}`;
   });
 }
 
@@ -96,35 +112,31 @@ function insertPlugin(source: string, port: number | undefined, captureBodies: b
  * Add a whole `plugins: [reticle()]` key to a config object that has none, matching the layout of
  * the object it lands in: a multi-line object gets its own indented line, a one-liner stays inline.
  */
-function insertPluginsKey(
-  source: string,
-  port: number | undefined,
-  captureBodies: boolean,
-): string {
+function insertPluginsKey(source: string, call: string): string {
   return source.replace(CONFIG_OBJECT, (_match, prefix: string, offset: number) => {
     const rest = source.slice(offset + _match.length);
     const multiline = /^\s*\n/.test(rest);
     const indent = /^\s*\n(\s*)\S/.exec(rest)?.[1] ?? '  ';
-    const key = `plugins: [${reticlePluginCall(port, captureBodies)}],`;
+    const key = `plugins: [${call}],`;
     return multiline ? `${prefix}{\n${indent}${key}` : `${prefix}{ ${key}`;
   });
 }
 
-export function patchViteConfig(source: string, port?: number, captureBodies = false): VitePatch {
+export function patchViteConfig(
+  source: string,
+  port?: number,
+  captureBodies = false,
+  sourceMapping = true,
+): VitePatch {
   if (source.includes(RETICLE_MARKER)) {
     return { kind: VitePatchKind.ALREADY };
   }
+  const call = reticlePluginCall({ port, captureBodies, sourceMapping });
   if (PLUGINS_ARRAY.test(source)) {
-    return {
-      kind: VitePatchKind.APPLY,
-      code: insertImport(insertPlugin(source, port, captureBodies)),
-    };
+    return { kind: VitePatchKind.APPLY, code: insertImport(insertPlugin(source, call)) };
   }
   if (CONFIG_OBJECT.test(source)) {
-    return {
-      kind: VitePatchKind.APPLY,
-      code: insertImport(insertPluginsKey(source, port, captureBodies)),
-    };
+    return { kind: VitePatchKind.APPLY, code: insertImport(insertPluginsKey(source, call)) };
   }
   return { kind: VitePatchKind.MANUAL, reason: NO_PLUGINS_REASON };
 }


### PR DESCRIPTION
`#901` shipped the allowlist as the fix for the react-three-fiber crash. It is a mitigation, and the file it landed in described the remedy as already true: nothing read the manifest, so an R3F app still came out of `init` crashing.

## Why the allowlist cannot finish the job

React is a reconciler interface. A lowercase JSX tag is a host element in every renderer, but only React DOM's host instances are nodes that take attributes. R3F's `applyProps` reads any dashed prop as a pierced property path, walks `data` → `reticle` on a three.js instance that has no `data`, and throws from inside the commit phase — unmounting the whole tree to a white screen. It fires on an element UPDATE rather than a mount, so the app looks fine until it does not.

The allowlist keeps the stamp off `<mesh>` and `<group>`. It cannot help with the tags that **collide**: `<line>` is SVG's `<line>` *and* `THREE.Line`; `<audio>` is both. A tag name cannot separate them, and a lexical "is it under a `<Canvas>`" walk only sees the file being transformed — a scene component in its own file still slips through.

## The remedy

The manifest can tell them apart. `detect` now reports `customReconciler` for `@react-three/fiber`, `react-three-fiber`, `@react-pdf/renderer`, `ink` and `react-native`, and the plan writes `sourceMapping: false` rather than shipping a crash. The cost is source pointers on that app; the alternative cost is the app.

**Both install paths**, because a detection only one of them reads leaves the other crashing exactly as before:

- **Vite** carries the flag in the plugin call, and in the manual recipe for configs the patcher declines to rewrite.
- **Next** has no plugin call, so `withReticle` takes a second argument and the auto-applied config wrap emits `withReticle(nextConfig, { sourceMapping: false })`.

## Test

Asserted on the plan's **output** — the config text a user actually receives — because a correct detection that nothing writes down is the state this repo was already in. The Next half goes red without the wrap change (verified by reverting it).

Gates: format, lint, typecheck green; 6758 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)