### PR TITLE
fix(replay): a request still on the wire is not a call that never happened

### DIFF
--- a/packages/core/src/flow-constants.ts
+++ b/packages/core/src/flow-constants.ts
@@ -121,6 +121,20 @@ export const DriftReason = {
    * step whose anchor was fine.
    */
   EXPECT_ELEMENT_NOT_FOUND: 'expect_element_not_found',
+  /**
+   * The step's `expect.net` budget ran out while a request matching its URL and method was STILL ON
+   * THE WIRE. The call was not missing; the wait ended before the app did.
+   *
+   * Distinct from SIGNAL_NOT_OBSERVED, and the distinction is the whole point of the member. "No
+   * network call matched POST /geometry" reads as a feature that regressed and sends a reader to
+   * look for deleted code; the truth was a slow backend and a budget that expired, which is a
+   * different fix in a different file. Reported from the field against a replay whose verdict said
+   * the call never happened while `reticle_network` showed that exact POST pending.
+   *
+   * The live path already draws this line -- see `namedNetIsInFlight`, which this reuses rather than
+   * reimplements, so the two paths cannot come to disagree about what "in flight" means.
+   */
+  REQUEST_STILL_IN_FLIGHT: 'request_still_in_flight',
 } as const;
 export type DriftReason = (typeof DriftReason)[keyof typeof DriftReason];
 

