### PR TITLE
fix(actions): picking a value is not performing the act it feeds

### DIFF
--- a/packages/browser/src/actions/actions.danger-context.test.ts
+++ b/packages/browser/src/actions/actions.danger-context.test.ts
@@ -104,3 +104,71 @@ describe('Enter in a form is judged by what it submits', () => {
     await expect(executeAction(refTo('#n'), 'press', { text: 'Escape' })).resolves.toBeDefined();
   });
 });
+
+/**
+ * Picking a value is not performing the act it feeds.
+ *
+ * Two more false positives from the same field session, both still live after the submit-control
+ * fix above. Choosing "Inlet" from two radio-like choices was blocked, and pressing Enter in a
+ * textarea was blocked while clicking the adjacent submit button -- same form, same handler, same
+ * effect -- was not.
+ *
+ * The reporter's summary is the cost, and it is why narrowing is the safe direction: "I ended up
+ * passing confirmDangerous: true reflexively on every action, which is how a safety guard becomes
+ * decoration." A guard that fires on picking a value is not protecting the destructive action
+ * either. The negative controls below are what keep the narrowing honest -- a false block costs a
+ * round trip, a missed block cannot be undone (#894).
+ */
+describe('a value picker is judged by what the choice feeds, not by the choice', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('does not block a radio whose label reads like the action it will cause', async () => {
+    document.body.innerHTML =
+      '<form action="/api/refund"><input type="radio" id="r" name="reason" aria-label="Refund">' +
+      '<button type="submit">Continue</button></form>';
+    await expect(executeAction(refTo('#r'), 'check')).resolves.toBeDefined();
+  });
+
+  it('still blocks the submit that the choice feeds', async () => {
+    // The act is the submit, judged on its own terms. That is the whole argument for exempting the
+    // choice, so it has to hold.
+    document.body.innerHTML =
+      '<form action="/api/refund"><input type="radio" id="r" name="reason" aria-label="Refund">' +
+      '<button type="submit" id="go">Issue refund</button></form>';
+    await expect(executeAction(refTo('#go'), 'click')).rejects.toThrow(/confirmDangerous/);
+  });
+
+  it('still blocks a checkbox, which is also how a one-click confirmation is spelled', async () => {
+    document.body.innerHTML = '<input type="checkbox" id="w" aria-label="Delete this repository">';
+    await expect(executeAction(refTo('#w'), 'check')).rejects.toThrow(/confirmDangerous/);
+  });
+
+  it('still blocks a menuitem, because a menu item labelled Delete IS one', async () => {
+    document.body.innerHTML = '<button role="menuitem" id="d">Delete project</button>';
+    await expect(executeAction(refTo('#d'), 'click')).rejects.toThrow(/confirmDangerous/);
+  });
+});
+
+describe('Enter in a textarea submits nothing, so it triggers nothing', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it("is not judged by the form's submit button", async () => {
+    // Enter here inserts a newline. Blocking it refuses the one keystroke on the page that does the
+    // least, beside a button whose click would be judged the same way and allowed.
+    document.body.innerHTML =
+      '<form><label for="n">Notes</label><textarea id="n"></textarea>' +
+      '<button type="submit">Delete account</button></form>';
+    await expect(executeAction(refTo('#n'), 'press', { text: 'Enter' })).resolves.toBeDefined();
+  });
+
+  it('still blocks a click on that submit button from the same form', async () => {
+    document.body.innerHTML =
+      '<form><label for="n">Notes</label><textarea id="n"></textarea>' +
+      '<button type="submit" id="go">Delete account</button></form>';
+    await expect(executeAction(refTo('#go'), 'click')).rejects.toThrow(/confirmDangerous/);
+  });
+});

--- a/packages/browser/src/actions/danger-context.ts
+++ b/packages/browser/src/actions/danger-context.ts
@@ -13,6 +13,7 @@
 
 import { isDangerousActionText } from '@reticlehq/core';
 import { getAccessibleName } from '../dom/a11y.js';
