### PR TITLE
fix(browser,server): a cut present-testid list says it was cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
+### Fixed
+
+- **`@reticlehq/core` + `@reticlehq/browser` + `@reticlehq/server` — a miss whose present-testid list was cut says so, instead of handing back a partial list as the whole page.** On a zero-match query the browser reports the testids that _are_ in scope, capped at twelve in document order, and the cap was silent: no marker on the wire, and `reticle_assert` put the list straight into `evidence` as if it were everything. A detail panel sits after the header, nav and list, so on any page with a dozen testids before it the panel's are exactly the ones dropped — and a list with the panel missing from it was read in the field as proof the panel never rendered, the false-negative shape produced by a trim nobody was told about. The browser now reports `presentTestidsTotal` when the cap cut something (present only then, the same convention as the result's own `total`/`truncated` pair), it is declared in the tool output schema so it is not stripped the way `presentRegions` once was, and the assert failure says _"the present-testid list shows the first 12 of 41 in document order — absence from it proves nothing"_. `presentTestids` stays deprecated; this makes its last cycle stop lying. Part of [#793](https://github.com/reticlehq/reticle/issues/793).
+
 ## [2.14.0] — 2026-09-10
 
 ### Added

--- a/packages/browser/src/dom/browser.test.ts
+++ b/packages/browser/src/dom/browser.test.ts
@@ -256,6 +256,27 @@ describe('query empty hint', () => {
     expect(r.hint?.presentTestids).toHaveLength(12);
   });
 
+  it('says how many testids the cap cut, so a list that stops is not read as the whole page', () => {
+    // The cut is in document order, and a detail panel sits after the header, nav and list. On a
+    // page with a dozen testids before it, the panel's are exactly the ones dropped — and a list
+    // handed back with no marker reads as "here is what is present", with the panel absent from it.
+    // That is what a field reporter read as proof the panel never rendered. A trim is never silent.
+    render(
+      Array.from({ length: 20 }, (_, i) => `<div data-testid="t${i}"></div>`).join('') +
+        '<div data-testid="t0"></div>', // the duplicate must not count twice
+    );
+    const r = runQuery({ role: 'button', name: 'nope' });
+    expect(r.hint?.presentTestids).toHaveLength(12);
+    expect(r.hint?.presentTestidsTotal).toBe(20);
+  });
+
+  it('omits the total when nothing was cut — present only when it carries information', () => {
+    render('<div data-testid="a"></div><div data-testid="b"></div>');
+    const r = runQuery({ role: 'button', name: 'nope' });
+    expect(r.hint?.presentTestids).toHaveLength(2);
+    expect(r.hint?.presentTestidsTotal).toBeUndefined();
+  });
+
   /**
    * The field report this came from: a label rendered with `v-html` spans several child nodes, so
    * `by: text` — which reads an element's OWN text nodes — matched nothing while the string was

--- a/packages/browser/src/dom/query.ts
+++ b/packages/browser/src/dom/query.ts
@@ -653,13 +653,16 @@ function buildEmptyHint(query: ElementQuery): QueryEmptyHint {
   const container = resolveContainer(query.scope).container ?? document.body;
   const all = container.querySelectorAll(`[${TESTID_ATTR}]`);
   const present: string[] = [];
+  // Counted past the cap rather than stopping at it. The list is capped so the hint stays a hint;
+  // the COUNT is what stops a capped list being read as the whole page. `all` is already in hand,
+  // so the walk costs nothing the query had not already paid for.
+  const seen = new Set<string>();
   for (const el of Array.from(all)) {
     if (isIgnored(el)) continue; // the "what IS here" hint must not advertise Reticle's own UI either
     const id = el.getAttribute(TESTID_ATTR);
-    if (id !== null && id.length > 0 && !present.includes(id)) {
-      present.push(id);
-      if (present.length >= MAX_PRESENT_TESTIDS) break;
-    }
+    if (null === id || 0 === id.length || seen.has(id)) continue;
+    seen.add(id);
+    if (present.length < MAX_PRESENT_TESTIDS) present.push(id);
   }
   // DECLARED, not observed: see declaredTestids. Every present testid is also an observed one, so
   // the merged list would make this flag true for any page that has a testid at all.
@@ -669,6 +672,9 @@ function buildEmptyHint(query: ElementQuery): QueryEmptyHint {
   const hint: QueryEmptyHint = {
     route,
     presentTestids: present,
+    // Present only when the cap cut something: the same convention as the query result's own
+    // `total`/`truncated` pair, and for the same reason — a field on every result carries nothing.
+    ...(seen.size > present.length ? { presentTestidsTotal: seen.size } : {}),
     presentRegions: buildPresentRegions(query),
     knownEmptyState,
   };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -151,6 +151,14 @@ export interface QueryEmptyHint {
   presentRegions: PresentRegion[];
   /** @deprecated Use presentRegions. Kept for one major cycle; removed next major. */
   presentTestids: string[];
+  /**
+   * Present only when `presentTestids` was cut at its cap: how many distinct testids there were
+   * before the cut. The list is collected in DOCUMENT ORDER, so what the cap drops is whatever sits
+   * lowest on the page — a detail panel after the header, nav and list — and a list handed back
+   * with no marker reads as "here is what is present", with the panel absent from it. That was read
+   * in the field as proof the panel never rendered. A trim is never silent.
+   */
+  presentTestidsTotal?: number;
   /** True if a capability-registered testid is present in the scope. */
   knownEmptyState: boolean;
   /**

--- a/packages/server/src/events/predicate-element.ts
+++ b/packages/server/src/events/predicate-element.ts
@@ -27,6 +27,18 @@ import type { PredicateSession } from './predicate.js';
 import { describeTestidMiss } from './testid-near-miss.js';
 import { describeSplitTextMiss } from './split-text-miss.js';
 
+/**
+ * The caveat for a present-testid list that was cut at its cap, or nothing when it was whole.
+ *
+ * Phrased as what the list IS — "the first N of M in document order" — rather than as an apology,
+ * because the agent's next move depends on knowing the shape: a region absent from a capped list is
+ * unexamined, not absent. Empty when nothing was cut, so an ordinary miss keeps the message it had.
+ */
+function describePresentTestidsCut(shown: number, total: number | undefined): string {
+  if (total === undefined || total <= shown) return '';
+  return ` (the present-testid list shows the first ${String(shown)} of ${String(total)} in document order — absence from it proves nothing)`;
+}
+
 export async function matchOnce(
   session: PredicateSession,
   query: ElementQuery,
@@ -241,12 +253,24 @@ export async function evalElement(
   const splitText = describeSplitTextMiss(match.hint?.splitText, query.text);
   const clause = splitText ?? (alsoHere === undefined || '' === alsoHere ? undefined : alsoHere);
   const suffix = clause === undefined ? '' : ` — ${clause}`;
+  // The evidence list is capped in document order, so a region low on the page is exactly what it
+  // drops. Handed back with no marker it reads as the whole page, and the field report this came
+  // from read a missing detail panel as proof the panel never rendered. Say the cut happened (#793).
+  const total = match.hint?.presentTestidsTotal;
+  const cut = describePresentTestidsCut(present.length, total);
   return {
     pass: false,
-    failureReason: `no element matched ${subject}${state === undefined ? '' : ` in state '${state}'`}${suffix}`,
+    failureReason: `no element matched ${subject}${state === undefined ? '' : ` in state '${state}'`}${suffix}${cut}`,
     observed: `no matching element on the page${suffix}`,
     expected: `an element matching ${subject}${state === undefined ? '' : ` in state '${state}'`}`,
     assertion: 'element.present',
-    ...(present.length > 0 ? { evidence: { presentTestids: present } } : {}),
+    ...(present.length > 0
+      ? {
+          evidence: {
+            presentTestids: present,
+            ...(total === undefined ? {} : { presentTestidsTotal: total }),
+          },
+        }
+      : {}),
   };
 }

--- a/packages/server/src/events/predicate-text-scope.test.ts
+++ b/packages/server/src/events/predicate-text-scope.test.ts
@@ -171,3 +171,52 @@ describe('text predicate: scope narrows the search', () => {
     expect(different.pass, 'self must still enforce the requested text').toBe(false);
   });
 });