--- a/packages/server/src/flows/flow-replay.in-flight.test.ts
+++ b/packages/server/src/flows/flow-replay.in-flight.test.ts
@@ -1,0 +1,223 @@
+/**
+ * A request still on the wire when the budget ends is not a call that never happened.
+ *
+ * Reported from the field. Replay said:
+ *
+ *     verdict: "drift"
+ *     whatChanged: "no network call matched {kind:net, method:POST, urlContains:/geometry, status:200}"
+ *
+ * while `reticle_network` showed, at that same moment:
+ *
+ *     POST /api/v0/interview/itv_.../geometry   status: "pending"
+ *
+ * The request existed and was on the wire. The replayer had already given up and called it drift,
+ * which reads to a user as "this feature regressed" when the truth is "the wait ended before the app
+ * did" (#896).
+ *
+ * `fix(server): an in-flight named request is not a failed assertion` drew exactly this line for
+ * `reticle_assert`. Replay never got it, so the two paths disagreed about the same fact. This reuses
+ * `namedNetIsInFlight` rather than reimplementing the match, so they cannot drift apart again.
+ *
+ * The verdict stays a DRIFT. The step did not prove its consequence and pretending otherwise would
+ * be the opposite error. What changes is the reason kind, and therefore what a reader is sent to do:
+ * raise a budget, rather than hunt for deleted code.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  AnchorKind,
+  DriftReason,
+  EventType,
+  FLOW_FILE_VERSION,
+  ReticleCommand,
+  type CommandResult,
+  type ElementDescriptor,
+  type FlowFile,
+  type FlowStep,
+  type ReticleEvent,
+} from '@reticlehq/core';
+import { replayFlow, type FlowReplaySession } from './flow-replay.js';
+import { waitForPredicate } from '../events/predicate.js';
+
+const URL_MATCHED = 'https://app.test/api/v0/interview/itv_38e855c1/geometry';
+
+/** A request that STARTED and never completed: a NET_PENDING with no matching NET_REQUEST. */
+const pendingPost = (url: string, method = 'POST'): ReticleEvent => ({
+  t: 1,
+  type: EventType.NET_PENDING,
+  sessionId: 's',
+  data: { id: `r-${url}-${method}`, method, url, initiator: 'fetch' },
+});
+
+/** One live element, so the step's anchor resolves and the run reaches its `expect`. */
+const ELEMENT = {
+  ref: 'e1',
+  role: 'button',
+  name: 'Import',
+  states: [],
+  visible: true,
+} as unknown as ElementDescriptor;
+
+/**
+ * A session whose buffer holds whatever the test puts on the wire, and nothing else.
+ *
+ * The anchor always resolves and the act always succeeds: every test here is about what happens
+ * AFTER that, when the declared consequence's budget runs out.
+ */
+class WireSession implements FlowReplaySession {
+  readonly #events: ReticleEvent[];
+  constructor(events: ReticleEvent[] = []) {
+    this.#events = events;
+  }
+  command(name: string): Promise<CommandResult> {
+    if (name === ReticleCommand.QUERY) {
+      return Promise.resolve({
+        kind: 'command_result',
+        id: 'q',
+        ok: true,
+        result: { elements: [ELEMENT], count: 1 },
+      });
+    }
+    if (name === ReticleCommand.MATCH) {
+      return Promise.resolve({
+        kind: 'command_result',
+        id: 'm',
+        ok: true,
+        result: { matched: true, count: 1, elements: [ELEMENT] },
+      });
+    }
+    return Promise.resolve({ kind: 'command_result', id: 'c', ok: true, result: { ok: true } });
+  }
+  eventsSince(): ReticleEvent[] {
+    return this.#events;
+  }
+  onEvent(): () => void {
+    return () => undefined;
+  }
+  elapsed(): number {
+    return 0;
+  }
+}
+
+const flowExpecting = (net: Record<string, unknown>): FlowFile => {
+  const step: FlowStep = {
+    tool: 'reticle_act',
+    anchor: { kind: AnchorKind.TESTID, value: 'import' },
+  };
+  step.expect = { net };
+  return { version: FLOW_FILE_VERSION, name: 'import-geometry', createdAt: 0, steps: [step] };
+};
+
+/** Short, so a test that is meant to time out does so quickly. */
+const BUDGET = 40;
+
+describe("a wait that expires with the step's own request still open", () => {
+  it('does not report the call as one that never happened', async () => {
+    const session = new WireSession([pendingPost(URL_MATCHED)]);
+
+    const [step] = await replayFlow(
+      session,
+      flowExpecting({ method: 'POST', urlContains: '/geometry', status: 200 }),
+      waitForPredicate,
+      BUDGET,
+    );
+
+    expect(step?.ok, 'the consequence did not hold, so this is still a drift').toBe(false);
+    expect(step?.drift?.reasonKind).toBe(DriftReason.REQUEST_STILL_IN_FLIGHT);
+    expect(step?.drift?.reasonKind).not.toBe(DriftReason.SIGNAL_NOT_OBSERVED);
+  });
+
+  it('names the pending call, so the claim can be checked', async () => {
+    const session = new WireSession([pendingPost(URL_MATCHED)]);
+
+    const [step] = await replayFlow(
+      session,
+      flowExpecting({ method: 'POST', urlContains: '/geometry', status: 200 }),
+      waitForPredicate,
+      BUDGET,
+    );
+
+    expect(step?.drift?.reason).toContain('STILL IN FLIGHT');
+    expect(step?.drift?.reason).toContain('/geometry');
+  });
+
+  it('sends the reader to a budget rather than to a regression', async () => {
+    const session = new WireSession([pendingPost(URL_MATCHED)]);
+
+    const [step] = await replayFlow(
+      session,
+      flowExpecting({ method: 'POST', urlContains: '/geometry', status: 200 }),
+      waitForPredicate,
+      BUDGET,
+    );
+
+    expect(step?.drift?.reason).toContain('timeoutMs');
+    expect(step?.drift?.reason).toContain('signalTimeoutMs');
+    // The sentence that produced the false reading. It may be denied, as it is here, but it must
+    // not be the whole message the way it was.
+    expect(step?.drift?.reason).not.toContain('no network call matched');
+  });
+});
+
+describe('what the excuse must not pardon', () => {
+  it('keeps the ordinary miss when nothing is on the wire', async () => {
+    const session = new WireSession([]);
+
+    const [step] = await replayFlow(
+      session,
+      flowExpecting({ method: 'POST', urlContains: '/geometry', status: 200 }),
+      waitForPredicate,
+      BUDGET,
+    );
+
+    expect(step?.drift?.reasonKind).toBe(DriftReason.SIGNAL_NOT_OBSERVED);
+  });
+
+  it('keeps the ordinary miss when an UNRELATED request is hanging', async () => {
+    // A dashboard poll left open must not pardon a named URL that never started. This is the whole
+    // reason the check matches rather than asking "is anything pending".
+    const session = new WireSession([pendingPost('https://app.test/api/v0/notifications')]);
+
+    const [step] = await replayFlow(
+      session,
+      flowExpecting({ method: 'POST', urlContains: '/geometry', status: 200 }),
+      waitForPredicate,
+      BUDGET,
+    );
+
+    expect(step?.drift?.reasonKind).toBe(DriftReason.SIGNAL_NOT_OBSERVED);
+  });
+
+  it('keeps the ordinary miss when the pending call uses a different method', async () => {
+    const session = new WireSession([pendingPost(URL_MATCHED, 'GET')]);
+
+    const [step] = await replayFlow(
+      session,
+      flowExpecting({ method: 'POST', urlContains: '/geometry', status: 200 }),
+      waitForPredicate,
+      BUDGET,
+    );
+
+    expect(step?.drift?.reasonKind).toBe(DriftReason.SIGNAL_NOT_OBSERVED);
+  });
+
+  it('does not fire for a completed request that simply did not match', async () => {
+    // The call finished with the wrong status. The app answered; that is a real finding.
+    const session = new WireSession([
+      {
+        t: 2,
+        type: EventType.NET_REQUEST,
+        sessionId: 's',
+        data: { id: 'r1', method: 'POST', url: URL_MATCHED, status: 500 },
+      },
+    ]);
+
+    const [step] = await replayFlow(
+      session,
+      flowExpecting({ method: 'POST', urlContains: '/geometry', status: 200 }),
+      waitForPredicate,
+      BUDGET,
+    );
+
+    expect(step?.drift?.reasonKind).toBe(DriftReason.SIGNAL_NOT_OBSERVED);
+  });
+});

--- a/packages/server/src/flows/flow-replay.ts
+++ b/packages/server/src/flows/flow-replay.ts
@@ -30,6 +30,8 @@ import {
 } from './flow-step-runners.js';
 import { successToPredicate } from './flow-success.js';
 import { ReticleTool } from '../tools/tool-names.js';
