### PR TITLE
fix(snapshot): an empty tree with uncaught errors beside it is a crash

### DIFF
--- a/packages/server/src/tools/crashed-root-note.ts
+++ b/packages/server/src/tools/crashed-root-note.ts
@@ -1,0 +1,72 @@
+/**
+ * An empty tree with uncaught errors beside it is a crashed app, not a page that has not rendered.
+ *
+ * `reticle_snapshot` returning `{ nodes: 0 }` is indistinguishable from "the view has not rendered
+ * yet", which is the far more common reading and the wrong one to act on. From the field: an
+ * unhandled throw in a commit phase unmounted the React root, the page went white, and the snapshot
+ * came back with an empty tree and `presentRegions` listing only Reticle's own dialogs. The reporter
+ * took a screenshot, then read `reticle_console`, and found five `Uncaught Error` entries -- about
+ * fifteen tool calls after the crash (#899).
+ *
+ * `noteHiddenPage` already covers the hidden cause and #672's fix covers the hidden-on-a-full-page
+ * cause. A crashed root is a third cause with the same symptom, and it is the one that means
+ * something is badly wrong right now.
+ *
+ * Deliberately NOT framework-specific. The condition is "the tree is empty and the window carries
+ * uncaught errors", which holds for React, Vue, Svelte and a hand-written app alike; nothing here
+ * looks for a React root, because the tell that matters is the pair, not the framework.
+ *
+ * And deliberately NOT a diagnosis. The note says the app MAY have crashed and hands over the
+ * channel that knows -- it does not claim to have read the error. A note that overclaimed would be
+ * the same kind of confident wrong answer as the bare zero it replaces.
+ */
+
+import { EventType } from '@reticlehq/core';
+import type { ReticleEvent } from '@reticlehq/core';
+
+/** How many error messages to name before the note stops being a note. */
+const MAX_NAMED = 2;
+
+/** Enough of a message to recognise it; this is read in a tool result, not a log. */
+const MAX_MESSAGE = 120;
+
+function truncate(value: string): string {
+  return value.length > MAX_MESSAGE ? `${value.slice(0, MAX_MESSAGE)}…` : value;
+}
+
+/** The uncaught errors in this window, most recent last, as their messages. */
+export function uncaughtMessages(events: readonly ReticleEvent[]): string[] {
+  const messages: string[] = [];
+  for (const event of events) {
+    if (event.type !== EventType.ERROR_UNCAUGHT) continue;
+    const message = event.data['message'];
+    messages.push(
+      'string' === typeof message && message.length > 0 ? message : 'an uncaught error',
+    );
+  }
+  return messages;
+}
+
+/**
+ * The note for an empty tree with uncaught errors beside it, or undefined when there is none to give.
+ *
+ * Undefined matters as much as the sentence: an empty tree on a page that threw nothing is an
+ * ordinary "not rendered yet", and a note that fired on every empty snapshot would stop being read
+ * exactly where it is needed.
+ */
+export function crashedRootNote(events: readonly ReticleEvent[]): string | undefined {
+  const messages = uncaughtMessages(events);
+  if (0 === messages.length) return undefined;
+  // The LAST errors, not the first: a crash is the most recent thing that happened, and a page that
+  // logged an unrelated throw on load would otherwise name that one instead.
+  const named = messages.slice(-MAX_NAMED).map((message) => JSON.stringify(truncate(message)));
+  const count = messages.length;
+  const plural = 1 === count ? 'error' : 'errors';
+  return (
+    `this is probably NOT a page that has not rendered yet: the tree is empty AND ${String(count)} ` +
+    `uncaught ${plural} ${1 === count ? 'was' : 'were'} logged in this session (${named.join(', ')}), ` +
+    `which is what an app that threw during render and unmounted its root looks like. Read ` +
+    `reticle_console for the full errors and their stacks before treating this as a timing problem — ` +
+    `retrying or waiting will not fix a crashed root.`
+  );
+}

