### PR TITLE
feat(predicate): stop making the grammar something you learn by provoking

### DIFF
--- a/packages/server/src/events/predicate-parse.ts
+++ b/packages/server/src/events/predicate-parse.ts
@@ -97,6 +97,59 @@ function placeholderValue(input: unknown): string | undefined {
   return 'string' === typeof value && UNFILLED_PLACEHOLDER.test(value) ? value : undefined;
 }
 
+/**
+ * The timeout spellings a predicate may carry harmlessly, and why they are dropped rather than
+ * rejected.
+ *
+ * `reticle_act_and_wait { until: { kind: "element", query: {...}, timeout_ms: 30000 } }` came from
+ * the field. The rejection was good -- precise, and it named the accepted fields -- but the agent
+ * had to provoke it, and a rejected predicate produces no verdict at all, so the round trip ended
+ * with nothing (#877).
+ *
+ * The enclosing call already carries `timeout_ms` and it means exactly the same thing, so the
+ * intent is unambiguous and refusing buys nothing. That equality is the whole licence: this must
+ * NOT grow to cover a field that would CHANGE behaviour, because silently dropping one of those is
+ * how a step-level timeout went missing and a flow reported a working feature as a regression.
+ *
+ * Live calls only. Flow files validate through `PredicateSchema` directly (flow-expect-grammar.ts,
+ * replay.ts), so #744's rule that a saved contract rejects unknown keys is untouched -- a flow file
+ * is a contract, a live call is not.
+ */
+const REDUNDANT_TIMEOUT_KEYS = ['timeout_ms', 'timeoutMs'] as const;
+
+/**
+ * `input` without a redundant timeout at any predicate level, or `input` unchanged.
+ *
+ * Recursive through the combinators: an agent that writes the field once writes it inside an
+ * `allOf` member for the same reason, and the outer call's timeout governs the whole tree either
+ * way. Returns the original object when there is nothing to strip, so the ordinary path allocates
+ * nothing.
+ */
+function withoutRedundantTimeout(input: unknown): unknown {
+  if ('object' !== typeof input || null === input || Array.isArray(input)) return input;
+  const record = input as Record<string, unknown>;
+  const carries = REDUNDANT_TIMEOUT_KEYS.some((key) => key in record);
+
+  const nestedOne = record['predicate'];
+  const strippedOne = withoutRedundantTimeout(nestedOne);
+  const nestedMany = record['predicates'];
+  const strippedMany = Array.isArray(nestedMany)
+    ? nestedMany.map(withoutRedundantTimeout)
+    : nestedMany;
+  const nestedChanged =
+    strippedOne !== nestedOne ||
+    (Array.isArray(nestedMany) &&
+      (strippedMany as unknown[]).some((value, index) => value !== nestedMany[index]));
+
+  if (!carries && !nestedChanged) return input;
+
+  const out: Record<string, unknown> = { ...record };
+  for (const key of REDUNDANT_TIMEOUT_KEYS) delete out[key];
+  if (nestedOne !== undefined) out['predicate'] = strippedOne;
+  if (Array.isArray(nestedMany)) out['predicates'] = strippedMany;
+  return out;
+}
+
 export function parsePredicate(input: unknown): z.infer<typeof PredicateSchema> {
   const unfilled = placeholderValue(input);
   if (unfilled !== undefined) {
@@ -108,7 +161,7 @@ export function parsePredicate(input: unknown): z.infer<typeof PredicateSchema> 
         'route, or store state. Text on screen that was already there proves nothing.',
     );
   }
-  const parsed = PredicateSchema.safeParse(input);
+  const parsed = PredicateSchema.safeParse(withoutRedundantTimeout(input));
   if (parsed.success) return parsed.data;
   const kind =
     'object' === typeof input && null !== input && 'kind' in input