+import { inFlightRequestLabels } from '../tools/settle-in-flight.js';
+import { namedNetIsInFlight } from '../honesty/unsettled.js';
 
 /**
  * The session surface flow-replay needs: QUERY to re-resolve a testid anchor against the live
@@ -475,12 +477,49 @@ async function assertStepExpect(
   if (predicate === undefined) return undefined;
   const verdict = await waitForSignal(session, predicate, timeoutMs, since);
   if (verdict.pass) return undefined;
+
+  // The budget ended; that does not mean the call never happened. A request matching this step's
+  // URL and method may be sitting on the wire right now, and "no network call matched POST
+  // /geometry" reads as a feature that regressed. See pendingRequestDrift.
+  const pending = pendingRequestDrift(session, expect, predicate, since);
+  if (pending !== undefined) return pending;
+
   return {
     // The store case keeps its own kind because heal and the run report branch on it; everything
     // else is a consequence that did not hold, and the reason carries observed-vs-expected.
     reasonKind:
       expect.state !== undefined ? DriftReason.STATE_MISMATCH : DriftReason.SIGNAL_NOT_OBSERVED,
     reason: verdict.failureReason ?? "the step's declared consequence did not hold",
+    anchor: expectLabel(expect),
+    nearest: null,
+  };
+}
+
+/**
+ * The drift for a step whose wait expired while its own request was still open, or undefined.
+ *
+ * Undefined is the common case and has to stay cheap: an ordinary miss keeps the reason it had, and
+ * an unrelated poll left hanging must not pardon a named URL that never started -- which is exactly
+ * what `namedNetIsInFlight` discriminates, and why this reuses it instead of matching URLs here.
+ *
+ * The verdict stays a drift. The step did not prove its consequence, and pretending otherwise would
+ * be the opposite error. What changes is what a reader is sent to do about it: a budget to raise
+ * (`timeoutMs` on the step, or `signalTimeoutMs` on the flow) rather than a deleted feature to hunt.
+ */
+function pendingRequestDrift(
+  session: FlowReplaySession,
+  expect: NonNullable<FlowStep['expect']>,
+  predicate: Predicate,
+  since: number,
+): Drift | undefined {
+  const stillInFlight = inFlightRequestLabels(session.eventsSince(since));
+  if (!namedNetIsInFlight(predicate, stillInFlight)) return undefined;
+  return {
+    reasonKind: DriftReason.REQUEST_STILL_IN_FLIGHT,
+    reason:
+      `the wait ended while a matching request was STILL IN FLIGHT (${stillInFlight.join(', ')}), ` +
+      'so this is a timeout against a slow app, not a call that never happened. Raise the budget — ' +
+      '`timeoutMs` on this step, or `signalTimeoutMs` on the flow — before looking for a regression',
     anchor: expectLabel(expect),
     nearest: null,
   };


### PR DESCRIPTION
Closes #896.

## What

On replay, a request still **in flight** was reported as one that never happened:

```
verdict: "drift"
whatChanged: "no network call matched {kind:net, method:POST, urlContains:/geometry, status:200}"
```

while `reticle_network` showed, at that same moment:

```
POST /api/v0/interview/itv_38e855c15d/geometry   status: "pending"
```

The request existed and was on the wire. That verdict reads to a user as "this feature regressed".

## The live path already drew this line

`fix(server): an in-flight named request is not a failed assertion` did exactly this for `reticle_assert`, and the issue is right that replay never got it — grepping `flow-replay.ts` for `pending`/`inFlight` returned nothing before this change.

So this **reuses** `namedNetIsInFlight` and `inFlightRequestLabels` rather than reimplementing the match. Two spellings of "is this request still open" would eventually disagree, and the disagreement would be invisible.

## A new `DriftReason`, not a reused one

The issue flags this as the part that matters, and it is: `signal_not_observed` sends a reader to look for a deleted feature. `REQUEST_STILL_IN_FLIGHT` sends them to a budget.

No consumer branches exhaustively on `DriftReason` (`heal.ts` tests one member and falls through), so the new member is additive.

The verdict **stays a drift**. The step did not prove its consequence, and pretending otherwise would be the opposite error. What changes is what a reader is sent to do:

```
the wait ended while a matching request was STILL IN FLIGHT (POST https://…/geometry),
so this is a timeout against a slow app, not a call that never happened. Raise the budget —
`timeoutMs` on this step, or `signalTimeoutMs` on the flow — before looking for a regression
```

Both of those knobs now exist, which is what makes the advice followable.

## What the excuse must not pardon

Four of the seven tests are the negative space, because an excuse that fires too widely is worse than the bug it fixes:

- nothing on the wire → ordinary miss
- an **unrelated** request hanging (a dashboard poll) → ordinary miss. This is why the check matches URL and method rather than asking "is anything pending".
- a pending call with a **different method** → ordinary miss
- a **completed** call that simply did not match (the app answered 500) → ordinary miss. The app answered; that is a real finding.

**Control run:** the other 3 fail against main.

## Verification

```
pnpm lint && pnpm typecheck && pnpm test:unit   # green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)