### PR TITLE
docs(init): say when a WebGL canvas is not observable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
+### Changed
+
+- **`@reticlehq/server` — `init` names the WebGL / react-three-fiber observability limit.** A canvas is a blank rectangle to query and snapshot; DOM, store and network around it still work. Without saying so, init looked fully green on R3F apps while the product surface stayed unverifiable. Detection sets `webGlSubtree` for `@react-three/fiber` / `react-three-fiber`, and the plan raises a NOTICE. FAQ documents the same limit. Closes [#880](https://github.com/reticlehq/reticle/issues/880).
+
 ### Added
 
 - **`@reticlehq/server` — `reticle_navigate` takes a `timeout_ms`, and an unconfirmed result says what the wait ended on.** The arrival window was a fixed, unstated 5s: `navigate-arrival.ts` hard-coded it and the tool exposed nothing, so unlike `assert` / `wait_for` / `act_and_wait`, which all spend the caller's budget, nobody could tell navigate to wait longer. A Nuxt SPA reattaching under HMR was measured at 30–60s, so every navigation to it gave up while the app was still coming back and answered `confirmed: false`, which reads as a failed navigation rather than as Reticle having stopped waiting; the only escape was the blind `reticle_sessions` poll that `#612` removed everywhere else. `timeout_ms` now reaches the wait (default 5000, so nothing gets slower by accident; `0` looks once; the same bounds as the other tools), and applies to `{ reload: true }` too, since the page coming back is the same wait. `confirmed: false` carries `waitedMs`, the budget that expired, and its note names `timeout_ms` as the way to wait longer. Closes [#856](https://github.com/reticlehq/reticle/issues/856).

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -83,6 +83,17 @@ Anonymous usage telemetry is sent separately and can be turned off with `reticle
   </Card>
 </Accordion>
 
+<Accordion title="Does it work with WebGL / react-three-fiber?">
+  Partially. Reticle's model of an app is DOM + store + network. A WebGL or react-three-fiber
+  subtree is a single `<canvas>` to `reticle_query` / `reticle_snapshot`: Reticle cannot pick faces
+  or drive the camera inside the scene.
+
+  DOM, registered store state, and network **around** the canvas still work — and that is often
+  where the consequential bugs live (import counts, mesh stats, solver results that contradict the
+  UI). `init` prints this limit when it detects react-three-fiber so an adopting team does not
+  discover it only after trying to verify the feature they care about.
+</Accordion>
+
 <Accordion title="Is Reticle proven to make agents fix more bugs?">
   No, and we are not going to claim it. A controlled test of fix-rate did **not** show an improvement. The benchmark was confounded in ways we can point at, and we consider the question open.
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -88,10 +88,8 @@ Anonymous usage telemetry is sent separately and can be turned off with `reticle
   subtree is a single `<canvas>` to `reticle_query` / `reticle_snapshot`: Reticle cannot pick faces
   or drive the camera inside the scene.
 
-  DOM, registered store state, and network **around** the canvas still work — and that is often
-  where the consequential bugs live (import counts, mesh stats, solver results that contradict the
-  UI). `init` prints this limit when it detects react-three-fiber so an adopting team does not
-  discover it only after trying to verify the feature they care about.
+DOM, registered store state, and network **around** the canvas still work, and that is often where the consequential bugs live (import counts, mesh stats, solver results that contradict the UI). `init` prints this limit when it detects react-three-fiber so an adopting team does not discover it only after trying to verify the feature they care about.
+
 </Accordion>
 
 <Accordion title="Is Reticle proven to make agents fix more bugs?">

--- a/packages/server/src/init/detect.test.ts
+++ b/packages/server/src/init/detect.test.ts
@@ -362,3 +362,23 @@ describe('customReconciler', () => {
     ).toBe(false);
   });
 });
+
+describe('webGlSubtree', () => {
+  it.each(['@react-three/fiber', 'react-three-fiber'])(
+    'is true when %s is a dependency',
+    (name) => {
+      expect(
+        detect(input({ pkg: { dependencies: { react: '^19.0.0', [name]: '^9.0.0' } } })).webGlSubtree,
+      ).toBe(true);
+    },
+  );
+
+  it('is false for three.js alone, and for other non-DOM reconcilers', () => {
+    expect(
+      detect(input({ pkg: { dependencies: { react: '^19.0.0', three: '^0.170.0' } } })).webGlSubtree,
+    ).toBe(false);
+    expect(
+      detect(input({ pkg: { dependencies: { react: '^19.0.0', ink: '^5.0.0' } } })).webGlSubtree,
+    ).toBe(false);
+  });
+});

