### PR TITLE
fix(server): rank ambiguous target candidates without guessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
+### Changed
+
+- **`@reticlehq/server` — an ambiguous target refusal ranks its candidates.** The refusal itself is unchanged (an action still must not guess), but the listed refs are ordered in-viewport then by role, and each entry says whether it is in-viewport, off-screen, visible, or hidden. A header CTA and an empty-state CTA sharing one name no longer cost a snapshot turn to pick between. Multi-match `QUERY` results stamp `inViewport` onto the described prefix so the ranker has the fact. Closes [#886](https://github.com/reticlehq/reticle/issues/886).
+
 ### Added
 
 - **`@reticlehq/server` — `reticle_navigate` takes a `timeout_ms`, and an unconfirmed result says what the wait ended on.** The arrival window was a fixed, unstated 5s: `navigate-arrival.ts` hard-coded it and the tool exposed nothing, so unlike `assert` / `wait_for` / `act_and_wait`, which all spend the caller's budget, nobody could tell navigate to wait longer. A Nuxt SPA reattaching under HMR was measured at 30–60s, so every navigation to it gave up while the app was still coming back and answered `confirmed: false`, which reads as a failed navigation rather than as Reticle having stopped waiting; the only escape was the blind `reticle_sessions` poll that `#612` removed everywhere else. `timeout_ms` now reaches the wait (default 5000, so nothing gets slower by accident; `0` looks once; the same bounds as the other tools), and applies to `{ reload: true }` too, since the page coming back is the same wait. `confirmed: false` carries `waitedMs`, the budget that expired, and its note names `timeout_ms` as the way to wait longer. Closes [#856](https://github.com/reticlehq/reticle/issues/856).

--- a/packages/browser/src/dom/in-viewport.test.ts
+++ b/packages/browser/src/dom/in-viewport.test.ts
@@ -78,4 +78,22 @@ describe('isInViewport (#398)', () => {
     const inView = matchQuery({ role: 'button', name: 'Go' }, ElementState.IN_VIEWPORT);
     expect(inView.count).toBe(1);
   });
+
+  it('stamps inViewport onto multi-match descriptors so ambiguity can be ranked (#886)', () => {
+    const onScreen = boxed(
+      { top: 100, left: 100, bottom: 140, right: 200, width: 100, height: 40 },
+      'button',
+    );
+    onScreen.textContent = 'Go';
+    const belowFold = boxed(
+      { top: 3000, left: 100, bottom: 3040, right: 200, width: 100, height: 40 },
+      'button',
+    );
+    belowFold.textContent = 'Go';
+
+    const all = matchQuery({ role: 'button', name: 'Go' });
+    expect(all.elements).toHaveLength(2);
+    const stamped = all.elements.filter((e) => e.states.includes(ElementState.IN_VIEWPORT));
+    expect(stamped).toHaveLength(1);
+  });
 });