--- a/packages/server/src/tools/snapshot-crashed-root-note.test.ts
+++ b/packages/server/src/tools/snapshot-crashed-root-note.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { EventType, SnapshotMode } from '@reticlehq/core';
+import { Bridge } from '../bridge/bridge.js';
+import type { ToolDeps } from './tools.js';
+import { ReticleTool } from './tool-names.js';
+import { FakeBrowser, callTool, makeDeps, waitUntil } from '../bridge/bridge.test-harness.js';
+
+/**
+ * An empty tree with uncaught errors beside it is a crashed app, not one that has not rendered.
+ *
+ * `nodes: 0` is indistinguishable from "the view has not rendered yet", which is the far more
+ * common reading and the wrong one to act on: waiting and retrying will not bring back a root that
+ * threw during render and unmounted. Reported from the field — the page went white, the snapshot
+ * came back empty, and the five `Uncaught Error` entries that explained it were found about fifteen
+ * tool calls later, by reading `reticle_console` on a hunch (#899).
+ *
+ * `noteHiddenPage` covers the hidden cause. This is the third cause with the same symptom, and the
+ * only one that means something is wrong right now.
+ */
+describe('reticle_snapshot — an empty tree with uncaught errors beside it', () => {
+  let bridge: Bridge;
+  let deps: ToolDeps;
+  let browser: FakeBrowser;
+
+  beforeAll(async () => {
+    bridge = new Bridge({ port: 0 });
+    const port = await bridge.ready;
+    deps = makeDeps(bridge);
+    browser = new FakeBrowser(port, 'demo', true);
+    await browser.open();
+    await waitUntil(() => 1 === bridge.sessions.count());
+  });
+
+  afterAll(async () => {
+    browser.close();
+    await bridge.close();
+  });
+
+  const emptyTree = { tree: '', status: { route: '/app' }, nodes: 0 };
+
+  async function snapshot(mode: string = SnapshotMode.FULL): Promise<Record<string, unknown>> {
+    return (await callTool(deps, ReticleTool.SNAPSHOT, { mode })) as Record<string, unknown>;
+  }
+
+  async function throwOnce(message: string): Promise<void> {
+    const before = bridge.sessions.resolve().eventsSince(0).length;
+    browser.emit(EventType.ERROR_UNCAUGHT, { message, kind: 'error' });
+    await waitUntil(() => bridge.sessions.resolve().eventsSince(0).length > before);
+  }
+
+  it('says an empty tree with a throw beside it is probably a crash', async () => {
+    await throwOnce('Cannot read properties of null (reading "map")');
+    browser.snapshotResult = emptyTree;
+
+    const note = String((await snapshot())['note']);
+
+    expect(note).toContain('NOT a page that has not rendered yet');
+    expect(note).toContain('reading');
+  });
+
+  it('sends the reader to the channel that knows, rather than diagnosing', async () => {
+    // The note must not claim to have read the error: it names the channel and says what NOT to do.
+    await throwOnce('boom');
+    browser.snapshotResult = emptyTree;
+
+    const note = String((await snapshot())['note']);
+
+    expect(note).toContain('reticle_console');
+    expect(note).toContain('will not fix');
+    expect(note).toContain('probably');
+  });
+
+  it('names the most recent throws, not the oldest', async () => {
+    // A crash is the most recent thing that happened. Naming the FIRST error would name an
+    // unrelated load-time throw on any app that has one, which most do. Two are named, because a
+    // crash commonly throws a pair (the error, then the boundary's own failure to recover).
+    await throwOnce('OLDEST-marker, from page load');
+    await throwOnce('MIDDLE-marker, the throw that unmounted the root');
+    await throwOnce('NEWEST-marker, the boundary failing too');
+    browser.snapshotResult = emptyTree;
+
+    const note = String((await snapshot())['note']);
+
+    expect(note).toContain('NEWEST-marker');
+    expect(note).toContain('MIDDLE-marker');
+    expect(note).not.toContain('OLDEST-marker');
+  });
+
+  it('truncates a message rather than pasting a stack-sized string into the note', async () => {
+    await throwOnce(`x${'y'.repeat(400)}`);
+    browser.snapshotResult = emptyTree;
+
+    const note = String((await snapshot())['note']);
+
+    expect(note).toContain('…');
+    expect(note.length).toBeLessThan(600);
+  });
+
+  it('says nothing about a crash when the tree has nodes in it', async () => {
+    await throwOnce('a handled-looking throw on a page that rendered fine');
+    browser.snapshotResult = {
+      tree: '- button "Pay" (ref=e7)',
+      status: { route: '/app' },
+      nodes: 1,
+    };
+
+    expect((await snapshot())['note']).toBeUndefined();
+  });
+
+  it('leaves the hidden-page note alone, because that one explains this tree', async () => {
+    // Both causes cannot be true of one tree, and two explanations is worse than the better one.
+    await throwOnce('an unrelated throw');
+    browser.snapshotResult = { ...emptyTree, hiddenSkipped: 3 };
+
+    const note = String((await snapshot())['note']);
+
+    expect(note).toContain('NOT an empty page');
+    expect(note).not.toContain('reticle_console');
+  });
+
+  it('leaves a status snapshot alone, which carries no tree to explain', async () => {
+    await throwOnce('boom');
+    browser.snapshotResult = emptyTree;
+
+    expect((await snapshot(SnapshotMode.STATUS))['note']).toBeUndefined();
+  });
+});

--- a/packages/server/src/tools/tools.ts
+++ b/packages/server/src/tools/tools.ts
@@ -4,6 +4,8 @@ import { ReticleTool } from './tool-names.js';
 import { withSizeCost } from '../session/output-budget.js';
 import { applySnapshotDelta, SnapshotCache } from './snapshot-delta.js';
 import { asRecord, asString, asNumber } from './tools-helpers.js';
+import { crashedRootNote } from './crashed-root-note.js';
+import type { ReticleEvent } from '@reticlehq/core';
 import { countSchema } from './numeric-bounds.js';
 import { normalizeQueryArgs } from './query-shape.js';
 import { paginateQueryResult } from './query-paginate.js';
