### PR TITLE
feat(server): a route that 500s is named as a server error, not a closed tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **`@reticlehq/*`** packages are documented here (each
 
 ## [Unreleased]
 
+### Fixed
+
+- **`@reticlehq/core` + `@reticlehq/server` — a route that 500s is named as a server error, not as a closed tab.** A route that throws server-side tears the page down and the SDK never reconnects, so `reticle_sessions` was empty and the diagnosis said the tab was torn down while on that URL (#862) — which is true, and indistinguishable from somebody closing it. The daemon now asks the route itself: when a session has gone and its last URL is held, the no-session watch does one `GET` of that URL in the background, on the same cadence as its port scan, and the diagnosis reads the answer. A 5xx becomes `NoSessionReason.ROUTE_SERVER_ERROR`, ranked above `TAB_GONE` because it is not an absence: _the page was torn down while on /X, and that route answers HTTP 500 right now — a server error in the app, not a closed tab and not an install problem_. Present tense on purpose, since a 500 now does not prove the teardown was a 500 then. The probe fetches loopback `http:` only, `GET` only, never reads the body, and treats an error or a timeout as no fact — the diagnosis is then unchanged rather than wrong. A non-5xx status stays with the closed-tab wording. Part of [#808](https://github.com/reticlehq/reticle/issues/808); the overlay-read option stays open.
+
 ## [2.14.0] — 2026-09-10
 
 ### Added

--- a/packages/core/src/no-session-reason.ts
+++ b/packages/core/src/no-session-reason.ts
@@ -19,6 +19,13 @@ export const NoSessionReason = {
   LEASE_EXPIRED: 'lease_expired',
   /** Connected before; the tab was closed, navigated away, or hard-reloaded. */
   TAB_GONE: 'tab_gone',
+  /**
+   * Connected before, and the route the tab was on answers 5xx right now. A server error tears the
+   * page down and the SDK never reconnects, so it used to read as TAB_GONE — the URL was known, and
+   * nothing asked it what it answers. This is the answer, and it outranks TAB_GONE because it is not
+   * an absence. Present tense only: a 5xx now is what was observed, not a claim about then.
+   */
+  ROUTE_SERVER_ERROR: 'route_server_error',
   /** This project has connected before, but not to this daemon run. Usually a restart with no reopen. */
   APP_NOT_REOPENED: 'app_not_reopened',
   /** A `.reticle.json` exists OUTSIDE this daemon's directory: a scope problem, not an install one. */

--- a/packages/server/src/session/no-session-diagnosis.ts
+++ b/packages/server/src/session/no-session-diagnosis.ts
@@ -140,7 +140,17 @@ export interface NoSessionFacts {
    * or the ring has forgotten — inventing a URL is worse than the silence this exists to end.
    */
   lastKnownUrl?: string;
+  /**
+   * What a plain GET of `lastKnownUrl` answered, done out of band by the watch after the session
+   * went. The one fact that separates a server error from a closed tab and from an install
+   * problem (#808, option 3). Present only when the fetch got an HTTP status back — a failed or
+   * timed-out fetch is no fact, and this stays absent rather than guessing.
+   */
+  lastKnownStatus?: number;
 }
+
+/** The lowest HTTP status that means the server itself failed to answer the route. */
+const SERVER_ERROR_FLOOR = 500;
 
 /** The one framework whose most likely cause differs from every other framework's. */
 const NUXT = 'nuxt';
@@ -538,6 +548,27 @@ export function explainNoSession(facts: NoSessionFacts): {
           'headless context, not a human tab, and it takes its cookies with it (so an authenticated ' +
           'app needs signing in again). Re-acquire with reticle_lease {action:"acquire", url} and ' +
           `carry on.${alreadyListeningClause(listening)} ${RETRY}`,
+      );
+    }
+    // Ranked above TAB_GONE because it is not an absence: the route itself answered. A tab that a
+    // 5xx tore down and a tab a human closed produce the same empty list, and until the watch asked
+    // the route, they produced the same sentence. Present tense throughout — "answers ... right
+    // now" — because a 500 now does not prove the teardown was a 500 then, and saying so would
+    // turn an observation into a story.
+    if (
+      facts.lastKnownStatus !== undefined &&
+      facts.lastKnownStatus >= SERVER_ERROR_FLOOR &&
+      facts.lastKnownUrl !== undefined &&
+      '' !== facts.lastKnownUrl
+    ) {
+      return reason(
+        NoSessionReason.ROUTE_SERVER_ERROR,
+        'no browser session connected, but one WAS connected to this daemon earlier, so the wiring ' +
+          `is correct. The page was torn down while on ${facts.lastKnownUrl}, and that route answers ` +
+          `HTTP ${String(facts.lastKnownStatus)} right now — a server error in the app, not a closed ` +
+          'tab and not an install problem. A route that throws server-side tears the page down and ' +
+          'the SDK cannot reconnect to it. Fix the route, then reload the tab (or run ' +
+          `${OPEN_CMD_BARE}).${alreadyListeningClause(listening)} ${RETRY}`,
       );
     }
     return reason(

--- a/packages/server/src/session/no-session-reason.test.ts
+++ b/packages/server/src/session/no-session-reason.test.ts
@@ -33,6 +33,63 @@ describe('every no-session branch names itself', () => {
     expect(explainNoSession(facts({ everConnected: true })).reason).toBe(NoSessionReason.TAB_GONE);
   });
 
+  it('the route the tab died on answers 5xx right now — a server error, not a closed tab', () => {
+    // The route that 500s tears the page down and the SDK never reconnects, so the list is empty
+    // and the diagnosis said "the tab went away". It had the URL (#862) and nothing else; a plain
+    // GET of that URL, done out of band by the watch, is the one fact that separates a server error
+    // from a closed tab and from an install problem. It outranks TAB_GONE because it is not an
+    // absence — it is an answer from the route itself.
+    const got = explainNoSession(
+      facts({
+        everConnected: true,
+        lastKnownUrl: 'http://localhost:3000/orders/explode',
+        lastKnownStatus: 500,
+      }),
+    );
+    expect(got.reason).toBe(NoSessionReason.ROUTE_SERVER_ERROR);
+    expect(got.message).toContain('http://localhost:3000/orders/explode');
+    expect(got.message).toMatch(/HTTP 500/);
+    expect(got.message).toMatch(/server error/i);
+    expect(got.message).not.toMatch(/reticle init/);
+  });
+
+  it('claims the present tense only — the status is what the route answers NOW', () => {
+    // A 500 now does not prove the teardown was a 500 then; a dev server recompiles. The sentence
+    // must not say the page "was torn down BY" the error as though that were observed.
+    const got = explainNoSession(
+      facts({ everConnected: true, lastKnownUrl: 'http://localhost:3000/x', lastKnownStatus: 503 }),
+    );
+    expect(got.message).toMatch(/right now|answers HTTP 503/i);
+  });
+
+  it('a non-5xx status is not a server error, and the closed-tab wording stands', () => {
+    // A 404 after a route rename, a 401 from an auth guard, a 200 because the route recovered — all
+    // real information, none of them the claim this branch makes. Only 5xx becomes the new reason.
+    for (const status of [200, 302, 401, 404]) {
+      const got = explainNoSession(
+        facts({
+          everConnected: true,
+          lastKnownUrl: 'http://localhost:3000/x',
+          lastKnownStatus: status,
+        }),
+      );
+      expect(got.reason, `status ${String(status)}`).toBe(NoSessionReason.TAB_GONE);
+      expect(got.message).not.toMatch(/server error/i);
+    }
+  });
+
+  it('a reaped lease still wins over a 5xx — the thing that vanished was ours, not the app', () => {
+    const got = explainNoSession(
+      facts({
+        everConnected: true,
+        leaseExpired: true,
+        lastKnownUrl: 'http://localhost:3000/x',
+        lastKnownStatus: 500,
+      }),
+    );
+    expect(got.reason).toBe(NoSessionReason.LEASE_EXPIRED);
+  });
+
   it('this project has connected before, but not on this daemon run', () => {
     expect(explainNoSession(facts({ previouslyConnected: true })).reason).toBe(
       NoSessionReason.APP_NOT_REOPENED,

--- a/packages/server/src/session/no-session-watch.test.ts
+++ b/packages/server/src/session/no-session-watch.test.ts
@@ -145,3 +145,81 @@ describe('the no-session diagnosis and a config written after boot', () => {
     expect(message).not.toMatch(/the daemon this app wants/i);
   });
 });
+
+describe('the watch asks the route the tab died on what it answers now', () => {
+  /** A manager whose one departed session was on `url`. */
+  function stubWithLastKnown(url: string): ReturnType<typeof stubSessions> {
+    const stub = stubSessions();
+    const m = stub.manager as unknown as Record<string, unknown>;
+    m['everConnected'] = () => true;
+    m['lastKnown'] = () => ({ id: 's-gone', url });
+    return stub;
+  }
+
+  it('fetches the last-known URL in the background and the hint reads the status', async () => {
+    const dir = projectDir(JSON.stringify({ framework: 'next', projectId: 'app-1' }));
+    const { manager, hint } = stubWithLastKnown('http://localhost:3000/orders/explode');
+    const asked: string[] = [];
+    const stop = startNoSessionWatch({
+      sessions: manager,
+      port: 4400,
+      initialized: true,
+      directory: dir,
+      probe: () => Promise.resolve([3000]),
+      occupiedSiblings: () => Promise.resolve([]),
+      routeStatus: (url) => {
+        asked.push(url);
+        return Promise.resolve(500);
+      },
+    });
+    // One macrotask turn lets the whole background refresh chain settle — probe, siblings, route.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const message = hint();
+    stop();
+    expect(asked).toEqual(['http://localhost:3000/orders/explode']);
+    expect(message).toMatch(/HTTP 500/);
+    expect(message).toMatch(/server error/i);
+  });
+
+  it('a fetch that fails is no fact — the diagnosis is unchanged, not wrong', async () => {
+    const dir = projectDir(JSON.stringify({ framework: 'next', projectId: 'app-1' }));
+    const { manager, hint } = stubWithLastKnown('http://localhost:3000/orders/explode');
+    const stop = startNoSessionWatch({
+      sessions: manager,
+      port: 4400,
+      initialized: true,
+      directory: dir,
+      probe: () => Promise.resolve([3000]),
+      occupiedSiblings: () => Promise.resolve([]),
+      routeStatus: () => Promise.resolve(undefined),
+    });
+    // One macrotask turn lets the whole background refresh chain settle — probe, siblings, route.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const message = hint();
+    stop();
+    expect(message).toMatch(/torn down while on/i);
+    expect(message).not.toMatch(/server error|HTTP 5/i);
+  });
+
+  it('does not ask at all when nothing departed — no URL, no fetch', async () => {
+    const dir = projectDir(JSON.stringify({ framework: 'next', projectId: 'app-1' }));
+    const { manager } = stubSessions();
+    let asked = 0;
+    const stop = startNoSessionWatch({
+      sessions: manager,
+      port: 4400,
+      initialized: true,
+      directory: dir,
+      probe: () => Promise.resolve([3000]),
+      occupiedSiblings: () => Promise.resolve([]),
+      routeStatus: () => {
+        asked += 1;
+        return Promise.resolve(500);
+      },
+    });
+    // One macrotask turn lets the whole background refresh chain settle — probe, siblings, route.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    stop();
+    expect(asked).toBe(0);
+  });
+});

--- a/packages/server/src/session/no-session-watch.ts
+++ b/packages/server/src/session/no-session-watch.ts
@@ -10,6 +10,7 @@
  * daemon that outlives the agent by hours has no business scanning ports it does not need.
  */
 
+import { probeRouteStatus } from './route-status-probe.js';
 import { probeDevServers, probeDevServerStates } from './dev-server-probe.js';
 import type { NoSessionReason } from '@reticlehq/core/telemetry';
 import { homedir } from 'node:os';
@@ -91,6 +92,15 @@ interface NoSessionWatchOptions {
    */
   attach?: (url: string) => Promise<unknown>;
   /**
+   * What the route the last session was on answers right now, as an HTTP status, or undefined
+   * when there is no answer to report.
+   *
+   * Injected so tests can pin the observation without opening a socket. Production (no override)
+   * asks the route itself — see route-status-probe. The one fact that separates a route that 500s
+   * from a closed tab (#808, option 3).
+   */
+  routeStatus?: (url: string) => Promise<number | undefined>;
+  /**
    * Where the durable "an app has connected here before" bit lives. The daemon's state home unless
    * a test says otherwise.
    */
@@ -116,6 +126,15 @@ export function startNoSessionWatch(options: NoSessionWatchOptions): () => void 
    */
   let slowListeners: readonly number[] = [];
   let siblingListeners: readonly number[] = [];
+  /**
+   * What the last-known route answered, cached beside the port scan for the same reason the scan
+   * is cached: the hint is read synchronously, so every fact it carries has to be gathered before
+   * it is asked. Keyed by URL so a status is never attributed to a route other than the one it
+   * came from — a fresh departure on a different URL reads as "not asked yet", not as the old
+   * answer.
+   */
+  let lastKnownStatus: { url: string; status: number } | undefined;
+  const routeStatus = options.routeStatus ?? probeRouteStatus;
   let running = false;
   /** Ports auto-attach has already spent its one attempt on. Bounded: never a loop, never a retry. */
   const attempted = new Set<number>();
@@ -262,6 +281,13 @@ export function startNoSessionWatch(options: NoSessionWatchOptions): () => void 
             : options.probe === undefined
               ? await findOccupiedSiblings(options.port, probeDaemon)
               : [];
+        // Asked once per departed URL, on the same background cadence as the port scan, and never
+        // on the hint's own path. A url already answered is not asked again; a new departure is.
+        const known = options.sessions.lastKnown?.();
+        if (known !== undefined && lastKnownStatus?.url !== known.url) {
+          const status = await routeStatus(known.url);
+          if (status !== undefined) lastKnownStatus = { url: known.url, status };
+        }
         await autoAttach(ports);
       })
       .catch(() => {
@@ -352,7 +378,14 @@ export function startNoSessionWatch(options: NoSessionWatchOptions): () => void 
       // has none to name.
       ...(() => {
         const known = options.sessions.lastKnown?.();
-        return undefined === known ? {} : { lastKnownUrl: known.url };
+        if (undefined === known) return {};
+        // The status rides only when it was fetched for THIS url. A departure since the fetch
+        // means the cached answer is about a route nobody is asking about.
+        const status =
+          lastKnownStatus !== undefined && lastKnownStatus.url === known.url
+            ? { lastKnownStatus: lastKnownStatus.status }
+            : {};
+        return { lastKnownUrl: known.url, ...status };
       })(),
       // How long this daemon has been waiting with no app. The diagnosis uses it to surface
       // "install never finished" — the same condition telemetry already knows about.

--- a/packages/server/src/session/route-status-probe.test.ts
+++ b/packages/server/src/session/route-status-probe.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The out-of-band route fetch behind the ROUTE_SERVER_ERROR diagnosis (#808, option 3).
+ *
+ * Driven against a real local server rather than a stubbed request, because the guards this file
+ * exists for — loopback only, http only, never the body — are about what leaves the socket, and a
+ * stub cannot show that.
+ */
+
+import { createServer, type Server } from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+import { probeRouteStatus } from './route-status-probe.js';
+
+let server: Server | undefined;
+let seenPath: string | undefined;
+let seenMethod: string | undefined;
+
+function serve(status: number, body = 'x'.repeat(4096)): Promise<string> {
+  return new Promise((resolve) => {
+    server = createServer((req, res) => {
+      seenPath = req.url;
+      seenMethod = req.method;
+      res.statusCode = status;
+      res.end(body);
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const address = server?.address();
+      const port = 'object' === typeof address && address !== null ? address.port : 0;
+      resolve(`http://127.0.0.1:${String(port)}`);
+    });
+  });
+}
+
+afterEach(async () => {
+  const s = server;
+  server = undefined;
+  seenPath = undefined;
+  seenMethod = undefined;
+  if (s !== undefined) await new Promise<void>((resolve) => s.close(() => resolve()));
+});
+
+describe('probeRouteStatus', () => {
+  it('reports the status a local route answers, for the exact path asked', async () => {
+    const origin = await serve(500);
+    const status = await probeRouteStatus(`${origin}/orders/explode?tab=1`);
+    expect(status).toBe(500);
+    // The exact path, query included — a probe of `/` would say nothing about the route that died.
+    expect(seenPath).toBe('/orders/explode?tab=1');
+    expect(seenMethod).toBe('GET');
+  });
+
+  it('reports a healthy answer as its status too, so the caller decides what it means', async () => {
+    const origin = await serve(200);
+    expect(await probeRouteStatus(`${origin}/`)).toBe(200);
+  });
+
+  it('never leaves loopback — a non-local hostname is not fetched', async () => {
+    // The daemon is localhost-only. A diagnostic that reaches out to an arbitrary host on a
+    // remembered URL is a posture change, and no status is worth it.
+    expect(await probeRouteStatus('http://example.com/orders')).toBeUndefined();
+    expect(await probeRouteStatus('http://10.0.0.5:3000/orders')).toBeUndefined();
+  });
+
+  it('skips https rather than fetching with verification off', async () => {
+    expect(await probeRouteStatus('https://localhost:3000/orders')).toBeUndefined();
+  });
+
+  it('answers undefined, never a status, for a URL it cannot parse', async () => {
+    expect(await probeRouteStatus('not a url')).toBeUndefined();
+  });
+
+  it('answers undefined when nothing is listening — no fact, not a wrong one', async () => {
+    // Bind then close, so the port is known free.
+    const origin = await serve(200);
+    const s = server;
+    server = undefined;
+    await new Promise<void>((resolve) => s?.close(() => resolve()));
+    expect(await probeRouteStatus(`${origin}/orders`)).toBeUndefined();
+  });
+
+  it('gives up on a server that accepts and never answers, inside the budget', async () => {
+    await new Promise<void>((resolve) => {
+      server = createServer(() => {
+        /* accept, and never respond */
+      });
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+    const address = server?.address();
+    const port = 'object' === typeof address && address !== null ? address.port : 0;
+    // A tight injected budget; the property is that it RETURNS, not how long it took.
+    expect(await probeRouteStatus(`http://127.0.0.1:${String(port)}/slow`, 100)).toBeUndefined();
+  }, 5_000);
+});

--- a/packages/server/src/session/route-status-probe.ts
+++ b/packages/server/src/session/route-status-probe.ts
@@ -1,0 +1,66 @@
+/**
+ * What does the route a tab died on answer right now?
+ *
+ * A route that throws server-side tears the page down and the SDK never reconnects, so the daemon
+ * is left with an empty session list and the URL it last saw (#862). The URL alone cannot separate
+ * "the route 500s" from "somebody closed the tab" — one plain GET can, and the daemon is the only
+ * party placed to make it: the page is gone, the agent is inside an MCP call, and the daemon is on
+ * the same machine as the dev server.
+ *
+ * What it refuses to do, because this runs unattended in a diagnostic loop:
+ *   - only loopback hostnames — the daemon is localhost-only and a diagnostic must not reach out;
+ *   - only `http:` — `https:` on localhost means a self-signed certificate, and fetching it with
+ *     verification off would be a posture change for a status code;
+ *   - GET only, redirects not followed, the body never read — the status is the only thing that
+ *     leaves the socket, and it is drained so the connection closes rather than lingers;
+ *   - an error or a timeout is `undefined`, never a status. No fact is better than a wrong one.
+ *
+ * Same shape as `dev-server-probe.ts`, which asks a port whether it serves a document; this asks
+ * one exact path what it answers.
+ */
+
+import { request } from 'node:http';
+import { isLoopbackHostname } from '@reticlehq/core';
+
+/** Short on purpose: a dev server that has not answered a route in this long is not going to. */
+export const ROUTE_STATUS_TIMEOUT_MS = 2_000;
+
+const HTTP = 'http:';
+
+/** The HTTP status `url` answers a GET with, or undefined when there is no answer to report. */
+export function probeRouteStatus(
+  url: string,
+  timeoutMs: number = ROUTE_STATUS_TIMEOUT_MS,
+): Promise<number | undefined> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return Promise.resolve(undefined);
+  }
+  if (parsed.protocol !== HTTP || !isLoopbackHostname(parsed.hostname)) {
+    return Promise.resolve(undefined);
+  }
+  return new Promise((resolve) => {
+    const req = request(
+      {
+        host: parsed.hostname,
+        port: parsed.port,
+        path: `${parsed.pathname}${parsed.search}`,
+        method: 'GET',
+        timeout: timeoutMs,
+      },
+      (res) => {
+        const status = res.statusCode;
+        res.resume(); // drain, so the socket closes rather than lingering
+        resolve(status);
+      },
+    );
+    req.once('timeout', () => {
+      req.destroy();
+      resolve(undefined);
+    });
+    req.once('error', () => resolve(undefined));
+    req.end();
+  });
+}


### PR DESCRIPTION
## What & why

Part of #808 — **option 3**, the out-of-band fetch, [claimed on the issue](https://github.com/reticlehq/reticle/issues/808#issuecomment-5647240910) after #862 landed option 1 and left this open. Option 2 (reading the overlay via CDP) stays open.

A route that throws server-side tears the page down and the SDK never reconnects. Since #862 the diagnosis can say *the page was torn down while on /orders/explode* instead of handing back an empty list — which is true, and indistinguishable from somebody closing the tab. The report this came from called the route that 500s *"the one state in which Reticle has nothing to say"*, and asked for exactly one thing: *a verdict that the route 500'd would still be useful*.

One plain `GET` separates the two, and the daemon is the only party placed to make it: the page is gone, the agent is inside an MCP call, and the daemon is on the same machine as the dev server.

## Where it lives, and why there

`no-session-diagnosis.ts` is pure by design — *"everything it needs is passed in, so the probe that discovers listening ports stays out of it"* — and `no-session-watch.ts` already runs a background port scan and hands the synchronous hint a cached answer. The route fetch follows that shape exactly:

- when a session has gone and `lastKnown.url` is held, the watch does one `GET` in the background, on the same cadence as the scan, and caches `{ url, status }`;
- the hint reads it synchronously, and **only when the cached url is the current last-known one** — a fresh departure on a different URL reads as "not asked yet", never as the old answer;
- never on the hint's own path, never while a session is live, asked once per departed URL.

## What it says

A 5xx becomes `NoSessionReason.ROUTE_SERVER_ERROR`, ranked above `TAB_GONE` because it is not an absence — the route itself answered:

> no browser session connected, but one WAS connected to this daemon earlier, so the wiring is correct. The page was torn down while on http://localhost:3000/orders/explode, and that route answers **HTTP 500 right now** — a server error in the app, not a closed tab and not an install problem. A route that throws server-side tears the page down and the SDK cannot reconnect to it. Fix the route, then reload the tab …

**Present tense throughout, on purpose.** A 500 now does not prove the teardown was a 500 then (a dev server recompiles), and a 200 now does not prove it was not. The sentence claims what was observed and nothing about causation. A test pins that wording.

A reaped lease still outranks it — the thing that vanished was ours, not the app.

## What it refuses to do

Because this runs unattended in a diagnostic loop:

- **loopback hostnames only** (`isLoopbackHostname` from core) — the daemon is localhost-only and a diagnostic must not reach out on a remembered URL;
- **`http:` only** — `https:` on localhost means a self-signed certificate, and fetching it with verification off would be a posture change for a status code;
- **`GET` only, redirects not followed, the body never read** — the status is the only thing that leaves the socket, and it is drained so the connection closes;
- **an error or a timeout is `undefined`, never a status** — no fact is better than a wrong one, and the diagnosis is then unchanged rather than wrong.

A **non-5xx** status stays with the closed-tab wording. A 404 after a route rename or a 401 from an auth guard is real information and a different claim; only 5xx makes the one this branch makes. A Vite SPA answers 200 for every route, so this helps server-rendered frameworks — the reporter's Next.js case — and says nothing false about the others.

## Telemetry

`noSessionReason` on the refusal schema is `z.nativeEnum(NoSessionReason)`, so the new member rides into telemetry with no allowlist change. `telemetry-contract.test.ts`, `orphan-modules.test.ts` and `e2e-surface-drift.test.ts` all pass.

## How it was verified

RED first. Without the change the diagnosis case, the present-tense case and the watch case fail; the guards pass — non-5xx stays `TAB_GONE`, a reaped lease still wins, a failed fetch leaves the diagnosis unchanged, and no departure means no fetch at all. Re-checked adversarially by reverting `no-session-diagnosis.ts` and `no-session-watch.ts` together against the kept tests.

The pre-existing guard *"does not invent a 500 — we did not fetch the route"* still passes: when there is no status, there is no 500 in the sentence.

The probe itself is driven against a **real local `http` server** rather than a stub, because its guards are about what leaves the socket: exact path and query asked, `GET` seen, a non-loopback host not fetched, `https` skipped, a closed port and a listener that accepts-and-never-answers both `undefined` inside a tight injected budget.

## Gates run

- [x] `format:check` clean; `tsc -b` clean on core and server; `eslint` clean on every touched file; `check-boundaries` (11 packages) and `check-lossy-transforms` OK
- [x] Core **442** and server **6449** passing, zero failures, on a clean run. An earlier run showed two tree-scanning guards red while prettier was rewriting the CHANGELOG mid-suite; both pass alone and on the clean re-run, and the heavy-IO guard caught a `for`/`await` loop I had put in a watch test, which I replaced with the file's existing yield style.
- [ ] `pnpm test:e2e` — not run locally. This changes the no-session diagnosis, so it is the tier that matters; leaving it to CI.

## Follow-up, not here

`reticle_sessions`' `lastKnown` could carry the status too, now that the fact exists. That means plumbing the watch's cache into the manager, and it is a separate change.

## Checklist

- [x] Commit signed off
- [x] Tests added RED → GREEN
- [x] No `any`, no free strings (the reason is a core constant; the floor and the scheme are named), no non-null `!`
- [x] No `console.log` or internal tracking codes
- [x] Files under the cap (`no-session-diagnosis.ts` 706, `no-session-watch.ts` 452)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Security posture kept: loopback-only, `http`-only, `GET`-only, no body read, no verification disabled — and a test on each

🤖 Generated with [Claude Code](https://claude.com/claude-code)
