### PR TITLE
ci(install-gate): capture evidence for the failure that actually fails

### DIFF
--- a/apps/e2e/install-gate.mjs
+++ b/apps/e2e/install-gate.mjs
@@ -883,9 +883,15 @@ async function clearInitDevPorts(scaffold, note, exceptPort) {
 async function driveScaffold(scaffold, index) {
   let pass = 0;
   let fail = 0;
+  const failedChecks = [];
   const chk = (label, ok, detail = '') => {
     console.log(`   ${ok ? '✅' : '❌'} ${label}${detail ? '  — ' + detail : ''}`);
-    ok ? (pass += 1) : (fail += 1);
+    if (ok) {
+      pass += 1;
+    } else {
+      fail += 1;
+      failedChecks.push(label);
+    }
   };
   const note = (line) => console.log(`   · ${line}`);
 
@@ -1012,6 +1018,24 @@ async function driveScaffold(scaffold, index) {
 
     handedOverPorts = portsMentionedIn(report);
     chk('init exits 0', initExit === 0, `exit ${String(initExit)}`);
+    // Evidence for the OTHER failure path, which had none (#818).
+    //
+    // `dumpEvidence` ran only when the gate's own session check failed. The intermittent Windows
+    // failure is not that check -- it is this one: `init`'s own post-install verification reports
+    // "the SDK IS in the page and never dialled the bridge" against the dev server IT started and
+    // handed over, `init` exits 1, and then the gate boots the app itself and the session appears
+    // fine. So the run ended with a truncated headline and no evidence, and the one hypothesis the
+    // message itself names -- "a bridge port that differs on the two sides" -- is answerable from
+    // the registry and the daemon log, both of which were right there and never printed.
+    //
+    // Init drives its own page in a subprocess, so there is no page console to capture here. What
+    // there is: which bridge port init was told to use, which ports its report mentions, and which
+    // daemon claims which project.
+    if (0 !== initExit) {
+      note(`init was told to use bridge port ${String(SELF_TEST ? bridgePort + 1 : bridgePort)}`);
+      note(`init's report mentions ports: ${handedOverPorts.join(', ') || '(none)'}`);
+      dumpEvidence([], bridgePort);
+    }
 
     // The load-bearing assertion, and now an absolute one. A ⚠ is a step nothing performed, so the
     // app never dials the bridge and every tool answers "no browser session connected" — a
@@ -1311,7 +1335,12 @@ async function driveScaffold(scaffold, index) {
     }
   }
 
-  console.log(`   ${fail === 0 ? '✓' : '✗'} ${scaffold.id}: ${pass} passed, ${fail} failed`);
+  // Name the failing check, not just the count. "8 passed, 1 failed" sent every reader of #818
+  // scrolling to find out which one -- and the answer turned out to matter: the intermittent
+  // Windows failure is `init exits 0`, while the gate's own session check passes on the same
+  // scaffold seconds later.
+  const which = 0 === failedChecks.length ? '' : ` (${failedChecks.join('; ')})`;
+  console.log(`   ${fail === 0 ? '✓' : '✗'} ${scaffold.id}: ${pass} passed, ${fail} failed${which}`);
   return { id: scaffold.id, pass, fail };
 }
 


### PR DESCRIPTION
Towards #818. The issue asks for the evidence needed to rule the product code path in or out. Reading a fresh occurrence closely first changed what I think that evidence is.

## The failing check is not the one the issue names

Run 34315734383, `vite-vue`, Windows. The same scaffold, seconds apart:

```
❌ init exits 0  — exit 1
...
✅ a session appears and can answer a state question  — http://localhost:4822/
```

`init` starts a dev server on **5175**, its own post-install verification reports *"The SDK IS in the page at http://localhost:5175 and never dialled the bridge"*, and `init` exits 1. The gate then boots the app itself on **4822**, and the session appears **and answers a state question**.

So the SDK's localhost guard is not losing a race in the page — the very next boot of the same scaffold connects cleanly. What loses is **init's own verification against the dev server it started and handed over**.

That is a narrower and more tractable suspect than "connect() returning early behind a localhost/protocol guard", and the message itself already names a candidate: *"a bridge port that differs on the two sides"*. Two ports are in play on this path (the bridge port init is told to use, and whatever its handed-over dev server ends up dialling), and only one of them is in the log today.

I have not fixed the race — I do not have a Windows reproduction — so this does not close the issue.

## What this changes

**`dumpEvidence` ran only on the session-check path.** This failure path had none, which is exactly why the three reference runs produced a truncated headline and nothing to diagnose from. It now runs when `init` exits non-zero, alongside the two facts only this call site knows:

```
   · init was told to use bridge port 4790
   · init's report mentions ports: 5175
      ── daemon registry ──
      ── daemon log (…/daemon-4790.log) ──
```

Init drives its own page in a subprocess, so there is no page console to capture here. The daemon registry and the daemon log are what answer the port question — both were already being written on every run and neither was ever printed.

**The per-scaffold line names the failing check.** `8 passed, 1 failed` is what sends a reader scrolling, and in this case which check it was turned out to be the whole finding:

```
   ✗ vite-vue: 8 passed, 1 failed (init exits 0)
```

## Also worth correcting in the issue's framing

> The message means the SDK bundle **evaluated** and returned before dialling. That is a product code path, not a harness one.

Still true, but it is `init`'s verification reporting it about `init`'s own dev server, not the gate reporting it about the app the gate booted. The gate's session check passes on the same scaffold. Anyone picking this up should start at init's post-install verify and the port it watches, not at `connect()`'s guard.

## Verification

`node --check` passes; `pnpm lint` and `pnpm format` clean.

The gate itself is not run here: it takes 40–70 minutes, the failure is Windows-only and intermittent at roughly 1 in 3, and this change is purely additive to a path that only executes when `init` has already failed. The next occurrence on CI is what it is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)