--- a/packages/browser/src/dom/query.ts
+++ b/packages/browser/src/dom/query.ts
@@ -470,8 +470,15 @@ export function matchQuery(
     state === undefined ? elements : elements.filter((el) => inState(el, state, visMemo));
   const attrs = query.attrs;
   const described = filtered.slice(0, Math.max(0, Math.min(limit, MAX_DESCRIBED)));
+  // When more than one match is described, stamp `inViewport` onto those that sit in the window.
+  // Target resolution (#886) ranks ambiguity refusals by that fact; it is omitted from single-match
+  // and snapshot-wide describes because it would bloat every element on every look (#398).
+  const stampViewport = described.length > 1;
   const descriptors: ElementDescriptor[] = described.map((el) => {
-    const base = describe(el, visMemo);
+    let base = describe(el, visMemo);
+    if (stampViewport && isInViewport(el, visMemo) && !base.states.includes(ElementState.IN_VIEWPORT)) {
+      base = { ...base, states: [...base.states, ElementState.IN_VIEWPORT] };
+    }
     if (attrs === undefined || 0 === attrs.length) return base;
     const projected = projectAttrs(el, attrs);
     return projected === undefined ? base : { ...base, attrs: projected };

--- a/packages/browser/src/dom/query.ts
+++ b/packages/browser/src/dom/query.ts
@@ -476,7 +476,11 @@ export function matchQuery(
   const stampViewport = described.length > 1;
   const descriptors: ElementDescriptor[] = described.map((el) => {
     let base = describe(el, visMemo);
-    if (stampViewport && isInViewport(el, visMemo) && !base.states.includes(ElementState.IN_VIEWPORT)) {
+    if (
+      stampViewport &&
+      isInViewport(el, visMemo) &&
+      !base.states.includes(ElementState.IN_VIEWPORT)
+    ) {
       base = { ...base, states: [...base.states, ElementState.IN_VIEWPORT] };
     }
     if (attrs === undefined || 0 === attrs.length) return base;

--- a/packages/server/src/tools/resolve-target.test.ts
+++ b/packages/server/src/tools/resolve-target.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { ElementState } from '@reticlehq/core';
 import { resolveTargetRef } from './resolve-target.js';
 
 describe('resolving a target query to one ref', () => {
@@ -48,5 +49,58 @@ describe('resolving a target query to one ref', () => {
 
   it('refuses a match with no ref instead of acting on undefined', () => {
     expect(resolveTargetRef([{ role: 'button', visible: true }]).kind).toBe('error');
+  });
+});
+
+/**
+ * Ambiguity must stay a refusal — ranking is advice for the next call, never a silent pick (#886).
+ * The field case was a header CTA and an empty-state CTA sharing one name: the agent spent a
+ * snapshot turn to learn which ref to pass, while the refusal already knew both candidates.
+ */
+describe('an ambiguous refusal ranks the candidates it already has', () => {
+  it('lists in-viewport before off-screen, and says which is which', () => {
+    const r = resolveTargetRef([
+      {
+        ref: 'e2',
+        role: 'button',
+        name: 'New bill',
+        visible: true,
+        states: [ElementState.VISIBLE],
+      },
+      {
+        ref: 'e1',
+        role: 'button',
+        name: 'New bill',
+        visible: true,
+        states: [ElementState.VISIBLE, ElementState.IN_VIEWPORT],
+      },
+    ]);
+    expect(r.kind).toBe('error');
+    if (r.kind !== 'error') return;
+    const e1 = r.message.indexOf('e1');
+    const e2 = r.message.indexOf('e2');
+    expect(e1, 'in-viewport candidate leads').toBeGreaterThanOrEqual(0);
+    expect(e2).toBeGreaterThanOrEqual(0);
+    expect(e1).toBeLessThan(e2);
+    expect(r.message).toContain('in-viewport');
+    expect(r.message).toContain('off-screen');
+  });
+
+  it('lists a button ahead of a generic with the same name', () => {
+    const r = resolveTargetRef([
+      { ref: 'e1310', role: 'generic', name: 'New bill', visible: true },
+      { ref: 'e1309', role: 'button', name: 'New bill', visible: true },
+    ]);
+    expect(r.kind).toBe('error');
+    if (r.kind !== 'error') return;
+    expect(r.message.indexOf('e1309')).toBeLessThan(r.message.indexOf('e1310'));
+  });
+
+  it('still refuses — ranking is not a choice', () => {
+    const r = resolveTargetRef([
+      { ref: 'e1', role: 'button', name: 'Save', visible: true, states: [ElementState.IN_VIEWPORT] },
+      { ref: 'e2', role: 'button', name: 'Save', visible: true },
+    ]);
+    expect(r.kind).toBe('error');
   });
 });

--- a/packages/server/src/tools/resolve-target.test.ts
+++ b/packages/server/src/tools/resolve-target.test.ts
@@ -98,7 +98,13 @@ describe('an ambiguous refusal ranks the candidates it already has', () => {
 
   it('still refuses — ranking is not a choice', () => {
     const r = resolveTargetRef([
-      { ref: 'e1', role: 'button', name: 'Save', visible: true, states: [ElementState.IN_VIEWPORT] },
+      {
+        ref: 'e1',
+        role: 'button',
+        name: 'Save',
+        visible: true,
+        states: [ElementState.IN_VIEWPORT],
+      },
       { ref: 'e2', role: 'button', name: 'Save', visible: true },
     ]);
     expect(r.kind).toBe('error');

--- a/packages/server/src/tools/resolve-target.ts
+++ b/packages/server/src/tools/resolve-target.ts
@@ -39,9 +39,7 @@ function roleRank(role: unknown): number {
 }
 
 function statesOf(c: TargetCandidate): readonly string[] {
-  return Array.isArray(c.states)
-    ? c.states.filter((s): s is string => 'string' === typeof s)
-    : [];
+  return Array.isArray(c.states) ? c.states.filter((s): s is string => 'string' === typeof s) : [];
 }
 
 function inViewport(c: TargetCandidate): boolean {

--- a/packages/server/src/tools/resolve-target.ts
+++ b/packages/server/src/tools/resolve-target.ts
@@ -1,3 +1,4 @@
+import { ElementState } from '@reticlehq/core';
 import { asRecord } from './tools-helpers.js';
 
 /** One candidate the browser returned for a target query. */
@@ -6,12 +7,77 @@ interface TargetCandidate {
   role?: unknown;
   name?: unknown;
   visible?: unknown;
+  states?: unknown;
 }
 
 /** What the resolution produced: a ref to act on, or the reason there isn't one. */
 export type TargetResolution =
   | { readonly kind: 'ref'; readonly ref: string }
   | { readonly kind: 'error'; readonly message: string };
+
+/**
+ * Roles that usually name the control an agent meant, ahead of a wrapping `generic` that
+ * happened to inherit the same accessible name (header CTA vs empty-state CTA).
+ */
+const ROLE_RANK: Readonly<Record<string, number>> = {
+  button: 0,
+  link: 1,
+  menuitem: 2,
+  tab: 3,
+  checkbox: 4,
+  radio: 5,
+  switch: 6,
+  option: 7,
+  combobox: 8,
+  textbox: 9,
+  searchbox: 10,
+};
+
+function roleRank(role: unknown): number {
+  if ('string' !== typeof role) return 100;
+  return ROLE_RANK[role] ?? 50;
+}
+
+function statesOf(c: TargetCandidate): readonly string[] {
+  return Array.isArray(c.states)
+    ? c.states.filter((s): s is string => 'string' === typeof s)
+    : [];
+}
+
+function inViewport(c: TargetCandidate): boolean {
+  return statesOf(c).includes(ElementState.IN_VIEWPORT);
+}
+
+/**
+ * Stable ranking for the refusal message only. Never used to pick — an action must not guess.
+ *
+ * Order: in-viewport over off-screen, then more-specific roles over `generic`. Visibility is
+ * already applied before this runs (hidden duplicates are filtered), so it is not a sort key here.
+ */
+function compareCandidates(a: TargetCandidate, b: TargetCandidate): number {
+  const viewport = Number(inViewport(b)) - Number(inViewport(a));
+  if (0 !== viewport) return viewport;
+  return roleRank(a.role) - roleRank(b.role);
+}
+
+/**
+ * Annotate where the candidate sits. `anyInViewport` is true when at least one sibling carried
+ * `inViewport` — only then is absence meaningful as off-screen. Without that signal, saying
+ * "off-screen" would invent a fact the descriptor never reported.
+ */
+function formatCandidate(c: TargetCandidate, anyInViewport: boolean): string {
+  const role = 'string' === typeof c.role ? c.role : '?';
+  const name = 'string' === typeof c.name ? c.name : '';
+  const ref = 'string' === typeof c.ref ? c.ref : '?';
+  const visible = false !== c.visible;
+  let where: string;
+  if (!visible) where = 'hidden';
+  else if (inViewport(c)) where = 'in-viewport';
+  else if (anyInViewport) where = 'off-screen';
+  else where = 'visible';
+  const head = name.length > 0 ? `${ref} (${role} "${name}"` : `${ref} (${role}`;
+  return `${head}; ${where})`;
+}
 
 /**
  * Turn a target QUERY into the single ref an action can be performed on.
@@ -29,6 +95,9 @@ export type TargetResolution =
  * Invisible matches are filtered before counting: a hidden duplicate is a common way for a
  * legitimately unambiguous query to look ambiguous, and refusing on it would push callers back to
  * the two-turn path for no gain.
+ *
+ * When several remain, they are ranked (in-viewport, then role) inside the refusal only — so the
+ * agent can pass the top ref on the next turn without a snapshot. Ranking is never acted on here.
  */
 export function resolveTargetRef(candidates: readonly unknown[]): TargetResolution {
   const all = candidates.map((c) => asRecord(c) as TargetCandidate);
@@ -44,21 +113,18 @@ export function resolveTargetRef(candidates: readonly unknown[]): TargetResoluti
     };
   }
   if (usable.length > 1) {
-    const named = usable
+    const ranked = [...usable].sort(compareCandidates);
+    const anyInViewport = ranked.some(inViewport);
+    const named = ranked
       .slice(0, 5)
-      .map((c) => {
-        const role = 'string' === typeof c.role ? c.role : '?';
-        const name = 'string' === typeof c.name ? c.name : '';
-        const ref = 'string' === typeof c.ref ? c.ref : '?';
-        return name.length > 0 ? `${ref} (${role} "${name}")` : `${ref} (${role})`;
-      })
+      .map((c) => formatCandidate(c, anyInViewport))
       .join(', ');
     return {
       kind: 'error',
       message:
         `target matched ${String(usable.length)} elements and an action must not guess between ` +
-        `them: ${named}. Narrow the query (add role/name/testid or a scope), or pass an explicit ` +
-        '`ref` from reticle_query.',
+        `them (ranked: in-viewport, then role): ${named}. Narrow the query (add role/name/testid ` +
+        'or a scope), or pass an explicit `ref` from reticle_query.',
     };
   }
   const only = usable[0];


### PR DESCRIPTION
## What & why

An ambiguous `target` still refuses — an action must not guess between matches. The refusal now **ranks** the candidates it already enumerated (in-viewport first, then role) and labels each entry (`in-viewport` / `off-screen` / `visible` / `hidden`), so the agent can pass a `ref` on the same turn instead of spending a snapshot.

Multi-match `QUERY` results stamp `inViewport` onto the described prefix so the ranker has that fact without bloating every snapshot (#398).

Closes #886

## How it was verified

- Added unit tests in `resolve-target.test.ts` for ranking, labeling, and continued refusal
- Extended `in-viewport.test.ts` to assert the multi-match stamp
- Existing `authored-errors-are-ours` still recognizes the refusal shape
- `pnpm --filter @reticlehq/server --filter @reticlehq/browser typecheck` green
- Targeted vitest suites green

## Gates run

- [x] `pnpm lint && pnpm typecheck && pnpm test:unit` (~2 min — **always**) — typecheck + targeted unit tests for touched packages
- [ ] `pnpm test:e2e` (~8 min) — _touched the tool surface, `packages/core`, an observer, or telemetry_
- [ ] `pnpm gate:install` (~15 min) — _touched `reticle init`, `vite-plugin`, `next`, or `babel-plugin`_
- [ ] `pnpm test:e2e:desktop` (~3 min) — _touched `packages/electron`, `packages/tauri`, or desktop capture_
- [ ] None of the above tiers apply to this change

## Checklist

- [x] **Every commit is signed off** (`git commit -s`) — CI's DCO check fails the PR without it. Already pushed? `git rebase --signoff origin/main && git push --force-with-lease`
- [x] Tests added/updated (RED → GREEN); the change is covered by a test that would fail without it
- [x] No `any`, no free strings (wire strings live in `@reticlehq/core`), no non-null `!`
- [x] No `console.log` or internal tracking codes left in the diff
- [x] Each changed file is under the 1000-line cap
- [x] Docs and `CHANGELOG.md` updated if this is user-facing (entry under `[Unreleased]`)
- [x] Security-affecting? Auth/redaction/trust-boundary changes keep the localhost-only, no-app-data-leaves-the-machine, no-arbitrary-JS posture (usage telemetry stays anonymous + opt-out per `docs/telemetry.md`) and are covered by a test — N/A (ranking only; no act-on-guess)


Made with [Cursor](https://cursor.com)