+
+describe('a miss whose present-testid list was cut says so', () => {
+  /** A page with more testids than the hint carries: the browser reports the total it cut to. */
+  class CutListSession extends ScopedSession {
+    constructor(private readonly total: number | undefined) {
+      super([]);
+    }
+    override command(name: string, args: Record<string, unknown> = {}): Promise<CommandResult> {
+      if (name !== ReticleCommand.MATCH) return super.command(name, args);
+      const result: MatchResult = {
+        matched: false,
+        count: 0,
+        elements: [],
+        hint: {
+          route: '/orders/42',
+          presentTestids: Array.from({ length: 12 }, (_, i) => `header-${String(i)}`),
+          presentRegions: [],
+          knownEmptyState: false,
+          ...(this.total === undefined ? {} : { presentTestidsTotal: this.total }),
+        },
+      };
+      return Promise.resolve({ kind: 'command_result', id: 'x', ok: true, result });
+    }
+  }
+
+  it('carries the total in the evidence and says absence from the list proves nothing', async () => {
+    // The reporter's case: `evidence.presentTestids` omitted the detail-panel testids that
+    // reticle_query had just proved present, and the omission read as proof of absence. The list was
+    // the first twelve in document order and nothing said so.
+    const result = await evaluatePredicate(new CutListSession(41), {
+      kind: 'element',
+      query: { testid: 'detail-panel' },
+    });
+    expect(result.pass).toBe(false);
+    expect(result.evidence).toMatchObject({ presentTestidsTotal: 41 });
+    expect(result.failureReason).toMatch(/12 of 41/);
+    expect(result.failureReason).toMatch(/proves nothing/i);
+  });
+
+  it('adds no caveat when the list was whole', async () => {
+    const result = await evaluatePredicate(new CutListSession(undefined), {
+      kind: 'element',
+      query: { testid: 'detail-panel' },
+    });
+    expect(result.pass).toBe(false);
+    expect(result.failureReason).not.toMatch(/proves nothing/i);
+    expect(result.evidence).not.toHaveProperty('presentTestidsTotal');
+  });
+});

