### PR TITLE
fix(server): reticle_lineage reads the attribution the SDK already stamped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
+### Fixed
+
+- **`@reticlehq/server` — `reticle_lineage` reads the attribution the SDK already stamped, instead of only a fresh timing window.** Every event observed under a driven action carries `actionId` + `attribution` at `window` tier — the same heuristic the tool was recomputing from `t`, already labelled and narrower. The tool ignored it, with two consequences that ran the wrong way for an honesty tool. Five seconds spans several driven acts, so a request fired by the _previous_ click was named as a candidate for a change caused by _this_ one, and the chain reported "ambiguous — timing alone cannot choose" while holding the stamp that had already chosen. And because its only middle link was an app-emitted signal, which most apps never emit, a change Reticle itself drove came back "its cause is not in evidence" — a factual claim, false whenever the change carried the id of the act Reticle dispatched. A candidate stamped with a _different_ act is now excluded (the stamp rules out; it never rules in, so an unstamped pre-dispatch request stays a candidate), and a stamped change with no signal behind it names the act at the tier the event carries, then looks for the request behind it under the same stamp. An ambient change, with no stamp, is traced exactly as before. Closes [#939](https://github.com/reticlehq/reticle/issues/939).
+
 ## [2.14.0] — 2026-09-10
 
 ### Added

--- a/packages/server/src/events/lineage.test.ts
+++ b/packages/server/src/events/lineage.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { EventType, type ReticleEvent } from '@reticlehq/core';
+import { EventAttribution, EventType, type ReticleEvent } from '@reticlehq/core';
 import { traceLineage } from './lineage.js';
 
 const state = (t: number, path: string, value: unknown): ReticleEvent =>
@@ -25,6 +25,15 @@ const signal = (t: number, name: string): ReticleEvent =>
   ({ type: EventType.SIGNAL, t, data: { name } }) as unknown as ReticleEvent;
 const net = (t: number, method: string, url: string, status: number): ReticleEvent =>
   ({ type: EventType.NET_REQUEST, t, data: { method, url, status } }) as unknown as ReticleEvent;
+/**
+ * The event as the SDK stamps it while a driven action is active: `actionId` plus the tier that
+ * link is worth. Set together, exactly as `core/messages.ts` says they are.
+ */
+const stamped = (e: ReticleEvent, actionId: string): ReticleEvent => ({
+  ...e,
+  actionId,
+  attribution: EventAttribution.WINDOW,
+});
 
 describe('traceLineage — what was observed', () => {
   it('finds the state change that set the value, and marks it observed', () => {
@@ -122,5 +131,90 @@ describe('traceLineage renders a block a reader can scan', () => {
     const text = out.chain.map((l) => l.text).join('\n');
     expect(text.indexOf('user.name')).toBeLessThan(text.indexOf('USER_FETCH_SUCCESS'));
     expect(text.indexOf('USER_FETCH_SUCCESS')).toBeLessThan(text.indexOf('/api/user/1'));
+  });
+});
+
+describe('traceLineage reads the attribution the SDK already stamped', () => {
+  // Every event observed while a driven action is active carries that action's id, at `window`
+  // tier — the same tier, already computed, already labelled, and narrower than a fresh five-second
+  // look-back. The tool used to read only the look-back. These pin what changes when it reads both.
+
+  it('does not offer a candidate stamped with a DIFFERENT act as ambiguity for this one', () => {
+    // Five seconds spans several driven acts. Two signals in the window, but the change carries
+    // `a7` and one of the signals carries `a6`: the ambiguity was never real — "timing alone cannot
+    // choose" is true, and the stamp already had. Reporting two candidates here manufactures an
+    // ambiguity the tool is holding the resolution to.
+    const out = traceLineage(
+      [
+        stamped(signal(80, 'PREVIOUS_CLICK_DONE'), 'a6'),
+        stamped(signal(90, 'CART_UPDATED'), 'a7'),
+        stamped(state(100, 'cart.total', 1499), 'a7'),
+      ],
+      { path: 'cart.total' },
+    );
+    const link = out.chain[1];
+    expect(link?.text).toContain('CART_UPDATED');
+    expect(link?.text).not.toContain('PREVIOUS_CLICK_DONE');
+    expect(link?.candidates, 'one candidate is not an ambiguity').toBeUndefined();
+  });
+
+  it('keeps an UNSTAMPED candidate — the stamp rules out, it never rules in', () => {
+    // A request fired just before dispatch carries no stamp, and its response can land inside the
+    // act. The stamp proves an event belongs to ANOTHER act; it cannot prove an unstamped one is
+    // unrelated. So the look-back still applies to unstamped candidates, and this stays ambiguous.
+    const out = traceLineage(
+      [
+        signal(85, 'PREFETCH_DONE'),
+        stamped(signal(90, 'CART_UPDATED'), 'a7'),
+        stamped(state(100, 'cart.total', 1499), 'a7'),
+      ],
+      { path: 'cart.total' },
+    );
+    expect(out.chain[1]?.candidates).toEqual(['PREFETCH_DONE', 'CART_UPDATED']);
+  });
+
+  it('names the act a stamped change is attributed to when no signal fired, instead of "not in evidence"', () => {
+    // The common case, not the edge case: `reticle.signal()` is a call the APP must make, so on
+    // most apps no signal ever fires. The tool then said the cause was "not in evidence" — a
+    // factual claim, and false whenever the change carries the id of the act Reticle dispatched.
+    // The cause IS in evidence, at window tier, which is the only tier there is.
+    const out = traceLineage([stamped(state(100, 'cart.total', 1499), 'a7')], {
+      path: 'cart.total',
+    });
+    expect(out.chain).toHaveLength(2);
+    const link = out.chain[1];
+    expect(link?.kind).toBe('act');
+    expect(link?.observed, 'window tier is a heuristic, not an observation').toBe(false);
+    expect(link?.text).toContain('a7');
+    expect(link?.text).toMatch(/window/i);
+    expect(String(out.note)).not.toMatch(/not in evidence/i);
+  });
+
+  it('carries the request behind a driven change through the act, filtered by the same stamp', () => {
+    const out = traceLineage(
+      [
+        stamped(net(40, 'POST', '/api/previous', 200), 'a6'),
+        stamped(net(60, 'POST', '/api/cart/add', 200), 'a7'),
+        stamped(state(100, 'cart.total', 1499), 'a7'),
+      ],
+      { path: 'cart.total' },
+    );
+    expect(out.chain).toHaveLength(3);
+    expect(out.chain[1]?.kind).toBe('act');
+    expect(out.chain[2]?.kind).toBe('net');
+    expect(out.chain[2]?.text).toContain('/api/cart/add');
+    expect(out.chain[2]?.text).not.toContain('/api/previous');
+  });
+
+  it('leaves an ambient change exactly as it was — the look-back is the right tool for that', () => {
+    // No stamp on the change means nothing was driving, so there is nothing to filter by and
+    // nothing to attribute to. This is the case `CAUSE_WINDOW_MS` fits, and it is unchanged.
+    const out = traceLineage([stamped(signal(90, 'SOMEONE_ELSES'), 'a6'), state(100, 'x', 1)], {
+      path: 'x',
+    });
+    expect(out.chain[1]?.text).toContain('SOMEONE_ELSES');
+    const bare = traceLineage([state(100, 'x', 1)], { path: 'x' });
+    expect(bare.chain).toHaveLength(1);
+    expect(String(bare.note)).toMatch(/not seen to pass through/i);
   });
 });

--- a/packages/server/src/events/lineage.ts
+++ b/packages/server/src/events/lineage.ts
@@ -16,10 +16,18 @@
  *   one thing a correlation cannot justify;
  * - no candidate says the value was not seen to pass through one, and reaches for nothing.
  *
+ * One more source, read rather than recomputed: the SDK stamps `actionId` + `attribution` onto every
+ * event observed while a driven action is active (see `core/messages.ts`). That is a time-window
+ * heuristic too — `EventAttribution.WINDOW`'s own comment says so — but it is the same tier, already
+ * computed, already labelled, and narrower than a fresh look-back, so the join reads it two ways:
+ * a candidate stamped with a DIFFERENT act is not a candidate for this one (the stamp rules out; it
+ * never rules in), and a stamped change with no signal behind it names the act rather than calling
+ * its cause "not in evidence" when the evidence is on the event (#939).
+ *
  * Read-only. Produces no verdict, is not reachable from an assert path, and changes nothing.
  */
 
-import { EventType, type ReticleEvent } from '@reticlehq/core';
+import { EventAttribution, EventType, type ReticleEvent } from '@reticlehq/core';
 import { asString } from '../tools/tools-helpers.js';
 
 /** What the caller is asking about. `value` narrows a path that changed more than once. */
@@ -30,8 +38,8 @@ export interface LineageQuery {
 
 /** One line of the chain, with the confidence that produced it. */
 export interface LineageLink {
-  /** Which stream this came from. */
-  kind: 'state' | 'signal' | 'net';
+  /** Which stream this came from. `act` is the driven action the event was stamped with. */
+  kind: 'state' | 'act' | 'signal' | 'net';
   /** The rendered line, already carrying its own hedge. */
   text: string;
   /** True only when this is an event we hold. A join is never observed. */
@@ -68,9 +76,45 @@ function stateChangesFor(events: readonly ReticleEvent[], query: LineageQuery): 
   });
 }
 
-/** Events of one kind inside the causal window before `t`, oldest first. */
-function precursors(events: readonly ReticleEvent[], type: string, t: number): ReticleEvent[] {
-  return events.filter((e) => e.type === type && e.t < t && e.t >= t - CAUSE_WINDOW_MS);
+/**
+ * Events of one kind inside the causal window before `t`, oldest first.
+ *
+ * When the change being traced carries an `actionId`, a candidate stamped with a DIFFERENT one is
+ * dropped: the SDK observed it under another driven action, and five seconds spans several of
+ * those. An UNSTAMPED candidate stays. A request fired just before dispatch carries no stamp and its
+ * response can still land inside the act — the stamp proves an event belongs elsewhere, it cannot
+ * prove an unstamped one is unrelated. Rules out, never rules in.
+ */
+function precursors(
+  events: readonly ReticleEvent[],
+  type: string,
+  t: number,
+  actionId: string | undefined,
+): ReticleEvent[] {
+  return events.filter(
+    (e) =>
+      e.type === type &&
+      e.t < t &&
+      e.t >= t - CAUSE_WINDOW_MS &&
+      (actionId === undefined || e.actionId === undefined || e.actionId === actionId),
+  );
+}
+
+/**
+ * The link from a stamped change to the act that was active when it was observed.
+ *
+ * Rendered from the tier the event carries, not asserted: `attribution` is present iff `actionId`
+ * is, and today there is one tier. It is not an observation — the SDK stamped an id across a span
+ * of time — and the text says what that span is, so a reader who acts on the arrow has been told
+ * what the arrow is worth.
+ */
+function actLink(actionId: string, attribution: string | undefined): LineageLink {
+  const tier = attribution ?? EventAttribution.WINDOW;
+  return {
+    kind: 'act',
+    text: `← attributed to action ${actionId} — ${tier} tier: the SDK stamped this action's id on every event between its dispatch and settle. A time window, not dataflow.`,
+    observed: false,
+  };
 }
 
 /**
@@ -130,20 +174,37 @@ export function traceLineage(events: readonly ReticleEvent[], query: LineageQuer
     },
   ];
 
-  const signals = precursors(events, EventType.SIGNAL, latest.t);
+  const actionId = latest.actionId;
+  const signals = precursors(events, EventType.SIGNAL, latest.t, actionId);
   if (0 === signals.length) {
-    return {
-      found: true,
-      chain,
-      note: 'No signal fired in the window before this change, so the value was not seen to pass through one. Nothing further is claimed — the change is real, its cause is not in evidence.',
-    };
+    if (actionId === undefined) {
+      return {
+        found: true,
+        chain,
+        note: 'No signal fired in the window before this change, so the value was not seen to pass through one. Nothing further is claimed — the change is real, its cause is not in evidence.',
+      };
+    }
+    // The common case: `reticle.signal()` is a call the APP must make, and most apps never do. But
+    // this change was observed under a driven action, and that is on the event. Saying its cause is
+    // "not in evidence" would be a factual claim, and a false one.
+    chain.push(actLink(actionId, latest.attribution));
+    const driven = precursors(events, EventType.NET_REQUEST, latest.t, actionId);
+    if (0 === driven.length) {
+      return {
+        found: true,
+        chain,
+        note: 'No signal fired, and no request in the window carries this action or none at all, so the chain stops at the act rather than joining across a gap in the evidence.',
+      };
+    }
+    chain.push(inferredLink('net', driven.map(netLabel)));
+    return { found: true, chain };
   }
   chain.push(inferredLink('signal', signals.map(signalLabel)));
 
   // Anchored on the OLDEST candidate signal: a request that preceded any of them could have produced
   // it, and narrowing to the newest would quietly discard candidates for the link below.
   const anchor = signals[0]?.t ?? latest.t;
-  const calls = precursors(events, EventType.NET_REQUEST, anchor);
+  const calls = precursors(events, EventType.NET_REQUEST, anchor, actionId);
   if (0 === calls.length) {
     return {
       found: true,

--- a/packages/server/src/tools/lineage-tools.ts
+++ b/packages/server/src/tools/lineage-tools.ts
@@ -23,7 +23,7 @@ export const LINEAGE_TOOLS: ToolDef[] = [
     name: ReticleTool.LINEAGE,
     example: { path: 'user.profile.name' },
     description:
-      'Trace BACKWARDS from a runtime value: which state change set it, which signal preceded that, and which request preceded the signal. Read-only — it draws no verdict and changes nothing. The state change is OBSERVED; every link above it is an INFERENCE from timing and says so in its own text. Where several candidates could explain a link it names ALL of them rather than choosing, because timing alone cannot justify the choice — so a chain here is a place to look, never a proven cause. Use it after a `no` verdict or a contradiction, instead of correlating reticle_state, reticle_network and reticle_observe by hand.',
+      'Trace BACKWARDS from a runtime value: which state change set it, which driven action it was observed under, which signal preceded it, and which request preceded that. Read-only — it draws no verdict and changes nothing. The state change is OBSERVED; every link above it is an INFERENCE and says so in its own text — a driven action is the window-tier stamp the SDK put on the event, a signal or request is a timing look-back. A candidate stamped with a DIFFERENT action is excluded; an unstamped one is kept. Where several candidates could still explain a link it names ALL of them rather than choosing, because timing alone cannot justify the choice — so a chain here is a place to look, never a proven cause. Use it after a `no` verdict or a contradiction, instead of correlating reticle_state, reticle_network and reticle_observe by hand.',
     inputSchema: {
       path: z
         .string()


### PR DESCRIPTION
## What & why

Closes #939, filed yesterday with the evidence; this is the fix it offered. Nothing here argues for a cleverer join. It reads evidence the tool was already holding.

Every event observed under a driven action carries `actionId` + `attribution` at `window` tier. The tier's own comment in `@reticlehq/core` says what it is worth — *"a time-window heuristic, not proven dataflow"* — which is the same hedge `reticle_lineage` expresses on a link it recomputes from `t` with a five-second look-back, and never reads from the event. Same tier, already computed, already labelled, and narrower.

Ignoring it had two consequences that ran the wrong way for an honesty tool.

## Consequence 1: an ambiguity the tool held the resolution to

Five seconds spans several driven acts. A request fired by the *previous* click was a candidate for a change caused by *this* one, and the chain reported:

> `← ambiguous: 2 candidates … not resolved, because timing alone cannot choose between them`

True of the look-back. Not true of the event: the candidates carried different `actionId`s, and the stamp had already chosen.

**Now:** a candidate stamped with a *different* act is excluded. **The stamp rules out; it never rules in.** A request fired just before dispatch carries no stamp and its response can still land inside the act, so an unstamped candidate stays, and the look-back still governs it. That asymmetry is the whole design and there is a test on each side of it.

## Consequence 2: "not in evidence" was false on the common case

The chain's only middle link was `EventType.SIGNAL`, and `reticle.signal()` is a call the **app** must make — most never do. So on most apps a change Reticle itself drove came back:

> *its cause is not in evidence*

That is a factual claim, and it is false whenever the change carries the id of the act Reticle dispatched. Under-claiming is the safe direction for a verdict; this is the tool an agent reaches for *after* a `no` verdict, and "nothing caused this" sends it looking in the wrong place.

**Now:** a stamped change with no signal behind it names the act, at the tier the event carries, and then looks for the request behind it under the same stamp:

```
cart.total = 1499  (observed: state change at 2143ms)
← attributed to action a7 — window tier: the SDK stamped this action's id on every event
  between its dispatch and settle. A time window, not dataflow.
← likely POST /api/cart/add (200) (inferred from timing, 1 candidate)
```

The act link is rendered from `attribution` on the event rather than asserted, so if a second tier ever exists the line will say so without this code changing.

## The judgement calls, so they can be argued with

- **The act link appears only when no signal fired.** When a signal exists the chain keeps its shape and only the candidate set narrows. Adding the act line to every driven chain would be more consistent and would change the output for everyone; I kept the smaller change against fresh work. One condition to flip if you prefer the other.
- **An ambient change is untouched.** No stamp means nothing was driving, so nothing to filter by and nothing to attribute to. `CAUSE_WINDOW_MS` is the right tool there and it is unchanged. A test pins it.
- **The tool description now says the act link exists** and states the rule-out/never-rule-in asymmetry, since agents read descriptions to know what they will get.

## How it was verified

RED first. Without the change **three of the five** new cases fail — cross-act exclusion, the act link, and the request behind the act — and the **two guards pass**: the unstamped candidate kept, and the ambient change unchanged. That split is what shows the stamp only narrows. Re-checked adversarially by reverting only `lineage.ts` and keeping the tests.

## Gates run

- [x] `format:check` clean; `eslint` clean on the three touched files; `tsc -b` clean on `@reticlehq/server`; `check-boundaries` and `check-lossy-transforms` OK
- [x] Server suite **6440 passing across 659 files, zero failures** — the first fully clean local run this box has produced; the long-standing `symlinkSync` `EPERM` in `init/format-generated.test.ts` is gone after the 2.14.0 install
- [ ] **`pnpm bench:full && pnpm bench:gate` — running locally as I open this, and not yet usable.** The observation-cost pass is failing every cell on this Windows box with *"the daemon connection dropped"*, a transport failure that a change to a pure function over events cannot produce. I will paste the gate output here from CI's `bench` job, which runs on every PR and has passed on my last four, rather than report a local number I do not trust. If the local run finishes clean I will paste that too.
- [ ] `pnpm test:e2e` — not run locally; this touches the tool surface, so leaving it to CI rather than reporting a result I do not have.

## Not in scope

No new tier — `EventAttribution` has one, and its comment already names the future one. No new wire fields — both are on `ReticleEvent`. The output schema takes `kind` as a string, so `act` needs no schema change. Naming the *tool* behind the act (`reticle_act "Add to cart"`) would need the journal, which `traceLineage` does not have; the act id is what the event carries, so that is what is rendered.

## Checklist

- [x] Commit signed off
- [x] Tests added RED → GREEN
- [x] No `any`, no free strings, no non-null `!`
- [x] No `console.log` or internal tracking codes
- [x] Files under the cap (`lineage.ts` at 217 lines)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Not security-affecting: read-only, no verdict, unreachable from any assert path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