@@ -293,21 +295,25 @@ export const RAW_TOOLS: ToolDef[] = [
         mode,
       }).then((raw) =>
         withSizeCost(
-          noteHiddenPage(
-            noteEmptyLeanTree(
-              applySnapshotDelta(
-                raw,
-                {
-                  sessionId: resolved.id,
-                  scope: asString(args['scope']) ?? '',
-                  mode,
-                  diff: true === args['diff'],
-                },
-                SNAPSHOT_CACHE,
+          noteCrashedRoot(
+            noteHiddenPage(
+              noteEmptyLeanTree(
+                applySnapshotDelta(
+                  raw,
+                  {
+                    sessionId: resolved.id,
+                    scope: asString(args['scope']) ?? '',
+                    mode,
+                    diff: true === args['diff'],
+                  },
+                  SNAPSHOT_CACHE,
+                ),
+                mode,
               ),
               mode,
             ),
             mode,
+            resolved.eventsSince(0),
           ),
         ),
       );
@@ -762,6 +768,30 @@ function noteEmptyLeanTree(result: unknown, mode: string): unknown {
  * cannot know why, and a note that guessed would be the same kind of overconfident answer as the
  * empty tree it replaces.
  */
+/**
+ * The third cause of an empty tree, and the only one that means something is wrong RIGHT NOW.
+ *
+ * `noteHiddenPage` explains an empty tree by what the walk skipped. When it skipped nothing, the
+ * tree is empty because the page is, and "the view has not rendered yet" is the reading an agent
+ * reaches for -- correctly, almost always. A crashed root produces the identical shape and needs the
+ * opposite response: waiting will not fix it. See crashed-root-note.ts.
+ *
+ * Takes the session's events rather than the snapshot payload because the tell is not in the tree:
+ * it is the uncaught errors sitting beside it, which the server already holds.
+ */
+function noteCrashedRoot(result: unknown, mode: string, events: readonly ReticleEvent[]): unknown {
+  if (SnapshotMode.STATUS === mode) return result;
+  const row = asRecord(result);
+  if (0 !== asNumber(row['nodes'])) return result;
+  // A note already there is the more specific one, and two explanations for one empty tree is worse
+  // than the better of them alone -- the same rule noteHiddenPage follows.
+  if (row['note'] !== undefined) return result;
+  // Hiddenness explains this tree; that is noteHiddenPage's answer, not this one's.
+  if ((asNumber(row['hiddenSkipped']) ?? 0) > 0) return result;
+  const note = crashedRootNote(events);
+  return note === undefined ? result : { ...row, note };
+}
+
 function noteHiddenPage(result: unknown, mode: string): unknown {
   if (SnapshotMode.STATUS === mode) return result;
   const row = asRecord(result);


### PR DESCRIPTION
Closes #899.

## What

`reticle_snapshot` returning `{ nodes: 0 }` is indistinguishable from "the view has not rendered yet" — the far more common reading, and the wrong one to act on. Waiting and retrying will not bring back a root that threw during render and unmounted.

From the report: an unhandled throw in a commit phase, the page went white, the snapshot came back empty with `presentRegions` listing only Reticle's own dialogs. The reporter took a screenshot, then read `reticle_console` on a hunch, and found five `Uncaught Error` entries — about fifteen tool calls after the crash.

## Where it sits

`noteHiddenPage` explains an empty tree by what the walk **skipped**. When it skipped nothing, the tree is empty because the page is, and "not rendered yet" is the reading an agent reaches for — correctly, almost always. A crashed root produces the identical shape and needs the opposite response. This is the third cause with the same symptom.

The tell is not in the tree, so the note reads the session's events rather than the snapshot payload: the uncaught errors sitting beside it, which the server already holds.

## Two things it deliberately does not do

**It is not framework-specific.** The issue asks whether the same shape covers Vue and Svelte. It does, because the condition here is "the tree is empty and the window carries uncaught errors" — nothing looks for a React root. The pair is the tell, not the framework.

**It does not diagnose.** The note says the app *probably* crashed, names the most recent throws, and hands over `reticle_console`. It does not claim to have read the error or to know why. A note that overclaimed would be the same kind of confident wrong answer as the bare zero it replaces — the same line `noteHiddenPage` already draws about not guessing *why* a page is hidden.

## Silence, where a note would be noise

- a tree with nodes in it
- a `status` snapshot, which carries no tree to explain
- a page that threw nothing — an ordinary "not rendered yet" keeps its plain answer
- any tree the hidden-page note already explains; two explanations for one empty tree is worse than the better of them alone

Messages are truncated at 120 characters and the two most **recent** are named, not the first — a crash is the most recent thing that happened, and most apps have an unrelated load-time throw that would otherwise be named instead. Two rather than one because a crash commonly throws a pair: the error, then the boundary failing to recover.

## Verification

```
pnpm lint && pnpm typecheck && pnpm test:unit   # 17/17 tasks green
```

Seven tests in `snapshot-crashed-root-note.test.ts`, driven through the real snapshot tool over the bridge harness rather than against the helper. **Control run:** 4 of the 7 fail against main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)