--- a/packages/server/src/tools/tools.ts
+++ b/packages/server/src/tools/tools.ts
@@ -453,6 +453,14 @@ export const RAW_TOOLS: ToolDef[] = [
             .optional()
             .describe('Structural clusters on the page — what IS here, to diagnose the miss.'),
           presentTestids: z.array(z.string()).optional(),
+          // Declared for the same reason presentRegions had to be: undeclared here, it is stripped
+          // from structuredContent without a word — and this field exists precisely to say a word.
+          presentTestidsTotal: z
+            .number()
+            .optional()
+            .describe(
+              'Present only when presentTestids was cut at its cap: how many there were. The list is document order, so a region low on the page is what got dropped — absence from the list proves nothing.',
+            ),
           knownEmptyState: z.boolean(),
           splitText: z
             .object({


### PR DESCRIPTION
## What & why

Part of #793 — the half [claimed on the issue](https://github.com/reticlehq/reticle/issues/793#issuecomment-5644027360), and only that half. The split-text question stays with @divshekhar's chase and the reporter's DOM; the two are independent, and this one is provable from source alone.

The report's second observation:

> `evidence.presentTestids` omits the detail-panel testids that step 2 just proved present

has a mechanism that is not split text. On a zero-match query the browser reports the testids that *are* in scope, capped at twelve in **document order**:

```ts
// browser/src/dom/query.ts
const MAX_PRESENT_TESTIDS = 12;
…
present.push(id);
if (present.length >= MAX_PRESENT_TESTIDS) break;
```

and the cap was silent: `QueryEmptyHint` carried no marker, and `predicate-element.ts` put the list straight into `evidence` as if it were the whole page.

## Why document order makes the silence expensive

A detail panel sits after the header, the nav and the list. On any page with a dozen testids before it, the panel's are exactly the ones dropped. The evidence then reads *"here is what is present"* with the panel missing from it — and the reporter read that as proof the panel never rendered, on the same tab where `reticle_query` had just returned it. That is the false-negative shape, produced by a trim nobody was told about.

The rule already exists, in `causal-summary.ts`: *"a trim is never silent, so an agent can always see that something was ignored."* This list broke it on the one path where the omission does the most damage.

## The change, in three places

- **`@reticlehq/browser`** counts distinct testids past the cap and reports `presentTestidsTotal` when the cap cut something. Present only then — the same convention as the result's own `total`/`truncated` pair one field up, and for the same reason: a field on every result carries nothing. The walk costs nothing new; the node list was already in hand.
- **`@reticlehq/server`, tool schema** declares the field, because an undeclared hint field is stripped from `structuredContent` without a word — which is exactly how `presentRegions` was once invisible, per the comment beside it.
- **`@reticlehq/server`, assert path** says what the list is: *"the present-testid list shows the first 12 of 41 in document order — absence from it proves nothing"*, and carries the total in `evidence`.

`presentTestids` is deprecated and this does not extend its life. It makes its last cycle stop lying.

## Two things checked and left

- **Flow replay** reads the same list, but only to pick a nearest-testid rebind — never as evidence shown to the caller — so the honesty defect does not reach it. That the rebind cannot see a near-miss past position twelve is a healing-quality limit, not a lie; noted, not changed.
- **`describeTestidMiss`** (the near-miss on the assert path) reads the same capped list, with the same limit. Same reasoning, same call.

## How it was verified

RED first on both sides. Without the browser change its one new case fails and the omit-when-whole guard passes; without the server change its one new case fails and the no-caveat-when-whole guard passes. Re-checked by reverting each side's source separately against the kept tests.

## Gates run

- [x] `format:check` clean; `tsc -b` clean on core, browser, server; `eslint` clean on every touched file; `check-boundaries` (11 packages) and `check-lossy-transforms` OK
- [x] Core **442**, browser **1412**, server **6437** — all passing, zero failures across the three suites
- [ ] `pnpm test:e2e` — not run locally; this adds a field to a command result, so it is the tier that matters. Leaving it to CI rather than reporting a result I do not have.

## Checklist

- [x] Commit signed off
- [x] Tests added RED → GREEN, both sides
- [x] No `any`, no free strings, no non-null `!`
- [x] No `console.log` or internal tracking codes
- [x] Files under the cap (`query.ts` at 712, `predicate-element.ts` at 276)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Not security-affecting: one additive optional number on a diagnostic hint, and a clause on a failure message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