--- a/packages/server/src/events/predicate-redundant-timeout.test.ts
+++ b/packages/server/src/events/predicate-redundant-timeout.test.ts
@@ -1,0 +1,105 @@
+/**
+ * A predicate that carries the timeout the enclosing call already carries is accepted, not refused.
+ *
+ * From the field:
+ *
+ *   reticle_act_and_wait { until: { kind: "element", query: {...}, timeout_ms: 30000 } }
+ *   -> "that predicate did not parse (kind \"element\"): unknown field timeout_ms; ..."
+ *
+ * The reporter called that error good — it is precise and it names the accepted fields. The
+ * complaint is that they had to provoke it, and a rejected predicate produces NO verdict, so the
+ * round trip ended with nothing. The call already carries `timeout_ms` and it means exactly the
+ * same thing, so refusing buys nothing (#877).
+ *
+ * The boundary matters as much as the tolerance. #744 deliberately made unknown keys loud in flow
+ * `expect`/`success` blocks: a flow file is a saved contract and a live call is not. Flow files
+ * validate through `PredicateSchema` directly, so they are untouched here — pinned below.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parsePredicate } from './predicate-parse.js';
+import { PredicateSchema } from './predicate.js';
+import { PredicateKind } from '@reticlehq/core';
+
+describe('a redundant timeout inside a live predicate', () => {
+  it('is accepted, where it used to end the call with no verdict', () => {
+    const parsed = parsePredicate({
+      kind: PredicateKind.ELEMENT,
+      query: { role: 'button', name: 'Save' },
+      timeout_ms: 30_000,
+    });
+
+    expect(parsed.kind).toBe(PredicateKind.ELEMENT);
+  });
+
+  it('is dropped rather than carried, so nothing downstream can read it as a real field', () => {
+    const parsed = parsePredicate({
+      kind: PredicateKind.TEXT,
+      contains: 'Saved',
+      timeout_ms: 30_000,
+    });
+
+    expect(parsed).not.toHaveProperty('timeout_ms');
+  });
+
+  it('accepts the camelCase spelling too', () => {
+    expect(
+      parsePredicate({ kind: PredicateKind.TEXT, contains: 'Saved', timeoutMs: 500 }).kind,
+    ).toBe(PredicateKind.TEXT);
+  });
+
+  it('is tolerated inside a combinator member, for the same reason', () => {
+    const parsed = parsePredicate({
+      kind: PredicateKind.ALL_OF,
+      predicates: [
+        { kind: PredicateKind.TEXT, contains: 'Saved', timeout_ms: 1000 },
+        { kind: PredicateKind.CONSOLE, level: 'error', absent: true },
+      ],
+    });
+
+    expect(parsed.kind).toBe(PredicateKind.ALL_OF);
+  });
+
+  it('is tolerated inside not, which nests one predicate rather than a list', () => {
+    const parsed = parsePredicate({
+      kind: PredicateKind.NOT,
+      predicate: { kind: PredicateKind.TEXT, contains: 'Error', timeout_ms: 1000 },
+    });
+
+    expect(parsed.kind).toBe(PredicateKind.NOT);
+  });
+});
+
+describe('the tolerance does not become a general shrug', () => {
+  it('still refuses a field that would change behaviour', () => {
+    expect(() =>
+      parsePredicate({ kind: PredicateKind.TEXT, contains: 'Saved', selector: '.toast' }),
+    ).toThrow(/unknown field selector/);
+  });
+
+  it('still reports the real mistake when a timeout rides along with one', () => {
+    // Stripping must not swallow the error the agent actually needs to read.
+    expect(() =>
+      parsePredicate({ kind: PredicateKind.TEXT, contains: 'Saved', timeout_ms: 1, nope: 1 }),
+    ).toThrow(/unknown field nope/);
+  });
+
+  it('leaves an unknown KIND unknown', () => {
+    expect(() => parsePredicate({ kind: 'elementt', timeout_ms: 1 })).toThrow(
+      /not a predicate kind/,
+    );
+  });
+});
+
+describe('a saved flow contract stays loud (#744)', () => {
+  it('still rejects the same key when validated as a flow expect block', () => {
+    // Flow files go through PredicateSchema directly, which is the seam this tolerance sits above.
+    const result = PredicateSchema.safeParse({
+      kind: PredicateKind.TEXT,
+      contains: 'Saved',
+      timeout_ms: 30_000,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/server/src/mcp/mcp.ts
+++ b/packages/server/src/mcp/mcp.ts
@@ -126,7 +126,9 @@ export function firstSentence(description: string): string {
  */
 const PREDICATE_KINDS =
   'Predicate object: { kind, ...fields }. kind is one of element | text | net | route | console | ' +
-  'animation | signal | state | settled | allOf | anyOf | not.';
+  'animation | signal | state | settled | allOf | anyOf | not. Combinators: allOf/anyOf take ' +
+  '`predicates: [...]`, not takes `predicate: {...}`. A predicate carries no timeout — the ' +
+  "enclosing call's timeout_ms governs it.";
 
 /**
  * Said once per turn: the bug-catching options, and where to get the rest of the field grammar.


### PR DESCRIPTION
Closes #877.

Both fixes the issue offers, because they answer different halves of the complaint.

## 1. Publish what has to be guessed

The kind list is already carried on every predicate parameter. What the reporter guessed *after* reading the rejection were the shapes of `not` and `allOf`, and whether a predicate takes its own timeout. Two clauses, added to the string that is already sent, where the agent is already looking:

> Combinators: allOf/anyOf take `predicates: [...]`, not takes `predicate: {...}`. A predicate carries no timeout — the enclosing call's timeout_ms governs it.

Deliberately not the full per-kind field grammar: the comments in `mcp.ts` record why that is behind `reticle_tools` (72% of the advertised input schema across three tools, re-sent every turn), and this PR is not the place to reopen that trade. These two clauses are what an agent needs to *write* a predicate, which is the line that file already draws.

## 2. Accept a redundant `timeout_ms`

```
reticle_act_and_wait { until: { kind: "element", query: {...}, timeout_ms: 30000 } }
-> that predicate did not parse (kind "element"): unknown field timeout_ms; element accepts: query, state, absent
```

The error is good. The cost is that it has to be provoked, and a rejected predicate produces **no verdict at all**, so that round trip ends with nothing. The enclosing call already carries `timeout_ms` and it means exactly the same thing.

Tolerated recursively through the combinators — an agent that writes the field once writes it inside an `allOf` member for the same reason, and the outer timeout governs the whole tree either way.

## The boundary, drawn twice

The issue is explicit that this must not become a general shrug, and points at #744. Both halves are pinned by tests:

- **Only where the outer call means the same thing.** It does not extend to a field that would change behaviour — that is how a step-level `timeout_ms` went missing and a flow reported a working feature as a regression. A predicate carrying both a redundant timeout *and* a real mistake still reports the real mistake, and an unknown `kind` stays unknown.
- **Only for live calls.** The tolerance lives in `parsePredicate`. Flow `expect`/`success` blocks validate through `PredicateSchema` directly (`flow-expect-grammar.ts`, `replay.ts`), so #744 is untouched: a flow file is a saved contract, a live call is not. A test asserts the same key is still rejected on that path.

No predicate kind accepts a timeout field today, so nothing legitimate is stripped.

## Verification

```
pnpm lint && pnpm typecheck && pnpm test:unit   # 17/17 tasks green
```

9 new tests in `predicate-redundant-timeout.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)