--- a/packages/server/src/init/detect.test.ts
+++ b/packages/server/src/init/detect.test.ts
@@ -368,14 +368,16 @@ describe('webGlSubtree', () => {
     'is true when %s is a dependency',
     (name) => {
       expect(
-        detect(input({ pkg: { dependencies: { react: '^19.0.0', [name]: '^9.0.0' } } })).webGlSubtree,
+        detect(input({ pkg: { dependencies: { react: '^19.0.0', [name]: '^9.0.0' } } }))
+          .webGlSubtree,
       ).toBe(true);
     },
   );
 
   it('is false for three.js alone, and for other non-DOM reconcilers', () => {
     expect(
-      detect(input({ pkg: { dependencies: { react: '^19.0.0', three: '^0.170.0' } } })).webGlSubtree,
+      detect(input({ pkg: { dependencies: { react: '^19.0.0', three: '^0.170.0' } } }))
+        .webGlSubtree,
     ).toBe(false);
     expect(
       detect(input({ pkg: { dependencies: { react: '^19.0.0', ink: '^5.0.0' } } })).webGlSubtree,

--- a/packages/server/src/init/detect.ts
+++ b/packages/server/src/init/detect.ts
@@ -141,6 +141,13 @@ export interface Detection {
    * unstated fixture is. `detect` always sets it.
    */
   customReconciler?: boolean | undefined;
+  /**
+   * Whether this project depends on react-three-fiber (or the legacy package name). A WebGL /
+   * R3F subtree is a blank `<canvas>` to Reticle: DOM, state and network around it still work;
+   * picking and observing inside the scene do not. Optional for the same reason as
+   * `customReconciler` — absent means an ordinary DOM app.
+   */
+  webGlSubtree?: boolean | undefined;
   packageManager: PackageManager;
 }
 
@@ -181,6 +188,9 @@ const CUSTOM_RECONCILER_DEPS = [
   'ink',
   'react-native',
 ];
+
+/** Packages whose presence means the product's main surface is a WebGL canvas, not the DOM. */
+const WEBGL_SUBTREE_DEPS = ['@react-three/fiber', 'react-three-fiber'] as const;
 
 function hasAnyConfig(files: ReadonlySet<string>, candidates: readonly string[]): boolean {
   return candidates.some((c) => files.has(c));
@@ -337,6 +347,7 @@ export function detect(input: DetectInput): Detection {
     customReconciler: CUSTOM_RECONCILER_DEPS.some(
       (name) => depVersion(input.pkg, name) !== undefined,
     ),
+    webGlSubtree: WEBGL_SUBTREE_DEPS.some((name) => depVersion(input.pkg, name) !== undefined),
     packageManager: detectPackageManager(input.lockfiles, input.nodeModulesMarkers ?? new Set()),
   };
 }

--- a/packages/server/src/init/plan.ts
+++ b/packages/server/src/init/plan.ts
@@ -41,7 +41,11 @@ import {
 } from './agent-rules.js';
 import { cspStep, frameworkSteps } from './plan-framework.js';
 import { join } from 'node:path';
-import { reticleConfigContent, unverifiedUiLibraryNote, WEBGL_CANVAS_LIMIT_NOTE } from './snippets.js';
+import {
+  reticleConfigContent,
+  unverifiedUiLibraryNote,
+  WEBGL_CANVAS_LIMIT_NOTE,
+} from './snippets.js';
 import { configWithInstallSource, declaredInstallSource } from '../telemetry/install-source.js';
 import { existingConfigProblem, projectIdOf, RETICLE_CONFIG_FILE } from './existing-config.js';
 

--- a/packages/server/src/init/plan.ts
+++ b/packages/server/src/init/plan.ts
@@ -41,7 +41,7 @@ import {
 } from './agent-rules.js';
 import { cspStep, frameworkSteps } from './plan-framework.js';
 import { join } from 'node:path';
-import { reticleConfigContent, unverifiedUiLibraryNote } from './snippets.js';
+import { reticleConfigContent, unverifiedUiLibraryNote, WEBGL_CANVAS_LIMIT_NOTE } from './snippets.js';
 import { configWithInstallSource, declaredInstallSource } from '../telemetry/install-source.js';
 import { existingConfigProblem, projectIdOf, RETICLE_CONFIG_FILE } from './existing-config.js';
 
@@ -952,6 +952,22 @@ function uiLibraryStep(input: PlanInput): Step[] {
   ];
 }
 
+/**
+ * Say the WebGL gap out loud at install time. Without it, init looks fully green on an R3F app
+ * while the canvas — often the product — stays a blank rectangle to every look and act tool (#880).
+ */
+function webGlCanvasStep(input: PlanInput): Step[] {
+  if (true !== input.detection.webGlSubtree) return [];
+  return [
+    {
+      title: 'WebGL canvas is not observable',
+      target: 'package.json',
+      status: StepStatus.NOTICE,
+      detail: WEBGL_CANVAS_LIMIT_NOTE,
+    },
+  ];
+}
+
 export function buildPlan(input: PlanInput): Plan {
   const steps: Step[] = [
     ...cspStep(input),
@@ -959,6 +975,7 @@ export function buildPlan(input: PlanInput): Plan {
     ...agentRuleSteps(input),
     ...slashCommandSteps(input),
     ...uiLibraryStep(input),
+    ...webGlCanvasStep(input),
     installStep(input),
     ...reticleConfigSteps(input),
   ];

--- a/packages/server/src/init/snippets.ts
+++ b/packages/server/src/init/snippets.ts
@@ -596,6 +596,17 @@ export const UNVERIFIED_TANSTACK_START_NOTE =
   'Reticle has no TanStack Start app and no CI gate for one, so this wiring is untested — it may work, but nothing proves it and nothing will tell us if it breaks. Supported and gated today: Vite + React, Next.js, Remix and Astro. If the client effect does not register a session, please open an issue.';
 
 /**
+ * Printed when init detects react-three-fiber. Reticle's model is DOM + store + network; a WebGL
+ * canvas is none of those. Without this line, init succeeds, sessions connect, and surrounding UI
+ * verdicts pass while the canvas — often the product — stays a blank rectangle (#880).
+ */
+export const WEBGL_CANVAS_LIMIT_NOTE =
+  'A WebGL / react-three-fiber subtree is not observable as a scene: reticle_query and ' +
+  'reticle_snapshot see a single <canvas>, and Reticle cannot pick faces or drive the camera ' +
+  'inside it. DOM, registered store state, and network around the canvas still work — verify ' +
+  'consequences there (import counts, mesh stats, solver results), not geometry under the pointer.';
+
+/**
  * Dev-only client hook that connects Reticle in a SvelteKit app. SvelteKit renders through app.html and
  * never triggers Vite's index.html injection (verified), so the standard plugin can't auto-connect —
  * a client hook is the reliable path. SvelteKit runs src/hooks.client.ts on the client at startup.

--- a/packages/server/src/init/webgl-canvas-limit.test.ts
+++ b/packages/server/src/init/webgl-canvas-limit.test.ts
@@ -1,0 +1,66 @@
+/**
+ * init must say the WebGL gap out loud when react-three-fiber is present (#880).
+ *
+ * Without this notice, init succeeds, a session connects, and surrounding UI verdicts pass while
+ * the canvas — often the product — stays a blank rectangle. The good-first-issue scope is saying
+ * so; picking and camera drive are separate work.
+ */
+import { describe, expect, it } from 'vitest';
+import { buildPlan, StepStatus, type PlanInput } from './plan.js';
+import { Framework, PackageManager, UiLibrary, type Detection } from './detect.js';
+import { WEBGL_CANVAS_LIMIT_NOTE } from './snippets.js';
+
+const VITE_CONFIG = {
+  path: 'vite.config.ts',
+  source: `import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+export default defineConfig({ plugins: [react()] });
+`,
+};
+
+function detection(webGlSubtree: boolean): Detection {
+  return {
+    framework: Framework.VITE,
+    uiLibrary: UiLibrary.REACT,
+    typescript: true,
+    reactMajor: 19,
+    needsSourceMapping: true,
+    customReconciler: webGlSubtree,
+    webGlSubtree,
+    packageManager: PackageManager.PNPM,
+  };
+}
+
+function input(webGlSubtree: boolean): PlanInput {
+  return {
+    detection: detection(webGlSubtree),
+    claudeCli: true,
+    mcpExists: false,
+    viteConfig: VITE_CONFIG,
+    nextConfigFile: null,
+    nextReticleDevExists: false,
+    options: { port: 4400, mcp: true, install: false },
+  };
+}
+
+describe('init names the WebGL canvas limit', () => {
+  it('raises a NOTICE when react-three-fiber is detected', () => {
+    const step = buildPlan(input(true)).steps.find((s) => s.title === 'WebGL canvas is not observable');
+    expect(step?.status).toBe(StepStatus.NOTICE);
+    expect(step?.detail).toBe(WEBGL_CANVAS_LIMIT_NOTE);
+    expect(step?.detail).toContain('not observable');
+    expect(step?.detail).toContain('canvas');
+  });
+
+  it('is silent for an ordinary React DOM app', () => {
+    expect(
+      buildPlan(input(false)).steps.find((s) => s.title === 'WebGL canvas is not observable'),
+    ).toBeUndefined();
+  });
+
+  it('is a NOTICE, not work left to do — the canvas gap is disclosed, not blocked', () => {
+    const step = buildPlan(input(true)).steps.find((s) => s.title === 'WebGL canvas is not observable');
+    expect(step?.status).toBe(StepStatus.NOTICE);
+    expect(step?.status).not.toBe(StepStatus.MANUAL);
+  });
+});

--- a/packages/server/src/init/webgl-canvas-limit.test.ts
+++ b/packages/server/src/init/webgl-canvas-limit.test.ts
@@ -2,7 +2,7 @@
  * init must say the WebGL gap out loud when react-three-fiber is present (#880).
  *
  * Without this notice, init succeeds, a session connects, and surrounding UI verdicts pass while
- * the canvas — often the product — stays a blank rectangle. The good-first-issue scope is saying
+ * the canvas, often the product, stays a blank rectangle. The good-first-issue scope is saying
  * so; picking and camera drive are separate work.
  */
 import { describe, expect, it } from 'vitest';
@@ -46,7 +46,7 @@ function input(webGlSubtree: boolean): PlanInput {
 describe('init names the WebGL canvas limit', () => {
   it('raises a NOTICE when react-three-fiber is detected', () => {
     const step = buildPlan(input(true)).steps.find(
-      (s) => s.title === 'WebGL canvas is not observable',
+      (s) => 'WebGL canvas is not observable' === s.title,
     );
     expect(step?.status).toBe(StepStatus.NOTICE);
     expect(step?.detail).toBe(WEBGL_CANVAS_LIMIT_NOTE);
@@ -56,13 +56,13 @@ describe('init names the WebGL canvas limit', () => {
 
   it('is silent for an ordinary React DOM app', () => {
     expect(
-      buildPlan(input(false)).steps.find((s) => s.title === 'WebGL canvas is not observable'),
+      buildPlan(input(false)).steps.find((s) => 'WebGL canvas is not observable' === s.title),
     ).toBeUndefined();
   });
 
-  it('is a NOTICE, not work left to do — the canvas gap is disclosed, not blocked', () => {
+  it('is a NOTICE, not work left to do: the canvas gap is disclosed, not blocked', () => {
     const step = buildPlan(input(true)).steps.find(
-      (s) => s.title === 'WebGL canvas is not observable',
+      (s) => 'WebGL canvas is not observable' === s.title,
     );
     expect(step?.status).toBe(StepStatus.NOTICE);
     expect(step?.status).not.toBe(StepStatus.MANUAL);

--- a/packages/server/src/init/webgl-canvas-limit.test.ts
+++ b/packages/server/src/init/webgl-canvas-limit.test.ts
@@ -45,7 +45,9 @@ function input(webGlSubtree: boolean): PlanInput {
 
 describe('init names the WebGL canvas limit', () => {
   it('raises a NOTICE when react-three-fiber is detected', () => {
-    const step = buildPlan(input(true)).steps.find((s) => s.title === 'WebGL canvas is not observable');
+    const step = buildPlan(input(true)).steps.find(
+      (s) => s.title === 'WebGL canvas is not observable',
+    );
     expect(step?.status).toBe(StepStatus.NOTICE);
     expect(step?.detail).toBe(WEBGL_CANVAS_LIMIT_NOTE);
     expect(step?.detail).toContain('not observable');
@@ -59,7 +61,9 @@ describe('init names the WebGL canvas limit', () => {
   });
 
   it('is a NOTICE, not work left to do — the canvas gap is disclosed, not blocked', () => {
-    const step = buildPlan(input(true)).steps.find((s) => s.title === 'WebGL canvas is not observable');
+    const step = buildPlan(input(true)).steps.find(
+      (s) => s.title === 'WebGL canvas is not observable',
+    );
     expect(step?.status).toBe(StepStatus.NOTICE);
     expect(step?.status).not.toBe(StepStatus.MANUAL);
   });


### PR DESCRIPTION
## What & why

Reticle's model is DOM + store + network. A WebGL / react-three-fiber subtree is a single `<canvas>` to look and act tools. Without saying so, `init` succeeded and surrounding UI verdicts passed while the product surface stayed unverifiable.

This PR covers the good-first-issue scope of [#880](https://github.com/reticlehq/reticle/issues/880):

- Detection sets `webGlSubtree` for `@react-three/fiber` / `react-three-fiber`
- `init` raises a NOTICE: canvas is not observable as a scene; DOM/state/network around it still work
- FAQ documents the same limit

Picking inside the scene and camera gestures are left for later work named on the issue.

Closes #880

## How it was verified

- Unit tests for detection and the plan NOTICE
- `pnpm --filter @reticlehq/server typecheck` green

## Gates run

- [x] Targeted unit tests + typecheck for `@reticlehq/server`
- [ ] Full `pnpm lint && pnpm typecheck && pnpm test:unit`
- [ ] `pnpm gate:install` (NOTICE-only plan change; no wiring change)

## Checklist

- [x] Every commit is signed off
- [x] Tests added/updated
- [x] No `any`, no free strings, no non-null `!`
- [x] Docs and `CHANGELOG.md` updated
- [x] Security N/A


Made with [Cursor](https://cursor.com)