+import { isTextArea } from '../dom/realm.js';
 
 /**
  * Input types whose `value` IS the visible label rather than data the user put there.
@@ -73,6 +74,12 @@ const SUBMIT_CONTROL_SELECTOR =
   'button[type="submit"], input[type="submit"], button:not([type]):not([type=""])';
 
 export function submitControlFor(el: HTMLElement): HTMLElement | null {
+  // Except in a textarea, where Enter inserts a NEWLINE and submits nothing. Judging it by the
+  // form's submit button blocks the one keystroke on the page that does the least: the field is
+  // exempted from its own text above, and then the button beside it supplies the danger anyway.
+  // That is the reported false positive in its second shape -- Enter in a notes box refused, next
+  // to a submit button whose click would be judged the same way and allowed.
+  if (isTextArea(el)) return null;
   const found = el.closest('form')?.querySelector(SUBMIT_CONTROL_SELECTOR);
   return found instanceof HTMLElement ? found : null;
 }

--- a/packages/core/src/security.ts
+++ b/packages/core/src/security.ts
@@ -40,10 +40,22 @@ const DANGEROUS_ACTION =
   /\b(delete|remove|destroy|erase|drop|terminate|revoke|reset|close account|cancel subscription|purchase|buy|pay|payment|place order|confirm order|send money|send funds|transfer|withdraw|refund)\b/i;
 
 /**
- * Roles that pick a value from a list, not perform an action. Selecting "Payment" as a document
- * type is not a payment. `menuitem` is deliberately not here: a menu item labelled Delete still is.
+ * Roles that pick a VALUE, not perform an action. Selecting "Payment" as a document type is not a
+ * payment, and choosing "Refund" from a reason group is not a refund -- the act those choices feed
+ * is the submit that follows, and that control is judged on its own terms.
+ *
+ * `radio` joins `option` on exactly that argument. Reported from the field alongside the other
+ * false positives in the same session: choosing "Inlet" from two radio-like choices was blocked,
+ * and the reporter's summary is the cost -- "I ended up passing confirmDangerous: true reflexively
+ * on every action, which is how a safety guard becomes decoration". A guard that fires on picking a
+ * value is not protecting the destructive action either.
+ *
+ * `checkbox` is deliberately NOT here. It is a value picker too, but it is also the shape a
+ * one-click irreversible confirmation takes ("Delete this repository" with no separate submit), and
+ * this guard is asymmetric on purpose: a false block costs a round trip, a missed block cannot be
+ * undone. `menuitem` stays out for the reason it always did -- a menu item labelled Delete IS one.
  */
-const VALUE_PICKER_ROLE = 'option';
+const VALUE_PICKER_ROLES: ReadonlySet<string> = new Set(['option', 'radio']);
 
 /** The hostnames that ARE loopback outright, with no parsing: the name, and IPv6 ::1 both ways. */
 const LOOPBACK_HOSTNAMES: readonly string[] = ['localhost', '::1', '0:0:0:0:0:0:0:1'];
@@ -124,6 +136,6 @@ export function isOpaqueOrigin(origin: string): boolean {
  * role (a tool name, a click with no role on the descriptor) omit it and the text decides.
  */
 export function isDangerousActionText(text: string, role?: string): boolean {
-  if (role !== undefined && role.trim().toLowerCase() === VALUE_PICKER_ROLE) return false;
+  if (role !== undefined && VALUE_PICKER_ROLES.has(role.trim().toLowerCase())) return false;
   return DANGEROUS_ACTION.test(text.replace(/[_-]+/g, ' '));
 }


### PR DESCRIPTION
Towards #894 (part B). **Rebuilt on main**, which landed most of that part while this was open.

`submitControlFor` now judges Enter by the form's submit control, and `holdsUserText` stops a field's own content being read as its label. Between them they cover the "pressure drop" case and the "Delete account" case. Two of the reported false positives survive both.

Part A — the replay message naming a path a flow cannot take — was already on main when I first looked; `replayDestructiveActionHint` covers it including the CI-path caveat.

## 1. Choosing "Inlet" from two radio-like choices

`radio` joins `option` as a value-picker role, on the argument already written at that constant: selecting a value is not performing the act, and the submit that follows is judged on its own terms.

`checkbox` deliberately stays out. It is a value picker too, but it is also the shape a one-click irreversible confirmation takes — "Delete this repository" with no separate submit — and this guard is asymmetric on purpose: a false block costs a round trip, a missed block cannot be undone. `menuitem` stays out for the reason it always did.

## 2. Enter in a textarea is still judged by the submit button

Enter in a `<textarea>` inserts a **newline**. It submits nothing, so there is nothing to confirm — but `submitControlFor` walks `el.closest('form')` regardless, so in a form with a "Delete account" button it is refused.

That is the reported case in its second shape, and it is a strange one: the field is exempted from its own text by `holdsUserText`, and then the button beside it supplies the danger anyway. The keystroke that does the least on the page is refused, next to a button whose *click* would be judged the same way and allowed.

`submitControlFor` returns `null` for a textarea.

## Why narrowing is the safe direction

> I ended up passing `confirmDangerous: true` reflexively on every action, which is how a safety guard becomes decoration.

A guard that fires on picking a material is not protecting the destructive action either — the same argument this codebase already made when it dropped `deploy`, `publish` and `log out` from the pattern, and again in the commit above this one.

## Tests

Six cases appended to `actions.danger-context.test.ts`, which already owns this ground. **Four of the six are negative controls**, because an over-wide exemption is worse than the bug:

- the submit a radio choice feeds is still blocked
- a "Delete this repository" **checkbox** is still blocked
- a Delete **menuitem** is still blocked
- a **click** on the textarea's own submit button is still blocked

**Control run:** the other 2 fail against main.

## Verification

```
pnpm lint && pnpm typecheck && pnpm test:unit   # 17/17 tasks green
```

(If you hit `TypeError: pressKeyFromArgs is not a function` locally, that is a stale `packages/core/dist` — `tsc -b` reports success from its `.tsbuildinfo` without rebuilding. Deleting the tsbuildinfo and rebuilding fixes it; nothing to do with this change.)

## Not in this PR

The material-list case from the same report. Without the app I cannot tell whether those choices carried `role=option` (already exempt), a custom role, or a genuinely matching label, and guessing at a third rule would widen the change past what the report supports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)